### PR TITLE
Core: Reduce assignments in Variant Object constructor

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -2534,8 +2534,12 @@ Variant::Variant(const ::RID &p_rid) :
 
 Variant::Variant(const Object *p_object) :
 		type(OBJECT) {
-	_get_obj() = ObjData();
-	_get_obj().ref_pointer(const_cast<Object *>(p_object));
+	// Mirrors ObjData::ref_pointer(Object *) but without the cleanup
+	if (p_object && (!p_object->is_ref_counted() || static_cast<RefCounted *>(const_cast<Object *>(p_object))->init_ref())) {
+		memnew_placement(_data._mem, ObjData({ p_object->get_instance_id(), const_cast<Object *>(p_object) }));
+	} else {
+		memnew_placement(_data._mem, ObjData());
+	}
 }
 
 Variant::Variant(const Callable &p_callable) :


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Removes redundant assignments in the `Variant` `Object*` constructor.

## Additional information

- In the constructor `Variant(Object *)`, `ObjData` is empty-initialized because `ref_pointer` unrefs the old value. This is not needed in a constructor so the new implementation extracts the main body from `ref_pointer`.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
