### PR TITLE
Editor: Threaded scene imports and parallel glTF/mesh processing

### DIFF
--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -273,7 +273,7 @@ Error ResourceFormatImporter::get_import_order_threads_and_importer(const String
 	if (importer.is_valid()) {
 		r_order = importer->get_import_order();
 		r_importer = importer->get_importer_name();
-		r_can_threads = importer->can_import_threaded();
+		r_can_threads = importer->can_import_file_threaded(p_path);
 		return OK;
 	} else {
 		return ERR_INVALID_PARAMETER;

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -156,6 +156,8 @@ public:
 
 	virtual Error import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files = nullptr, Variant *r_metadata = nullptr) = 0;
 	virtual bool can_import_threaded() const { return false; }
+	// Per-file variant of can_import_threaded(); defaults to the importer-wide setting.
+	virtual bool can_import_file_threaded(const String &p_path) const { return can_import_threaded(); }
 	virtual void import_threaded_begin() {}
 	virtual void import_threaded_end() {}
 

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -52,6 +52,7 @@
 #include "scene/main/scene_tree.h"
 #include "scene/resources/packed_scene.h"
 #include "servers/display/display_server.h"
+#include "servers/rendering/rendering_server.h"
 
 EditorFileSystem *EditorFileSystem::singleton = nullptr;
 int EditorFileSystem::nb_files_total = 0;
@@ -993,7 +994,31 @@ bool EditorFileSystem::_update_scan_actions() {
 					for (const String &dep : dependencies) {
 						const String &dependency_path = dep.contains("::") ? dep.get_slice("::", 0) : dep;
 						if (_can_import_file(dep)) {
-							reimports.push_back(dependency_path);
+							// Only reimport dependency if it actually needs it.
+							bool dep_needs_reimport = true;
+							String dep_import_md5;
+							if (file_cache.has(dependency_path)) {
+								FileCache &fc = file_cache[dependency_path];
+								dep_import_md5 = fc.import_md5;
+								uint64_t dep_mt = FileAccess::get_modified_time(dependency_path);
+								if (fc.modification_time == dep_mt && fc.import_modification_time == FileAccess::get_modified_time(dependency_path + ".import")) {
+									// File modification times match cache, skip expensive reimport check,
+									// unless an imported destination file was deleted in the meantime.
+									dep_needs_reimport = false;
+									for (const String &dest_path : fc.import_dest_paths) {
+										if (!FileAccess::exists(dest_path)) {
+											dep_needs_reimport = true;
+											break;
+										}
+									}
+								}
+							}
+							if (dep_needs_reimport) {
+								dep_needs_reimport = _test_for_reimport(dependency_path, dep_import_md5);
+							}
+							if (dep_needs_reimport) {
+								reimports.push_back(dependency_path);
+							}
 						}
 					}
 				} else {
@@ -3241,8 +3266,6 @@ void EditorFileSystem::_reimport_thread(uint32_t p_index, ImportThreadData *p_im
 	int file_idx = p_import_data->reimport_from + int(p_index);
 	_reimport_file(p_import_data->reimport_files[file_idx].path);
 	ResourceLoader::set_is_import_thread(false);
-
-	p_import_data->imported_sem->post();
 }
 
 void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
@@ -3326,7 +3349,6 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 #endif
 
 	int from = 0;
-	Semaphore imported_sem;
 	for (int i = 0; i < reimport_files.size(); i++) {
 		if (groups_to_reimport.has(reimport_files[i].path)) {
 			from = i + 1;
@@ -3352,27 +3374,27 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 					ImportThreadData tdata;
 					tdata.reimport_from = from;
 					tdata.reimport_files = reimport_files.ptr();
-					tdata.imported_sem = &imported_sem;
 
 					int item_count = i - from + 1;
 					WorkerThreadPool::GroupID group_task = WorkerThreadPool::get_singleton()->add_template_group_task(this, &EditorFileSystem::_reimport_thread, &tdata, item_count, -1, false, vformat(TTR("Import resources of type: %s"), reimport_files[from].importer));
 
 					int imported_count = 0;
 					while (true) {
-						while (true) {
-							ep->step(reimport_files[imported_count].path.get_file(), from + imported_count, false);
-							if (imported_sem.try_wait()) {
-								imported_count++;
-								break;
-							}
+						uint32_t processed = WorkerThreadPool::get_singleton()->get_group_processed_element_count(group_task);
+						for (; imported_count < (int)processed; imported_count++) {
+							ep->step(reimport_files[from + imported_count].path.get_file(), from + imported_count, false);
 						}
 						if (imported_count == item_count) {
 							break;
 						}
+						// Service synchronous rendering server calls made by import threads
+						// (e.g. scene packing querying instance properties), which would
+						// otherwise deadlock waiting for the main thread.
+						RenderingServer::get_singleton()->sync();
+						OS::get_singleton()->delay_usec(1000);
 					}
 
 					WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
-					DEV_ASSERT(!imported_sem.try_wait());
 
 					importer->import_threaded_end();
 				}
@@ -3435,13 +3457,21 @@ Error EditorFileSystem::reimport_append(const String &p_file, const HashMap<Stri
 	Vector<String> reloads;
 	reloads.append(p_file);
 
-	// Emit the resource_reimporting signal for the single file before the actual importation.
-	emit_signal(SNAME("resources_reimporting"), reloads);
+	// Signals and file system tree updates are main-thread only; when appending from an import
+	// thread (e.g. glTF importing its extracted textures during a threaded scene import), skip
+	// both. The caller is responsible for registering the file on the main thread afterwards.
+	const bool main_thread = Thread::is_main_thread();
+	if (main_thread) {
+		// Emit the resource_reimporting signal for the single file before the actual importation.
+		emit_signal(SNAME("resources_reimporting"), reloads);
+	}
 
-	Error ret = _reimport_file(p_file, p_custom_options, p_custom_importer, &p_generator_parameters);
+	Error ret = _reimport_file(p_file, p_custom_options, p_custom_importer, &p_generator_parameters, main_thread);
 
-	// Emit the resource_reimported signal for the single file we just reimported.
-	emit_signal(SNAME("resources_reimported"), reloads);
+	if (main_thread) {
+		// Emit the resource_reimported signal for the single file we just reimported.
+		emit_signal(SNAME("resources_reimported"), reloads);
+	}
 	return ret;
 }
 

--- a/editor/file_system/editor_file_system.h
+++ b/editor/file_system/editor_file_system.h
@@ -354,7 +354,6 @@ class EditorFileSystem : public Node {
 	struct ImportThreadData {
 		const ImportFile *reimport_files;
 		int reimport_from;
-		Semaphore *imported_sem = nullptr;
 	};
 
 	void _reimport_thread(uint32_t p_index, ImportThreadData *p_import_data);

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -2688,6 +2688,9 @@ void ResourceImporterScene::get_import_options(const String &p_path, List<Import
 
 	_plugins_get_import_options(p_path, r_options);
 
+	// Scene format importers are shared instances holding scratch state
+	// (current_option_list), so serialize access during threaded imports.
+	MutexLock lock(post_import_mutex);
 	for (Ref<EditorSceneFormatImporter> importer_elem : scene_importers) {
 		importer_elem->get_import_options(p_path, r_options);
 	}

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -2933,7 +2933,7 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 	Mutex save_mutex;
 	MeshProcessBatchData batch_data = { mesh_tasks.ptrw(), &p_src_lightmap_cache, &r_lightmap_caches, &lightmap_mutex, &save_mutex };
 
-	if (mesh_tasks.size() > 1 && WorkerThreadPool::get_singleton()->get_caller_task_id() == WorkerThreadPool::INVALID_TASK_ID) {
+	if (mesh_tasks.size() > 1 && WorkerThreadPool::get_singleton()->get_thread_index() == -1) {
 		// Not on a worker thread: process meshes in parallel. A worker thread blocking on
 		// wait_for_group_task_completion() can starve the pool, so import threads process inline.
 		WorkerThreadPool::GroupID group = WorkerThreadPool::get_singleton()->add_native_group_task(_process_mesh_worker, &batch_data, mesh_tasks.size(), -1, false, SNAME("SceneMeshProcessing"));

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -31,6 +31,7 @@
 #include "resource_importer_scene.h"
 
 #include "core/error/error_macros.h"
+#include "core/io/config_file.h"
 #include "core/io/dir_access.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
@@ -3659,6 +3660,21 @@ void ResourceImporterScene::_plugins_get_import_options(const String &p_path, Li
 	for (int i = 0; i < post_importer_plugins.size(); i++) {
 		post_importer_plugins.write[i]->get_import_options(p_path, r_options);
 	}
+}
+
+bool ResourceImporterScene::can_import_file_threaded(const String &p_path) const {
+	if (!can_import_threaded()) {
+		return false;
+	}
+	// Files with a post-import script run user code during import; import them on the main thread.
+	if (FileAccess::exists(p_path + ".import")) {
+		Ref<ConfigFile> cf;
+		cf.instantiate();
+		if (cf->load(p_path + ".import") == OK && !String(cf->get_value("params/import_script/path", "")).is_empty()) {
+			return false;
+		}
+	}
+	return true;
 }
 
 void ResourceImporterScene::import_threaded_begin() {

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -34,8 +34,13 @@
 #include "core/io/dir_access.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
+#include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "core/object/message_queue.h"
 #include "core/object/script_language.h"
+#include "core/object/worker_thread_pool.h"
+#include "core/os/mutex.h"
+#include "core/os/thread.h"
 #include "editor/editor_interface.h"
 #include "editor/editor_node.h"
 #include "editor/import/3d/scene_import_settings.h"
@@ -60,6 +65,8 @@
 #include "scene/resources/packed_scene.h"
 #include "scene/resources/physics_material.h"
 #include "scene/resources/resource_format_text.h"
+
+#include <functional>
 
 void EditorSceneFormatImporter::get_extensions(List<String> *r_extensions) const {
 	Vector<String> arr;
@@ -332,6 +339,8 @@ bool ResourceImporterScene::get_option_visibility(const String &p_path, const St
 		return false;
 	}
 
+	// Plugins are not expected to be thread-safe; serialize their execution during threaded imports.
+	MutexLock lock(post_import_mutex);
 	for (int i = 0; i < post_importer_plugins.size(); i++) {
 		Variant ret = post_importer_plugins.write[i]->get_option_visibility(p_path, _scene_import_type, p_option, p_options);
 		if (ret.get_type() == Variant::BOOL) {
@@ -1505,6 +1514,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 
 	{
 		ObjectID node_id = p_node->get_instance_id();
+		MutexLock lock(post_import_mutex); // Plugins are not expected to be thread-safe.
 		for (int i = 0; i < post_importer_plugins.size(); i++) {
 			post_importer_plugins.write[i]->internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_NODE, p_root, p_node, Ref<Resource>(), node_settings);
 			if (ObjectDB::get_instance(node_id) == nullptr) { //may have been erased, so do not continue
@@ -1515,6 +1525,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 
 	if (Object::cast_to<ImporterMeshInstance3D>(p_node)) {
 		ObjectID node_id = p_node->get_instance_id();
+		MutexLock lock(post_import_mutex); // Plugins are not expected to be thread-safe.
 		for (int i = 0; i < post_importer_plugins.size(); i++) {
 			post_importer_plugins.write[i]->internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_MESH_3D_NODE, p_root, p_node, Ref<Resource>(), node_settings);
 			if (ObjectDB::get_instance(node_id) == nullptr) { //may have been erased, so do not continue
@@ -1593,6 +1604,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 		}
 
 		ObjectID node_id = p_node->get_instance_id();
+		MutexLock lock(post_import_mutex); // Plugins are not expected to be thread-safe.
 		for (int i = 0; i < post_importer_plugins.size(); i++) {
 			post_importer_plugins.write[i]->internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_SKELETON_3D_NODE, p_root, p_node, Ref<Resource>(), node_settings);
 			if (ObjectDB::get_instance(node_id) == nullptr) { //may have been erased, so do not continue
@@ -1651,9 +1663,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 							}
 						}
 					}
-					for (int j = 0; j < post_importer_plugins.size(); j++) {
-						post_importer_plugins.write[j]->internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_MATERIAL, p_root, p_node, mat, matdata);
-					}
+					_plugins_internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_MATERIAL, p_root, p_node, mat, matdata);
 					if (extract_mat != 0) {
 						// If no file path was specified, generate one based on the material name and the selected format.
 						if (file_path.is_empty()) {
@@ -1921,9 +1931,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 	if (Object::cast_to<AnimationPlayer>(p_node)) {
 		AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(p_node);
 
-		for (int i = 0; i < post_importer_plugins.size(); i++) {
-			post_importer_plugins.write[i]->internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_ANIMATION_NODE, p_root, p_node, Ref<Resource>(), node_settings);
-		}
+		_plugins_internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_ANIMATION_NODE, p_root, p_node, Ref<Resource>(), node_settings);
 
 		if (post_importer_plugins.size()) {
 			LocalVector<StringName> anims;
@@ -1943,9 +1951,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, HashMap<
 						}
 					}
 
-					for (int i = 0; i < post_importer_plugins.size(); i++) {
-						post_importer_plugins.write[i]->internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_ANIMATION, p_root, p_node, anim, anim_settings);
-					}
+					_plugins_internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_ANIMATION, p_root, p_node, anim, anim_settings);
 				}
 			}
 		}
@@ -2389,9 +2395,7 @@ void ResourceImporterScene::get_internal_import_options(InternalImportCategory p
 		}
 	}
 
-	for (int i = 0; i < post_importer_plugins.size(); i++) {
-		post_importer_plugins.write[i]->get_internal_import_options(EditorScenePostImportPlugin::InternalImportCategory(p_category), r_options);
-	}
+	_plugins_get_internal_import_options(EditorScenePostImportPlugin::InternalImportCategory(p_category), r_options);
 }
 
 bool ResourceImporterScene::get_internal_option_visibility(InternalImportCategory p_category, const String &p_option, const HashMap<StringName, Variant> &p_options) const {
@@ -2588,6 +2592,7 @@ bool ResourceImporterScene::get_internal_option_visibility(InternalImportCategor
 	}
 
 	// TODO: If there are more than 2 or equal get_internal_option_visibility method, visibility state is broken.
+	MutexLock lock(post_import_mutex); // Plugins are not expected to be thread-safe.
 	for (int i = 0; i < post_importer_plugins.size(); i++) {
 		Variant ret = post_importer_plugins.write[i]->get_internal_option_visibility(EditorScenePostImportPlugin::InternalImportCategory(p_category), _scene_import_type, p_option, p_options);
 		if (ret.get_type() == Variant::BOOL) {
@@ -2625,6 +2630,7 @@ bool ResourceImporterScene::get_internal_option_update_view_required(InternalImp
 		}
 	}
 
+	MutexLock lock(post_import_mutex); // Plugins are not expected to be thread-safe.
 	for (int i = 0; i < post_importer_plugins.size(); i++) {
 		Variant ret = post_importer_plugins.write[i]->get_internal_option_update_view_required(EditorScenePostImportPlugin::InternalImportCategory(p_category), p_option, p_options);
 		if (ret.get_type() == Variant::BOOL) {
@@ -2680,9 +2686,7 @@ void ResourceImporterScene::get_import_options(const String &p_path, List<Import
 
 	r_options->push_back(ImportOption(PropertyInfo(Variant::DICTIONARY, "_subresources", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), Dictionary()));
 
-	for (int i = 0; i < post_importer_plugins.size(); i++) {
-		post_importer_plugins.write[i]->get_import_options(p_path, r_options);
-	}
+	_plugins_get_import_options(p_path, r_options);
 
 	for (Ref<EditorSceneFormatImporter> importer_elem : scene_importers) {
 		importer_elem->get_import_options(p_path, r_options);
@@ -2739,202 +2743,270 @@ Array ResourceImporterScene::_get_skinned_pose_transforms(ImporterMeshInstance3D
 	return skin_pose_transform_array;
 }
 
+namespace {
+struct MeshProcessTask {
+	Ref<ImporterMesh> importer_mesh;
+	Transform3D world_xf;
+	Array skin_pose_transforms;
+	bool generate_lods;
+	float merge_angle;
+	bool create_shadow_meshes;
+	bool bake_lightmaps;
+	float lightmap_texel_size;
+	String save_to_file;
+};
+
+struct MeshProcessBatchData {
+	MeshProcessTask *tasks;
+	const Vector<uint8_t> *src_lightmap_cache;
+	Vector<Vector<uint8_t>> *lightmap_caches;
+	Mutex *lightmap_mutex;
+	Mutex *save_mutex;
+};
+
+void _process_mesh_worker(void *p_userdata, uint32_t p_index) {
+	MeshProcessBatchData *data = static_cast<MeshProcessBatchData *>(p_userdata);
+	MeshProcessTask &task = data->tasks[p_index];
+
+	if (task.bake_lightmaps) {
+		Vector<uint8_t> lightmap_cache;
+		task.importer_mesh->lightmap_unwrap_cached(task.world_xf, task.lightmap_texel_size, *data->src_lightmap_cache, lightmap_cache);
+
+		if (!lightmap_cache.is_empty()) {
+			MutexLock lock(*data->lightmap_mutex);
+			String new_md5 = String::md5(lightmap_cache.ptr()); // MD5 is stored at the beginning of the cache data
+			// Keep caches sorted by MD5, skipping duplicates; append when it sorts after all existing entries.
+			int insert_idx = data->lightmap_caches->size();
+			for (int i = 0; i < data->lightmap_caches->size(); i++) {
+				String md5 = String::md5((*data->lightmap_caches)[i].ptr());
+				if (new_md5 < md5) {
+					insert_idx = i;
+					break;
+				}
+				if (new_md5 == md5) {
+					insert_idx = -1;
+					break;
+				}
+			}
+			if (insert_idx >= 0) {
+				data->lightmap_caches->insert(insert_idx, lightmap_cache);
+			}
+		}
+	}
+
+	if (task.generate_lods) {
+		task.importer_mesh->generate_lods(task.merge_angle, task.skin_pose_transforms);
+	}
+
+	if (task.create_shadow_meshes) {
+		task.importer_mesh->create_shadow_mesh();
+	}
+
+	task.importer_mesh->optimize_indices();
+
+	if (!task.save_to_file.is_empty()) {
+		// Serialize resource saves: the resource cache, ResourceUID and file writes are not safe to race.
+		MutexLock lock(*data->save_mutex);
+		String save_res_path = ResourceUID::ensure_path(task.save_to_file);
+		Ref<Mesh> existing = ResourceCache::get_ref(save_res_path);
+		if (existing.is_valid()) {
+			existing->reset_state();
+		}
+		Ref<ArrayMesh> mesh = task.importer_mesh->get_mesh(existing);
+		Error err = ResourceSaver::save(mesh, save_res_path);
+		if (err != OK) {
+			WARN_PRINT(vformat("Failed to save mesh %s to '%s'.", mesh->get_name(), save_res_path));
+		}
+		if (err == OK && task.save_to_file.begins_with("uid://")) {
+			ResourceSaver::set_uid(save_res_path, ResourceUID::get_singleton()->text_to_id(task.save_to_file));
+		}
+		mesh->set_path(save_res_path, true);
+	}
+}
+} // anonymous namespace
+
 Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_mesh_data, bool p_generate_lods, bool p_create_shadow_meshes, LightBakeMode p_light_bake_mode, float p_lightmap_texel_size, const Vector<uint8_t> &p_src_lightmap_cache, Vector<Vector<uint8_t>> &r_lightmap_caches) {
-	ImporterMeshInstance3D *src_mesh_node = Object::cast_to<ImporterMeshInstance3D>(p_node);
-	if (src_mesh_node) {
-		//is mesh
-		MeshInstance3D *mesh_node = memnew(MeshInstance3D);
-		mesh_node->set_name(src_mesh_node->get_name());
-		mesh_node->set_transform(src_mesh_node->get_transform());
-		mesh_node->set_skin(src_mesh_node->get_skin());
-		mesh_node->set_skeleton_path(src_mesh_node->get_skeleton_path());
-		mesh_node->merge_meta_from(src_mesh_node);
+	// Pass 1: Collect all ImporterMeshInstance3D nodes and unique meshes that need processing.
+	// Does NOT modify the tree, only reads mesh/node data.
+	Vector<MeshProcessTask> mesh_tasks;
+	HashMap<ImporterMesh *, int> mesh_task_index; // Deduplicate by ImporterMesh pointer.
 
-		Ref<ImporterMesh> importer_mesh = src_mesh_node->get_mesh();
-		if (importer_mesh.is_valid()) {
-			Ref<ArrayMesh> mesh;
-			if (!importer_mesh->has_mesh()) {
-				//do mesh processing
+	std::function<void(Node *)> collect_func = [&](Node *p_collect_node) {
+		ImporterMeshInstance3D *src_mesh_node = Object::cast_to<ImporterMeshInstance3D>(p_collect_node);
+		if (src_mesh_node) {
+			Ref<ImporterMesh> importer_mesh = src_mesh_node->get_mesh();
 
-				bool generate_lods = p_generate_lods;
-				float merge_angle = 20.0f;
-				bool create_shadow_meshes = p_create_shadow_meshes;
-				bool bake_lightmaps = p_light_bake_mode == LIGHT_BAKE_STATIC_LIGHTMAPS;
-				String save_to_file;
+			if (importer_mesh.is_valid() && !importer_mesh->has_mesh()) {
+				if (!mesh_task_index.has(importer_mesh.ptr())) {
+					MeshProcessTask task;
+					task.importer_mesh = importer_mesh;
+					task.generate_lods = p_generate_lods;
+					task.merge_angle = 20.0f;
+					task.create_shadow_meshes = p_create_shadow_meshes;
+					task.bake_lightmaps = (p_light_bake_mode == LIGHT_BAKE_STATIC_LIGHTMAPS);
+					task.lightmap_texel_size = p_lightmap_texel_size;
 
-				String mesh_id = importer_mesh->get_meta("import_id", importer_mesh->get_name());
-
-				if (!mesh_id.is_empty() && p_mesh_data.has(mesh_id)) {
-					Dictionary mesh_settings = p_mesh_data[mesh_id];
-					{
-						//fill node settings for this node with default values
-						List<ImportOption> iopts;
-						get_internal_import_options(INTERNAL_IMPORT_CATEGORY_MESH, &iopts);
-						for (const ImportOption &E : iopts) {
-							if (!mesh_settings.has(E.option.name)) {
-								mesh_settings[E.option.name] = E.default_value;
-							}
+					if (task.bake_lightmaps) {
+						Transform3D xf;
+						Node3D *n = src_mesh_node;
+						while (n) {
+							xf = n->get_transform() * xf;
+							n = n->get_parent_node_3d();
 						}
+						task.world_xf = xf;
 					}
 
-					if (mesh_settings.has("generate/shadow_meshes")) {
-						int shadow_meshes = mesh_settings["generate/shadow_meshes"];
-						if (shadow_meshes == MESH_OVERRIDE_ENABLE) {
-							create_shadow_meshes = true;
-						} else if (shadow_meshes == MESH_OVERRIDE_DISABLE) {
-							create_shadow_meshes = false;
-						}
-					}
+					String mesh_id = importer_mesh->get_meta("import_id", importer_mesh->get_name());
 
-					if (mesh_settings.has("generate/lightmap_uv")) {
-						int lightmap_uv = mesh_settings["generate/lightmap_uv"];
-						if (lightmap_uv == MESH_OVERRIDE_ENABLE) {
-							bake_lightmaps = true;
-						} else if (lightmap_uv == MESH_OVERRIDE_DISABLE) {
-							bake_lightmaps = false;
-						}
-					}
-
-					if (mesh_settings.has("generate/lods")) {
-						int lods = mesh_settings["generate/lods"];
-						if (lods == MESH_OVERRIDE_ENABLE) {
-							generate_lods = true;
-						} else if (lods == MESH_OVERRIDE_DISABLE) {
-							generate_lods = false;
-						}
-					}
-
-					if (mesh_settings.has("lods/normal_merge_angle")) {
-						merge_angle = mesh_settings["lods/normal_merge_angle"];
-					}
-
-					if (bool(mesh_settings.get("save_to_file/enabled", false))) {
-						save_to_file = mesh_settings.get("save_to_file/path", String());
-						if (!ResourceUID::ensure_path(save_to_file).is_resource_file()) {
-							save_to_file = "";
-						}
-					}
-
-					for (int i = 0; i < post_importer_plugins.size(); i++) {
-						post_importer_plugins.write[i]->internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_MESH, nullptr, src_mesh_node, importer_mesh, mesh_settings);
-					}
-				}
-
-				if (bake_lightmaps) {
-					Transform3D xf;
-					Node3D *n = src_mesh_node;
-					while (n) {
-						xf = n->get_transform() * xf;
-						n = n->get_parent_node_3d();
-					}
-
-					Vector<uint8_t> lightmap_cache;
-					importer_mesh->lightmap_unwrap_cached(xf, p_lightmap_texel_size, p_src_lightmap_cache, lightmap_cache);
-
-					if (!lightmap_cache.is_empty()) {
-						if (r_lightmap_caches.is_empty()) {
-							r_lightmap_caches.push_back(lightmap_cache);
-						} else {
-							String new_md5 = String::md5(lightmap_cache.ptr()); // MD5 is stored at the beginning of the cache data
-
-							for (int i = 0; i < r_lightmap_caches.size(); i++) {
-								String md5 = String::md5(r_lightmap_caches[i].ptr());
-								if (new_md5 < md5) {
-									r_lightmap_caches.insert(i, lightmap_cache);
-									break;
-								}
-
-								if (new_md5 == md5) {
-									break;
+					if (!mesh_id.is_empty() && p_mesh_data.has(mesh_id)) {
+						Dictionary mesh_settings = p_mesh_data[mesh_id];
+						{
+							List<ImportOption> iopts;
+							get_internal_import_options(INTERNAL_IMPORT_CATEGORY_MESH, &iopts);
+							for (const ImportOption &E : iopts) {
+								if (!mesh_settings.has(E.option.name)) {
+									mesh_settings[E.option.name] = E.default_value;
 								}
 							}
 						}
+
+						if (mesh_settings.has("generate/shadow_meshes")) {
+							int shadow_meshes = mesh_settings["generate/shadow_meshes"];
+							if (shadow_meshes == MESH_OVERRIDE_ENABLE) {
+								task.create_shadow_meshes = true;
+							} else if (shadow_meshes == MESH_OVERRIDE_DISABLE) {
+								task.create_shadow_meshes = false;
+							}
+						}
+
+						if (mesh_settings.has("generate/lightmap_uv")) {
+							int lightmap_uv = mesh_settings["generate/lightmap_uv"];
+							if (lightmap_uv == MESH_OVERRIDE_ENABLE) {
+								task.bake_lightmaps = true;
+							} else if (lightmap_uv == MESH_OVERRIDE_DISABLE) {
+								task.bake_lightmaps = false;
+							}
+						}
+
+						if (mesh_settings.has("generate/lods")) {
+							int lods = mesh_settings["generate/lods"];
+							if (lods == MESH_OVERRIDE_ENABLE) {
+								task.generate_lods = true;
+							} else if (lods == MESH_OVERRIDE_DISABLE) {
+								task.generate_lods = false;
+							}
+						}
+
+						if (mesh_settings.has("lods/normal_merge_angle")) {
+							task.merge_angle = mesh_settings["lods/normal_merge_angle"];
+						}
+
+						if (bool(mesh_settings.get("save_to_file/enabled", false))) {
+							task.save_to_file = mesh_settings.get("save_to_file/path", String());
+							if (!ResourceUID::ensure_path(task.save_to_file).is_resource_file()) {
+								task.save_to_file = "";
+							}
+						}
+
+						_plugins_internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_MESH, nullptr, src_mesh_node, importer_mesh, mesh_settings);
 					}
-				}
 
-				if (generate_lods) {
-					Array skin_pose_transform_array = _get_skinned_pose_transforms(src_mesh_node);
-					importer_mesh->generate_lods(merge_angle, skin_pose_transform_array);
-				}
-
-				if (create_shadow_meshes) {
-					importer_mesh->create_shadow_mesh();
-				}
-
-				importer_mesh->optimize_indices();
-
-				if (!save_to_file.is_empty()) {
-					String save_res_path = ResourceUID::ensure_path(save_to_file);
-					Ref<Mesh> existing = ResourceCache::get_ref(save_res_path);
-					if (existing.is_valid()) {
-						//if somehow an existing one is useful, create
-						existing->reset_state();
-					}
-					mesh = importer_mesh->get_mesh(existing);
-
-					Error err = ResourceSaver::save(mesh, save_res_path); //override
-					if (err != OK) {
-						WARN_PRINT(vformat("Failed to save mesh %s to '%s'.", mesh->get_name(), save_res_path));
-					}
-					if (err == OK && save_to_file.begins_with("uid://")) {
-						// slow
-						ResourceSaver::set_uid(save_res_path, ResourceUID::get_singleton()->text_to_id(save_to_file));
+					if (task.generate_lods) {
+						task.skin_pose_transforms = _get_skinned_pose_transforms(src_mesh_node);
 					}
 
-					mesh->set_path(save_res_path, true); //takeover existing, if needed
-
-				} else {
-					mesh = importer_mesh->get_mesh();
+					mesh_task_index[importer_mesh.ptr()] = mesh_tasks.size();
+					mesh_tasks.push_back(task);
 				}
-			} else {
-				mesh = importer_mesh->get_mesh();
-			}
-
-			if (mesh.is_valid()) {
-				_copy_meta(importer_mesh.ptr(), mesh.ptr());
-				mesh_node->set_mesh(mesh);
-				for (int i = 0; i < mesh->get_surface_count(); i++) {
-					mesh_node->set_surface_override_material(i, src_mesh_node->get_surface_material(i));
-				}
-				mesh->merge_meta_from(*importer_mesh);
 			}
 		}
 
-		switch (p_light_bake_mode) {
-			case LIGHT_BAKE_DISABLED: {
-				mesh_node->set_gi_mode(GeometryInstance3D::GI_MODE_DISABLED);
-			} break;
-			case LIGHT_BAKE_DYNAMIC: {
-				mesh_node->set_gi_mode(GeometryInstance3D::GI_MODE_DYNAMIC);
-			} break;
-			case LIGHT_BAKE_STATIC:
-			case LIGHT_BAKE_STATIC_LIGHTMAPS: {
-				mesh_node->set_gi_mode(GeometryInstance3D::GI_MODE_STATIC);
-			} break;
+		for (int i = 0; i < p_collect_node->get_child_count(); i++) {
+			collect_func(p_collect_node->get_child(i));
+		}
+	};
+
+	collect_func(p_node);
+
+	// Pass 2: Process unique meshes in parallel.
+	Mutex lightmap_mutex;
+	Mutex save_mutex;
+	MeshProcessBatchData batch_data = { mesh_tasks.ptrw(), &p_src_lightmap_cache, &r_lightmap_caches, &lightmap_mutex, &save_mutex };
+
+	if (mesh_tasks.size() > 1 && WorkerThreadPool::get_singleton()->get_caller_task_id() == WorkerThreadPool::INVALID_TASK_ID) {
+		// Not on a worker thread: process meshes in parallel. A worker thread blocking on
+		// wait_for_group_task_completion() can starve the pool, so import threads process inline.
+		WorkerThreadPool::GroupID group = WorkerThreadPool::get_singleton()->add_native_group_task(_process_mesh_worker, &batch_data, mesh_tasks.size(), -1, false, SNAME("SceneMeshProcessing"));
+		WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group);
+	} else {
+		for (uint32_t i = 0; i < (uint32_t)mesh_tasks.size(); i++) {
+			_process_mesh_worker(&batch_data, i);
+		}
+	}
+
+	// Pass 3: Walk the tree and replace ImporterMeshInstance3D nodes with MeshInstance3D.
+	// All mesh processing is already done, so this just converts and replaces nodes.
+	std::function<Node *(Node *)> replace_func = [&](Node *p_replace_node) -> Node * {
+		ImporterMeshInstance3D *src_mesh_node = Object::cast_to<ImporterMeshInstance3D>(p_replace_node);
+		if (src_mesh_node) {
+			MeshInstance3D *mesh_node = memnew(MeshInstance3D);
+			mesh_node->set_name(src_mesh_node->get_name());
+			mesh_node->set_transform(src_mesh_node->get_transform());
+			mesh_node->set_skin(src_mesh_node->get_skin());
+			mesh_node->set_skeleton_path(src_mesh_node->get_skeleton_path());
+			mesh_node->merge_meta_from(src_mesh_node);
+
+			Ref<ImporterMesh> importer_mesh = src_mesh_node->get_mesh();
+			if (importer_mesh.is_valid()) {
+				Ref<ArrayMesh> mesh = importer_mesh->get_mesh();
+				if (mesh.is_valid()) {
+					_copy_meta(importer_mesh.ptr(), mesh.ptr());
+					mesh_node->set_mesh(mesh);
+					for (int i = 0; i < mesh->get_surface_count(); i++) {
+						mesh_node->set_surface_override_material(i, src_mesh_node->get_surface_material(i));
+					}
+					mesh->merge_meta_from(*importer_mesh);
+				}
+			}
+
+			switch (p_light_bake_mode) {
+				case LIGHT_BAKE_DISABLED: {
+					mesh_node->set_gi_mode(GeometryInstance3D::GI_MODE_DISABLED);
+				} break;
+				case LIGHT_BAKE_DYNAMIC: {
+					mesh_node->set_gi_mode(GeometryInstance3D::GI_MODE_DYNAMIC);
+				} break;
+				case LIGHT_BAKE_STATIC:
+				case LIGHT_BAKE_STATIC_LIGHTMAPS: {
+					mesh_node->set_gi_mode(GeometryInstance3D::GI_MODE_STATIC);
+				} break;
+			}
+
+			mesh_node->set_layer_mask(src_mesh_node->get_layer_mask());
+			mesh_node->set_cast_shadows_setting(src_mesh_node->get_cast_shadows_setting());
+			mesh_node->set_visible(src_mesh_node->is_visible());
+			mesh_node->set_visibility_range_begin(src_mesh_node->get_visibility_range_begin());
+			mesh_node->set_visibility_range_begin_margin(src_mesh_node->get_visibility_range_begin_margin());
+			mesh_node->set_visibility_range_end(src_mesh_node->get_visibility_range_end());
+			mesh_node->set_visibility_range_end_margin(src_mesh_node->get_visibility_range_end_margin());
+			mesh_node->set_visibility_range_fade_mode(src_mesh_node->get_visibility_range_fade_mode());
+
+			_copy_meta(p_replace_node, mesh_node);
+
+			p_replace_node->replace_by(mesh_node);
+			p_replace_node->set_owner(nullptr);
+			memdelete(p_replace_node);
+			p_replace_node = mesh_node;
 		}
 
-		mesh_node->set_layer_mask(src_mesh_node->get_layer_mask());
-		mesh_node->set_cast_shadows_setting(src_mesh_node->get_cast_shadows_setting());
-		mesh_node->set_visible(src_mesh_node->is_visible());
-		mesh_node->set_visibility_range_begin(src_mesh_node->get_visibility_range_begin());
-		mesh_node->set_visibility_range_begin_margin(src_mesh_node->get_visibility_range_begin_margin());
-		mesh_node->set_visibility_range_end(src_mesh_node->get_visibility_range_end());
-		mesh_node->set_visibility_range_end_margin(src_mesh_node->get_visibility_range_end_margin());
-		mesh_node->set_visibility_range_fade_mode(src_mesh_node->get_visibility_range_fade_mode());
+		for (int i = 0; i < p_replace_node->get_child_count(); i++) {
+			replace_func(p_replace_node->get_child(i));
+		}
 
-		_copy_meta(p_node, mesh_node);
+		return p_replace_node;
+	};
 
-		p_node->replace_by(mesh_node);
-		p_node->set_owner(nullptr);
-		memdelete(p_node);
-		p_node = mesh_node;
-	}
-
-	for (int i = 0; i < p_node->get_child_count(); i++) {
-		_generate_meshes(p_node->get_child(i), p_mesh_data, p_generate_lods, p_create_shadow_meshes, p_light_bake_mode, p_lightmap_texel_size, p_src_lightmap_cache, r_lightmap_caches);
-	}
-
-	return p_node;
+	return replace_func(p_node);
 }
 
 void ResourceImporterScene::_add_shapes(Node *p_node, const Vector<Ref<Shape3D>> &p_shapes) {
@@ -3112,7 +3184,8 @@ Node *ResourceImporterScene::pre_import(const String &p_source_file, const HashM
 	String ext = p_source_file.get_extension().to_lower();
 
 	// TRANSLATORS: This is an editor progress label.
-	EditorProgress progress("pre-import", TTR("Pre-Import Scene"), 0);
+	// Include the file in the task name so concurrent threaded imports don't collide.
+	EditorProgress progress("pre-import " + p_source_file, TTR("Pre-Import Scene"), 0);
 	progress.step(TTR("Importing Scene..."), 0);
 
 	for (Ref<EditorSceneFormatImporter> importer_elem : scene_importers) {
@@ -3215,13 +3288,27 @@ Error ResourceImporterScene::_check_resource_save_paths(ResourceUID::ID p_source
 	return OK;
 }
 
+// EditorNode::add_io_error() is main-thread only; when importing on a worker thread,
+// queue the error for display on the main thread and log it immediately.
+static void _report_scene_import_error(const String &p_error) {
+	if (Thread::is_main_thread()) {
+		EditorNode::add_io_error(p_error);
+	} else {
+		MessageQueue::get_main_singleton()->push_callable(callable_mp_static(&EditorNode::add_io_error).bind(p_error));
+		print_error(p_error);
+	}
+}
+
 Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p_source_file, const String &p_save_path, const HashMap<StringName, Variant> &p_options, List<String> *r_platform_variants, List<String> *r_gen_files, Variant *r_metadata) {
 	const String &src_path = p_source_file;
+
+	bool is_main_thread = Thread::is_main_thread();
 
 	Ref<EditorSceneFormatImporter> importer;
 	String ext = src_path.get_extension().to_lower();
 
-	EditorProgress progress("import", TTR("Import Scene"), 104);
+	// Include the file in the task name so concurrent threaded imports don't collide.
+	EditorProgress progress("import " + src_path, TTR("Import Scene"), 104);
 	progress.step(TTR("Importing Scene..."), 0);
 
 	for (Ref<EditorSceneFormatImporter> importer_elem : scene_importers) {
@@ -3322,9 +3409,7 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 
 	_pre_fix_node(scene, scene, collision_map, &occluder_arrays, node_renames, p_options);
 
-	for (int i = 0; i < post_importer_plugins.size(); i++) {
-		post_importer_plugins.write[i]->pre_process(scene, p_options);
-	}
+	_plugins_pre_process(scene, p_options);
 
 	// data in _subresources may be modified by pre_process(), so wait until now to check.
 	Dictionary node_data;
@@ -3420,14 +3505,14 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 		}
 		Ref<Script> scr = ResourceLoader::load(post_import_script_path);
 		if (scr.is_null()) {
-			EditorNode::add_io_error(TTR("Couldn't load post-import script:") + " " + post_import_script_path);
+			_report_scene_import_error(TTR("Couldn't load post-import script:") + " " + post_import_script_path);
 		} else if (scr->get_instance_base_type() != "EditorScenePostImport") {
-			EditorNode::add_io_error(TTR("Script is not a subtype of EditorScenePostImport:") + " " + post_import_script_path);
+			_report_scene_import_error(TTR("Script is not a subtype of EditorScenePostImport:") + " " + post_import_script_path);
 		} else {
 			post_import_script.instantiate();
 			post_import_script->set_script(scr);
 			if (!post_import_script->get_script_instance()) {
-				EditorNode::add_io_error(TTR("Invalid/broken script for post-import (check console):") + " " + post_import_script_path);
+				_report_scene_import_error(TTR("Invalid/broken script for post-import (check console):") + " " + post_import_script_path);
 				post_import_script.unref();
 				return ERR_CANT_CREATE;
 			}
@@ -3448,19 +3533,18 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 	}
 
 	if (post_import_script.is_valid()) {
+		// User-provided post-import scripts are not expected to be thread-safe; serialize their execution.
+		MutexLock lock(post_import_mutex);
 		post_import_script->init(p_source_file);
 		scene = post_import_script->post_import(scene);
 		if (!scene) {
-			EditorNode::add_io_error(
-					TTR("Error running post-import script:") + " " + post_import_script_path + "\n" +
+			_report_scene_import_error(TTR("Error running post-import script:") + " " + post_import_script_path + "\n" +
 					TTR("Did you return a Node-derived object in the `_post_import()` method?"));
 			return err;
 		}
 	}
 
-	for (int i = 0; i < post_importer_plugins.size(); i++) {
-		post_importer_plugins.write[i]->post_process(scene, p_options);
-	}
+	_plugins_post_process(scene, p_options);
 
 	progress.step(TTR("Saving..."), 104);
 
@@ -3496,7 +3580,13 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 		print_verbose("Saving scene to: " + p_save_path + ".scn");
 		err = ResourceSaver::save(packer, p_save_path + ".scn", flags); //do not take over, let the changed files reload themselves
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save scene to file '" + p_save_path + ".scn'.");
-		EditorInterface::get_singleton()->make_scene_preview(p_source_file, scene, 1024);
+		if (is_main_thread) {
+			EditorInterface::get_singleton()->make_scene_preview(p_source_file, scene, 1024);
+		} else {
+			// Previews require main-thread rendering; defer them to import_threaded_end().
+			MutexLock lock(post_import_mutex);
+			pending_scene_previews.push_back({ p_source_file, p_save_path });
+		}
 	} else if (_scene_import_type == "ArrayMesh") {
 		_save_scene_as_single_mesh(p_source_file, p_save_path, scene, p_options, flags);
 	} else if (_scene_import_type == "MeshLibrary") {
@@ -3515,6 +3605,84 @@ Error ResourceImporterScene::import(ResourceUID::ID p_source_id, const String &p
 
 Vector<Ref<EditorSceneFormatImporter>> ResourceImporterScene::scene_importers;
 Vector<Ref<EditorScenePostImportPlugin>> ResourceImporterScene::post_importer_plugins;
+Mutex ResourceImporterScene::post_import_mutex;
+
+void ResourceImporterScene::_plugins_internal_process(EditorScenePostImportPlugin::InternalImportCategory p_category, Node *p_base_scene, Node *p_node, const Ref<Resource> &p_resource, const Dictionary &p_options) {
+	// Plugins are not expected to be thread-safe; serialize their execution during threaded imports.
+	if (post_importer_plugins.is_empty()) {
+		return;
+	}
+	MutexLock lock(post_import_mutex);
+	for (int i = 0; i < post_importer_plugins.size(); i++) {
+		post_importer_plugins.write[i]->internal_process(p_category, p_base_scene, p_node, p_resource, p_options);
+	}
+}
+
+void ResourceImporterScene::_plugins_pre_process(Node *p_scene, const HashMap<StringName, Variant> &p_options) {
+	if (post_importer_plugins.is_empty()) {
+		return;
+	}
+	MutexLock lock(post_import_mutex);
+	for (int i = 0; i < post_importer_plugins.size(); i++) {
+		post_importer_plugins.write[i]->pre_process(p_scene, p_options);
+	}
+}
+
+void ResourceImporterScene::_plugins_post_process(Node *p_scene, const HashMap<StringName, Variant> &p_options) {
+	if (post_importer_plugins.is_empty()) {
+		return;
+	}
+	MutexLock lock(post_import_mutex);
+	for (int i = 0; i < post_importer_plugins.size(); i++) {
+		post_importer_plugins.write[i]->post_process(p_scene, p_options);
+	}
+}
+
+void ResourceImporterScene::_plugins_get_internal_import_options(EditorScenePostImportPlugin::InternalImportCategory p_category, List<ImportOption> *r_options) {
+	if (post_importer_plugins.is_empty()) {
+		return;
+	}
+	MutexLock lock(post_import_mutex);
+	for (int i = 0; i < post_importer_plugins.size(); i++) {
+		post_importer_plugins.write[i]->get_internal_import_options(p_category, r_options);
+	}
+}
+
+void ResourceImporterScene::_plugins_get_import_options(const String &p_path, List<ImportOption> *r_options) {
+	if (post_importer_plugins.is_empty()) {
+		return;
+	}
+	MutexLock lock(post_import_mutex);
+	for (int i = 0; i < post_importer_plugins.size(); i++) {
+		post_importer_plugins.write[i]->get_import_options(p_path, r_options);
+	}
+}
+
+void ResourceImporterScene::import_threaded_begin() {
+	MutexLock lock(post_import_mutex);
+	pending_scene_previews.clear();
+}
+
+void ResourceImporterScene::import_threaded_end() {
+	// Runs on the main thread after a batch of threaded imports: generate the scene
+	// previews that were deferred because they require main-thread rendering.
+	Vector<Pair<String, String>> previews;
+	{
+		MutexLock lock(post_import_mutex);
+		previews = pending_scene_previews;
+		pending_scene_previews.clear();
+	}
+	for (const Pair<String, String> &preview : previews) {
+		Ref<PackedScene> packed_scene = ResourceLoader::load(preview.second + ".scn", "", ResourceFormatLoader::CACHE_MODE_IGNORE);
+		if (packed_scene.is_valid()) {
+			Node *scene = packed_scene->instantiate();
+			if (scene) {
+				EditorInterface::get_singleton()->make_scene_preview(preview.first, scene, 1024);
+				memdelete(scene);
+			}
+		}
+	}
+}
 
 bool ResourceImporterScene::has_advanced_options() const {
 	return true;

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -32,6 +32,7 @@
 
 #include "core/error/error_macros.h"
 #include "core/io/resource_importer.h"
+#include "core/os/mutex.h"
 #include "core/variant/dictionary.h"
 #include "scene/3d/importer_mesh_instance_3d.h"
 #include "scene/resources/3d/box_shape_3d.h"
@@ -157,6 +158,19 @@ class ResourceImporterScene : public ResourceImporter {
 
 	static Vector<Ref<EditorSceneFormatImporter>> scene_importers;
 	static Vector<Ref<EditorScenePostImportPlugin>> post_importer_plugins;
+	// Serializes post-import script/plugin execution and preview queueing during threaded imports,
+	// as user-provided scripts and plugins are not expected to be thread-safe.
+	static Mutex post_import_mutex;
+	// Scenes imported on worker threads that still need a preview generated on the main thread
+	// (source file, save path). Flushed by import_threaded_end().
+	Vector<Pair<String, String>> pending_scene_previews;
+
+	// Serialized entry points for calls into post-import plugins, locking post_import_mutex.
+	static void _plugins_internal_process(EditorScenePostImportPlugin::InternalImportCategory p_category, Node *p_base_scene, Node *p_node, const Ref<Resource> &p_resource, const Dictionary &p_options);
+	static void _plugins_pre_process(Node *p_scene, const HashMap<StringName, Variant> &p_options);
+	static void _plugins_post_process(Node *p_scene, const HashMap<StringName, Variant> &p_options);
+	static void _plugins_get_internal_import_options(EditorScenePostImportPlugin::InternalImportCategory p_category, List<ImportOption> *r_options);
+	static void _plugins_get_import_options(const String &p_path, List<ImportOption> *r_options);
 
 	enum LightBakeMode {
 		LIGHT_BAKE_DISABLED,
@@ -279,6 +293,9 @@ public:
 	virtual void handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const override;
 	// Import scenes *after* everything else (such as textures).
 	virtual int get_import_order() const override { return ResourceImporter::IMPORT_ORDER_SCENE; }
+	virtual bool can_import_threaded() const override { return true; }
+	virtual void import_threaded_begin() override;
+	virtual void import_threaded_end() override;
 
 	void _pre_fix_global(Node *p_scene, const HashMap<StringName, Variant> &p_options) const;
 	Node *_pre_fix_node(Node *p_node, Node *p_root, HashMap<Ref<ImporterMesh>, Vector<Ref<Shape3D>>> &r_collision_map, Pair<PackedVector3Array, PackedInt32Array> *r_occluder_arrays, List<Pair<NodePath, Node *>> &r_node_renames, const HashMap<StringName, Variant> &p_options);

--- a/editor/import/3d/resource_importer_scene.h
+++ b/editor/import/3d/resource_importer_scene.h
@@ -293,7 +293,11 @@ public:
 	virtual void handle_compatibility_options(HashMap<StringName, Variant> &p_import_params) const override;
 	// Import scenes *after* everything else (such as textures).
 	virtual int get_import_order() const override { return ResourceImporter::IMPORT_ORDER_SCENE; }
-	virtual bool can_import_threaded() const override { return true; }
+	// Threaded scene import is disabled whenever user-provided post-import plugins are
+	// registered, as their code is not expected to be thread-safe.
+	virtual bool can_import_threaded() const override { return post_importer_plugins.is_empty(); }
+	// Files with a post-import script run user code during import; import them on the main thread.
+	virtual bool can_import_file_threaded(const String &p_path) const override;
 	virtual void import_threaded_begin() override;
 	virtual void import_threaded_end() override;
 

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -2053,7 +2053,7 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 	data.errors = &errors;
 	data.material_mutex = &material_mutex;
 
-	if (mesh_count > 1 && WorkerThreadPool::get_singleton()->get_caller_task_id() == WorkerThreadPool::INVALID_TASK_ID) {
+	if (mesh_count > 1 && WorkerThreadPool::get_singleton()->get_thread_index() == -1) {
 		// Not on a worker thread: parse meshes in parallel. A worker thread blocking on
 		// wait_for_group_task_completion() can starve the pool, so import threads parse inline.
 		WorkerThreadPool::GroupID group = WorkerThreadPool::get_singleton()->add_template_group_task(this, &GLTFDocument::_process_single_mesh, &data, mesh_count, -1, false, SNAME("GLTFMeshParsing"));

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -46,8 +46,11 @@
 #include "core/io/json.h"
 #include "core/io/resource_loader.h"
 #include "core/io/stream_peer.h"
+#include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/object/object_id.h"
+#include "core/object/worker_thread_pool.h"
+#include "core/os/mutex.h"
 #include "core/version.h"
 #include "scene/3d/bone_attachment_3d.h"
 #include "scene/3d/camera_3d.h"
@@ -74,7 +77,6 @@
 #include "modules/gridmap/grid_map.h"
 #endif
 
-#include <cstdio>
 #include <cstdlib>
 
 static void _attach_extras_to_meta(const Dictionary &p_extras, Ref<Resource> p_node) {
@@ -1420,585 +1422,652 @@ Error GLTFDocument::_serialize_meshes(Ref<GLTFState> p_state) {
 	return OK;
 }
 
+namespace {
+
+struct MeshParseData {
+	Ref<GLTFState> state;
+	const Array *meshes_json = nullptr;
+	const Vector<String> *precomputed_names = nullptr;
+	Vector<Error> *errors = nullptr;
+	Mutex *material_mutex = nullptr;
+};
+
+} //namespace
+
+Error GLTFDocument::_parse_single_mesh(const Ref<GLTFState> &p_state, const Array &p_meshes, GLTFMeshIndex i, const String &p_unique_name, Mutex *p_material_mutex) {
+	print_verbose("glTF: Parsing mesh: " + itos(i));
+	Dictionary mesh_dict = p_meshes[i];
+
+	Ref<GLTFMesh> mesh;
+	mesh.instantiate();
+	bool has_vertex_color = false;
+
+	ERR_FAIL_COND_V(!mesh_dict.has("primitives"), ERR_PARSE_ERROR);
+
+	Array primitives = mesh_dict["primitives"];
+	const Dictionary &extras = mesh_dict.has("extras") ? (Dictionary)mesh_dict["extras"] : Dictionary();
+	_attach_extras_to_meta(extras, mesh);
+	Ref<ImporterMesh> import_mesh;
+	import_mesh.instantiate();
+	String mesh_name = "mesh";
+	if (mesh_dict.has("name") && !String(mesh_dict["name"]).is_empty()) {
+		mesh_name = mesh_dict["name"];
+		mesh->set_original_name(mesh_name);
+	}
+	import_mesh->set_name(p_unique_name);
+	mesh->set_name(import_mesh->get_name());
+	TypedArray<Material> instance_materials;
+
+	for (int j = 0; j < primitives.size(); j++) {
+		uint64_t flags = RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
+		Dictionary mesh_prim = primitives[j];
+
+		// Read the material.
+		Ref<Material> mat;
+		String mat_name;
+		String mat_primary_texture_coord = "TEXCOORD_0";
+		String mat_secondary_texture_coord = "TEXCOORD_1";
+		if (!p_state->discard_meshes_and_materials) {
+			if (mesh_prim.has("material")) {
+				const int material = mesh_prim["material"];
+				ERR_FAIL_INDEX_V(material, p_state->materials.size(), ERR_FILE_CORRUPT);
+				Ref<Material> mat3d = p_state->materials[material];
+				ERR_FAIL_COND_V(mat3d.is_null(), ERR_FILE_CORRUPT);
+				// Remap the glTF file's UV texture coordinates to Godot's UV and UV2 as best as possible.
+				if (mat3d->has_meta("_gltf_primary_texture_coord")) {
+					const int tex_coord = mat3d->get_meta("_gltf_primary_texture_coord");
+					mat_primary_texture_coord = "TEXCOORD_" + itos(tex_coord);
+					if (tex_coord != 0 && !mat3d->has_meta("_gltf_secondary_texture_coord")) {
+						mat_secondary_texture_coord = "TEXCOORD_0";
+					}
+				}
+				if (mat3d->has_meta("_gltf_secondary_texture_coord")) {
+					const int tex_coord = mat3d->get_meta("_gltf_secondary_texture_coord");
+					mat_secondary_texture_coord = "TEXCOORD_" + itos(tex_coord);
+				}
+				Ref<BaseMaterial3D> base_material = mat3d;
+				if (has_vertex_color && base_material.is_valid()) {
+					// Materials are shared between meshes; serialize mutation during parallel parsing.
+					MutexLock lock(*p_material_mutex);
+					base_material->set_flag(BaseMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
+				}
+				mat = mat3d;
+
+			} else {
+				Ref<StandardMaterial3D> mat3d;
+				mat3d.instantiate();
+				if (has_vertex_color) {
+					mat3d->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
+				}
+				mat = mat3d;
+			}
+			ERR_FAIL_COND_V(mat.is_null(), ERR_FILE_CORRUPT);
+			instance_materials.append(mat);
+			mat_name = mat->get_name();
+		}
+
+		// Read the mesh primitive data into Godot ArrayMesh array data.
+		Array array;
+		array.resize(Mesh::ARRAY_MAX);
+
+		ERR_FAIL_COND_V(!mesh_prim.has("attributes"), ERR_PARSE_ERROR);
+
+		Dictionary a = mesh_prim["attributes"];
+
+		Mesh::PrimitiveType primitive = Mesh::PRIMITIVE_TRIANGLES;
+		if (mesh_prim.has("mode")) {
+			const int mode = mesh_prim["mode"];
+			ERR_FAIL_INDEX_V(mode, 7, ERR_FILE_CORRUPT);
+			// Convert mesh.primitive.mode to Godot Mesh enum. See:
+			// https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#_mesh_primitive_mode
+			static const Mesh::PrimitiveType primitives2[7] = {
+				Mesh::PRIMITIVE_POINTS, // 0 POINTS
+				Mesh::PRIMITIVE_LINES, // 1 LINES
+				Mesh::PRIMITIVE_LINES, // 2 LINE_LOOP; loop not supported, should be converted
+				Mesh::PRIMITIVE_LINE_STRIP, // 3 LINE_STRIP
+				Mesh::PRIMITIVE_TRIANGLES, // 4 TRIANGLES
+				Mesh::PRIMITIVE_TRIANGLE_STRIP, // 5 TRIANGLE_STRIP
+				Mesh::PRIMITIVE_TRIANGLES, // 6 TRIANGLE_FAN fan not supported, should be converted
+				// TODO: Line loop and triangle fan are not supported and need to be converted to lines and triangles.
+			};
+
+			primitive = primitives2[mode];
+		}
+
+		int32_t orig_vertex_num = 0;
+		ERR_FAIL_COND_V(!a.has("POSITION"), ERR_PARSE_ERROR);
+		if (a.has("POSITION")) {
+			PackedVector3Array vertices = _decode_accessor_as_vec3(p_state, a["POSITION"]);
+			array[Mesh::ARRAY_VERTEX] = vertices;
+			orig_vertex_num = vertices.size();
+		}
+		int32_t vertex_num = orig_vertex_num;
+
+		Vector<int> indices;
+		Vector<int> indices_mapping;
+		Vector<int> indices_rev_mapping;
+		Vector<int> indices_vec4_mapping;
+		if (mesh_prim.has("indices")) {
+			indices = _decode_accessor_as_int32s(p_state, mesh_prim["indices"]);
+			const int index_count = indices.size();
+
+			if (primitive == Mesh::PRIMITIVE_TRIANGLES) {
+				ERR_FAIL_COND_V_MSG(index_count % 3 != 0, ERR_PARSE_ERROR, "glTF import: Mesh " + itos(i) + " surface " + itos(j) + " in file " + p_state->filename + " is invalid. Indexed triangle meshes MUST have an index array with a size that is a multiple of 3, but got " + itos(index_count) + " indices.");
+				// Swap around indices, convert ccw to cw for front face.
+
+				int *w = indices.ptrw();
+				for (int k = 0; k < index_count; k += 3) {
+					SWAP(w[k + 1], w[k + 2]);
+				}
+			}
+
+			const int *indices_w = indices.ptrw();
+			Vector<bool> used_indices;
+			used_indices.resize_initialized(orig_vertex_num);
+			bool *used_w = used_indices.ptrw();
+			for (int idx_i = 0; idx_i < index_count; idx_i++) {
+				ERR_FAIL_INDEX_V(indices_w[idx_i], orig_vertex_num, ERR_INVALID_DATA);
+				used_w[indices_w[idx_i]] = true;
+			}
+			indices_rev_mapping.resize_initialized(orig_vertex_num);
+			int *rev_w = indices_rev_mapping.ptrw();
+			vertex_num = 0;
+			for (int vert_i = 0; vert_i < orig_vertex_num; vert_i++) {
+				if (used_w[vert_i]) {
+					rev_w[vert_i] = indices_mapping.size();
+					indices_mapping.push_back(vert_i);
+					indices_vec4_mapping.push_back(vert_i * 4 + 0);
+					indices_vec4_mapping.push_back(vert_i * 4 + 1);
+					indices_vec4_mapping.push_back(vert_i * 4 + 2);
+					indices_vec4_mapping.push_back(vert_i * 4 + 3);
+					vertex_num++;
+				}
+			}
+		}
+		ERR_FAIL_COND_V(vertex_num <= 0, ERR_INVALID_DECLARATION);
+
+		if (a.has("POSITION")) {
+			PackedVector3Array vertices = _decode_accessor_as_vec3(p_state, a["POSITION"], indices_mapping);
+			array[Mesh::ARRAY_VERTEX] = vertices;
+		}
+		if (a.has("NORMAL")) {
+			array[Mesh::ARRAY_NORMAL] = _decode_accessor_as_vec3(p_state, a["NORMAL"], indices_mapping);
+		}
+		if (a.has("TANGENT")) {
+			array[Mesh::ARRAY_TANGENT] = _decode_accessor_as_float32s(p_state, a["TANGENT"], indices_vec4_mapping);
+		}
+		// Usually mat_primary_texture_coord is "TEXCOORD_0", but in some edge cases it might be different.
+		if (a.has(mat_primary_texture_coord)) {
+			array[Mesh::ARRAY_TEX_UV] = _decode_accessor_as_vec2(p_state, a[mat_primary_texture_coord], indices_mapping);
+		}
+		// Usually mat_secondary_texture_coord is "TEXCOORD_1", but in some edge cases it might be different.
+		if (a.has(mat_secondary_texture_coord)) {
+			array[Mesh::ARRAY_TEX_UV2] = _decode_accessor_as_vec2(p_state, a[mat_secondary_texture_coord], indices_mapping);
+		}
+		for (int custom_i = 0; custom_i < 4; custom_i++) {
+			Vector<float> cur_custom;
+			int num_channels = 0;
+
+			// Attempt to read from "_CUSTOM" attributes first.
+			String gltf_custom_key = vformat("_CUSTOM%d", custom_i);
+			if (a.has(gltf_custom_key)) {
+				num_channels = 4;
+				Vector<Vector4> custom_vector4 = _decode_accessor_as_vec4(p_state, a[gltf_custom_key], indices_mapping);
+				cur_custom.resize_initialized(vertex_num * 4);
+				for (int32_t uv_i = 0; uv_i < custom_vector4.size() && uv_i < vertex_num; uv_i++) {
+					cur_custom.write[uv_i * 4 + 0] = custom_vector4[uv_i].x;
+					cur_custom.write[uv_i * 4 + 1] = custom_vector4[uv_i].y;
+					cur_custom.write[uv_i * 4 + 2] = custom_vector4[uv_i].z;
+					cur_custom.write[uv_i * 4 + 3] = custom_vector4[uv_i].w;
+				}
+			} else {
+				// Attempt to read from UVs 3 to 10 as an alternative source for custom data.
+				// Note that Blender has a limit of 8 UV sets; therefore, CUSTOM3 cannot be read this way
+				// for models exported from Blender. Use a custom attribute named "_CUSTOM3" instead.
+				Vector<Vector2> texcoord_first;
+				Vector<Vector2> texcoord_second;
+				int texcoord_i = 2 + 2 * custom_i;
+				String gltf_texcoord_key = vformat("TEXCOORD_%d", texcoord_i);
+				if (a.has(gltf_texcoord_key)) {
+					texcoord_first = _decode_accessor_as_vec2(p_state, a[gltf_texcoord_key], indices_mapping);
+					num_channels = 2;
+				}
+				gltf_texcoord_key = vformat("TEXCOORD_%d", texcoord_i + 1);
+				if (a.has(gltf_texcoord_key)) {
+					texcoord_second = _decode_accessor_as_vec2(p_state, a[gltf_texcoord_key], indices_mapping);
+					num_channels = 4;
+				}
+				if (!num_channels) {
+					break;
+				}
+				if (num_channels == 2 || num_channels == 4) {
+					cur_custom.resize_initialized(vertex_num * num_channels);
+					for (int32_t uv_i = 0; uv_i < texcoord_first.size() && uv_i < vertex_num; uv_i++) {
+						cur_custom.write[uv_i * num_channels + 0] = texcoord_first[uv_i].x;
+						cur_custom.write[uv_i * num_channels + 1] = texcoord_first[uv_i].y;
+					}
+					if (num_channels == 4) {
+						for (int32_t uv_i = 0; uv_i < texcoord_second.size() && uv_i < vertex_num; uv_i++) {
+							cur_custom.write[uv_i * num_channels + 2] = texcoord_second[uv_i].x;
+							cur_custom.write[uv_i * num_channels + 3] = texcoord_second[uv_i].y;
+						}
+					}
+				}
+			}
+			if (cur_custom.size() > 0) {
+				array[Mesh::ARRAY_CUSTOM0 + custom_i] = cur_custom;
+				int custom_shift = Mesh::ARRAY_FORMAT_CUSTOM0_SHIFT + custom_i * Mesh::ARRAY_FORMAT_CUSTOM_BITS;
+				if (num_channels == 2) {
+					flags |= Mesh::ARRAY_CUSTOM_RG_FLOAT << custom_shift;
+				} else {
+					flags |= Mesh::ARRAY_CUSTOM_RGBA_FLOAT << custom_shift;
+				}
+			}
+		}
+		if (a.has("COLOR_0")) {
+			array[Mesh::ARRAY_COLOR] = _decode_accessor_as_color(p_state, a["COLOR_0"], indices_mapping);
+			has_vertex_color = true;
+		}
+		if (a.has("JOINTS_0") && !a.has("JOINTS_1")) {
+			PackedInt32Array joints_0 = _decode_accessor_as_int32s(p_state, a["JOINTS_0"], indices_vec4_mapping);
+			ERR_FAIL_COND_V(joints_0.size() != 4 * vertex_num, ERR_INVALID_DATA);
+			array[Mesh::ARRAY_BONES] = joints_0;
+		} else if (a.has("JOINTS_0") && a.has("JOINTS_1")) {
+			PackedInt32Array joints_0 = _decode_accessor_as_int32s(p_state, a["JOINTS_0"], indices_vec4_mapping);
+			PackedInt32Array joints_1 = _decode_accessor_as_int32s(p_state, a["JOINTS_1"], indices_vec4_mapping);
+			ERR_FAIL_COND_V(joints_0.size() != joints_1.size(), ERR_INVALID_DATA);
+			ERR_FAIL_COND_V(joints_0.size() != 4 * vertex_num, ERR_INVALID_DATA);
+			int32_t weight_8_count = JOINT_GROUP_SIZE * 2;
+			Vector<int> joints;
+			joints.resize(vertex_num * weight_8_count);
+			for (int32_t vertex_i = 0; vertex_i < vertex_num; vertex_i++) {
+				joints.write[vertex_i * weight_8_count + 0] = joints_0[vertex_i * JOINT_GROUP_SIZE + 0];
+				joints.write[vertex_i * weight_8_count + 1] = joints_0[vertex_i * JOINT_GROUP_SIZE + 1];
+				joints.write[vertex_i * weight_8_count + 2] = joints_0[vertex_i * JOINT_GROUP_SIZE + 2];
+				joints.write[vertex_i * weight_8_count + 3] = joints_0[vertex_i * JOINT_GROUP_SIZE + 3];
+				joints.write[vertex_i * weight_8_count + 4] = joints_1[vertex_i * JOINT_GROUP_SIZE + 0];
+				joints.write[vertex_i * weight_8_count + 5] = joints_1[vertex_i * JOINT_GROUP_SIZE + 1];
+				joints.write[vertex_i * weight_8_count + 6] = joints_1[vertex_i * JOINT_GROUP_SIZE + 2];
+				joints.write[vertex_i * weight_8_count + 7] = joints_1[vertex_i * JOINT_GROUP_SIZE + 3];
+			}
+			array[Mesh::ARRAY_BONES] = joints;
+		}
+		// glTF stores weights as a VEC4 array or multiple VEC4 arrays, but Godot's
+		// ArrayMesh uses a flat array of either 4 or 8 floats per vertex.
+		// Therefore, decode up to two glTF VEC4 arrays as float arrays.
+		if (a.has("WEIGHTS_0") && !a.has("WEIGHTS_1")) {
+			Vector<float> weights = _decode_accessor_as_float32s(p_state, a["WEIGHTS_0"], indices_vec4_mapping);
+			ERR_FAIL_COND_V(weights.size() != 4 * vertex_num, ERR_INVALID_DATA);
+			{ // glTF does not seem to normalize the weights for some reason.
+				int wc = weights.size();
+				float *w = weights.ptrw();
+
+				for (int k = 0; k < wc; k += 4) {
+					float total = 0.0;
+					total += w[k + 0];
+					total += w[k + 1];
+					total += w[k + 2];
+					total += w[k + 3];
+					if (total > 0.0) {
+						w[k + 0] /= total;
+						w[k + 1] /= total;
+						w[k + 2] /= total;
+						w[k + 3] /= total;
+					}
+				}
+			}
+			array[Mesh::ARRAY_WEIGHTS] = weights;
+		} else if (a.has("WEIGHTS_0") && a.has("WEIGHTS_1")) {
+			Vector<float> weights_0 = _decode_accessor_as_float32s(p_state, a["WEIGHTS_0"], indices_vec4_mapping);
+			Vector<float> weights_1 = _decode_accessor_as_float32s(p_state, a["WEIGHTS_1"], indices_vec4_mapping);
+			Vector<float> weights;
+			ERR_FAIL_COND_V(weights_0.size() != weights_1.size(), ERR_INVALID_DATA);
+			ERR_FAIL_COND_V(weights_0.size() != 4 * vertex_num, ERR_INVALID_DATA);
+			int32_t weight_8_count = JOINT_GROUP_SIZE * 2;
+			weights.resize(vertex_num * weight_8_count);
+			for (int32_t vertex_i = 0; vertex_i < vertex_num; vertex_i++) {
+				weights.write[vertex_i * weight_8_count + 0] = weights_0[vertex_i * JOINT_GROUP_SIZE + 0];
+				weights.write[vertex_i * weight_8_count + 1] = weights_0[vertex_i * JOINT_GROUP_SIZE + 1];
+				weights.write[vertex_i * weight_8_count + 2] = weights_0[vertex_i * JOINT_GROUP_SIZE + 2];
+				weights.write[vertex_i * weight_8_count + 3] = weights_0[vertex_i * JOINT_GROUP_SIZE + 3];
+				weights.write[vertex_i * weight_8_count + 4] = weights_1[vertex_i * JOINT_GROUP_SIZE + 0];
+				weights.write[vertex_i * weight_8_count + 5] = weights_1[vertex_i * JOINT_GROUP_SIZE + 1];
+				weights.write[vertex_i * weight_8_count + 6] = weights_1[vertex_i * JOINT_GROUP_SIZE + 2];
+				weights.write[vertex_i * weight_8_count + 7] = weights_1[vertex_i * JOINT_GROUP_SIZE + 3];
+			}
+			{ // glTF does not seem to normalize the weights for some reason.
+				int wc = weights.size();
+				float *w = weights.ptrw();
+
+				for (int k = 0; k < wc; k += weight_8_count) {
+					float total = 0.0;
+					total += w[k + 0];
+					total += w[k + 1];
+					total += w[k + 2];
+					total += w[k + 3];
+					total += w[k + 4];
+					total += w[k + 5];
+					total += w[k + 6];
+					total += w[k + 7];
+					if (total > 0.0) {
+						w[k + 0] /= total;
+						w[k + 1] /= total;
+						w[k + 2] /= total;
+						w[k + 3] /= total;
+						w[k + 4] /= total;
+						w[k + 5] /= total;
+						w[k + 6] /= total;
+						w[k + 7] /= total;
+					}
+				}
+			}
+			array[Mesh::ARRAY_WEIGHTS] = weights;
+			flags |= Mesh::ARRAY_FLAG_USE_8_BONE_WEIGHTS;
+		}
+
+		if (!indices.is_empty()) {
+			int *w = indices.ptrw();
+			const int is = indices.size();
+			for (int ind_i = 0; ind_i < is; ind_i++) {
+				w[ind_i] = indices_rev_mapping[indices[ind_i]];
+			}
+			array[Mesh::ARRAY_INDEX] = indices;
+
+		} else if (primitive == Mesh::PRIMITIVE_TRIANGLES) {
+			// Generate indices because they need to be swapped for CW/CCW.
+			const Vector<Vector3> &vertices = array[Mesh::ARRAY_VERTEX];
+			ERR_FAIL_COND_V(vertices.is_empty(), ERR_PARSE_ERROR);
+			const int vertex_count = vertices.size();
+			ERR_FAIL_COND_V_MSG(vertex_count % 3 != 0, ERR_PARSE_ERROR, "glTF import: Mesh " + itos(i) + " surface " + itos(j) + " in file " + p_state->filename + " is invalid. Non-indexed triangle meshes MUST have a vertex array with a size that is a multiple of 3, but got " + itos(vertex_count) + " vertices.");
+			indices.resize(vertex_count);
+			{
+				int *w = indices.ptrw();
+				for (int k = 0; k < vertex_count; k += 3) {
+					w[k] = k;
+					w[k + 1] = k + 2;
+					w[k + 2] = k + 1;
+				}
+			}
+			array[Mesh::ARRAY_INDEX] = indices;
+		}
+
+		bool generate_tangents = p_state->force_generate_tangents && (primitive == Mesh::PRIMITIVE_TRIANGLES && !a.has("TANGENT") && a.has("NORMAL"));
+
+		if (generate_tangents && !a.has("TEXCOORD_0")) {
+			// If we don't have UVs we provide a dummy tangent array.
+			Vector<float> tangents;
+			tangents.resize(vertex_num * 4);
+			float *tangentsw = tangents.ptrw();
+
+			Vector<Vector3> normals = array[Mesh::ARRAY_NORMAL];
+			for (int k = 0; k < vertex_num; k++) {
+				Vector3 tan = Vector3(normals[k].z, -normals[k].x, normals[k].y).cross(normals[k].normalized()).normalized();
+				tangentsw[k * 4 + 0] = tan.x;
+				tangentsw[k * 4 + 1] = tan.y;
+				tangentsw[k * 4 + 2] = tan.z;
+				tangentsw[k * 4 + 3] = 1.0;
+			}
+			array[Mesh::ARRAY_TANGENT] = tangents;
+		}
+
+		// Disable compression if all z equals 0 (the mesh is 2D).
+		const Vector<Vector3> &vertices = array[Mesh::ARRAY_VERTEX];
+		bool is_mesh_2d = true;
+		for (int k = 0; k < vertices.size(); k++) {
+			if (!Math::is_zero_approx(vertices[k].z)) {
+				is_mesh_2d = false;
+				break;
+			}
+		}
+
+		if (p_state->force_disable_compression || is_mesh_2d || !a.has("POSITION") || !a.has("NORMAL") || mesh_prim.has("targets") || (a.has("JOINTS_0") || a.has("JOINTS_1"))) {
+			flags &= ~RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
+		}
+
+		Ref<SurfaceTool> mesh_surface_tool;
+		mesh_surface_tool.instantiate();
+		mesh_surface_tool->create_from_triangle_arrays(array);
+		if (a.has("JOINTS_0") && a.has("JOINTS_1")) {
+			mesh_surface_tool->set_skin_weight_count(SurfaceTool::SKIN_8_WEIGHTS);
+		}
+		mesh_surface_tool->index();
+		if (generate_tangents && a.has("TEXCOORD_0")) {
+			mesh_surface_tool->generate_tangents(/*split*/ !mesh_prim.has("targets"));
+		}
+		array = mesh_surface_tool->commit_to_arrays();
+
+		if ((flags & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES) && a.has("NORMAL") && (a.has("TANGENT") || generate_tangents)) {
+			// Compression is enabled, so let's validate that the normals and tangents are correct.
+			Vector<Vector3> normals = array[Mesh::ARRAY_NORMAL];
+			Vector<float> tangents = array[Mesh::ARRAY_TANGENT];
+			if (unlikely(tangents.size() < normals.size() * 4)) {
+				ERR_PRINT("glTF import: Mesh " + itos(i) + " has invalid tangents.");
+				flags &= ~RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
+			} else {
+				for (int vert = 0; vert < normals.size(); vert++) {
+					Vector3 tan = Vector3(tangents[vert * 4 + 0], tangents[vert * 4 + 1], tangents[vert * 4 + 2]);
+					if (std::abs(tan.dot(normals[vert])) > 0.0001) {
+						// Tangent is not perpendicular to the normal, so we can't use compression.
+						flags &= ~RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
+					}
+				}
+			}
+		}
+
+		Array morphs;
+		// Blend shapes
+		if (mesh_prim.has("targets")) {
+			print_verbose("glTF: Mesh has targets");
+			const Array &targets = mesh_prim["targets"];
+
+			import_mesh->set_blend_shape_mode(Mesh::BLEND_SHAPE_MODE_NORMALIZED);
+
+			if (j == 0) {
+				const Array &target_names = extras.has("targetNames") ? (Array)extras["targetNames"] : Array();
+				for (int k = 0; k < targets.size(); k++) {
+					String bs_name;
+					if (k < target_names.size() && ((String)target_names[k]).size() != 0) {
+						bs_name = (String)target_names[k];
+					} else {
+						bs_name = String("morph_") + itos(k);
+					}
+					import_mesh->add_blend_shape(bs_name);
+				}
+			}
+
+			for (int k = 0; k < targets.size(); k++) {
+				const Dictionary &t = targets[k];
+
+				Array array_copy;
+				array_copy.resize(Mesh::ARRAY_MAX);
+
+				for (int l = 0; l < Mesh::ARRAY_MAX; l++) {
+					array_copy[l] = array[l];
+				}
+
+				if (t.has("POSITION")) {
+					Vector<Vector3> varr = _decode_accessor_as_vec3(p_state, t["POSITION"], indices_mapping);
+					const Vector<Vector3> src_varr = array[Mesh::ARRAY_VERTEX];
+					const int size = src_varr.size();
+					ERR_FAIL_COND_V(size == 0, ERR_PARSE_ERROR);
+					{
+						const int max_idx = varr.size();
+						varr.resize(size);
+
+						Vector3 *w_varr = varr.ptrw();
+						const Vector3 *r_varr = varr.ptr();
+						const Vector3 *r_src_varr = src_varr.ptr();
+						for (int l = 0; l < size; l++) {
+							if (l < max_idx) {
+								w_varr[l] = r_varr[l] + r_src_varr[l];
+							} else {
+								w_varr[l] = r_src_varr[l];
+							}
+						}
+					}
+					array_copy[Mesh::ARRAY_VERTEX] = varr;
+				}
+				if (t.has("NORMAL")) {
+					Vector<Vector3> narr = _decode_accessor_as_vec3(p_state, t["NORMAL"], indices_mapping);
+					const Vector<Vector3> src_narr = array[Mesh::ARRAY_NORMAL];
+					int size = src_narr.size();
+					ERR_FAIL_COND_V(size == 0, ERR_PARSE_ERROR);
+					{
+						int max_idx = narr.size();
+						narr.resize(size);
+
+						Vector3 *w_narr = narr.ptrw();
+						const Vector3 *r_narr = narr.ptr();
+						const Vector3 *r_src_narr = src_narr.ptr();
+						for (int l = 0; l < size; l++) {
+							if (l < max_idx) {
+								w_narr[l] = r_narr[l] + r_src_narr[l];
+							} else {
+								w_narr[l] = r_src_narr[l];
+							}
+						}
+					}
+					array_copy[Mesh::ARRAY_NORMAL] = narr;
+				}
+				if (t.has("TANGENT")) {
+					const Vector<Vector3> tangents_v3 = _decode_accessor_as_vec3(p_state, t["TANGENT"], indices_mapping);
+					const Vector<float> src_tangents = array[Mesh::ARRAY_TANGENT];
+					ERR_FAIL_COND_V(src_tangents.is_empty(), ERR_PARSE_ERROR);
+
+					Vector<float> tangents_v4;
+
+					{
+						int max_idx = tangents_v3.size();
+
+						int size4 = src_tangents.size();
+						tangents_v4.resize(size4);
+						float *w4 = tangents_v4.ptrw();
+
+						const Vector3 *r3 = tangents_v3.ptr();
+						const float *r4 = src_tangents.ptr();
+
+						for (int l = 0; l < size4 / 4; l++) {
+							if (l < max_idx) {
+								w4[l * 4 + 0] = r3[l].x + r4[l * 4 + 0];
+								w4[l * 4 + 1] = r3[l].y + r4[l * 4 + 1];
+								w4[l * 4 + 2] = r3[l].z + r4[l * 4 + 2];
+							} else {
+								w4[l * 4 + 0] = r4[l * 4 + 0];
+								w4[l * 4 + 1] = r4[l * 4 + 1];
+								w4[l * 4 + 2] = r4[l * 4 + 2];
+							}
+							w4[l * 4 + 3] = r4[l * 4 + 3]; //copy flip value
+						}
+					}
+
+					array_copy[Mesh::ARRAY_TANGENT] = tangents_v4;
+				}
+
+				Ref<SurfaceTool> blend_surface_tool;
+				blend_surface_tool.instantiate();
+				blend_surface_tool->create_from_triangle_arrays(array_copy);
+				if (a.has("JOINTS_0") && a.has("JOINTS_1")) {
+					blend_surface_tool->set_skin_weight_count(SurfaceTool::SKIN_8_WEIGHTS);
+				}
+				blend_surface_tool->index();
+				if (generate_tangents) {
+					blend_surface_tool->generate_tangents(/*split*/ false);
+				}
+				array_copy = blend_surface_tool->commit_to_arrays();
+
+				// Enforce blend shape mask array format
+				for (int l = 0; l < Mesh::ARRAY_MAX; l++) {
+					if (!(Mesh::ARRAY_FORMAT_BLEND_SHAPE_MASK & (1ULL << l))) {
+						array_copy[l] = Variant();
+					}
+				}
+
+				morphs.push_back(array_copy);
+			}
+		}
+		import_mesh->add_surface(primitive, array, morphs,
+				Dictionary(), mat, mat_name, flags);
+	}
+
+	Vector<float> blend_weights;
+	blend_weights.resize(import_mesh->get_blend_shape_count());
+	for (int32_t weight_i = 0; weight_i < blend_weights.size(); weight_i++) {
+		blend_weights.write[weight_i] = 0.0f;
+	}
+
+	if (mesh_dict.has("weights")) {
+		const Array &weights = mesh_dict["weights"];
+		for (int j = 0; j < weights.size(); j++) {
+			if (j >= blend_weights.size()) {
+				break;
+			}
+			blend_weights.write[j] = weights[j];
+		}
+	}
+	mesh->set_blend_weights(blend_weights);
+	mesh->set_instance_materials(instance_materials);
+	mesh->set_mesh(import_mesh);
+
+	p_state->meshes.write[i] = mesh;
+	return OK;
+}
+
+void GLTFDocument::_process_single_mesh(uint32_t p_index, void *p_userdata) {
+	MeshParseData *data = static_cast<MeshParseData *>(p_userdata);
+	data->errors->write[p_index] = _parse_single_mesh(data->state, *data->meshes_json, static_cast<GLTFMeshIndex>(p_index), (*data->precomputed_names)[p_index], data->material_mutex);
+}
+
 Error GLTFDocument::_parse_meshes(Ref<GLTFState> p_state) {
 	if (!p_state->json.has("meshes")) {
 		return OK;
 	}
 
 	Array meshes = p_state->json["meshes"];
-	for (GLTFMeshIndex i = 0; i < meshes.size(); i++) {
-		print_verbose("glTF: Parsing mesh: " + itos(i));
+	const int mesh_count = meshes.size();
+
+	// Pre-generate unique mesh names on this thread, as _gen_unique_name() mutates shared state.
+	Vector<String> precomputed_names;
+	precomputed_names.resize(mesh_count);
+	for (int i = 0; i < mesh_count; i++) {
 		Dictionary mesh_dict = meshes[i];
-
-		Ref<GLTFMesh> mesh;
-		mesh.instantiate();
-		bool has_vertex_color = false;
-
-		ERR_FAIL_COND_V(!mesh_dict.has("primitives"), ERR_PARSE_ERROR);
-
-		Array primitives = mesh_dict["primitives"];
-		const Dictionary &extras = mesh_dict.has("extras") ? (Dictionary)mesh_dict["extras"] : Dictionary();
-		_attach_extras_to_meta(extras, mesh);
-		Ref<ImporterMesh> import_mesh;
-		import_mesh.instantiate();
 		String mesh_name = "mesh";
 		if (mesh_dict.has("name") && !String(mesh_dict["name"]).is_empty()) {
 			mesh_name = mesh_dict["name"];
-			mesh->set_original_name(mesh_name);
 		}
-		import_mesh->set_name(_gen_unique_name(p_state, vformat("%s_%s", p_state->scene_name, mesh_name)));
-		mesh->set_name(import_mesh->get_name());
-		TypedArray<Material> instance_materials;
+		precomputed_names.write[i] = _gen_unique_name(p_state, vformat("%s_%s", p_state->scene_name, mesh_name));
+	}
 
-		for (int j = 0; j < primitives.size(); j++) {
-			uint64_t flags = RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
-			Dictionary mesh_prim = primitives[j];
+	// Pre-allocate output slots so workers can write their own mesh and error independently.
+	p_state->meshes.resize(mesh_count);
+	Vector<Error> errors;
+	errors.resize(mesh_count);
+	for (int i = 0; i < mesh_count; i++) {
+		errors.write[i] = OK;
+	}
 
-			// Read the material.
-			Ref<Material> mat;
-			String mat_name;
-			String mat_primary_texture_coord = "TEXCOORD_0";
-			String mat_secondary_texture_coord = "TEXCOORD_1";
-			if (!p_state->discard_meshes_and_materials) {
-				if (mesh_prim.has("material")) {
-					const int material = mesh_prim["material"];
-					ERR_FAIL_INDEX_V(material, p_state->materials.size(), ERR_FILE_CORRUPT);
-					Ref<Material> mat3d = p_state->materials[material];
-					ERR_FAIL_COND_V(mat3d.is_null(), ERR_FILE_CORRUPT);
-					// Remap the glTF file's UV texture coordinates to Godot's UV and UV2 as best as possible.
-					if (mat3d->has_meta("_gltf_primary_texture_coord")) {
-						const int tex_coord = mat3d->get_meta("_gltf_primary_texture_coord");
-						mat_primary_texture_coord = "TEXCOORD_" + itos(tex_coord);
-						if (tex_coord != 0 && !mat3d->has_meta("_gltf_secondary_texture_coord")) {
-							mat_secondary_texture_coord = "TEXCOORD_0";
-						}
-					}
-					if (mat3d->has_meta("_gltf_secondary_texture_coord")) {
-						const int tex_coord = mat3d->get_meta("_gltf_secondary_texture_coord");
-						mat_secondary_texture_coord = "TEXCOORD_" + itos(tex_coord);
-					}
-					Ref<BaseMaterial3D> base_material = mat3d;
-					if (has_vertex_color && base_material.is_valid()) {
-						base_material->set_flag(BaseMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
-					}
-					mat = mat3d;
+	Mutex material_mutex;
+	MeshParseData data;
+	data.state = p_state;
+	data.meshes_json = &meshes;
+	data.precomputed_names = &precomputed_names;
+	data.errors = &errors;
+	data.material_mutex = &material_mutex;
 
-				} else {
-					Ref<StandardMaterial3D> mat3d;
-					mat3d.instantiate();
-					if (has_vertex_color) {
-						mat3d->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
-					}
-					mat = mat3d;
-				}
-				ERR_FAIL_COND_V(mat.is_null(), ERR_FILE_CORRUPT);
-				instance_materials.append(mat);
-				mat_name = mat->get_name();
-			}
-
-			// Read the mesh primitive data into Godot ArrayMesh array data.
-			Array array;
-			array.resize(Mesh::ARRAY_MAX);
-
-			ERR_FAIL_COND_V(!mesh_prim.has("attributes"), ERR_PARSE_ERROR);
-
-			Dictionary a = mesh_prim["attributes"];
-
-			Mesh::PrimitiveType primitive = Mesh::PRIMITIVE_TRIANGLES;
-			if (mesh_prim.has("mode")) {
-				const int mode = mesh_prim["mode"];
-				ERR_FAIL_INDEX_V(mode, 7, ERR_FILE_CORRUPT);
-				// Convert mesh.primitive.mode to Godot Mesh enum. See:
-				// https://www.khronos.org/registry/glTF/specs/2.0/glTF-2.0.html#_mesh_primitive_mode
-				static const Mesh::PrimitiveType primitives2[7] = {
-					Mesh::PRIMITIVE_POINTS, // 0 POINTS
-					Mesh::PRIMITIVE_LINES, // 1 LINES
-					Mesh::PRIMITIVE_LINES, // 2 LINE_LOOP; loop not supported, should be converted
-					Mesh::PRIMITIVE_LINE_STRIP, // 3 LINE_STRIP
-					Mesh::PRIMITIVE_TRIANGLES, // 4 TRIANGLES
-					Mesh::PRIMITIVE_TRIANGLE_STRIP, // 5 TRIANGLE_STRIP
-					Mesh::PRIMITIVE_TRIANGLES, // 6 TRIANGLE_FAN fan not supported, should be converted
-					// TODO: Line loop and triangle fan are not supported and need to be converted to lines and triangles.
-				};
-
-				primitive = primitives2[mode];
-			}
-
-			int32_t orig_vertex_num = 0;
-			ERR_FAIL_COND_V(!a.has("POSITION"), ERR_PARSE_ERROR);
-			if (a.has("POSITION")) {
-				PackedVector3Array vertices = _decode_accessor_as_vec3(p_state, a["POSITION"]);
-				array[Mesh::ARRAY_VERTEX] = vertices;
-				orig_vertex_num = vertices.size();
-			}
-			int32_t vertex_num = orig_vertex_num;
-
-			Vector<int> indices;
-			Vector<int> indices_mapping;
-			Vector<int> indices_rev_mapping;
-			Vector<int> indices_vec4_mapping;
-			if (mesh_prim.has("indices")) {
-				indices = _decode_accessor_as_int32s(p_state, mesh_prim["indices"]);
-				const int index_count = indices.size();
-
-				if (primitive == Mesh::PRIMITIVE_TRIANGLES) {
-					ERR_FAIL_COND_V_MSG(index_count % 3 != 0, ERR_PARSE_ERROR, "glTF import: Mesh " + itos(i) + " surface " + itos(j) + " in file " + p_state->filename + " is invalid. Indexed triangle meshes MUST have an index array with a size that is a multiple of 3, but got " + itos(index_count) + " indices.");
-					// Swap around indices, convert ccw to cw for front face.
-
-					int *w = indices.ptrw();
-					for (int k = 0; k < index_count; k += 3) {
-						SWAP(w[k + 1], w[k + 2]);
-					}
-				}
-
-				const int *indices_w = indices.ptrw();
-				Vector<bool> used_indices;
-				used_indices.resize_initialized(orig_vertex_num);
-				bool *used_w = used_indices.ptrw();
-				for (int idx_i = 0; idx_i < index_count; idx_i++) {
-					ERR_FAIL_INDEX_V(indices_w[idx_i], orig_vertex_num, ERR_INVALID_DATA);
-					used_w[indices_w[idx_i]] = true;
-				}
-				indices_rev_mapping.resize_initialized(orig_vertex_num);
-				int *rev_w = indices_rev_mapping.ptrw();
-				vertex_num = 0;
-				for (int vert_i = 0; vert_i < orig_vertex_num; vert_i++) {
-					if (used_w[vert_i]) {
-						rev_w[vert_i] = indices_mapping.size();
-						indices_mapping.push_back(vert_i);
-						indices_vec4_mapping.push_back(vert_i * 4 + 0);
-						indices_vec4_mapping.push_back(vert_i * 4 + 1);
-						indices_vec4_mapping.push_back(vert_i * 4 + 2);
-						indices_vec4_mapping.push_back(vert_i * 4 + 3);
-						vertex_num++;
-					}
-				}
-			}
-			ERR_FAIL_COND_V(vertex_num <= 0, ERR_INVALID_DECLARATION);
-
-			if (a.has("POSITION")) {
-				PackedVector3Array vertices = _decode_accessor_as_vec3(p_state, a["POSITION"], indices_mapping);
-				array[Mesh::ARRAY_VERTEX] = vertices;
-			}
-			if (a.has("NORMAL")) {
-				array[Mesh::ARRAY_NORMAL] = _decode_accessor_as_vec3(p_state, a["NORMAL"], indices_mapping);
-			}
-			if (a.has("TANGENT")) {
-				array[Mesh::ARRAY_TANGENT] = _decode_accessor_as_float32s(p_state, a["TANGENT"], indices_vec4_mapping);
-			}
-			// Usually mat_primary_texture_coord is "TEXCOORD_0", but in some edge cases it might be different.
-			if (a.has(mat_primary_texture_coord)) {
-				array[Mesh::ARRAY_TEX_UV] = _decode_accessor_as_vec2(p_state, a[mat_primary_texture_coord], indices_mapping);
-			}
-			// Usually mat_secondary_texture_coord is "TEXCOORD_1", but in some edge cases it might be different.
-			if (a.has(mat_secondary_texture_coord)) {
-				array[Mesh::ARRAY_TEX_UV2] = _decode_accessor_as_vec2(p_state, a[mat_secondary_texture_coord], indices_mapping);
-			}
-			for (int custom_i = 0; custom_i < 4; custom_i++) {
-				Vector<float> cur_custom;
-				int num_channels = 0;
-
-				// Attempt to read from "_CUSTOM" attributes first.
-				String gltf_custom_key = vformat("_CUSTOM%d", custom_i);
-				if (a.has(gltf_custom_key)) {
-					num_channels = 4;
-					Vector<Vector4> custom_vector4 = _decode_accessor_as_vec4(p_state, a[gltf_custom_key], indices_mapping);
-					cur_custom.resize_initialized(vertex_num * 4);
-					for (int32_t uv_i = 0; uv_i < custom_vector4.size() && uv_i < vertex_num; uv_i++) {
-						cur_custom.write[uv_i * 4 + 0] = custom_vector4[uv_i].x;
-						cur_custom.write[uv_i * 4 + 1] = custom_vector4[uv_i].y;
-						cur_custom.write[uv_i * 4 + 2] = custom_vector4[uv_i].z;
-						cur_custom.write[uv_i * 4 + 3] = custom_vector4[uv_i].w;
-					}
-				} else {
-					// Attempt to read from UVs 3 to 10 as an alternative source for custom data.
-					// Note that Blender has a limit of 8 UV sets; therefore, CUSTOM3 cannot be read this way
-					// for models exported from Blender. Use a custom attribute named "_CUSTOM3" instead.
-					Vector<Vector2> texcoord_first;
-					Vector<Vector2> texcoord_second;
-					int texcoord_i = 2 + 2 * custom_i;
-					String gltf_texcoord_key = vformat("TEXCOORD_%d", texcoord_i);
-					if (a.has(gltf_texcoord_key)) {
-						texcoord_first = _decode_accessor_as_vec2(p_state, a[gltf_texcoord_key], indices_mapping);
-						num_channels = 2;
-					}
-					gltf_texcoord_key = vformat("TEXCOORD_%d", texcoord_i + 1);
-					if (a.has(gltf_texcoord_key)) {
-						texcoord_second = _decode_accessor_as_vec2(p_state, a[gltf_texcoord_key], indices_mapping);
-						num_channels = 4;
-					}
-					if (!num_channels) {
-						break;
-					}
-					if (num_channels == 2 || num_channels == 4) {
-						cur_custom.resize_initialized(vertex_num * num_channels);
-						for (int32_t uv_i = 0; uv_i < texcoord_first.size() && uv_i < vertex_num; uv_i++) {
-							cur_custom.write[uv_i * num_channels + 0] = texcoord_first[uv_i].x;
-							cur_custom.write[uv_i * num_channels + 1] = texcoord_first[uv_i].y;
-						}
-						if (num_channels == 4) {
-							for (int32_t uv_i = 0; uv_i < texcoord_second.size() && uv_i < vertex_num; uv_i++) {
-								cur_custom.write[uv_i * num_channels + 2] = texcoord_second[uv_i].x;
-								cur_custom.write[uv_i * num_channels + 3] = texcoord_second[uv_i].y;
-							}
-						}
-					}
-				}
-				if (cur_custom.size() > 0) {
-					array[Mesh::ARRAY_CUSTOM0 + custom_i] = cur_custom;
-					int custom_shift = Mesh::ARRAY_FORMAT_CUSTOM0_SHIFT + custom_i * Mesh::ARRAY_FORMAT_CUSTOM_BITS;
-					if (num_channels == 2) {
-						flags |= Mesh::ARRAY_CUSTOM_RG_FLOAT << custom_shift;
-					} else {
-						flags |= Mesh::ARRAY_CUSTOM_RGBA_FLOAT << custom_shift;
-					}
-				}
-			}
-			if (a.has("COLOR_0")) {
-				array[Mesh::ARRAY_COLOR] = _decode_accessor_as_color(p_state, a["COLOR_0"], indices_mapping);
-				has_vertex_color = true;
-			}
-			if (a.has("JOINTS_0") && !a.has("JOINTS_1")) {
-				PackedInt32Array joints_0 = _decode_accessor_as_int32s(p_state, a["JOINTS_0"], indices_vec4_mapping);
-				ERR_FAIL_COND_V(joints_0.size() != 4 * vertex_num, ERR_INVALID_DATA);
-				array[Mesh::ARRAY_BONES] = joints_0;
-			} else if (a.has("JOINTS_0") && a.has("JOINTS_1")) {
-				PackedInt32Array joints_0 = _decode_accessor_as_int32s(p_state, a["JOINTS_0"], indices_vec4_mapping);
-				PackedInt32Array joints_1 = _decode_accessor_as_int32s(p_state, a["JOINTS_1"], indices_vec4_mapping);
-				ERR_FAIL_COND_V(joints_0.size() != joints_1.size(), ERR_INVALID_DATA);
-				ERR_FAIL_COND_V(joints_0.size() != 4 * vertex_num, ERR_INVALID_DATA);
-				int32_t weight_8_count = JOINT_GROUP_SIZE * 2;
-				Vector<int> joints;
-				joints.resize(vertex_num * weight_8_count);
-				for (int32_t vertex_i = 0; vertex_i < vertex_num; vertex_i++) {
-					joints.write[vertex_i * weight_8_count + 0] = joints_0[vertex_i * JOINT_GROUP_SIZE + 0];
-					joints.write[vertex_i * weight_8_count + 1] = joints_0[vertex_i * JOINT_GROUP_SIZE + 1];
-					joints.write[vertex_i * weight_8_count + 2] = joints_0[vertex_i * JOINT_GROUP_SIZE + 2];
-					joints.write[vertex_i * weight_8_count + 3] = joints_0[vertex_i * JOINT_GROUP_SIZE + 3];
-					joints.write[vertex_i * weight_8_count + 4] = joints_1[vertex_i * JOINT_GROUP_SIZE + 0];
-					joints.write[vertex_i * weight_8_count + 5] = joints_1[vertex_i * JOINT_GROUP_SIZE + 1];
-					joints.write[vertex_i * weight_8_count + 6] = joints_1[vertex_i * JOINT_GROUP_SIZE + 2];
-					joints.write[vertex_i * weight_8_count + 7] = joints_1[vertex_i * JOINT_GROUP_SIZE + 3];
-				}
-				array[Mesh::ARRAY_BONES] = joints;
-			}
-			// glTF stores weights as a VEC4 array or multiple VEC4 arrays, but Godot's
-			// ArrayMesh uses a flat array of either 4 or 8 floats per vertex.
-			// Therefore, decode up to two glTF VEC4 arrays as float arrays.
-			if (a.has("WEIGHTS_0") && !a.has("WEIGHTS_1")) {
-				Vector<float> weights = _decode_accessor_as_float32s(p_state, a["WEIGHTS_0"], indices_vec4_mapping);
-				ERR_FAIL_COND_V(weights.size() != 4 * vertex_num, ERR_INVALID_DATA);
-				{ // glTF does not seem to normalize the weights for some reason.
-					int wc = weights.size();
-					float *w = weights.ptrw();
-
-					for (int k = 0; k < wc; k += 4) {
-						float total = 0.0;
-						total += w[k + 0];
-						total += w[k + 1];
-						total += w[k + 2];
-						total += w[k + 3];
-						if (total > 0.0) {
-							w[k + 0] /= total;
-							w[k + 1] /= total;
-							w[k + 2] /= total;
-							w[k + 3] /= total;
-						}
-					}
-				}
-				array[Mesh::ARRAY_WEIGHTS] = weights;
-			} else if (a.has("WEIGHTS_0") && a.has("WEIGHTS_1")) {
-				Vector<float> weights_0 = _decode_accessor_as_float32s(p_state, a["WEIGHTS_0"], indices_vec4_mapping);
-				Vector<float> weights_1 = _decode_accessor_as_float32s(p_state, a["WEIGHTS_1"], indices_vec4_mapping);
-				Vector<float> weights;
-				ERR_FAIL_COND_V(weights_0.size() != weights_1.size(), ERR_INVALID_DATA);
-				ERR_FAIL_COND_V(weights_0.size() != 4 * vertex_num, ERR_INVALID_DATA);
-				int32_t weight_8_count = JOINT_GROUP_SIZE * 2;
-				weights.resize(vertex_num * weight_8_count);
-				for (int32_t vertex_i = 0; vertex_i < vertex_num; vertex_i++) {
-					weights.write[vertex_i * weight_8_count + 0] = weights_0[vertex_i * JOINT_GROUP_SIZE + 0];
-					weights.write[vertex_i * weight_8_count + 1] = weights_0[vertex_i * JOINT_GROUP_SIZE + 1];
-					weights.write[vertex_i * weight_8_count + 2] = weights_0[vertex_i * JOINT_GROUP_SIZE + 2];
-					weights.write[vertex_i * weight_8_count + 3] = weights_0[vertex_i * JOINT_GROUP_SIZE + 3];
-					weights.write[vertex_i * weight_8_count + 4] = weights_1[vertex_i * JOINT_GROUP_SIZE + 0];
-					weights.write[vertex_i * weight_8_count + 5] = weights_1[vertex_i * JOINT_GROUP_SIZE + 1];
-					weights.write[vertex_i * weight_8_count + 6] = weights_1[vertex_i * JOINT_GROUP_SIZE + 2];
-					weights.write[vertex_i * weight_8_count + 7] = weights_1[vertex_i * JOINT_GROUP_SIZE + 3];
-				}
-				{ // glTF does not seem to normalize the weights for some reason.
-					int wc = weights.size();
-					float *w = weights.ptrw();
-
-					for (int k = 0; k < wc; k += weight_8_count) {
-						float total = 0.0;
-						total += w[k + 0];
-						total += w[k + 1];
-						total += w[k + 2];
-						total += w[k + 3];
-						total += w[k + 4];
-						total += w[k + 5];
-						total += w[k + 6];
-						total += w[k + 7];
-						if (total > 0.0) {
-							w[k + 0] /= total;
-							w[k + 1] /= total;
-							w[k + 2] /= total;
-							w[k + 3] /= total;
-							w[k + 4] /= total;
-							w[k + 5] /= total;
-							w[k + 6] /= total;
-							w[k + 7] /= total;
-						}
-					}
-				}
-				array[Mesh::ARRAY_WEIGHTS] = weights;
-				flags |= Mesh::ARRAY_FLAG_USE_8_BONE_WEIGHTS;
-			}
-
-			if (!indices.is_empty()) {
-				int *w = indices.ptrw();
-				const int is = indices.size();
-				for (int ind_i = 0; ind_i < is; ind_i++) {
-					w[ind_i] = indices_rev_mapping[indices[ind_i]];
-				}
-				array[Mesh::ARRAY_INDEX] = indices;
-
-			} else if (primitive == Mesh::PRIMITIVE_TRIANGLES) {
-				// Generate indices because they need to be swapped for CW/CCW.
-				const Vector<Vector3> &vertices = array[Mesh::ARRAY_VERTEX];
-				ERR_FAIL_COND_V(vertices.is_empty(), ERR_PARSE_ERROR);
-				const int vertex_count = vertices.size();
-				ERR_FAIL_COND_V_MSG(vertex_count % 3 != 0, ERR_PARSE_ERROR, "glTF import: Mesh " + itos(i) + " surface " + itos(j) + " in file " + p_state->filename + " is invalid. Non-indexed triangle meshes MUST have a vertex array with a size that is a multiple of 3, but got " + itos(vertex_count) + " vertices.");
-				indices.resize(vertex_count);
-				{
-					int *w = indices.ptrw();
-					for (int k = 0; k < vertex_count; k += 3) {
-						w[k] = k;
-						w[k + 1] = k + 2;
-						w[k + 2] = k + 1;
-					}
-				}
-				array[Mesh::ARRAY_INDEX] = indices;
-			}
-
-			bool generate_tangents = p_state->force_generate_tangents && (primitive == Mesh::PRIMITIVE_TRIANGLES && !a.has("TANGENT") && a.has("NORMAL"));
-
-			if (generate_tangents && !a.has("TEXCOORD_0")) {
-				// If we don't have UVs we provide a dummy tangent array.
-				Vector<float> tangents;
-				tangents.resize(vertex_num * 4);
-				float *tangentsw = tangents.ptrw();
-
-				Vector<Vector3> normals = array[Mesh::ARRAY_NORMAL];
-				for (int k = 0; k < vertex_num; k++) {
-					Vector3 tan = Vector3(normals[k].z, -normals[k].x, normals[k].y).cross(normals[k].normalized()).normalized();
-					tangentsw[k * 4 + 0] = tan.x;
-					tangentsw[k * 4 + 1] = tan.y;
-					tangentsw[k * 4 + 2] = tan.z;
-					tangentsw[k * 4 + 3] = 1.0;
-				}
-				array[Mesh::ARRAY_TANGENT] = tangents;
-			}
-
-			// Disable compression if all z equals 0 (the mesh is 2D).
-			const Vector<Vector3> &vertices = array[Mesh::ARRAY_VERTEX];
-			bool is_mesh_2d = true;
-			for (int k = 0; k < vertices.size(); k++) {
-				if (!Math::is_zero_approx(vertices[k].z)) {
-					is_mesh_2d = false;
-					break;
-				}
-			}
-
-			if (p_state->force_disable_compression || is_mesh_2d || !a.has("POSITION") || !a.has("NORMAL") || mesh_prim.has("targets") || (a.has("JOINTS_0") || a.has("JOINTS_1"))) {
-				flags &= ~RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
-			}
-
-			Ref<SurfaceTool> mesh_surface_tool;
-			mesh_surface_tool.instantiate();
-			mesh_surface_tool->create_from_triangle_arrays(array);
-			if (a.has("JOINTS_0") && a.has("JOINTS_1")) {
-				mesh_surface_tool->set_skin_weight_count(SurfaceTool::SKIN_8_WEIGHTS);
-			}
-			mesh_surface_tool->index();
-			if (generate_tangents && a.has("TEXCOORD_0")) {
-				mesh_surface_tool->generate_tangents(/*split*/ !mesh_prim.has("targets"));
-			}
-			array = mesh_surface_tool->commit_to_arrays();
-
-			if ((flags & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES) && a.has("NORMAL") && (a.has("TANGENT") || generate_tangents)) {
-				// Compression is enabled, so let's validate that the normals and tangents are correct.
-				Vector<Vector3> normals = array[Mesh::ARRAY_NORMAL];
-				Vector<float> tangents = array[Mesh::ARRAY_TANGENT];
-				if (unlikely(tangents.size() < normals.size() * 4)) {
-					ERR_PRINT("glTF import: Mesh " + itos(i) + " has invalid tangents.");
-					flags &= ~RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
-				} else {
-					for (int vert = 0; vert < normals.size(); vert++) {
-						Vector3 tan = Vector3(tangents[vert * 4 + 0], tangents[vert * 4 + 1], tangents[vert * 4 + 2]);
-						if (std::abs(tan.dot(normals[vert])) > 0.0001) {
-							// Tangent is not perpendicular to the normal, so we can't use compression.
-							flags &= ~RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
-						}
-					}
-				}
-			}
-
-			Array morphs;
-			// Blend shapes
-			if (mesh_prim.has("targets")) {
-				print_verbose("glTF: Mesh has targets");
-				const Array &targets = mesh_prim["targets"];
-
-				import_mesh->set_blend_shape_mode(Mesh::BLEND_SHAPE_MODE_NORMALIZED);
-
-				if (j == 0) {
-					const Array &target_names = extras.has("targetNames") ? (Array)extras["targetNames"] : Array();
-					for (int k = 0; k < targets.size(); k++) {
-						String bs_name;
-						if (k < target_names.size() && ((String)target_names[k]).size() != 0) {
-							bs_name = (String)target_names[k];
-						} else {
-							bs_name = String("morph_") + itos(k);
-						}
-						import_mesh->add_blend_shape(bs_name);
-					}
-				}
-
-				for (int k = 0; k < targets.size(); k++) {
-					const Dictionary &t = targets[k];
-
-					Array array_copy;
-					array_copy.resize(Mesh::ARRAY_MAX);
-
-					for (int l = 0; l < Mesh::ARRAY_MAX; l++) {
-						array_copy[l] = array[l];
-					}
-
-					if (t.has("POSITION")) {
-						Vector<Vector3> varr = _decode_accessor_as_vec3(p_state, t["POSITION"], indices_mapping);
-						const Vector<Vector3> src_varr = array[Mesh::ARRAY_VERTEX];
-						const int size = src_varr.size();
-						ERR_FAIL_COND_V(size == 0, ERR_PARSE_ERROR);
-						{
-							const int max_idx = varr.size();
-							varr.resize(size);
-
-							Vector3 *w_varr = varr.ptrw();
-							const Vector3 *r_varr = varr.ptr();
-							const Vector3 *r_src_varr = src_varr.ptr();
-							for (int l = 0; l < size; l++) {
-								if (l < max_idx) {
-									w_varr[l] = r_varr[l] + r_src_varr[l];
-								} else {
-									w_varr[l] = r_src_varr[l];
-								}
-							}
-						}
-						array_copy[Mesh::ARRAY_VERTEX] = varr;
-					}
-					if (t.has("NORMAL")) {
-						Vector<Vector3> narr = _decode_accessor_as_vec3(p_state, t["NORMAL"], indices_mapping);
-						const Vector<Vector3> src_narr = array[Mesh::ARRAY_NORMAL];
-						int size = src_narr.size();
-						ERR_FAIL_COND_V(size == 0, ERR_PARSE_ERROR);
-						{
-							int max_idx = narr.size();
-							narr.resize(size);
-
-							Vector3 *w_narr = narr.ptrw();
-							const Vector3 *r_narr = narr.ptr();
-							const Vector3 *r_src_narr = src_narr.ptr();
-							for (int l = 0; l < size; l++) {
-								if (l < max_idx) {
-									w_narr[l] = r_narr[l] + r_src_narr[l];
-								} else {
-									w_narr[l] = r_src_narr[l];
-								}
-							}
-						}
-						array_copy[Mesh::ARRAY_NORMAL] = narr;
-					}
-					if (t.has("TANGENT")) {
-						const Vector<Vector3> tangents_v3 = _decode_accessor_as_vec3(p_state, t["TANGENT"], indices_mapping);
-						const Vector<float> src_tangents = array[Mesh::ARRAY_TANGENT];
-						ERR_FAIL_COND_V(src_tangents.is_empty(), ERR_PARSE_ERROR);
-
-						Vector<float> tangents_v4;
-
-						{
-							int max_idx = tangents_v3.size();
-
-							int size4 = src_tangents.size();
-							tangents_v4.resize(size4);
-							float *w4 = tangents_v4.ptrw();
-
-							const Vector3 *r3 = tangents_v3.ptr();
-							const float *r4 = src_tangents.ptr();
-
-							for (int l = 0; l < size4 / 4; l++) {
-								if (l < max_idx) {
-									w4[l * 4 + 0] = r3[l].x + r4[l * 4 + 0];
-									w4[l * 4 + 1] = r3[l].y + r4[l * 4 + 1];
-									w4[l * 4 + 2] = r3[l].z + r4[l * 4 + 2];
-								} else {
-									w4[l * 4 + 0] = r4[l * 4 + 0];
-									w4[l * 4 + 1] = r4[l * 4 + 1];
-									w4[l * 4 + 2] = r4[l * 4 + 2];
-								}
-								w4[l * 4 + 3] = r4[l * 4 + 3]; //copy flip value
-							}
-						}
-
-						array_copy[Mesh::ARRAY_TANGENT] = tangents_v4;
-					}
-
-					Ref<SurfaceTool> blend_surface_tool;
-					blend_surface_tool.instantiate();
-					blend_surface_tool->create_from_triangle_arrays(array_copy);
-					if (a.has("JOINTS_0") && a.has("JOINTS_1")) {
-						blend_surface_tool->set_skin_weight_count(SurfaceTool::SKIN_8_WEIGHTS);
-					}
-					blend_surface_tool->index();
-					if (generate_tangents) {
-						blend_surface_tool->generate_tangents(/*split*/ false);
-					}
-					array_copy = blend_surface_tool->commit_to_arrays();
-
-					// Enforce blend shape mask array format
-					for (int l = 0; l < Mesh::ARRAY_MAX; l++) {
-						if (!(Mesh::ARRAY_FORMAT_BLEND_SHAPE_MASK & (1ULL << l))) {
-							array_copy[l] = Variant();
-						}
-					}
-
-					morphs.push_back(array_copy);
-				}
-			}
-			import_mesh->add_surface(primitive, array, morphs,
-					Dictionary(), mat, mat_name, flags);
+	if (mesh_count > 1 && WorkerThreadPool::get_singleton()->get_caller_task_id() == WorkerThreadPool::INVALID_TASK_ID) {
+		// Not on a worker thread: parse meshes in parallel. A worker thread blocking on
+		// wait_for_group_task_completion() can starve the pool, so import threads parse inline.
+		WorkerThreadPool::GroupID group = WorkerThreadPool::get_singleton()->add_template_group_task(this, &GLTFDocument::_process_single_mesh, &data, mesh_count, -1, false, SNAME("GLTFMeshParsing"));
+		WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group);
+	} else {
+		for (uint32_t i = 0; i < (uint32_t)mesh_count; i++) {
+			_process_single_mesh(i, &data);
 		}
+	}
 
-		Vector<float> blend_weights;
-		blend_weights.resize(import_mesh->get_blend_shape_count());
-		for (int32_t weight_i = 0; weight_i < blend_weights.size(); weight_i++) {
-			blend_weights.write[weight_i] = 0.0f;
+	for (int i = 0; i < mesh_count; i++) {
+		if (errors[i] != OK) {
+			return errors[i];
 		}
-
-		if (mesh_dict.has("weights")) {
-			const Array &weights = mesh_dict["weights"];
-			for (int j = 0; j < weights.size(); j++) {
-				if (j >= blend_weights.size()) {
-					break;
-				}
-				blend_weights.write[j] = weights[j];
-			}
-		}
-		mesh->set_blend_weights(blend_weights);
-		mesh->set_instance_materials(instance_materials);
-		mesh->set_mesh(import_mesh);
-
-		p_state->meshes.push_back(mesh);
 	}
 
 	print_verbose("glTF: Total meshes: " + itos(p_state->meshes.size()));
@@ -2291,13 +2360,20 @@ void GLTFDocument::_parse_image_save_image(Ref<GLTFState> p_state, const Vector<
 				custom_options[SNAME("mipmaps/generate")] = true;
 				// Will only use project settings defaults if custom_importer is empty.
 
-				EditorFileSystem::get_singleton()->update_file(file_path);
+				if (Thread::is_main_thread()) {
+					EditorFileSystem::get_singleton()->update_file(file_path);
+				} else {
+					// The file system tree is main-thread only; register the new file once the import batch finishes.
+					callable_mp(EditorFileSystem::get_singleton(), &EditorFileSystem::update_file).call_deferred(file_path);
+				}
 				EditorFileSystem::get_singleton()->reimport_append(file_path, custom_options, String(), generator_parameters);
 			}
 			Ref<Texture2D> saved_image = ResourceLoader::load(file_path, "Texture2D");
 			if (saved_image.is_valid()) {
 				p_state->images.push_back(saved_image);
-				p_state->source_images.push_back(saved_image->get_image());
+				// CompressedTexture2D::get_image() reads back from the rendering server, which is
+				// only safe on the main thread; on import threads keep the decoded source image.
+				p_state->source_images.push_back(Thread::is_main_thread() ? saved_image->get_image() : p_image);
 				return;
 			} else {
 				WARN_PRINT(vformat("glTF: Image index '%d' with the name '%s' resolved to %s couldn't be imported. It will be loaded directly instead, uncompressed.", p_index, p_image->get_name(), file_path));
@@ -7172,17 +7248,17 @@ Error GLTFDocument::_parse_gltf_state(Ref<GLTFState> p_state, const String &p_se
 		ERR_FAIL_COND_V(err != OK, ERR_PARSE_ERROR);
 
 		/* PARSE TEXTURE SAMPLERS */
-		err = _parse_texture_samplers(p_state);
+	err = _parse_texture_samplers(p_state);
 
 		ERR_FAIL_COND_V(err != OK, ERR_PARSE_ERROR);
 
 		/* PARSE TEXTURES */
-		err = _parse_textures(p_state);
+	err = _parse_textures(p_state);
 
 		ERR_FAIL_COND_V(err != OK, ERR_PARSE_ERROR);
 
 		/* PARSE TEXTURES */
-		err = _parse_materials(p_state);
+	err = _parse_materials(p_state);
 
 		ERR_FAIL_COND_V(err != OK, ERR_PARSE_ERROR);
 	}

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -35,6 +35,7 @@
 #include "gltf_defines.h"
 #include "gltf_state.h"
 
+#include "core/os/mutex.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/multimesh_instance_3d.h"
 
@@ -157,6 +158,8 @@ private:
 	Vector<Quaternion> _decode_accessor_as_quaternion(const Ref<GLTFState> p_gltf_state, GLTFAccessorIndex p_accessor_index);
 	Array _decode_accessor_as_variants(const Ref<GLTFState> p_gltf_state, GLTFAccessorIndex p_accessor_index, Variant::Type p_variant_type);
 	Error _parse_meshes(Ref<GLTFState> p_state);
+	Error _parse_single_mesh(const Ref<GLTFState> &p_state, const Array &p_meshes, GLTFMeshIndex i, const String &p_unique_name, Mutex *p_material_mutex);
+	void _process_single_mesh(uint32_t p_index, void *p_data);
 	Error _serialize_textures(Ref<GLTFState> p_state);
 	Error _serialize_texture_samplers(Ref<GLTFState> p_state);
 	Error _serialize_images(Ref<GLTFState> p_state);

--- a/servers/rendering/dummy/storage/light_storage.h
+++ b/servers/rendering/dummy/storage/light_storage.h
@@ -50,7 +50,7 @@ private:
 		RID lightmap;
 	};
 
-	mutable RID_Owner<LightmapInstance> lightmap_instance_owner;
+	mutable RID_Owner<LightmapInstance, true> lightmap_instance_owner;
 
 public:
 	static LightStorage *get_singleton();

--- a/servers/rendering/dummy/storage/material_storage.h
+++ b/servers/rendering/dummy/storage/material_storage.h
@@ -50,7 +50,7 @@ private:
 		HashMap<StringName, ShaderLanguage::ShaderNode::Uniform> uniforms;
 	};
 
-	mutable RID_Owner<DummyShader> shader_owner;
+	mutable RID_Owner<DummyShader, true> shader_owner;
 
 	ShaderCompiler dummy_compiler;
 	HashSet<RID> dummy_embedded_set;
@@ -60,7 +60,7 @@ private:
 		RID next_pass;
 	};
 
-	mutable RID_Owner<DummyMaterial> material_owner;
+	mutable RID_Owner<DummyMaterial, true> material_owner;
 
 public:
 	static MaterialStorage *get_singleton() { return singleton; }

--- a/servers/rendering/dummy/storage/mesh_storage.h
+++ b/servers/rendering/dummy/storage/mesh_storage.h
@@ -47,13 +47,13 @@ class MeshStorage : public RendererMeshStorage {
 private:
 	static MeshStorage *singleton;
 
-	mutable RID_Owner<DummyMesh> mesh_owner;
+	mutable RID_Owner<DummyMesh, true> mesh_owner;
 
 	struct DummyMultiMesh {
 		PackedFloat32Array buffer;
 	};
 
-	mutable RID_Owner<DummyMultiMesh> multimesh_owner;
+	mutable RID_Owner<DummyMultiMesh, true> multimesh_owner;
 
 public:
 	static MeshStorage *get_singleton() { return singleton; }

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -42,7 +42,7 @@ private:
 	struct DummyTexture {
 		Ref<Image> image;
 	};
-	mutable RID_PtrOwner<DummyTexture> texture_owner;
+	mutable RID_PtrOwner<DummyTexture, true> texture_owner;
 
 public:
 	static TextureStorage *get_singleton() { return singleton; }

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -45,7 +45,7 @@
 
 // careful, these may run in different threads than the rendering server
 
-int RenderingServerDefault::changes = 0;
+std::atomic<int> RenderingServerDefault::changes = 0;
 
 /* FREE */
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -38,6 +38,8 @@
 #include "servers/rendering/renderer_compositor.h"
 #include "servers/rendering/renderer_viewport.h"
 #include "servers/rendering/rendering_method.h"
+
+#include <atomic>
 #include "servers/rendering/rendering_server.h"
 #include "servers/rendering/rendering_server_enums.h"
 #include "servers/rendering/rendering_server_globals.h"
@@ -59,7 +61,7 @@ class RenderingServerDefault : public RenderingServer {
 
 	};
 
-	static int changes;
+	static std::atomic<int> changes;
 	RID test_cube;
 
 	List<Callable> frame_drawn_callbacks;

--- a/tests/scene/test_gltf_document.cpp
+++ b/tests/scene/test_gltf_document.cpp
@@ -214,6 +214,20 @@ TEST_CASE("[SceneTree][GLTFDocument] Load cube.gltf") {
 	CHECK(node->get_child(0)->is_class("MeshInstance3D"));
 	CHECK(node->get_child(0)->get_name() == "Cube");
 
+	// Verify mesh surface data is correctly parsed by the parallel mesh parser.
+	MeshInstance3D *mi = Object::cast_to<MeshInstance3D>(node->get_child(0));
+	REQUIRE(mi != nullptr);
+	Ref<ArrayMesh> arr_mesh = mi->get_mesh();
+	REQUIRE(arr_mesh.is_valid());
+	CHECK(arr_mesh->get_surface_count() == 2);
+	// Validate vertex count for both surfaces.
+	for (int surface = 0; surface < arr_mesh->get_surface_count(); surface++) {
+		Array surface_arrays = arr_mesh->surface_get_arrays(surface);
+		CHECK(surface_arrays[Mesh::ARRAY_VERTEX].get_type() == Variant::PACKED_VECTOR3_ARRAY);
+		PackedVector3Array vertices = surface_arrays[Mesh::ARRAY_VERTEX];
+		CHECK(vertices.size() > 0);
+	}
+
 	CHECK(node->get_child(1)->is_class("AnimationPlayer"));
 	CHECK(node->get_child(1)->get_name() == "AnimationPlayer");
 
@@ -242,6 +256,16 @@ TEST_CASE("[SceneTree][GLTFDocument] Load suzanne.glb") {
 	CHECK(node->get_child(0)->is_class("MeshInstance3D"));
 	CHECK(node->get_child(0)->get_name() == "Suzanne");
 
+	// Verify mesh surface data is correctly parsed by the parallel mesh parser.
+	MeshInstance3D *mi2 = Object::cast_to<MeshInstance3D>(node->get_child(0));
+	REQUIRE(mi2 != nullptr);
+	Ref<ArrayMesh> arr_mesh2 = mi2->get_mesh();
+	REQUIRE(arr_mesh2.is_valid());
+	CHECK(arr_mesh2->get_surface_count() == 1);
+	Array surface_arrays2 = arr_mesh2->surface_get_arrays(0);
+	PackedVector3Array vertices2 = surface_arrays2[Mesh::ARRAY_VERTEX];
+	CHECK(vertices2.size() > 0);
+
 	CHECK(node->get_child(1)->is_class("Camera3D"));
 	CHECK(node->get_child(1)->get_name() == "Camera");
 
@@ -249,6 +273,20 @@ TEST_CASE("[SceneTree][GLTFDocument] Load suzanne.glb") {
 
 	// Clean up the node.
 	memdelete(node);
+}
+
+TEST_CASE("[GLTFDocument] Invalid mesh data reports an error") {
+	Ref<GLTFDocument> gltf_document;
+	gltf_document.instantiate();
+	Ref<GLTFState> gltf_state;
+	gltf_state.instantiate();
+
+	// A mesh without the required "primitives" property must fail parsing instead of
+	// silently producing a null mesh (regression test for parallel mesh parsing).
+	String json = R"({"asset":{"version":"2.0"},"meshes":[{"name":"BadMesh"}]})";
+	PackedByteArray bytes = json.to_utf8_buffer();
+	Error err = gltf_document->append_from_buffer(bytes, "", gltf_state);
+	CHECK(err == ERR_PARSE_ERROR);
 }
 
 } // namespace TestGLTFDocument

--- a/tests/scene/test_resource_importer_scene.cpp
+++ b/tests/scene/test_resource_importer_scene.cpp
@@ -1,0 +1,54 @@
+/**************************************************************************/
+/*  test_resource_importer_scene.cpp                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_resource_importer_scene)
+
+#if defined(TOOLS_ENABLED) && !defined(_3D_DISABLED)
+
+#include "core/io/resource_importer.h"
+#include "editor/import/3d/resource_importer_scene.h"
+
+namespace TestResourceImporterScene {
+
+TEST_CASE("[Editor][ResourceImporterScene] Threaded import support") {
+	ResourceImporterScene importer;
+
+	// Verify that the scene importer now supports threaded imports (Phase 1).
+	CHECK(importer.can_import_threaded());
+
+	// Verify import order is set to SCENE (processed after textures and other fast assets).
+	CHECK(importer.get_import_order() == ResourceImporter::IMPORT_ORDER_SCENE);
+}
+
+} // namespace TestResourceImporterScene
+
+#endif // TOOLS_ENABLED && !_3D_DISABLED

--- a/tests/scene/test_resource_importer_scene.cpp
+++ b/tests/scene/test_resource_importer_scene.cpp
@@ -47,6 +47,19 @@ TEST_CASE("[Editor][ResourceImporterScene] Threaded import support") {
 
 	// Verify import order is set to SCENE (processed after textures and other fast assets).
 	CHECK(importer.get_import_order() == ResourceImporter::IMPORT_ORDER_SCENE);
+
+	// Files without a post-import script can be imported threaded.
+	CHECK(importer.can_import_file_threaded("res://some_file_without_import.glb"));
+
+	// Registering a post-import plugin disables threaded scene imports,
+	// as plugin code is not expected to be thread-safe.
+	Ref<EditorScenePostImportPlugin> plugin;
+	plugin.instantiate();
+	ResourceImporterScene::add_post_importer_plugin(plugin);
+	CHECK(!importer.can_import_threaded());
+	CHECK(!importer.can_import_file_threaded("res://some_file_without_import.glb"));
+	ResourceImporterScene::remove_post_importer_plugin(plugin);
+	CHECK(importer.can_import_threaded());
 }
 
 } // namespace TestResourceImporterScene


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Related to #95979

Importing projects with many or large 3D assets is slow because the scene import pipeline is fully serial: scene/3D imports never use multi-threading (the base `ResourceImporter::can_import_threaded()` returns `false` and `ResourceImporterScene` didn't override it), and even within a single scene import all mesh processing and glTF mesh parsing runs on one thread. On projects with many GLB/glTF files this dominates total import time.

This PR:

- **Threaded scene imports**: `ResourceImporterScene` now overrides `can_import_threaded()`, so multiple scene files import in parallel across worker threads.
- **Parallel mesh processing**: within a single scene import, unique meshes are processed in parallel (LOD generation, shadow meshes, lightmap UV unwrap, index optimization) while node tree mutation stays serial.
- **Parallel glTF mesh parsing**: `GLTFDocument::_parse_meshes()` distributes mesh parsing over the WorkerThreadPool.
- **Fewer redundant reimports**: dependencies of reimported files are only reimported when they actually changed, and the main thread no longer busy-waits on a semaphore during batch imports.

## Additional information

### Thread-safety work

- Post-import scripts and plugins are serialized with a mutex; helper entry points keep the locking in one place.
- Scene previews are deferred to `import_threaded_end()` on the main thread; IO errors are marshalled via `MessageQueue`; `EditorProgress` task names are unique per file.
- The main thread pumps `RenderingServer::sync()` while waiting for import workers, servicing synchronous RS calls (e.g. scene packing querying instance properties) that would otherwise deadlock.
- glTF extracted textures are reimported without touching the file system tree or emitting node signals from import threads; the decoded source image is kept instead of a rendering-server read-back.
- Dummy renderer RID owners are now `THREAD_SAFE` — concurrent RID allocation from import workers in headless mode raced and could hand out the same RID twice.
- When already on a worker thread, mesh parsing/processing runs inline to avoid nested WorkerThreadPool group waits starving the pool (group tasks carry no task ID, so pool-thread detection must use `get_thread_index()`).
- `RenderingServerDefault::redraw_request()`'s change counter is now atomic, and scene format importer option queries are serialized (shared scratch state) — both found with ThreadSanitizer.

### Conservative behavior around user code

Post-import scripts and plugins run user code during import, written with the assumption of executing on the main thread. Rather than changing their execution context, the importer falls back to the old serial behavior in those cases:

- When any `EditorScenePostImportPlugin` is registered, scene imports stay serial globally.
- Files with a post-import script configured (`import_script/path`) are imported serially, via a new per-file `ResourceImporter::can_import_file_threaded()` hook — everything else still imports in parallel.

### Testing

- New unit tests: threaded-import support flags, serial fallback with plugins registered, glTF mesh surface validation, and a regression test that invalid mesh data fails parsing instead of silently producing null meshes.
- Full doctest suite passes.
- Headless batch imports of mixed glTF/GLB projects complete without errors, and output scenes are semantically identical to serial imports (same node trees, surface/vertex/index counts, AABBs).
- Verified on a real-world project (~570 MB, 1200+ GLB models with many meshes and embedded textures each): full import completes without errors or hangs.
- **ThreadSanitizer run**: no data races remain in the import path. The only remaining reports are a pre-existing lock-order inversion in TextServer text shaping at editor startup, unrelated to these changes.

### Areas for reviewer attention

- The restructured `_generate_meshes()` (collect/process/replace passes) and parallel `_parse_meshes()`.
- The `RenderingServer::sync()` pump in the reimport loop — alternatives considered were avoiding all synchronous RS calls on import threads, but scene packing queries instance properties.
- Post-import hooks still execute on import threads when no plugins are registered and no script is set; fully deferring them to the main thread would require restructuring the import flow and is left for follow-up work.

### AI disclosure

This PR was implemented with significant assistance from an AI coding agent (Kimi Code): implementation, debugging (including ThreadSanitizer and deadlock analysis via stack traces), and test authoring. All changes were built and verified locally (unit tests, headless import runs, threaded-vs-serial output comparison, ThreadSanitizer), and reviewed by a human before submission.
