### PR TITLE
Fix solid angle texel calculation in importance sampling

### DIFF
--- a/drivers/gles3/effects/cubemap_filter.cpp
+++ b/drivers/gles3/effects/cubemap_filter.cpp
@@ -157,7 +157,7 @@ void CubemapFilter::filter_radiance(GLuint p_source_cubemap, GLuint p_dest_cubem
 		float roughness4 = roughness * roughness;
 		roughness4 *= roughness4;
 
-		float solid_angle_texel = 4.0 * Math::PI / float(6 * size * size);
+		float solid_angle_texel = 4.0 * Math::PI / float(6 * p_source_size * p_source_size);
 
 		LocalVector<float> sample_directions;
 		sample_directions.resize(4 * sample_count);

--- a/servers/rendering/renderer_rd/shaders/effects/octmap_roughness.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/octmap_roughness.glsl
@@ -27,7 +27,7 @@ void main() {
 			imageStore(dest_octmap, ivec2(id), vec4(texture(source_oct, uv).rgb, 1.0));
 		}
 	} else {
-		float solid_angle_texel = 4.0 * M_PI / float(params.dest_size * params.dest_size);
+		float solid_angle_texel = 4.0 * M_PI / float(params.source_size * params.source_size);
 		float roughness2 = params.roughness * params.roughness;
 		float roughness4 = roughness2 * roughness2;
 

--- a/servers/rendering/renderer_rd/shaders/effects/octmap_roughness_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/octmap_roughness_raster.glsl
@@ -52,7 +52,7 @@ void main() {
 	} else {
 		vec3 N = oct_to_vec3_with_border(uv_interp, params.border_size.y);
 		vec4 sum = vec4(0.0, 0.0, 0.0, 0.0);
-		float solid_angle_texel = 4.0 * M_PI / (params.dest_size * params.dest_size);
+		float solid_angle_texel = 4.0 * M_PI / (params.source_size * params.source_size);
 		float roughness2 = params.roughness * params.roughness;
 		float roughness4 = roughness2 * roughness2;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

This issue has been lingering since previous versions, where solid_angle_texel multiplies by the resolution of the mipmap instead of the source image resolution. NVIDIA's article [GPU Gems 3](https://developer.nvidia.com/gpugems/gpugems3/part-iii-rendering/chapter-20-gpu-based-importance-sampling) explains this in Equation 12 "Here is how we proceed. First, we need to compute the number of environment map pixels in s . This number is given by the ratio of s to the solid angle subtended by one pixel of the zeroth mipmap level p , which in turn, is given by the texture resolution, w · h, and the mapping distortion factor d(u):"

## Additional information

Here are some comparisons showing a massive reduction in undersampling artifacts.

**No Array reflections with a radiance size of 2048**
|Before|After|
|--------|--------|
|<img width="1152" height="648" alt="before" src="https://github.com/user-attachments/assets/7fc7975b-6af2-45b0-b97c-3cbdec3d0769" />|<img width="1152" height="648" alt="after" src="https://github.com/user-attachments/assets/352b4a9b-d83a-4dd7-9db8-442592ec1f3b" />|

**Reflections from the reflection probe with a default size**
|Before|After|
|--------|--------|
|<img width="1152" height="648" alt="before" src="https://github.com/user-attachments/assets/3179f62a-e7db-4612-aadf-5398f4288d3d" />|<img width="1152" height="648" alt="after" src="https://github.com/user-attachments/assets/6002bb22-fa23-402c-adb4-289450d2dd12" />|