### PR TITLE
Move NavigationServer debug to dedicated files

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -604,25 +604,8 @@ void EditorNode::_update_from_settings() {
 	_update_translations();
 
 #ifdef DEBUG_ENABLED
-	NavigationServer2D::get_singleton()->set_debug_navigation_edge_connection_color(GLOBAL_GET("debug/shapes/navigation/2d/edge_connection_color"));
-	NavigationServer2D::get_singleton()->set_debug_navigation_geometry_edge_color(GLOBAL_GET("debug/shapes/navigation/2d/geometry_edge_color"));
-	NavigationServer2D::get_singleton()->set_debug_navigation_geometry_face_color(GLOBAL_GET("debug/shapes/navigation/2d/geometry_face_color"));
-	NavigationServer2D::get_singleton()->set_debug_navigation_geometry_edge_disabled_color(GLOBAL_GET("debug/shapes/navigation/2d/geometry_edge_disabled_color"));
-	NavigationServer2D::get_singleton()->set_debug_navigation_geometry_face_disabled_color(GLOBAL_GET("debug/shapes/navigation/2d/geometry_face_disabled_color"));
-	NavigationServer2D::get_singleton()->set_debug_navigation_enable_edge_connections(GLOBAL_GET("debug/shapes/navigation/2d/enable_edge_connections"));
-	NavigationServer2D::get_singleton()->set_debug_navigation_enable_edge_lines(GLOBAL_GET("debug/shapes/navigation/2d/enable_edge_lines"));
-	NavigationServer2D::get_singleton()->set_debug_navigation_enable_geometry_face_random_color(GLOBAL_GET("debug/shapes/navigation/2d/enable_geometry_face_random_color"));
-
-	NavigationServer3D::get_singleton()->set_debug_navigation_edge_connection_color(GLOBAL_GET("debug/shapes/navigation/3d/edge_connection_color"));
-	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_edge_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_edge_color"));
-	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_face_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_face_color"));
-	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_edge_disabled_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_edge_disabled_color"));
-	NavigationServer3D::get_singleton()->set_debug_navigation_geometry_face_disabled_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_face_disabled_color"));
-	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_connections(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_connections"));
-	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_connections_xray(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_connections_xray"));
-	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_lines(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_lines"));
-	NavigationServer3D::get_singleton()->set_debug_navigation_enable_edge_lines_xray(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_lines_xray"));
-	NavigationServer3D::get_singleton()->set_debug_navigation_enable_geometry_face_random_color(GLOBAL_GET("debug/shapes/navigation/3d/enable_geometry_face_random_color"));
+	NavigationServer2D::get_singleton()->update_from_settings();
+	NavigationServer3D::get_singleton()->update_from_settings();
 #endif // DEBUG_ENABLED
 }
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -90,6 +90,9 @@
 #ifndef NAVIGATION_2D_DISABLED
 #include "servers/navigation_2d/navigation_server_2d.h"
 #include "servers/navigation_2d/navigation_server_2d_manager.h"
+#ifdef DEBUG_ENABLED
+#include "servers/navigation_2d/navigation_server_2d_debug.h"
+#endif // DEBUG_ENABLED
 #endif // NAVIGATION_2D_DISABLED
 
 #ifndef PHYSICS_2D_DISABLED
@@ -101,6 +104,9 @@
 #ifndef NAVIGATION_3D_DISABLED
 #include "servers/navigation_3d/navigation_server_3d.h"
 #include "servers/navigation_3d/navigation_server_3d_manager.h"
+#ifdef DEBUG_ENABLED
+#include "servers/navigation_3d/navigation_server_3d_debug.h"
+#endif // DEBUG_ENABLED
 #endif // NAVIGATION_3D_DISABLED
 
 #ifndef PHYSICS_3D_DISABLED
@@ -4344,28 +4350,28 @@ int Main::start() {
 		if (debug_navigation) {
 			sml->set_debug_navigation_hint(true);
 #ifndef NAVIGATION_2D_DISABLED
-			NavigationServer2D::get_singleton()->set_debug_navigation_enabled(true);
+			NavigationServer2DDebug::get_singleton()->set_debug_navigation_enabled(true);
 #endif // NAVIGATION_2D_DISABLED
 #ifndef NAVIGATION_3D_DISABLED
-			NavigationServer3D::get_singleton()->set_debug_navigation_enabled(true);
+			NavigationServer3DDebug::get_singleton()->set_debug_navigation_enabled(true);
 #endif // NAVIGATION_3D_DISABLED
 		}
 		if (debug_avoidance) {
 #ifndef NAVIGATION_2D_DISABLED
-			NavigationServer2D::get_singleton()->set_debug_avoidance_enabled(true);
+			NavigationServer2DDebug::get_singleton()->set_debug_avoidance_enabled(true);
 #endif // NAVIGATION_2D_DISABLED
 #ifndef NAVIGATION_3D_DISABLED
-			NavigationServer3D::get_singleton()->set_debug_avoidance_enabled(true);
+			NavigationServer3DDebug::get_singleton()->set_debug_avoidance_enabled(true);
 #endif // NAVIGATION_3D_DISABLED
 		}
 		if (debug_navigation || debug_avoidance) {
 #ifndef NAVIGATION_2D_DISABLED
 			NavigationServer2D::get_singleton()->set_active(true);
-			NavigationServer2D::get_singleton()->set_debug_enabled(true);
+			NavigationServer2DDebug::get_singleton()->set_debug_enabled(true);
 #endif // NAVIGATION_2D_DISABLED
 #ifndef NAVIGATION_3D_DISABLED
 			NavigationServer3D::get_singleton()->set_active(true);
-			NavigationServer3D::get_singleton()->set_debug_enabled(true);
+			NavigationServer3DDebug::get_singleton()->set_debug_enabled(true);
 #endif // NAVIGATION_3D_DISABLED
 		}
 		if (debug_canvas_item_redraw) {

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -57,6 +57,9 @@
 #ifndef NAVIGATION_3D_DISABLED
 #include "scene/resources/3d/navigation_mesh_source_geometry_data_3d.h"
 #include "servers/navigation_3d/navigation_server_3d.h"
+#ifdef DEBUG_ENABLED
+#include "servers/navigation_3d/navigation_server_3d_debug.h"
+#endif // DEBUG_ENABLED
 
 Callable GridMap::_navmesh_source_geometry_parsing_callback;
 RID GridMap::_navmesh_source_geometry_parser;
@@ -1223,7 +1226,7 @@ void GridMap::_notification(int p_what) {
 			_debug_update();
 
 #ifndef NAVIGATION_3D_DISABLED
-			if (bake_navigation && NavigationServer3D::get_singleton()->get_debug_navigation_enabled()) {
+			if (bake_navigation && NavigationServer3DDebug::get_singleton()->get_debug_navigation_enabled()) {
 				_update_navigation_debug_edge_connections();
 			}
 #endif // NAVIGATION_3D_DISABLED
@@ -2124,7 +2127,7 @@ void GridMap::_update_octant_navigation_debug_edge_connections_mesh(const Octant
 	ERR_FAIL_COND(!octant_map.has(p_key));
 	Octant &g = *octant_map[p_key];
 
-	if (!NavigationServer3D::get_singleton()->get_debug_navigation_enabled()) {
+	if (!NavigationServer3DDebug::get_singleton()->get_debug_navigation_enabled()) {
 		if (g.navigation_debug_edge_connections_instance.is_valid()) {
 			RS::get_singleton()->instance_set_visible(g.navigation_debug_edge_connections_instance, false);
 		}
@@ -2197,7 +2200,7 @@ void GridMap::_update_octant_navigation_debug_edge_connections_mesh(const Octant
 		return;
 	}
 
-	Ref<StandardMaterial3D> edge_connections_material = NavigationServer3D::get_singleton()->get_debug_navigation_edge_connections_material();
+	Ref<StandardMaterial3D> edge_connections_material = NavigationServer3DDebug::get_singleton()->get_debug_navigation_edge_connections_material();
 
 	Array mesh_array;
 	mesh_array.resize(Mesh::ARRAY_MAX);
@@ -2212,7 +2215,7 @@ void GridMap::_update_octant_navigation_debug_edge_connections_mesh(const Octant
 		RS::get_singleton()->instance_set_scenario(g.navigation_debug_edge_connections_instance, get_world_3d()->get_scenario());
 	}
 
-	bool enable_edge_connections = NavigationServer3D::get_singleton()->get_debug_navigation_enable_edge_connections();
+	bool enable_edge_connections = NavigationServer3DDebug::get_singleton()->get_debug_navigation_enable_edge_connections();
 	if (!enable_edge_connections) {
 		RS::get_singleton()->instance_set_visible(g.navigation_debug_edge_connections_instance, false);
 	}

--- a/modules/navigation_3d/editor/navigation_link_3d_gizmo_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_link_3d_gizmo_plugin.cpp
@@ -34,10 +34,11 @@
 #include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "scene/3d/navigation/navigation_link_3d.h"
 #include "servers/navigation_3d/navigation_server_3d.h"
+#include "servers/navigation_3d/navigation_server_3d_debug.h"
 
 NavigationLink3DGizmoPlugin::NavigationLink3DGizmoPlugin() {
-	create_material("navigation_link_material", NavigationServer3D::get_singleton()->get_debug_navigation_link_connection_color());
-	create_material("navigation_link_material_disabled", NavigationServer3D::get_singleton()->get_debug_navigation_link_connection_disabled_color());
+	create_material("navigation_link_material", NavigationServer3DDebug::get_singleton()->get_debug_navigation_link_connection_color());
+	create_material("navigation_link_material_disabled", NavigationServer3DDebug::get_singleton()->get_debug_navigation_link_connection_disabled_color());
 	create_handle_material("handles");
 }
 

--- a/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
@@ -43,6 +43,7 @@
 #include "scene/gui/dialogs.h"
 #include "scene/main/scene_tree.h"
 #include "servers/navigation_3d/navigation_server_3d.h"
+#include "servers/navigation_3d/navigation_server_3d_debug.h"
 #include "servers/rendering/rendering_server.h"
 
 bool NavigationObstacle3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
@@ -106,12 +107,12 @@ void NavigationObstacle3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		lines_mesh_vertices_ptrw[vertex_index++] = safe_global_basis.xform(Vector3(point.x, height, point.z));
 	}
 
-	NavigationServer3D *ns3d = NavigationServer3D::get_singleton();
+	NavigationServer3DDebug *ns3dd = NavigationServer3DDebug::get_singleton();
 
 	if (obstacle->are_vertices_valid()) {
-		p_gizmo->add_lines(lines_mesh_vertices, ns3d->get_debug_navigation_avoidance_static_obstacle_pushout_edge_material());
+		p_gizmo->add_lines(lines_mesh_vertices, ns3dd->get_debug_navigation_avoidance_static_obstacle_pushout_edge_material());
 	} else {
-		p_gizmo->add_lines(lines_mesh_vertices, ns3d->get_debug_navigation_avoidance_static_obstacle_pushin_edge_material());
+		p_gizmo->add_lines(lines_mesh_vertices, ns3dd->get_debug_navigation_avoidance_static_obstacle_pushin_edge_material());
 	}
 	p_gizmo->add_collision_segments(lines_mesh_vertices);
 

--- a/modules/navigation_3d/editor/navigation_region_3d_gizmo_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_region_3d_gizmo_plugin.cpp
@@ -33,12 +33,13 @@
 #include "core/math/random_pcg.h"
 #include "scene/3d/navigation/navigation_region_3d.h"
 #include "servers/navigation_3d/navigation_server_3d.h"
+#include "servers/navigation_3d/navigation_server_3d_debug.h"
 
 NavigationRegion3DGizmoPlugin::NavigationRegion3DGizmoPlugin() {
-	create_material("face_material", NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_color(), false, false, true);
-	create_material("face_material_disabled", NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_disabled_color(), false, false, true);
-	create_material("edge_material", NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_color());
-	create_material("edge_material_disabled", NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_disabled_color());
+	create_material("face_material", NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_face_color(), false, false, true);
+	create_material("face_material_disabled", NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_face_disabled_color(), false, false, true);
+	create_material("edge_material", NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_edge_color());
+	create_material("edge_material_disabled", NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_edge_disabled_color());
 
 	Color baking_aabb_material_color = Color(0.8, 0.5, 0.7);
 	baking_aabb_material_color.a = 0.1;
@@ -161,9 +162,9 @@ void NavigationRegion3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 	// if enabled add vertex colors to colorize each face individually
 	RandomPCG rand;
-	bool enabled_geometry_face_random_color = NavigationServer3D::get_singleton()->get_debug_navigation_enable_geometry_face_random_color();
+	bool enabled_geometry_face_random_color = NavigationServer3DDebug::get_singleton()->get_debug_navigation_enable_geometry_face_random_color();
 	if (enabled_geometry_face_random_color) {
-		Color debug_navigation_geometry_face_color = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_color();
+		Color debug_navigation_geometry_face_color = NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_face_color();
 		Color polygon_color = debug_navigation_geometry_face_color;
 
 		Vector<Color> face_color_array;
@@ -186,13 +187,13 @@ void NavigationRegion3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	const String face_material_name = navigationregion->is_enabled() ? "face_material" : "face_material_disabled";
 	Ref<StandardMaterial3D> face_material = get_material(face_material_name, p_gizmo);
 	if (navigationregion->is_enabled()) {
-		Color mat_color = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_color();
+		Color mat_color = NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_face_color();
 		if (!p_gizmo->is_selected()) {
 			mat_color.a *= 0.3;
 		}
 		face_material->set_albedo(mat_color);
 	} else {
-		Color mat_color = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_disabled_color();
+		Color mat_color = NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_face_disabled_color();
 		if (!p_gizmo->is_selected()) {
 			mat_color.a *= 0.3;
 		}
@@ -201,7 +202,7 @@ void NavigationRegion3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	p_gizmo->add_mesh(debug_mesh, face_material);
 
 	// if enabled build geometry edge line surface
-	bool enabled_edge_lines = NavigationServer3D::get_singleton()->get_debug_navigation_enable_edge_lines();
+	bool enabled_edge_lines = NavigationServer3DDebug::get_singleton()->get_debug_navigation_enable_edge_lines();
 	if (enabled_edge_lines) {
 		Vector<Vector3> line_vertex_array;
 		line_vertex_array.resize(polygon_count * 6);
@@ -220,13 +221,13 @@ void NavigationRegion3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		const String line_material_name = navigationregion->is_enabled() ? "edge_material" : "edge_material_disabled";
 		Ref<StandardMaterial3D> line_material = get_material(line_material_name, p_gizmo);
 		if (navigationregion->is_enabled()) {
-			Color mat_color = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_color();
+			Color mat_color = NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_edge_color();
 			if (!p_gizmo->is_selected()) {
 				mat_color.a *= 0.3;
 			}
 			line_material->set_albedo(mat_color);
 		} else {
-			Color mat_color = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_disabled_color();
+			Color mat_color = NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_edge_disabled_color();
 			if (!p_gizmo->is_selected()) {
 				mat_color.a *= 0.3;
 			}

--- a/modules/tilemap/editor/tile_data_editors.cpp
+++ b/modules/tilemap/editor/tile_data_editors.cpp
@@ -53,6 +53,9 @@
 #include "scene/resources/2d/navigation_mesh_source_geometry_data_2d.h"
 #include "servers/navigation_2d/navigation_server_2d.h"
 #include "servers/rendering/rendering_server.h"
+#if defined(DEBUG_ENABLED) && !defined(NAVIGATION_2D_DISABLED)
+#include "servers/navigation_2d/navigation_server_2d_debug.h"
+#endif // defined(DEBUG_ENABLED) && !defined(NAVIGATION_2D_DISABLED)
 
 void TileDataEditor::_tile_set_changed_plan_update() {
 	_tile_set_changed_update_needed = true;
@@ -3005,9 +3008,9 @@ void TileDataNavigationEditor::_tile_set_changed() {
 void TileDataNavigationEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-#ifdef DEBUG_ENABLED
-			polygon_editor->set_polygons_color(NavigationServer2D::get_singleton()->get_debug_navigation_geometry_face_color());
-#endif // DEBUG_ENABLED
+#if defined(DEBUG_ENABLED) && !defined(NAVIGATION_2D_DISABLED)
+			polygon_editor->set_polygons_color(NavigationServer2DDebug::get_singleton()->get_debug_navigation_geometry_face_color());
+#endif // defined(DEBUG_ENABLED) && !defined(NAVIGATION_2D_DISABLED)
 		} break;
 	}
 }
@@ -3033,9 +3036,9 @@ void TileDataNavigationEditor::draw_over_tile(CanvasItem *p_canvas_item, Transfo
 		}
 
 		Color color = Color(0.5, 1.0, 1.0, 1.0);
-#ifdef DEBUG_ENABLED
-		color = NavigationServer2D::get_singleton()->get_debug_navigation_geometry_face_color();
-#endif // DEBUG_ENABLED
+#if defined(DEBUG_ENABLED) && !defined(NAVIGATION_2D_DISABLED)
+		color = NavigationServer2DDebug::get_singleton()->get_debug_navigation_geometry_face_color();
+#endif // defined(DEBUG_ENABLED) && !defined(NAVIGATION_2D_DISABLED)
 		if (p_selected) {
 			Color grid_color = EDITOR_GET("editors/tiles_editor/grid_color");
 			Color selection_color = Color::from_hsv(Math::fposmod(grid_color.get_h() + 0.5, 1.0), grid_color.get_s(), grid_color.get_v(), 1.0);

--- a/modules/tilemap/tile_map_layer.cpp
+++ b/modules/tilemap/tile_map_layer.cpp
@@ -52,6 +52,9 @@
 #ifndef NAVIGATION_2D_DISABLED
 #include "scene/resources/2d/navigation_mesh_source_geometry_data_2d.h"
 #include "servers/navigation_2d/navigation_server_2d.h"
+#ifdef DEBUG_ENABLED
+#include "servers/navigation_2d/navigation_server_2d_debug.h"
+#endif // DEBUG_ENABLED
 Callable TileMapLayer::_navmesh_source_geometry_parsing_callback;
 RID TileMapLayer::_navmesh_source_geometry_parser;
 #endif // NAVIGATION_2D_DISABLED
@@ -1489,13 +1492,13 @@ void TileMapLayer::_navigation_draw_cell_debug(const RID &p_canvas_item, const V
 	}
 
 	RenderingServer *rs = RenderingServer::get_singleton();
-	const NavigationServer2D *ns2d = NavigationServer2D::get_singleton();
+	const NavigationServer2DDebug *ns2dd = NavigationServer2DDebug::get_singleton();
 
-	bool enabled_geometry_face_random_color = ns2d->get_debug_navigation_enable_geometry_face_random_color();
-	bool enabled_edge_lines = ns2d->get_debug_navigation_enable_edge_lines();
+	bool enabled_geometry_face_random_color = ns2dd->get_debug_navigation_enable_geometry_face_random_color();
+	bool enabled_edge_lines = ns2dd->get_debug_navigation_enable_edge_lines();
 
-	Color debug_face_color = ns2d->get_debug_navigation_geometry_face_color();
-	Color debug_edge_color = ns2d->get_debug_navigation_geometry_edge_color();
+	Color debug_face_color = ns2dd->get_debug_navigation_geometry_face_color();
+	Color debug_edge_color = ns2dd->get_debug_navigation_geometry_edge_color();
 
 	RandomPCG rand;
 

--- a/scene/2d/navigation/navigation_agent_2d.cpp
+++ b/scene/2d/navigation/navigation_agent_2d.cpp
@@ -38,6 +38,9 @@
 #include "scene/resources/world_2d.h"
 #include "servers/navigation_2d/navigation_server_2d.h"
 #include "servers/rendering/rendering_server.h"
+#ifdef DEBUG_ENABLED
+#include "servers/navigation_2d/navigation_server_2d_debug.h"
+#endif // DEBUG_ENABLED
 
 void NavigationAgent2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_rid"), &NavigationAgent2D::get_rid);
@@ -240,7 +243,7 @@ void NavigationAgent2D::_notification(int p_what) {
 			}
 
 #ifdef DEBUG_ENABLED
-			if (NavigationServer2D::get_singleton()->get_debug_enabled()) {
+			if (NavigationServer2DDebug::get_singleton()->get_debug_enabled()) {
 				debug_path_dirty = true;
 			}
 #endif // DEBUG_ENABLED
@@ -1092,7 +1095,7 @@ void NavigationAgent2D::_update_debug_path() {
 
 	RenderingServer::get_singleton()->canvas_item_clear(debug_path_instance);
 
-	if (!(debug_enabled && NavigationServer2D::get_singleton()->get_debug_navigation_enable_agent_paths())) {
+	if (!(debug_enabled && NavigationServer2DDebug::get_singleton()->get_debug_navigation_enable_agent_paths())) {
 		return;
 	}
 
@@ -1110,7 +1113,7 @@ void NavigationAgent2D::_update_debug_path() {
 		return;
 	}
 
-	Color debug_path_color = NavigationServer2D::get_singleton()->get_debug_navigation_agent_path_color();
+	Color debug_path_color = NavigationServer2DDebug::get_singleton()->get_debug_navigation_agent_path_color();
 	if (debug_use_custom) {
 		debug_path_color = debug_path_custom_color;
 	}
@@ -1125,7 +1128,7 @@ void NavigationAgent2D::_update_debug_path() {
 		return;
 	}
 
-	float point_size = NavigationServer2D::get_singleton()->get_debug_navigation_agent_path_point_size();
+	float point_size = NavigationServer2DDebug::get_singleton()->get_debug_navigation_agent_path_point_size();
 	float half_point_size = point_size * 0.5;
 
 	if (debug_use_custom) {

--- a/scene/2d/navigation/navigation_link_2d.cpp
+++ b/scene/2d/navigation/navigation_link_2d.cpp
@@ -35,6 +35,9 @@
 #include "core/object/class_db.h"
 #include "scene/resources/world_2d.h"
 #include "servers/navigation_2d/navigation_server_2d.h"
+#ifdef DEBUG_ENABLED
+#include "servers/navigation_2d/navigation_server_2d_debug.h"
+#endif // DEBUG_ENABLED
 
 void NavigationLink2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_rid"), &NavigationLink2D::get_rid);
@@ -374,15 +377,15 @@ void NavigationLink2D::_update_debug_mesh() {
 		return;
 	}
 
-	if (!Engine::get_singleton()->is_editor_hint() && !NavigationServer2D::get_singleton()->get_debug_enabled()) {
+	if (!Engine::get_singleton()->is_editor_hint() && !NavigationServer2DDebug::get_singleton()->get_debug_enabled()) {
 		return;
 	}
 
 	Color color;
 	if (enabled) {
-		color = NavigationServer2D::get_singleton()->get_debug_navigation_link_connection_color();
+		color = NavigationServer2DDebug::get_singleton()->get_debug_navigation_link_connection_color();
 	} else {
-		color = NavigationServer2D::get_singleton()->get_debug_navigation_link_connection_disabled_color();
+		color = NavigationServer2DDebug::get_singleton()->get_debug_navigation_link_connection_disabled_color();
 	}
 
 	real_t radius = NavigationServer2D::get_singleton()->map_get_link_connection_radius(get_world_2d()->get_navigation_map());

--- a/scene/2d/navigation/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation/navigation_obstacle_2d.cpp
@@ -40,6 +40,9 @@
 #include "scene/resources/world_2d.h"
 #include "servers/navigation_2d/navigation_server_2d.h"
 #include "servers/rendering/rendering_server.h"
+#ifdef DEBUG_ENABLED
+#include "servers/navigation_2d/navigation_server_2d_debug.h"
+#endif // DEBUG_ENABLED
 
 Callable NavigationObstacle2D::_navmesh_source_geometry_parsing_callback;
 RID NavigationObstacle2D::_navmesh_source_geometry_parser;
@@ -170,7 +173,7 @@ void NavigationObstacle2D::_notification(int p_what) {
 				bool is_debug_enabled = false;
 				if (Engine::get_singleton()->is_editor_hint()) {
 					is_debug_enabled = true;
-				} else if (NavigationServer2D::get_singleton()->get_debug_enabled() && NavigationServer2D::get_singleton()->get_debug_avoidance_enabled()) {
+				} else if (NavigationServer2DDebug::get_singleton()->get_debug_enabled() && NavigationServer2DDebug::get_singleton()->get_debug_avoidance_enabled()) {
 					is_debug_enabled = true;
 				}
 
@@ -444,8 +447,8 @@ void NavigationObstacle2D::_update_transform() {
 
 #ifdef DEBUG_ENABLED
 void NavigationObstacle2D::_update_fake_agent_radius_debug() {
-	if (radius > 0.0 && NavigationServer2D::get_singleton()->get_debug_navigation_avoidance_enable_obstacles_radius()) {
-		Color debug_radius_color = NavigationServer2D::get_singleton()->get_debug_navigation_avoidance_obstacles_radius_color();
+	if (radius > 0.0 && NavigationServer2DDebug::get_singleton()->get_debug_navigation_avoidance_enable_obstacles_radius()) {
+		Color debug_radius_color = NavigationServer2DDebug::get_singleton()->get_debug_navigation_avoidance_obstacles_radius_color();
 		// Prevent non-positive scaling.
 		const Vector2 safe_scale = get_global_scale().abs().maxf(0.001);
 		// Agent radius is a scalar value and does not support non-uniform scaling, choose the largest axis.
@@ -461,7 +464,7 @@ void NavigationObstacle2D::_update_static_obstacle_debug() {
 		return;
 	}
 
-	if (!NavigationServer2D::get_singleton()->get_debug_navigation_avoidance_enable_obstacles_static()) {
+	if (!NavigationServer2DDebug::get_singleton()->get_debug_navigation_avoidance_enable_obstacles_static()) {
 		return;
 	}
 
@@ -496,9 +499,9 @@ void NavigationObstacle2D::_update_static_obstacle_debug() {
 	Color debug_static_obstacle_edge_color;
 
 	if (are_vertices_valid()) {
-		debug_static_obstacle_edge_color = NavigationServer2D::get_singleton()->get_debug_navigation_avoidance_static_obstacle_pushout_edge_color();
+		debug_static_obstacle_edge_color = NavigationServer2DDebug::get_singleton()->get_debug_navigation_avoidance_static_obstacle_pushout_edge_color();
 	} else {
-		debug_static_obstacle_edge_color = NavigationServer2D::get_singleton()->get_debug_navigation_avoidance_static_obstacle_pushin_edge_color();
+		debug_static_obstacle_edge_color = NavigationServer2DDebug::get_singleton()->get_debug_navigation_avoidance_static_obstacle_pushin_edge_color();
 	}
 
 	Vector<Color> line_color_array;

--- a/scene/2d/navigation/navigation_region_2d.cpp
+++ b/scene/2d/navigation/navigation_region_2d.cpp
@@ -39,6 +39,9 @@
 #include "scene/resources/world_2d.h"
 #include "servers/navigation_2d/navigation_server_2d.h"
 #include "servers/rendering/rendering_server.h"
+#ifdef DEBUG_ENABLED
+#include "servers/navigation_2d/navigation_server_2d_debug.h"
+#endif // DEBUG_ENABLED
 
 RID NavigationRegion2D::get_rid() const {
 	return region;
@@ -54,7 +57,7 @@ void NavigationRegion2D::set_enabled(bool p_enabled) {
 	NavigationServer2D::get_singleton()->region_set_enabled(region, enabled);
 
 #ifdef DEBUG_ENABLED
-	if (Engine::get_singleton()->is_editor_hint() || NavigationServer2D::get_singleton()->get_debug_navigation_enabled()) {
+	if (Engine::get_singleton()->is_editor_hint() || NavigationServer2DDebug::get_singleton()->get_debug_navigation_enabled()) {
 		queue_redraw();
 	}
 #endif // DEBUG_ENABLED
@@ -183,7 +186,7 @@ void NavigationRegion2D::_notification(int p_what) {
 
 		case NOTIFICATION_DRAW: {
 #ifdef DEBUG_ENABLED
-			if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || (NavigationServer2D::get_singleton()->get_debug_enabled() && NavigationServer2D::get_singleton()->get_debug_navigation_enabled())) && navigation_polygon.is_valid()) {
+			if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || (NavigationServer2DDebug::get_singleton()->get_debug_enabled() && NavigationServer2DDebug::get_singleton()->get_debug_navigation_enabled())) && navigation_polygon.is_valid()) {
 				_update_debug_mesh();
 				_update_debug_edge_connections_mesh();
 				_update_debug_baking_rect();
@@ -447,7 +450,7 @@ void NavigationRegion2D::_update_debug_mesh() {
 		return;
 	}
 
-	const NavigationServer2D *ns2d = NavigationServer2D::get_singleton();
+	const NavigationServer2DDebug *ns2dd = NavigationServer2DDebug::get_singleton();
 	RenderingServer *rs = RenderingServer::get_singleton();
 
 	if (!debug_instance_rid.is_valid()) {
@@ -481,15 +484,15 @@ void NavigationRegion2D::_update_debug_mesh() {
 		return;
 	}
 
-	bool enabled_geometry_face_random_color = ns2d->get_debug_navigation_enable_geometry_face_random_color();
-	bool enabled_edge_lines = ns2d->get_debug_navigation_enable_edge_lines();
+	bool enabled_geometry_face_random_color = ns2dd->get_debug_navigation_enable_geometry_face_random_color();
+	bool enabled_edge_lines = ns2dd->get_debug_navigation_enable_edge_lines();
 
-	Color debug_face_color = ns2d->get_debug_navigation_geometry_face_color();
-	Color debug_edge_color = ns2d->get_debug_navigation_geometry_edge_color();
+	Color debug_face_color = ns2dd->get_debug_navigation_geometry_face_color();
+	Color debug_edge_color = ns2dd->get_debug_navigation_geometry_edge_color();
 
 	if (!enabled) {
-		debug_face_color = ns2d->get_debug_navigation_geometry_face_disabled_color();
-		debug_edge_color = ns2d->get_debug_navigation_geometry_edge_disabled_color();
+		debug_face_color = ns2dd->get_debug_navigation_geometry_face_disabled_color();
+		debug_edge_color = ns2dd->get_debug_navigation_geometry_edge_disabled_color();
 	}
 
 	int vertex_count = 0;
@@ -601,10 +604,10 @@ void NavigationRegion2D::_update_debug_mesh() {
 #ifdef DEBUG_ENABLED
 void NavigationRegion2D::_update_debug_edge_connections_mesh() {
 	const NavigationServer2D *ns2d = NavigationServer2D::get_singleton();
-	bool enable_edge_connections = use_edge_connections && ns2d->get_debug_navigation_enable_edge_connections() && ns2d->map_get_use_edge_connections(get_world_2d()->get_navigation_map());
+	bool enable_edge_connections = use_edge_connections && NavigationServer2DDebug::get_singleton()->get_debug_navigation_enable_edge_connections() && ns2d->map_get_use_edge_connections(get_world_2d()->get_navigation_map());
 
 	if (enable_edge_connections) {
-		Color debug_edge_connection_color = ns2d->get_debug_navigation_edge_connection_color();
+		Color debug_edge_connection_color = NavigationServer2DDebug::get_singleton()->get_debug_navigation_edge_connection_color();
 		// Draw the region edge connections.
 		Transform2D xform = get_global_transform();
 		real_t radius = ns2d->map_get_edge_connection_margin(get_world_2d()->get_navigation_map()) / 2.0;

--- a/scene/3d/navigation/navigation_agent_3d.cpp
+++ b/scene/3d/navigation/navigation_agent_3d.cpp
@@ -38,6 +38,9 @@
 #include "scene/resources/mesh.h"
 #include "servers/navigation_3d/navigation_server_3d.h"
 #include "servers/rendering/rendering_server.h"
+#ifdef DEBUG_ENABLED
+#include "servers/navigation_3d/navigation_server_3d_debug.h"
+#endif // DEBUG_ENABLED
 
 void NavigationAgent3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_rid"), &NavigationAgent3D::get_rid);
@@ -1153,7 +1156,7 @@ void NavigationAgent3D::_update_debug_path() {
 
 	debug_path_mesh->clear_surfaces();
 
-	if (!(debug_enabled && NavigationServer3D::get_singleton()->get_debug_navigation_enable_agent_paths())) {
+	if (!(debug_enabled && NavigationServer3DDebug::get_singleton()->get_debug_navigation_enable_agent_paths())) {
 		return;
 	}
 
@@ -1180,7 +1183,7 @@ void NavigationAgent3D::_update_debug_path() {
 
 	debug_path_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_LINES, debug_path_lines_mesh_array);
 
-	Ref<StandardMaterial3D> debug_agent_path_line_material = NavigationServer3D::get_singleton()->get_debug_navigation_agent_path_line_material();
+	Ref<StandardMaterial3D> debug_agent_path_line_material = NavigationServer3DDebug::get_singleton()->get_debug_navigation_agent_path_line_material();
 	if (debug_use_custom) {
 		if (debug_agent_path_line_custom_material.is_null()) {
 			debug_agent_path_line_custom_material = debug_agent_path_line_material->duplicate();
@@ -1204,7 +1207,7 @@ void NavigationAgent3D::_update_debug_path() {
 
 		debug_path_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_POINTS, debug_path_points_mesh_array);
 
-		Ref<StandardMaterial3D> debug_agent_path_point_material = NavigationServer3D::get_singleton()->get_debug_navigation_agent_path_point_material();
+		Ref<StandardMaterial3D> debug_agent_path_point_material = NavigationServer3DDebug::get_singleton()->get_debug_navigation_agent_path_point_material();
 		if (debug_use_custom) {
 			if (debug_agent_path_point_custom_material.is_null()) {
 				debug_agent_path_point_custom_material = debug_agent_path_point_material->duplicate();

--- a/scene/3d/navigation/navigation_link_3d.cpp
+++ b/scene/3d/navigation/navigation_link_3d.cpp
@@ -35,6 +35,9 @@
 #include "scene/resources/mesh.h"
 #include "servers/navigation_3d/navigation_server_3d.h"
 #include "servers/rendering/rendering_server.h"
+#ifdef DEBUG_ENABLED
+#include "servers/navigation_3d/navigation_server_3d_debug.h"
+#endif // DEBUG_ENABLED
 
 #ifdef DEBUG_ENABLED
 void NavigationLink3D::_update_debug_mesh() {
@@ -48,7 +51,7 @@ void NavigationLink3D::_update_debug_mesh() {
 		return;
 	}
 
-	if (!NavigationServer3D::get_singleton()->get_debug_navigation_enabled()) {
+	if (!NavigationServer3DDebug::get_singleton()->get_debug_navigation_enabled()) {
 		if (debug_instance.is_valid()) {
 			RS::get_singleton()->instance_set_visible(debug_instance, false);
 		}
@@ -164,8 +167,8 @@ void NavigationLink3D::_update_debug_mesh() {
 	RS::get_singleton()->instance_set_scenario(debug_instance, get_world_3d()->get_scenario());
 	RS::get_singleton()->instance_set_visible(debug_instance, is_visible_in_tree());
 
-	Ref<StandardMaterial3D> link_material = NavigationServer3D::get_singleton()->get_debug_navigation_link_connections_material();
-	Ref<StandardMaterial3D> disabled_link_material = NavigationServer3D::get_singleton()->get_debug_navigation_link_connections_disabled_material();
+	Ref<StandardMaterial3D> link_material = NavigationServer3DDebug::get_singleton()->get_debug_navigation_link_connections_material();
+	Ref<StandardMaterial3D> disabled_link_material = NavigationServer3DDebug::get_singleton()->get_debug_navigation_link_connections_disabled_material();
 
 	if (enabled) {
 		RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, link_material->get_rid());
@@ -315,10 +318,10 @@ void NavigationLink3D::set_enabled(bool p_enabled) {
 #ifdef DEBUG_ENABLED
 	if (debug_instance.is_valid() && debug_mesh.is_valid()) {
 		if (enabled) {
-			Ref<StandardMaterial3D> link_material = NavigationServer3D::get_singleton()->get_debug_navigation_link_connections_material();
+			Ref<StandardMaterial3D> link_material = NavigationServer3DDebug::get_singleton()->get_debug_navigation_link_connections_material();
 			RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, link_material->get_rid());
 		} else {
-			Ref<StandardMaterial3D> disabled_link_material = NavigationServer3D::get_singleton()->get_debug_navigation_link_connections_disabled_material();
+			Ref<StandardMaterial3D> disabled_link_material = NavigationServer3DDebug::get_singleton()->get_debug_navigation_link_connections_disabled_material();
 			RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, disabled_link_material->get_rid());
 		}
 	}
@@ -516,7 +519,7 @@ void NavigationLink3D::_link_enter_navigation_map() {
 	NavigationServer3D::get_singleton()->link_set_enabled(link, enabled);
 
 #ifdef DEBUG_ENABLED
-	if (NavigationServer3D::get_singleton()->get_debug_navigation_enabled()) {
+	if (NavigationServer3DDebug::get_singleton()->get_debug_navigation_enabled()) {
 		_update_debug_mesh();
 	}
 #endif // DEBUG_ENABLED
@@ -539,7 +542,7 @@ void NavigationLink3D::_link_update_transform() {
 	NavigationServer3D::get_singleton()->link_set_start_position(link, get_global_transform().xform(start_position));
 	NavigationServer3D::get_singleton()->link_set_end_position(link, get_global_transform().xform(end_position));
 #ifdef DEBUG_ENABLED
-	if (NavigationServer3D::get_singleton()->get_debug_navigation_enabled()) {
+	if (NavigationServer3DDebug::get_singleton()->get_debug_navigation_enabled()) {
 		_update_debug_mesh();
 	}
 #endif // DEBUG_ENABLED

--- a/scene/3d/navigation/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation/navigation_obstacle_3d.cpp
@@ -39,6 +39,9 @@
 #include "scene/resources/navigation_mesh.h"
 #include "servers/navigation_3d/navigation_server_3d.h"
 #include "servers/rendering/rendering_server.h"
+#ifdef DEBUG_ENABLED
+#include "servers/navigation_3d/navigation_server_3d_debug.h"
+#endif // DEBUG_ENABLED
 
 Callable NavigationObstacle3D::_navmesh_source_geometry_parsing_callback;
 RID NavigationObstacle3D::_navmesh_source_geometry_parser;
@@ -550,15 +553,15 @@ void NavigationObstacle3D::_update_debug() {
 }
 
 void NavigationObstacle3D::_update_fake_agent_radius_debug() {
-	NavigationServer3D *ns3d = NavigationServer3D::get_singleton();
+	NavigationServer3DDebug *ns3ddebug = NavigationServer3DDebug::get_singleton();
 	RenderingServer *rs = RenderingServer::get_singleton();
 
 	bool is_debug_enabled = false;
 	if (Engine::get_singleton()->is_editor_hint()) {
 		is_debug_enabled = true;
-	} else if (ns3d->get_debug_enabled() &&
-			ns3d->get_debug_avoidance_enabled() &&
-			ns3d->get_debug_navigation_avoidance_enable_obstacles_radius()) {
+	} else if (ns3ddebug->get_debug_enabled() &&
+			ns3ddebug->get_debug_avoidance_enabled() &&
+			ns3ddebug->get_debug_navigation_avoidance_enable_obstacles_radius()) {
 		is_debug_enabled = true;
 	}
 
@@ -623,7 +626,7 @@ void NavigationObstacle3D::_update_fake_agent_radius_debug() {
 
 	rs->mesh_add_surface_from_arrays(fake_agent_radius_debug_mesh_rid, RSE::PRIMITIVE_TRIANGLES, face_mesh_array);
 
-	Ref<StandardMaterial3D> face_material = ns3d->get_debug_navigation_avoidance_obstacles_radius_material();
+	Ref<StandardMaterial3D> face_material = NavigationServer3DDebug::get_singleton()->get_debug_navigation_avoidance_obstacles_radius_material();
 	rs->instance_set_surface_override_material(fake_agent_radius_debug_instance_rid, 0, face_material->get_rid());
 
 	if (is_inside_tree()) {
@@ -640,13 +643,13 @@ void NavigationObstacle3D::_update_static_obstacle_debug() {
 		return;
 	}
 
-	NavigationServer3D *ns3d = NavigationServer3D::get_singleton();
+	NavigationServer3DDebug *ns3ddebug = NavigationServer3DDebug::get_singleton();
 	RenderingServer *rs = RenderingServer::get_singleton();
 
 	bool is_debug_enabled = false;
-	if (ns3d->get_debug_enabled() &&
-			ns3d->get_debug_avoidance_enabled() &&
-			ns3d->get_debug_navigation_avoidance_enable_obstacles_static()) {
+	if (ns3ddebug->get_debug_enabled() &&
+			ns3ddebug->get_debug_avoidance_enabled() &&
+			ns3ddebug->get_debug_navigation_avoidance_enable_obstacles_static()) {
 		is_debug_enabled = true;
 	}
 
@@ -702,9 +705,9 @@ void NavigationObstacle3D::_update_static_obstacle_debug() {
 	Ref<StandardMaterial3D> edge_material;
 
 	if (are_vertices_valid()) {
-		edge_material = ns3d->get_debug_navigation_avoidance_static_obstacle_pushout_edge_material();
+		edge_material = ns3ddebug->get_debug_navigation_avoidance_static_obstacle_pushout_edge_material();
 	} else {
-		edge_material = ns3d->get_debug_navigation_avoidance_static_obstacle_pushin_edge_material();
+		edge_material = ns3ddebug->get_debug_navigation_avoidance_static_obstacle_pushin_edge_material();
 	}
 
 	rs->instance_set_surface_override_material(static_obstacle_debug_instance_rid, 0, edge_material->get_rid());

--- a/scene/3d/navigation/navigation_region_3d.cpp
+++ b/scene/3d/navigation/navigation_region_3d.cpp
@@ -37,6 +37,9 @@
 #include "scene/resources/3d/navigation_mesh_source_geometry_data_3d.h"
 #include "servers/navigation_3d/navigation_server_3d.h"
 #include "servers/rendering/rendering_server.h"
+#ifdef DEBUG_ENABLED
+#include "servers/navigation_3d/navigation_server_3d_debug.h"
+#endif // DEBUG_ENABLED
 
 RID NavigationRegion3D::get_rid() const {
 	return region;
@@ -56,10 +59,10 @@ void NavigationRegion3D::set_enabled(bool p_enabled) {
 		if (!is_enabled()) {
 			if (debug_mesh.is_valid()) {
 				if (debug_mesh->get_surface_count() > 0) {
-					RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_disabled_material()->get_rid());
+					RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_face_disabled_material()->get_rid());
 				}
 				if (debug_mesh->get_surface_count() > 1) {
-					RS::get_singleton()->instance_set_surface_override_material(debug_instance, 1, NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_disabled_material()->get_rid());
+					RS::get_singleton()->instance_set_surface_override_material(debug_instance, 1, NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_edge_disabled_material()->get_rid());
 				}
 			}
 		} else {
@@ -330,7 +333,7 @@ void NavigationRegion3D::_navigation_mesh_changed() {
 	NavigationServer3D::get_singleton()->region_set_navigation_mesh(region, navigation_mesh);
 
 #ifdef DEBUG_ENABLED
-	if (is_inside_tree() && NavigationServer3D::get_singleton()->get_debug_navigation_enabled()) {
+	if (is_inside_tree() && NavigationServer3DDebug::get_singleton()->get_debug_navigation_enabled()) {
 		if (navigation_mesh.is_valid()) {
 			_update_debug_mesh();
 			_update_debug_edge_connections_mesh();
@@ -385,7 +388,7 @@ void NavigationRegion3D::_region_enter_navigation_map() {
 	NavigationServer3D::get_singleton()->region_set_enabled(region, enabled);
 
 #ifdef DEBUG_ENABLED
-	if (NavigationServer3D::get_singleton()->get_debug_navigation_enabled()) {
+	if (NavigationServer3DDebug::get_singleton()->get_debug_navigation_enabled()) {
 		_update_debug_mesh();
 	}
 #endif // DEBUG_ENABLED
@@ -468,7 +471,7 @@ void NavigationRegion3D::_update_debug_mesh() {
 		return;
 	}
 
-	if (!NavigationServer3D::get_singleton()->get_debug_enabled() || !NavigationServer3D::get_singleton()->get_debug_navigation_enabled()) {
+	if (!NavigationServer3DDebug::get_singleton()->get_debug_enabled() || !NavigationServer3DDebug::get_singleton()->get_debug_navigation_enabled()) {
 		if (debug_instance.is_valid()) {
 			RS::get_singleton()->instance_set_visible(debug_instance, false);
 		}
@@ -502,8 +505,8 @@ void NavigationRegion3D::_update_debug_mesh() {
 		return;
 	}
 
-	bool enabled_geometry_face_random_color = NavigationServer3D::get_singleton()->get_debug_navigation_enable_geometry_face_random_color();
-	bool enabled_edge_lines = NavigationServer3D::get_singleton()->get_debug_navigation_enable_edge_lines();
+	bool enabled_geometry_face_random_color = NavigationServer3DDebug::get_singleton()->get_debug_navigation_enable_geometry_face_random_color();
+	bool enabled_edge_lines = NavigationServer3DDebug::get_singleton()->get_debug_navigation_enable_edge_lines();
 
 	int vertex_count = 0;
 	int line_count = 0;
@@ -531,7 +534,7 @@ void NavigationRegion3D::_update_debug_mesh() {
 		line_vertex_array.resize(line_count);
 	}
 
-	Color debug_navigation_geometry_face_color = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_color();
+	Color debug_navigation_geometry_face_color = NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_face_color();
 
 	RandomPCG rand;
 	Color polygon_color = debug_navigation_geometry_face_color;
@@ -583,7 +586,7 @@ void NavigationRegion3D::_update_debug_mesh() {
 		}
 	}
 
-	Ref<StandardMaterial3D> face_material = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_material();
+	Ref<StandardMaterial3D> face_material = NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_face_material();
 
 	Array face_mesh_array;
 	face_mesh_array.resize(Mesh::ARRAY_MAX);
@@ -595,7 +598,7 @@ void NavigationRegion3D::_update_debug_mesh() {
 	debug_mesh->surface_set_material(0, face_material);
 
 	if (enabled_edge_lines) {
-		Ref<StandardMaterial3D> line_material = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_material();
+		Ref<StandardMaterial3D> line_material = NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_edge_material();
 
 		Array line_mesh_array;
 		line_mesh_array.resize(Mesh::ARRAY_MAX);
@@ -613,10 +616,10 @@ void NavigationRegion3D::_update_debug_mesh() {
 	if (!is_enabled()) {
 		if (debug_mesh.is_valid()) {
 			if (debug_mesh->get_surface_count() > 0) {
-				RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_disabled_material()->get_rid());
+				RS::get_singleton()->instance_set_surface_override_material(debug_instance, 0, NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_face_disabled_material()->get_rid());
 			}
 			if (debug_mesh->get_surface_count() > 1) {
-				RS::get_singleton()->instance_set_surface_override_material(debug_instance, 1, NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_disabled_material()->get_rid());
+				RS::get_singleton()->instance_set_surface_override_material(debug_instance, 1, NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_edge_disabled_material()->get_rid());
 			}
 		}
 	} else {
@@ -634,7 +637,7 @@ void NavigationRegion3D::_update_debug_mesh() {
 
 #ifdef DEBUG_ENABLED
 void NavigationRegion3D::_update_debug_edge_connections_mesh() {
-	if (!NavigationServer3D::get_singleton()->get_debug_enabled() || !NavigationServer3D::get_singleton()->get_debug_navigation_enabled()) {
+	if (!NavigationServer3DDebug::get_singleton()->get_debug_enabled() || !NavigationServer3DDebug::get_singleton()->get_debug_navigation_enabled()) {
 		if (debug_edge_connections_instance.is_valid()) {
 			RS::get_singleton()->instance_set_visible(debug_edge_connections_instance, false);
 		}
@@ -713,7 +716,7 @@ void NavigationRegion3D::_update_debug_edge_connections_mesh() {
 		return;
 	}
 
-	Ref<StandardMaterial3D> edge_connections_material = NavigationServer3D::get_singleton()->get_debug_navigation_edge_connections_material();
+	Ref<StandardMaterial3D> edge_connections_material = NavigationServer3DDebug::get_singleton()->get_debug_navigation_edge_connections_material();
 
 	Array mesh_array;
 	mesh_array.resize(Mesh::ARRAY_MAX);
@@ -728,7 +731,7 @@ void NavigationRegion3D::_update_debug_edge_connections_mesh() {
 		RS::get_singleton()->instance_set_scenario(debug_edge_connections_instance, get_world_3d()->get_scenario());
 	}
 
-	bool enable_edge_connections = NavigationServer3D::get_singleton()->get_debug_navigation_enable_edge_connections();
+	bool enable_edge_connections = NavigationServer3DDebug::get_singleton()->get_debug_navigation_enable_edge_connections();
 	if (!enable_edge_connections) {
 		RS::get_singleton()->instance_set_visible(debug_edge_connections_instance, false);
 	}

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -32,9 +32,9 @@
 
 #include "core/object/class_db.h"
 
-#ifdef DEBUG_ENABLED
-#include "servers/navigation_3d/navigation_server_3d.h"
-#endif // DEBUG_ENABLED
+#if defined(DEBUG_ENABLED) && !defined(NAVIGATION_3D_DISABLED)
+#include "servers/navigation_3d/navigation_server_3d_debug.h"
+#endif // defined(DEBUG_ENABLED) && !defined(NAVIGATION_3D_DISABLED)
 
 void NavigationMesh::create_from_mesh(const Ref<Mesh> &p_mesh) {
 	RWLockWrite write_lock(rwlock);
@@ -387,7 +387,7 @@ void NavigationMesh::get_data(Vector<Vector3> &r_vertices, Vector<Vector<int>> &
 	r_polygons = polygons;
 }
 
-#ifdef DEBUG_ENABLED
+#if defined(DEBUG_ENABLED)
 Ref<ArrayMesh> NavigationMesh::get_debug_mesh() {
 	if (debug_mesh.is_valid()) {
 		// Blocks further updates for now, code below is intended for dynamic updates e.g. when settings change.
@@ -429,10 +429,11 @@ Ref<ArrayMesh> NavigationMesh::get_debug_mesh() {
 	face_mesh_array.resize(Mesh::ARRAY_MAX);
 	face_mesh_array[Mesh::ARRAY_VERTEX] = face_vertex_array;
 
+#if !defined(NAVIGATION_3D_DISABLED)
 	// if enabled add vertex colors to colorize each face individually
-	bool enabled_geometry_face_random_color = NavigationServer3D::get_singleton()->get_debug_navigation_enable_geometry_face_random_color();
+	bool enabled_geometry_face_random_color = NavigationServer3DDebug::get_singleton()->get_debug_navigation_enable_geometry_face_random_color();
 	if (enabled_geometry_face_random_color) {
-		Color debug_navigation_geometry_face_color = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_color();
+		Color debug_navigation_geometry_face_color = NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_face_color();
 		Color polygon_color = debug_navigation_geometry_face_color;
 
 		Vector<Color> face_color_array;
@@ -447,13 +448,19 @@ Ref<ArrayMesh> NavigationMesh::get_debug_mesh() {
 		}
 		face_mesh_array[Mesh::ARRAY_COLOR] = face_color_array;
 	}
+#endif // !defined(NAVIGATION_3D_DISABLED)
 
 	debug_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, face_mesh_array);
-	Ref<StandardMaterial3D> debug_geometry_face_material = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_face_material();
+#if !defined(NAVIGATION_3D_DISABLED)
+	Ref<StandardMaterial3D> debug_geometry_face_material = NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_face_material();
 	debug_mesh->surface_set_material(0, debug_geometry_face_material);
+#endif // !defined(NAVIGATION_3D_DISABLED)
 
 	// if enabled build geometry edge line surface
-	bool enabled_edge_lines = NavigationServer3D::get_singleton()->get_debug_navigation_enable_edge_lines();
+	bool enabled_edge_lines = true;
+#if !defined(NAVIGATION_3D_DISABLED)
+	enabled_edge_lines = NavigationServer3DDebug::get_singleton()->get_debug_navigation_enable_edge_lines();
+#endif // !defined(NAVIGATION_3D_DISABLED)
 
 	if (enabled_edge_lines) {
 		Vector<Vector3> line_vertex_array;
@@ -474,8 +481,10 @@ Ref<ArrayMesh> NavigationMesh::get_debug_mesh() {
 		line_mesh_array.resize(Mesh::ARRAY_MAX);
 		line_mesh_array[Mesh::ARRAY_VERTEX] = line_vertex_array;
 		debug_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_LINES, line_mesh_array);
-		Ref<StandardMaterial3D> debug_geometry_edge_material = NavigationServer3D::get_singleton()->get_debug_navigation_geometry_edge_material();
+#if !defined(NAVIGATION_3D_DISABLED)
+		Ref<StandardMaterial3D> debug_geometry_edge_material = NavigationServer3DDebug::get_singleton()->get_debug_navigation_geometry_edge_material();
 		debug_mesh->surface_set_material(1, debug_geometry_edge_material);
+#endif // !defined(NAVIGATION_3D_DISABLED)
 	}
 
 	return debug_mesh;

--- a/servers/navigation_2d/navigation_server_2d.cpp
+++ b/servers/navigation_2d/navigation_server_2d.cpp
@@ -40,6 +40,9 @@
 #include "scene/resources/2d/navigation_polygon.h" // IWYU pragma: keep. Bind `NavigationPolygon`.
 #include "servers/navigation_2d/navigation_path_query_parameters_2d.h" // IWYU pragma: keep. Bind `NavigationPathQueryParameters2D`.
 #include "servers/navigation_2d/navigation_path_query_result_2d.h" // IWYU pragma: keep. Bind `NavigationPathQueryResult2D`.
+#ifdef DEBUG_ENABLED
+#include "servers/navigation_2d/navigation_server_2d_debug.h"
+#endif // DEBUG_ENABLED
 
 NavigationServer2D *NavigationServer2D::singleton = nullptr;
 
@@ -227,51 +230,30 @@ NavigationServer2D::NavigationServer2D() {
 	ERR_FAIL_COND(singleton != nullptr);
 	singleton = this;
 
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/2d/default_cell_size", PROPERTY_HINT_RANGE, NavigationDefaults2D::NAV_MESH_CELL_SIZE_HINT), NavigationDefaults2D::NAV_MESH_CELL_SIZE);
-	GLOBAL_DEF("navigation/2d/use_edge_connections", true);
-	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "navigation/2d/merge_rasterizer_cell_scale", PROPERTY_HINT_RANGE, "0.001,1,0.001,or_greater"), 1.0);
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/2d/default_edge_connection_margin", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), NavigationDefaults2D::EDGE_CONNECTION_MARGIN);
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/2d/default_link_connection_radius", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), NavigationDefaults2D::LINK_CONNECTION_RADIUS);
+#ifdef DEBUG_ENABLED
+	debug = memnew(NavigationServer2DDebug);
+	ERR_FAIL_NULL(NavigationServer2DDebug::get_singleton());
+#endif // DEBUG_ENABLED
+
+	register_settings();
 
 #ifdef DEBUG_ENABLED
-	debug_navigation_edge_connection_color = GLOBAL_DEF("debug/shapes/navigation/2d/edge_connection_color", Color(1.0, 0.0, 1.0, 1.0));
-	debug_navigation_geometry_edge_color = GLOBAL_DEF("debug/shapes/navigation/2d/geometry_edge_color", Color(0.5, 1.0, 1.0, 1.0));
-	debug_navigation_geometry_face_color = GLOBAL_DEF("debug/shapes/navigation/2d/geometry_face_color", Color(0.5, 1.0, 1.0, 0.4));
-	debug_navigation_geometry_edge_disabled_color = GLOBAL_DEF("debug/shapes/navigation/2d/geometry_edge_disabled_color", Color(0.5, 0.5, 0.5, 1.0));
-	debug_navigation_geometry_face_disabled_color = GLOBAL_DEF("debug/shapes/navigation/2d/geometry_face_disabled_color", Color(0.5, 0.5, 0.5, 0.4));
-	debug_navigation_link_connection_color = GLOBAL_DEF("debug/shapes/navigation/2d/link_connection_color", Color(1.0, 0.5, 1.0, 1.0));
-	debug_navigation_link_connection_disabled_color = GLOBAL_DEF("debug/shapes/navigation/2d/link_connection_disabled_color", Color(0.5, 0.5, 0.5, 1.0));
-	debug_navigation_agent_path_color = GLOBAL_DEF("debug/shapes/navigation/2d/agent_path_color", Color(1.0, 0.0, 0.0, 1.0));
-
-	debug_navigation_enable_edge_connections = GLOBAL_DEF("debug/shapes/navigation/2d/enable_edge_connections", true);
-	debug_navigation_enable_edge_lines = GLOBAL_DEF("debug/shapes/navigation/2d/enable_edge_lines", true);
-	debug_navigation_enable_geometry_face_random_color = GLOBAL_DEF("debug/shapes/navigation/2d/enable_geometry_face_random_color", true);
-	debug_navigation_enable_link_connections = GLOBAL_DEF("debug/shapes/navigation/2d/enable_link_connections", true);
-
-	debug_navigation_enable_agent_paths = GLOBAL_DEF("debug/shapes/navigation/2d/enable_agent_paths", true);
-	debug_navigation_agent_path_point_size = GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "debug/shapes/navigation/2d/agent_path_point_size", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), 4.0);
-
-	debug_navigation_avoidance_agents_radius_color = GLOBAL_DEF("debug/shapes/avoidance/2d/agents_radius_color", Color(1.0, 1.0, 0.0, 0.25));
-	debug_navigation_avoidance_obstacles_radius_color = GLOBAL_DEF("debug/shapes/avoidance/2d/obstacles_radius_color", Color(1.0, 0.5, 0.0, 0.25));
-	debug_navigation_avoidance_static_obstacle_pushin_face_color = GLOBAL_DEF("debug/shapes/avoidance/2d/obstacles_static_face_pushin_color", Color(1.0, 0.0, 0.0, 0.0));
-	debug_navigation_avoidance_static_obstacle_pushin_edge_color = GLOBAL_DEF("debug/shapes/avoidance/2d/obstacles_static_edge_pushin_color", Color(1.0, 0.0, 0.0, 1.0));
-	debug_navigation_avoidance_static_obstacle_pushout_face_color = GLOBAL_DEF("debug/shapes/avoidance/2d/obstacles_static_face_pushout_color", Color(1.0, 1.0, 0.0, 0.5));
-	debug_navigation_avoidance_static_obstacle_pushout_edge_color = GLOBAL_DEF("debug/shapes/avoidance/2d/obstacles_static_edge_pushout_color", Color(1.0, 1.0, 0.0, 1.0));
-	debug_navigation_avoidance_enable_agents_radius = GLOBAL_DEF("debug/shapes/avoidance/2d/enable_agents_radius", true);
-	debug_navigation_avoidance_enable_obstacles_radius = GLOBAL_DEF("debug/shapes/avoidance/2d/enable_obstacles_radius", true);
-	debug_navigation_avoidance_enable_obstacles_static = GLOBAL_DEF("debug/shapes/avoidance/2d/enable_obstacles_static", true);
-
 	if (Engine::get_singleton()->is_editor_hint()) {
 		// Enable NavigationServer2D when in Editor or navigation mesh edge connections are invisible.
 		// On runtime tests SceneTree has "Visible Navigation" set and main iteration takes care of this.
-		set_debug_enabled(true);
-		set_debug_navigation_enabled(true);
-		set_debug_avoidance_enabled(true);
+		NavigationServer2DDebug::get_singleton()->set_debug_enabled(true);
+		NavigationServer2DDebug::get_singleton()->set_debug_navigation_enabled(true);
+		NavigationServer2DDebug::get_singleton()->set_debug_avoidance_enabled(true);
 	}
 #endif // DEBUG_ENABLED
 }
 
 NavigationServer2D::~NavigationServer2D() {
+#ifdef DEBUG_ENABLED
+	memdelete(debug);
+	debug = nullptr;
+#endif // DEBUG_ENABLED
+
 	singleton = nullptr;
 
 	RWLockWrite write_lock(geometry_parser_rwlock);
@@ -318,27 +300,33 @@ void NavigationServer2D::source_geometry_parser_set_callback(RID p_parser, const
 
 void NavigationServer2D::set_debug_enabled(bool p_enabled) {
 #ifdef DEBUG_ENABLED
-	if (debug_enabled != p_enabled) {
-		debug_dirty = true;
-	}
-
-	debug_enabled = p_enabled;
-
-	if (debug_dirty) {
-		navigation_debug_dirty = true;
-		callable_mp(this, &NavigationServer2D::_emit_navigation_debug_changed_signal).call_deferred();
-
-		avoidance_debug_dirty = true;
-		callable_mp(this, &NavigationServer2D::_emit_avoidance_debug_changed_signal).call_deferred();
-	}
+	NavigationServer2DDebug::get_singleton()->set_debug_enabled(p_enabled);
 #endif // DEBUG_ENABLED
 }
 
 bool NavigationServer2D::get_debug_enabled() const {
-	return debug_enabled;
+#ifdef DEBUG_ENABLED
+	return NavigationServer2DDebug::get_singleton()->get_debug_enabled();
+#else
+	return false;
+#endif // DEBUG_ENABLED
 }
 
 #ifdef DEBUG_ENABLED
+void NavigationServer2D::emit_navigation_debug_changed() {
+	if (!navigation_debug_dirty) {
+		navigation_debug_dirty = true;
+		callable_mp(this, &NavigationServer2D::_emit_navigation_debug_changed_signal).call_deferred();
+	}
+}
+
+void NavigationServer2D::emit_avoidance_debug_changed() {
+	if (!avoidance_debug_dirty) {
+		avoidance_debug_dirty = true;
+		callable_mp(this, &NavigationServer2D::_emit_avoidance_debug_changed_signal).call_deferred();
+	}
+}
+
 void NavigationServer2D::_emit_navigation_debug_changed_signal() {
 	if (navigation_debug_dirty) {
 		navigation_debug_dirty = false;
@@ -354,200 +342,28 @@ void NavigationServer2D::_emit_avoidance_debug_changed_signal() {
 }
 #endif // DEBUG_ENABLED
 
+void NavigationServer2D::register_settings() {
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/2d/default_cell_size", PROPERTY_HINT_RANGE, NavigationDefaults2D::NAV_MESH_CELL_SIZE_HINT), NavigationDefaults2D::NAV_MESH_CELL_SIZE);
+	GLOBAL_DEF("navigation/2d/use_edge_connections", true);
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "navigation/2d/merge_rasterizer_cell_scale", PROPERTY_HINT_RANGE, "0.001,1,0.001,or_greater"), 1.0);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/2d/default_edge_connection_margin", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), NavigationDefaults2D::EDGE_CONNECTION_MARGIN);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/2d/default_link_connection_radius", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), NavigationDefaults2D::LINK_CONNECTION_RADIUS);
+
+	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &NavigationServer2D::update_from_settings));
+
 #ifdef DEBUG_ENABLED
-void NavigationServer2D::set_debug_navigation_enabled(bool p_enabled) {
-	debug_navigation_enabled = p_enabled;
-	navigation_debug_dirty = true;
-	callable_mp(this, &NavigationServer2D::_emit_navigation_debug_changed_signal).call_deferred();
-}
-
-bool NavigationServer2D::get_debug_navigation_enabled() const {
-	return debug_navigation_enabled;
-}
-
-void NavigationServer2D::set_debug_avoidance_enabled(bool p_enabled) {
-	debug_avoidance_enabled = p_enabled;
-	avoidance_debug_dirty = true;
-	callable_mp(this, &NavigationServer2D::_emit_avoidance_debug_changed_signal).call_deferred();
-}
-
-bool NavigationServer2D::get_debug_avoidance_enabled() const {
-	return debug_avoidance_enabled;
-}
-
-void NavigationServer2D::set_debug_navigation_edge_connection_color(const Color &p_color) {
-	debug_navigation_edge_connection_color = p_color;
-}
-
-Color NavigationServer2D::get_debug_navigation_edge_connection_color() const {
-	return debug_navigation_edge_connection_color;
-}
-
-void NavigationServer2D::set_debug_navigation_geometry_face_color(const Color &p_color) {
-	debug_navigation_geometry_face_color = p_color;
-}
-
-Color NavigationServer2D::get_debug_navigation_geometry_face_color() const {
-	return debug_navigation_geometry_face_color;
-}
-
-void NavigationServer2D::set_debug_navigation_geometry_face_disabled_color(const Color &p_color) {
-	debug_navigation_geometry_face_disabled_color = p_color;
-}
-
-Color NavigationServer2D::get_debug_navigation_geometry_face_disabled_color() const {
-	return debug_navigation_geometry_face_disabled_color;
-}
-
-void NavigationServer2D::set_debug_navigation_link_connection_color(const Color &p_color) {
-	debug_navigation_link_connection_color = p_color;
-}
-
-Color NavigationServer2D::get_debug_navigation_link_connection_color() const {
-	return debug_navigation_link_connection_color;
-}
-
-void NavigationServer2D::set_debug_navigation_link_connection_disabled_color(const Color &p_color) {
-	debug_navigation_link_connection_disabled_color = p_color;
-}
-
-Color NavigationServer2D::get_debug_navigation_link_connection_disabled_color() const {
-	return debug_navigation_link_connection_disabled_color;
-}
-
-void NavigationServer2D::set_debug_navigation_geometry_edge_color(const Color &p_color) {
-	debug_navigation_geometry_edge_color = p_color;
-}
-
-Color NavigationServer2D::get_debug_navigation_geometry_edge_color() const {
-	return debug_navigation_geometry_edge_color;
-}
-
-void NavigationServer2D::set_debug_navigation_geometry_edge_disabled_color(const Color &p_color) {
-	debug_navigation_geometry_edge_disabled_color = p_color;
-}
-
-Color NavigationServer2D::get_debug_navigation_geometry_edge_disabled_color() const {
-	return debug_navigation_geometry_edge_disabled_color;
-}
-
-void NavigationServer2D::set_debug_navigation_enable_edge_connections(const bool p_value) {
-	debug_navigation_enable_edge_connections = p_value;
-}
-
-bool NavigationServer2D::get_debug_navigation_enable_edge_connections() const {
-	return debug_navigation_enable_edge_connections;
-}
-
-void NavigationServer2D::set_debug_navigation_enable_geometry_face_random_color(const bool p_value) {
-	debug_navigation_enable_geometry_face_random_color = p_value;
-}
-
-bool NavigationServer2D::get_debug_navigation_enable_geometry_face_random_color() const {
-	return debug_navigation_enable_geometry_face_random_color;
-}
-
-void NavigationServer2D::set_debug_navigation_enable_edge_lines(const bool p_value) {
-	debug_navigation_enable_edge_lines = p_value;
-}
-
-bool NavigationServer2D::get_debug_navigation_enable_edge_lines() const {
-	return debug_navigation_enable_edge_lines;
-}
-
-void NavigationServer2D::set_debug_navigation_agent_path_color(const Color &p_color) {
-	debug_navigation_agent_path_color = p_color;
-}
-
-Color NavigationServer2D::get_debug_navigation_agent_path_color() const {
-	return debug_navigation_agent_path_color;
-}
-
-void NavigationServer2D::set_debug_navigation_enable_agent_paths(const bool p_value) {
-	debug_navigation_enable_agent_paths = p_value;
-}
-
-bool NavigationServer2D::get_debug_navigation_enable_agent_paths() const {
-	return debug_navigation_enable_agent_paths;
-}
-
-void NavigationServer2D::set_debug_navigation_agent_path_point_size(real_t p_point_size) {
-	debug_navigation_agent_path_point_size = p_point_size;
-}
-
-real_t NavigationServer2D::get_debug_navigation_agent_path_point_size() const {
-	return debug_navigation_agent_path_point_size;
-}
-
-void NavigationServer2D::set_debug_navigation_avoidance_enable_agents_radius(const bool p_value) {
-	debug_navigation_avoidance_enable_agents_radius = p_value;
-}
-
-bool NavigationServer2D::get_debug_navigation_avoidance_enable_agents_radius() const {
-	return debug_navigation_avoidance_enable_agents_radius;
-}
-
-void NavigationServer2D::set_debug_navigation_avoidance_enable_obstacles_radius(const bool p_value) {
-	debug_navigation_avoidance_enable_obstacles_radius = p_value;
-}
-
-bool NavigationServer2D::get_debug_navigation_avoidance_enable_obstacles_radius() const {
-	return debug_navigation_avoidance_enable_obstacles_radius;
-}
-
-void NavigationServer2D::set_debug_navigation_avoidance_agents_radius_color(const Color &p_color) {
-	debug_navigation_avoidance_agents_radius_color = p_color;
-}
-
-Color NavigationServer2D::get_debug_navigation_avoidance_agents_radius_color() const {
-	return debug_navigation_avoidance_agents_radius_color;
-}
-
-void NavigationServer2D::set_debug_navigation_avoidance_obstacles_radius_color(const Color &p_color) {
-	debug_navigation_avoidance_obstacles_radius_color = p_color;
-}
-
-Color NavigationServer2D::get_debug_navigation_avoidance_obstacles_radius_color() const {
-	return debug_navigation_avoidance_obstacles_radius_color;
-}
-
-void NavigationServer2D::set_debug_navigation_avoidance_static_obstacle_pushin_face_color(const Color &p_color) {
-	debug_navigation_avoidance_static_obstacle_pushin_face_color = p_color;
-}
-
-Color NavigationServer2D::get_debug_navigation_avoidance_static_obstacle_pushin_face_color() const {
-	return debug_navigation_avoidance_static_obstacle_pushin_face_color;
-}
-
-void NavigationServer2D::set_debug_navigation_avoidance_static_obstacle_pushout_face_color(const Color &p_color) {
-	debug_navigation_avoidance_static_obstacle_pushout_face_color = p_color;
-}
-
-Color NavigationServer2D::get_debug_navigation_avoidance_static_obstacle_pushout_face_color() const {
-	return debug_navigation_avoidance_static_obstacle_pushout_face_color;
-}
-
-void NavigationServer2D::set_debug_navigation_avoidance_static_obstacle_pushin_edge_color(const Color &p_color) {
-	debug_navigation_avoidance_static_obstacle_pushin_edge_color = p_color;
-}
-
-Color NavigationServer2D::get_debug_navigation_avoidance_static_obstacle_pushin_edge_color() const {
-	return debug_navigation_avoidance_static_obstacle_pushin_edge_color;
-}
-
-void NavigationServer2D::set_debug_navigation_avoidance_static_obstacle_pushout_edge_color(const Color &p_color) {
-	debug_navigation_avoidance_static_obstacle_pushout_edge_color = p_color;
-}
-
-Color NavigationServer2D::get_debug_navigation_avoidance_static_obstacle_pushout_edge_color() const {
-	return debug_navigation_avoidance_static_obstacle_pushout_edge_color;
-}
-
-void NavigationServer2D::set_debug_navigation_avoidance_enable_obstacles_static(const bool p_value) {
-	debug_navigation_avoidance_enable_obstacles_static = p_value;
-}
-
-bool NavigationServer2D::get_debug_navigation_avoidance_enable_obstacles_static() const {
-	return debug_navigation_avoidance_enable_obstacles_static;
-}
+	NavigationServer2DDebug::get_singleton()->register_settings();
 #endif // DEBUG_ENABLED
+}
+
+void NavigationServer2D::update_from_settings() {
+#ifdef DEBUG_ENABLED
+	NavigationServer2DDebug::get_singleton()->update_from_settings();
+	if (ProjectSettings::get_singleton()->check_changed_settings_in_group("debug/shapes/navigation/2d")) {
+		navigation_debug_dirty = true;
+		callable_mp(this, &NavigationServer2D::_emit_navigation_debug_changed_signal).call_deferred();
+		avoidance_debug_dirty = true;
+		callable_mp(this, &NavigationServer2D::_emit_avoidance_debug_changed_signal).call_deferred();
+	}
+#endif // DEBUG_ENABLED
+}

--- a/servers/navigation_2d/navigation_server_2d.h
+++ b/servers/navigation_2d/navigation_server_2d.h
@@ -34,6 +34,9 @@
 #include "core/os/rw_lock.h"
 #include "core/templates/rid_owner.h"
 #include "core/variant/type_info.h"
+#ifdef DEBUG_ENABLED
+class NavigationServer2DDebug;
+#endif // DEBUG_ENABLED
 
 class Node;
 class NavigationPolygon;
@@ -316,122 +319,24 @@ protected:
 	static void _bind_compatibility_methods();
 #endif
 
-private:
-	bool debug_enabled = false;
-
 #ifdef DEBUG_ENABLED
-	bool debug_dirty = true;
+public:
+	void emit_navigation_debug_changed();
+	void emit_avoidance_debug_changed();
 
-	bool debug_navigation_enabled = false;
-	bool navigation_debug_dirty = true;
+private:
+	NavigationServer2DDebug *debug = nullptr;
+
+	bool navigation_debug_dirty = false;
 	void _emit_navigation_debug_changed_signal();
 
-	bool debug_avoidance_enabled = false;
-	bool avoidance_debug_dirty = true;
+	bool avoidance_debug_dirty = false;
 	void _emit_avoidance_debug_changed_signal();
-
-	Color debug_navigation_edge_connection_color = Color(1.0, 0.0, 1.0, 1.0);
-	Color debug_navigation_geometry_edge_color = Color(0.5, 1.0, 1.0, 1.0);
-	Color debug_navigation_geometry_face_color = Color(0.5, 1.0, 1.0, 0.4);
-	Color debug_navigation_geometry_edge_disabled_color = Color(0.5, 0.5, 0.5, 1.0);
-	Color debug_navigation_geometry_face_disabled_color = Color(0.5, 0.5, 0.5, 0.4);
-	Color debug_navigation_link_connection_color = Color(1.0, 0.5, 1.0, 1.0);
-	Color debug_navigation_link_connection_disabled_color = Color(0.5, 0.5, 0.5, 1.0);
-	Color debug_navigation_agent_path_color = Color(1.0, 0.0, 0.0, 1.0);
-
-	real_t debug_navigation_agent_path_point_size = 4.0;
-
-	Color debug_navigation_avoidance_agents_radius_color = Color(1.0, 1.0, 0.0, 0.25);
-	Color debug_navigation_avoidance_obstacles_radius_color = Color(1.0, 0.5, 0.0, 0.25);
-
-	Color debug_navigation_avoidance_static_obstacle_pushin_face_color = Color(1.0, 0.0, 0.0, 0.0);
-	Color debug_navigation_avoidance_static_obstacle_pushout_face_color = Color(1.0, 1.0, 0.0, 0.5);
-	Color debug_navigation_avoidance_static_obstacle_pushin_edge_color = Color(1.0, 0.0, 0.0, 1.0);
-	Color debug_navigation_avoidance_static_obstacle_pushout_edge_color = Color(1.0, 1.0, 0.0, 1.0);
-
-	bool debug_navigation_enable_edge_connections = true;
-	bool debug_navigation_enable_edge_lines = true;
-	bool debug_navigation_enable_geometry_face_random_color = true;
-	bool debug_navigation_enable_link_connections = true;
-	bool debug_navigation_enable_agent_paths = true;
-
-	bool debug_navigation_avoidance_enable_agents_radius = true;
-	bool debug_navigation_avoidance_enable_obstacles_radius = true;
-	bool debug_navigation_avoidance_enable_obstacles_static = true;
+#endif // DEBUG_ENABLED
 
 public:
-	void set_debug_navigation_enabled(bool p_enabled);
-	bool get_debug_navigation_enabled() const;
-
-	void set_debug_avoidance_enabled(bool p_enabled);
-	bool get_debug_avoidance_enabled() const;
-
-	void set_debug_navigation_edge_connection_color(const Color &p_color);
-	Color get_debug_navigation_edge_connection_color() const;
-
-	void set_debug_navigation_geometry_face_color(const Color &p_color);
-	Color get_debug_navigation_geometry_face_color() const;
-
-	void set_debug_navigation_geometry_face_disabled_color(const Color &p_color);
-	Color get_debug_navigation_geometry_face_disabled_color() const;
-
-	void set_debug_navigation_geometry_edge_color(const Color &p_color);
-	Color get_debug_navigation_geometry_edge_color() const;
-
-	void set_debug_navigation_geometry_edge_disabled_color(const Color &p_color);
-	Color get_debug_navigation_geometry_edge_disabled_color() const;
-
-	void set_debug_navigation_link_connection_color(const Color &p_color);
-	Color get_debug_navigation_link_connection_color() const;
-
-	void set_debug_navigation_link_connection_disabled_color(const Color &p_color);
-	Color get_debug_navigation_link_connection_disabled_color() const;
-
-	void set_debug_navigation_enable_edge_connections(const bool p_value);
-	bool get_debug_navigation_enable_edge_connections() const;
-
-	void set_debug_navigation_enable_geometry_face_random_color(const bool p_value);
-	bool get_debug_navigation_enable_geometry_face_random_color() const;
-
-	void set_debug_navigation_enable_edge_lines(const bool p_value);
-	bool get_debug_navigation_enable_edge_lines() const;
-
-	void set_debug_navigation_agent_path_color(const Color &p_color);
-	Color get_debug_navigation_agent_path_color() const;
-
-	void set_debug_navigation_enable_agent_paths(const bool p_value);
-	bool get_debug_navigation_enable_agent_paths() const;
-
-	void set_debug_navigation_agent_path_point_size(real_t p_point_size);
-	real_t get_debug_navigation_agent_path_point_size() const;
-
-	void set_debug_navigation_avoidance_enable_agents_radius(const bool p_value);
-	bool get_debug_navigation_avoidance_enable_agents_radius() const;
-
-	void set_debug_navigation_avoidance_enable_obstacles_radius(const bool p_value);
-	bool get_debug_navigation_avoidance_enable_obstacles_radius() const;
-
-	void set_debug_navigation_avoidance_agents_radius_color(const Color &p_color);
-	Color get_debug_navigation_avoidance_agents_radius_color() const;
-
-	void set_debug_navigation_avoidance_obstacles_radius_color(const Color &p_color);
-	Color get_debug_navigation_avoidance_obstacles_radius_color() const;
-
-	void set_debug_navigation_avoidance_static_obstacle_pushin_face_color(const Color &p_color);
-	Color get_debug_navigation_avoidance_static_obstacle_pushin_face_color() const;
-
-	void set_debug_navigation_avoidance_static_obstacle_pushout_face_color(const Color &p_color);
-	Color get_debug_navigation_avoidance_static_obstacle_pushout_face_color() const;
-
-	void set_debug_navigation_avoidance_static_obstacle_pushin_edge_color(const Color &p_color);
-	Color get_debug_navigation_avoidance_static_obstacle_pushin_edge_color() const;
-
-	void set_debug_navigation_avoidance_static_obstacle_pushout_edge_color(const Color &p_color);
-	Color get_debug_navigation_avoidance_static_obstacle_pushout_edge_color() const;
-
-	void set_debug_navigation_avoidance_enable_obstacles_static(const bool p_value);
-	bool get_debug_navigation_avoidance_enable_obstacles_static() const;
-#endif // DEBUG_ENABLED
+	void register_settings();
+	void update_from_settings();
 };
 
 VARIANT_ENUM_CAST(NavigationServer2D::ProcessInfo);

--- a/servers/navigation_2d/navigation_server_2d_debug.cpp
+++ b/servers/navigation_2d/navigation_server_2d_debug.cpp
@@ -1,0 +1,302 @@
+/**************************************************************************/
+/*  navigation_server_2d_debug.cpp                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef DEBUG_ENABLED
+
+#include "navigation_server_2d_debug.h"
+
+#include "core/config/project_settings.h"
+#include "servers/navigation_2d/navigation_server_2d.h"
+
+NavigationServer2DDebug *NavigationServer2DDebug::singleton = nullptr;
+
+NavigationServer2DDebug *NavigationServer2DDebug::get_singleton() {
+	return singleton;
+}
+
+NavigationServer2DDebug::NavigationServer2DDebug() {
+	ERR_FAIL_COND(singleton != nullptr);
+	singleton = this;
+}
+
+NavigationServer2DDebug::~NavigationServer2DDebug() {
+	if (singleton == this) {
+		singleton = nullptr;
+	}
+}
+
+void NavigationServer2DDebug::register_settings() {
+	debug_navigation_edge_connection_color = GLOBAL_DEF("debug/shapes/navigation/2d/edge_connection_color", Color(1.0, 0.0, 1.0, 1.0));
+	debug_navigation_geometry_edge_color = GLOBAL_DEF("debug/shapes/navigation/2d/geometry_edge_color", Color(0.5, 1.0, 1.0, 1.0));
+	debug_navigation_geometry_face_color = GLOBAL_DEF("debug/shapes/navigation/2d/geometry_face_color", Color(0.5, 1.0, 1.0, 0.4));
+	debug_navigation_geometry_edge_disabled_color = GLOBAL_DEF("debug/shapes/navigation/2d/geometry_edge_disabled_color", Color(0.5, 0.5, 0.5, 1.0));
+	debug_navigation_geometry_face_disabled_color = GLOBAL_DEF("debug/shapes/navigation/2d/geometry_face_disabled_color", Color(0.5, 0.5, 0.5, 0.4));
+	debug_navigation_link_connection_color = GLOBAL_DEF("debug/shapes/navigation/2d/link_connection_color", Color(1.0, 0.5, 1.0, 1.0));
+	debug_navigation_link_connection_disabled_color = GLOBAL_DEF("debug/shapes/navigation/2d/link_connection_disabled_color", Color(0.5, 0.5, 0.5, 1.0));
+	debug_navigation_agent_path_color = GLOBAL_DEF("debug/shapes/navigation/2d/agent_path_color", Color(1.0, 0.0, 0.0, 1.0));
+
+	debug_navigation_enable_edge_connections = GLOBAL_DEF("debug/shapes/navigation/2d/enable_edge_connections", true);
+	debug_navigation_enable_edge_lines = GLOBAL_DEF("debug/shapes/navigation/2d/enable_edge_lines", true);
+	debug_navigation_enable_geometry_face_random_color = GLOBAL_DEF("debug/shapes/navigation/2d/enable_geometry_face_random_color", true);
+	debug_navigation_enable_link_connections = GLOBAL_DEF("debug/shapes/navigation/2d/enable_link_connections", true);
+
+	debug_navigation_enable_agent_paths = GLOBAL_DEF("debug/shapes/navigation/2d/enable_agent_paths", true);
+	debug_navigation_agent_path_point_size = GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "debug/shapes/navigation/2d/agent_path_point_size", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), 4.0);
+
+	debug_navigation_avoidance_agents_radius_color = GLOBAL_DEF("debug/shapes/avoidance/2d/agents_radius_color", Color(1.0, 1.0, 0.0, 0.25));
+	debug_navigation_avoidance_obstacles_radius_color = GLOBAL_DEF("debug/shapes/avoidance/2d/obstacles_radius_color", Color(1.0, 0.5, 0.0, 0.25));
+	debug_navigation_avoidance_static_obstacle_pushin_face_color = GLOBAL_DEF("debug/shapes/avoidance/2d/obstacles_static_face_pushin_color", Color(1.0, 0.0, 0.0, 0.0));
+	debug_navigation_avoidance_static_obstacle_pushin_edge_color = GLOBAL_DEF("debug/shapes/avoidance/2d/obstacles_static_edge_pushin_color", Color(1.0, 0.0, 0.0, 1.0));
+	debug_navigation_avoidance_static_obstacle_pushout_face_color = GLOBAL_DEF("debug/shapes/avoidance/2d/obstacles_static_face_pushout_color", Color(1.0, 1.0, 0.0, 0.5));
+	debug_navigation_avoidance_static_obstacle_pushout_edge_color = GLOBAL_DEF("debug/shapes/avoidance/2d/obstacles_static_edge_pushout_color", Color(1.0, 1.0, 0.0, 1.0));
+	debug_navigation_avoidance_enable_agents_radius = GLOBAL_DEF("debug/shapes/avoidance/2d/enable_agents_radius", true);
+	debug_navigation_avoidance_enable_obstacles_radius = GLOBAL_DEF("debug/shapes/avoidance/2d/enable_obstacles_radius", true);
+	debug_navigation_avoidance_enable_obstacles_static = GLOBAL_DEF("debug/shapes/avoidance/2d/enable_obstacles_static", true);
+}
+
+void NavigationServer2DDebug::update_from_settings() {
+	if (!ProjectSettings::get_singleton()->check_changed_settings_in_group("debug/shapes/navigation/2d")) {
+		return;
+	}
+	set_debug_navigation_edge_connection_color(GLOBAL_GET("debug/shapes/navigation/2d/edge_connection_color"));
+	set_debug_navigation_geometry_edge_color(GLOBAL_GET("debug/shapes/navigation/2d/geometry_edge_color"));
+	set_debug_navigation_geometry_face_color(GLOBAL_GET("debug/shapes/navigation/2d/geometry_face_color"));
+	set_debug_navigation_geometry_edge_disabled_color(GLOBAL_GET("debug/shapes/navigation/2d/geometry_edge_disabled_color"));
+	set_debug_navigation_geometry_face_disabled_color(GLOBAL_GET("debug/shapes/navigation/2d/geometry_face_disabled_color"));
+	set_debug_navigation_enable_edge_connections(GLOBAL_GET("debug/shapes/navigation/2d/enable_edge_connections"));
+	set_debug_navigation_enable_edge_lines(GLOBAL_GET("debug/shapes/navigation/2d/enable_edge_lines"));
+	set_debug_navigation_enable_geometry_face_random_color(GLOBAL_GET("debug/shapes/navigation/2d/enable_geometry_face_random_color"));
+}
+
+void NavigationServer2DDebug::set_debug_enabled(bool p_enabled) {
+	debug_enabled = p_enabled;
+	NavigationServer2D::get_singleton()->emit_navigation_debug_changed();
+	NavigationServer2D::get_singleton()->emit_avoidance_debug_changed();
+}
+
+bool NavigationServer2DDebug::get_debug_enabled() const {
+	return debug_enabled;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_enabled(bool p_enabled) {
+	debug_navigation_enabled = p_enabled;
+	NavigationServer2D::get_singleton()->emit_navigation_debug_changed();
+}
+
+bool NavigationServer2DDebug::get_debug_navigation_enabled() const {
+	return debug_navigation_enabled;
+}
+
+void NavigationServer2DDebug::set_debug_avoidance_enabled(bool p_enabled) {
+	debug_avoidance_enabled = p_enabled;
+	NavigationServer2D::get_singleton()->emit_avoidance_debug_changed();
+}
+
+bool NavigationServer2DDebug::get_debug_avoidance_enabled() const {
+	return debug_avoidance_enabled;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_edge_connection_color(const Color &p_color) {
+	debug_navigation_edge_connection_color = p_color;
+}
+
+Color NavigationServer2DDebug::get_debug_navigation_edge_connection_color() const {
+	return debug_navigation_edge_connection_color;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_geometry_face_color(const Color &p_color) {
+	debug_navigation_geometry_face_color = p_color;
+}
+
+Color NavigationServer2DDebug::get_debug_navigation_geometry_face_color() const {
+	return debug_navigation_geometry_face_color;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_geometry_face_disabled_color(const Color &p_color) {
+	debug_navigation_geometry_face_disabled_color = p_color;
+}
+
+Color NavigationServer2DDebug::get_debug_navigation_geometry_face_disabled_color() const {
+	return debug_navigation_geometry_face_disabled_color;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_link_connection_color(const Color &p_color) {
+	debug_navigation_link_connection_color = p_color;
+}
+
+Color NavigationServer2DDebug::get_debug_navigation_link_connection_color() const {
+	return debug_navigation_link_connection_color;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_link_connection_disabled_color(const Color &p_color) {
+	debug_navigation_link_connection_disabled_color = p_color;
+}
+
+Color NavigationServer2DDebug::get_debug_navigation_link_connection_disabled_color() const {
+	return debug_navigation_link_connection_disabled_color;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_geometry_edge_color(const Color &p_color) {
+	debug_navigation_geometry_edge_color = p_color;
+}
+
+Color NavigationServer2DDebug::get_debug_navigation_geometry_edge_color() const {
+	return debug_navigation_geometry_edge_color;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_geometry_edge_disabled_color(const Color &p_color) {
+	debug_navigation_geometry_edge_disabled_color = p_color;
+}
+
+Color NavigationServer2DDebug::get_debug_navigation_geometry_edge_disabled_color() const {
+	return debug_navigation_geometry_edge_disabled_color;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_enable_edge_connections(const bool p_value) {
+	debug_navigation_enable_edge_connections = p_value;
+}
+
+bool NavigationServer2DDebug::get_debug_navigation_enable_edge_connections() const {
+	return debug_navigation_enable_edge_connections;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_enable_geometry_face_random_color(const bool p_value) {
+	debug_navigation_enable_geometry_face_random_color = p_value;
+}
+
+bool NavigationServer2DDebug::get_debug_navigation_enable_geometry_face_random_color() const {
+	return debug_navigation_enable_geometry_face_random_color;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_enable_edge_lines(const bool p_value) {
+	debug_navigation_enable_edge_lines = p_value;
+}
+
+bool NavigationServer2DDebug::get_debug_navigation_enable_edge_lines() const {
+	return debug_navigation_enable_edge_lines;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_agent_path_color(const Color &p_color) {
+	debug_navigation_agent_path_color = p_color;
+}
+
+Color NavigationServer2DDebug::get_debug_navigation_agent_path_color() const {
+	return debug_navigation_agent_path_color;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_enable_agent_paths(const bool p_value) {
+	debug_navigation_enable_agent_paths = p_value;
+}
+
+bool NavigationServer2DDebug::get_debug_navigation_enable_agent_paths() const {
+	return debug_navigation_enable_agent_paths;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_agent_path_point_size(float p_point_size) {
+	debug_navigation_agent_path_point_size = p_point_size;
+}
+
+float NavigationServer2DDebug::get_debug_navigation_agent_path_point_size() const {
+	return debug_navigation_agent_path_point_size;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_avoidance_enable_agents_radius(const bool p_value) {
+	debug_navigation_avoidance_enable_agents_radius = p_value;
+}
+
+bool NavigationServer2DDebug::get_debug_navigation_avoidance_enable_agents_radius() const {
+	return debug_navigation_avoidance_enable_agents_radius;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_avoidance_enable_obstacles_radius(const bool p_value) {
+	debug_navigation_avoidance_enable_obstacles_radius = p_value;
+}
+
+bool NavigationServer2DDebug::get_debug_navigation_avoidance_enable_obstacles_radius() const {
+	return debug_navigation_avoidance_enable_obstacles_radius;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_avoidance_agents_radius_color(const Color &p_color) {
+	debug_navigation_avoidance_agents_radius_color = p_color;
+}
+
+Color NavigationServer2DDebug::get_debug_navigation_avoidance_agents_radius_color() const {
+	return debug_navigation_avoidance_agents_radius_color;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_avoidance_obstacles_radius_color(const Color &p_color) {
+	debug_navigation_avoidance_obstacles_radius_color = p_color;
+}
+
+Color NavigationServer2DDebug::get_debug_navigation_avoidance_obstacles_radius_color() const {
+	return debug_navigation_avoidance_obstacles_radius_color;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_avoidance_static_obstacle_pushin_face_color(const Color &p_color) {
+	debug_navigation_avoidance_static_obstacle_pushin_face_color = p_color;
+}
+
+Color NavigationServer2DDebug::get_debug_navigation_avoidance_static_obstacle_pushin_face_color() const {
+	return debug_navigation_avoidance_static_obstacle_pushin_face_color;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_avoidance_static_obstacle_pushout_face_color(const Color &p_color) {
+	debug_navigation_avoidance_static_obstacle_pushout_face_color = p_color;
+}
+
+Color NavigationServer2DDebug::get_debug_navigation_avoidance_static_obstacle_pushout_face_color() const {
+	return debug_navigation_avoidance_static_obstacle_pushout_face_color;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_avoidance_static_obstacle_pushin_edge_color(const Color &p_color) {
+	debug_navigation_avoidance_static_obstacle_pushin_edge_color = p_color;
+}
+
+Color NavigationServer2DDebug::get_debug_navigation_avoidance_static_obstacle_pushin_edge_color() const {
+	return debug_navigation_avoidance_static_obstacle_pushin_edge_color;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_avoidance_static_obstacle_pushout_edge_color(const Color &p_color) {
+	debug_navigation_avoidance_static_obstacle_pushout_edge_color = p_color;
+}
+
+Color NavigationServer2DDebug::get_debug_navigation_avoidance_static_obstacle_pushout_edge_color() const {
+	return debug_navigation_avoidance_static_obstacle_pushout_edge_color;
+}
+
+void NavigationServer2DDebug::set_debug_navigation_avoidance_enable_obstacles_static(const bool p_value) {
+	debug_navigation_avoidance_enable_obstacles_static = p_value;
+}
+
+bool NavigationServer2DDebug::get_debug_navigation_avoidance_enable_obstacles_static() const {
+	return debug_navigation_avoidance_enable_obstacles_static;
+}
+
+#endif // DEBUG_ENABLED

--- a/servers/navigation_2d/navigation_server_2d_debug.h
+++ b/servers/navigation_2d/navigation_server_2d_debug.h
@@ -1,0 +1,158 @@
+/**************************************************************************/
+/*  navigation_server_2d_debug.h                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef DEBUG_ENABLED
+
+#include "core/math/color.h"
+
+class NavigationServer2DDebug {
+	static NavigationServer2DDebug *singleton;
+
+	bool debug_enabled = false;
+	bool debug_navigation_enabled = false;
+	bool debug_avoidance_enabled = false;
+
+	Color debug_navigation_edge_connection_color;
+	Color debug_navigation_geometry_edge_color;
+	Color debug_navigation_geometry_face_color;
+	Color debug_navigation_geometry_edge_disabled_color;
+	Color debug_navigation_geometry_face_disabled_color;
+	Color debug_navigation_link_connection_color;
+	Color debug_navigation_link_connection_disabled_color;
+	Color debug_navigation_agent_path_color;
+
+	float debug_navigation_agent_path_point_size = 4.0;
+
+	Color debug_navigation_avoidance_agents_radius_color;
+	Color debug_navigation_avoidance_obstacles_radius_color;
+
+	Color debug_navigation_avoidance_static_obstacle_pushin_face_color;
+	Color debug_navigation_avoidance_static_obstacle_pushout_face_color;
+	Color debug_navigation_avoidance_static_obstacle_pushin_edge_color;
+	Color debug_navigation_avoidance_static_obstacle_pushout_edge_color;
+
+	bool debug_navigation_enable_edge_connections = true;
+	bool debug_navigation_enable_edge_lines = true;
+	bool debug_navigation_enable_geometry_face_random_color = true;
+	bool debug_navigation_enable_link_connections = true;
+	bool debug_navigation_enable_agent_paths = true;
+
+	bool debug_navigation_avoidance_enable_agents_radius = true;
+	bool debug_navigation_avoidance_enable_obstacles_radius = true;
+	bool debug_navigation_avoidance_enable_obstacles_static = true;
+
+public:
+	static NavigationServer2DDebug *get_singleton();
+
+	void set_debug_enabled(bool p_enabled);
+	bool get_debug_enabled() const;
+
+	void register_settings();
+	void update_from_settings();
+
+	void set_debug_navigation_enabled(bool p_enabled);
+	bool get_debug_navigation_enabled() const;
+
+	void set_debug_avoidance_enabled(bool p_enabled);
+	bool get_debug_avoidance_enabled() const;
+
+	void set_debug_navigation_edge_connection_color(const Color &p_color);
+	Color get_debug_navigation_edge_connection_color() const;
+
+	void set_debug_navigation_geometry_face_color(const Color &p_color);
+	Color get_debug_navigation_geometry_face_color() const;
+
+	void set_debug_navigation_geometry_face_disabled_color(const Color &p_color);
+	Color get_debug_navigation_geometry_face_disabled_color() const;
+
+	void set_debug_navigation_geometry_edge_color(const Color &p_color);
+	Color get_debug_navigation_geometry_edge_color() const;
+
+	void set_debug_navigation_geometry_edge_disabled_color(const Color &p_color);
+	Color get_debug_navigation_geometry_edge_disabled_color() const;
+
+	void set_debug_navigation_link_connection_color(const Color &p_color);
+	Color get_debug_navigation_link_connection_color() const;
+
+	void set_debug_navigation_link_connection_disabled_color(const Color &p_color);
+	Color get_debug_navigation_link_connection_disabled_color() const;
+
+	void set_debug_navigation_enable_edge_connections(const bool p_value);
+	bool get_debug_navigation_enable_edge_connections() const;
+
+	void set_debug_navigation_enable_geometry_face_random_color(const bool p_value);
+	bool get_debug_navigation_enable_geometry_face_random_color() const;
+
+	void set_debug_navigation_enable_edge_lines(const bool p_value);
+	bool get_debug_navigation_enable_edge_lines() const;
+
+	void set_debug_navigation_agent_path_color(const Color &p_color);
+	Color get_debug_navigation_agent_path_color() const;
+
+	void set_debug_navigation_enable_agent_paths(const bool p_value);
+	bool get_debug_navigation_enable_agent_paths() const;
+
+	void set_debug_navigation_agent_path_point_size(float p_point_size);
+	float get_debug_navigation_agent_path_point_size() const;
+
+	void set_debug_navigation_avoidance_enable_agents_radius(const bool p_value);
+	bool get_debug_navigation_avoidance_enable_agents_radius() const;
+
+	void set_debug_navigation_avoidance_enable_obstacles_radius(const bool p_value);
+	bool get_debug_navigation_avoidance_enable_obstacles_radius() const;
+
+	void set_debug_navigation_avoidance_agents_radius_color(const Color &p_color);
+	Color get_debug_navigation_avoidance_agents_radius_color() const;
+
+	void set_debug_navigation_avoidance_obstacles_radius_color(const Color &p_color);
+	Color get_debug_navigation_avoidance_obstacles_radius_color() const;
+
+	void set_debug_navigation_avoidance_static_obstacle_pushin_face_color(const Color &p_color);
+	Color get_debug_navigation_avoidance_static_obstacle_pushin_face_color() const;
+
+	void set_debug_navigation_avoidance_static_obstacle_pushout_face_color(const Color &p_color);
+	Color get_debug_navigation_avoidance_static_obstacle_pushout_face_color() const;
+
+	void set_debug_navigation_avoidance_static_obstacle_pushin_edge_color(const Color &p_color);
+	Color get_debug_navigation_avoidance_static_obstacle_pushin_edge_color() const;
+
+	void set_debug_navigation_avoidance_static_obstacle_pushout_edge_color(const Color &p_color);
+	Color get_debug_navigation_avoidance_static_obstacle_pushout_edge_color() const;
+
+	void set_debug_navigation_avoidance_enable_obstacles_static(const bool p_value);
+	bool get_debug_navigation_avoidance_enable_obstacles_static() const;
+
+	NavigationServer2DDebug();
+	~NavigationServer2DDebug();
+};
+
+#endif // DEBUG_ENABLED

--- a/servers/navigation_3d/navigation_server_3d.cpp
+++ b/servers/navigation_3d/navigation_server_3d.cpp
@@ -40,6 +40,9 @@
 #include "scene/resources/navigation_mesh.h" // IWYU pragma: keep. Bind `NavigationMesh`.
 #include "servers/navigation_3d/navigation_path_query_parameters_3d.h" // IWYU pragma: keep. Bind `NavigationPathQueryParameters3D`.
 #include "servers/navigation_3d/navigation_path_query_result_3d.h" // IWYU pragma: keep. Bind `NavigationPathQueryResult3D`.
+#ifdef DEBUG_ENABLED
+#include "servers/navigation_3d/navigation_server_3d_debug.h"
+#endif // DEBUG_ENABLED
 
 NavigationServer3D *NavigationServer3D::singleton = nullptr;
 
@@ -249,110 +252,30 @@ NavigationServer3D::NavigationServer3D() {
 	ERR_FAIL_COND(singleton != nullptr);
 	singleton = this;
 
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/3d/default_cell_size", PROPERTY_HINT_RANGE, NavigationDefaults3D::NAV_MESH_CELL_SIZE_HINT), NavigationDefaults3D::NAV_MESH_CELL_SIZE);
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/3d/default_cell_height", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater"), NavigationDefaults3D::NAV_MESH_CELL_HEIGHT);
-	GLOBAL_DEF("navigation/3d/default_up", Vector3(0, 1, 0));
-	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "navigation/3d/merge_rasterizer_cell_scale", PROPERTY_HINT_RANGE, "0.001,1,0.001,or_greater"), 1.0);
-	GLOBAL_DEF("navigation/3d/use_edge_connections", true);
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/3d/default_edge_connection_margin", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), NavigationDefaults3D::EDGE_CONNECTION_MARGIN);
-	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/3d/default_link_connection_radius", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), NavigationDefaults3D::LINK_CONNECTION_RADIUS);
+#ifdef DEBUG_ENABLED
+	debug = memnew(NavigationServer3DDebug);
+	ERR_FAIL_NULL(NavigationServer3DDebug::get_singleton());
+#endif // DEBUG_ENABLED
+
+	register_settings();
 
 #ifdef DEBUG_ENABLED
-#ifndef DISABLE_DEPRECATED
-#define MOVE_PROJECT_SETTING_1(m_old_setting, m_new_setting) \
-	if (!ProjectSettings::get_singleton()->has_setting(m_new_setting) && ProjectSettings::get_singleton()->has_setting(m_old_setting)) { \
-		Variant value = GLOBAL_GET(m_old_setting); \
-		ProjectSettings::get_singleton()->set_setting(m_new_setting, value); \
-		ProjectSettings::get_singleton()->clear(m_old_setting); \
-	}
-#define MOVE_PROJECT_SETTING_2(m_old_setting, m_new_setting_1, m_new_setting_2) \
-	if ((!ProjectSettings::get_singleton()->has_setting(m_new_setting_1) || !ProjectSettings::get_singleton()->has_setting(m_new_setting_2)) && \
-			ProjectSettings::get_singleton()->has_setting(m_old_setting)) { \
-		Variant value = GLOBAL_GET(m_old_setting); \
-		if (!ProjectSettings::get_singleton()->has_setting(m_new_setting_1)) { \
-			ProjectSettings::get_singleton()->set_setting(m_new_setting_1, value); \
-		} \
-		if (!ProjectSettings::get_singleton()->has_setting(m_new_setting_2)) { \
-			ProjectSettings::get_singleton()->set_setting(m_new_setting_2, value); \
-		} \
-		ProjectSettings::get_singleton()->clear(m_old_setting); \
-	}
-	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/edge_connection_color", "debug/shapes/navigation/2d/edge_connection_color", "debug/shapes/navigation/3d/edge_connection_color");
-	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/geometry_edge_color", "debug/shapes/navigation/2d/geometry_edge_color", "debug/shapes/navigation/3d/geometry_edge_color");
-	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/geometry_face_color", "debug/shapes/navigation/2d/geometry_face_color", "debug/shapes/navigation/3d/geometry_face_color");
-	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/geometry_edge_disabled_color", "debug/shapes/navigation/2d/geometry_edge_disabled_color", "debug/shapes/navigation/3d/geometry_edge_disabled_color");
-	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/geometry_face_disabled_color", "debug/shapes/navigation/2d/geometry_face_disabled_color", "debug/shapes/navigation/3d/geometry_face_disabled_color");
-	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/link_connection_color", "debug/shapes/navigation/2d/link_connection_color", "debug/shapes/navigation/3d/link_connection_color");
-	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/link_connection_disabled_color", "debug/shapes/navigation/2d/link_connection_disabled_color", "debug/shapes/navigation/3d/link_connection_disabled_color");
-	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/agent_path_color", "debug/shapes/navigation/2d/agent_path_color", "debug/shapes/navigation/3d/agent_path_color");
-
-	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/enable_edge_connections", "debug/shapes/navigation/2d/enable_edge_connections", "debug/shapes/navigation/3d/enable_edge_connections");
-	MOVE_PROJECT_SETTING_1("debug/shapes/navigation/enable_edge_connections_xray", "debug/shapes/navigation/3d/enable_edge_connections_xray");
-	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/enable_edge_lines", "debug/shapes/navigation/2d/enable_edge_lines", "debug/shapes/navigation/3d/enable_edge_lines");
-	MOVE_PROJECT_SETTING_1("debug/shapes/navigation/enable_edge_lines_xray", "debug/shapes/navigation/3d/enable_edge_lines_xray");
-	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/enable_geometry_face_random_color", "debug/shapes/navigation/2d/enable_geometry_face_random_color", "debug/shapes/navigation/3d/enable_geometry_face_random_color");
-	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/enable_link_connections", "debug/shapes/navigation/2d/enable_link_connections", "debug/shapes/navigation/3d/enable_link_connections");
-	MOVE_PROJECT_SETTING_1("debug/shapes/navigation/enable_link_connections_xray", "debug/shapes/navigation/3d/enable_link_connections_xray");
-
-	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/enable_agent_paths", "debug/shapes/navigation/2d/enable_agent_paths", "debug/shapes/navigation/3d/enable_agent_paths");
-	MOVE_PROJECT_SETTING_1("debug/shapes/navigation/enable_agent_paths_xray", "debug/shapes/navigation/3d/enable_agent_paths_xray");
-	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/agent_path_point_size", "debug/shapes/navigation/2d/agent_path_point_size", "debug/shapes/navigation/3d/agent_path_point_size");
-
-	MOVE_PROJECT_SETTING_2("debug/shapes/avoidance/agents_radius_color", "debug/shapes/avoidance/2d/agents_radius_color", "debug/shapes/avoidance/3d/agents_radius_color");
-	MOVE_PROJECT_SETTING_2("debug/shapes/avoidance/obstacles_radius_color", "debug/shapes/avoidance/2d/obstacles_radius_color", "debug/shapes/avoidance/3d/obstacles_radius_color");
-	MOVE_PROJECT_SETTING_2("debug/shapes/avoidance/obstacles_static_face_pushin_color", "debug/shapes/avoidance/2d/obstacles_static_face_pushin_color", "debug/shapes/avoidance/3d/obstacles_static_face_pushin_color");
-	MOVE_PROJECT_SETTING_2("debug/shapes/avoidance/obstacles_static_edge_pushin_color", "debug/shapes/avoidance/2d/obstacles_static_edge_pushin_color", "debug/shapes/avoidance/3d/obstacles_static_edge_pushin_color");
-	MOVE_PROJECT_SETTING_2("debug/shapes/avoidance/obstacles_static_face_pushout_color", "debug/shapes/avoidance/2d/obstacles_static_face_pushout_color", "debug/shapes/avoidance/3d/obstacles_static_face_pushout_color");
-	MOVE_PROJECT_SETTING_2("debug/shapes/avoidance/obstacles_static_edge_pushout_color", "debug/shapes/avoidance/2d/obstacles_static_edge_pushout_color", "debug/shapes/avoidance/3d/obstacles_static_edge_pushout_color");
-	MOVE_PROJECT_SETTING_2("debug/shapes/avoidance/enable_agents_radius", "debug/shapes/avoidance/2d/enable_agents_radius", "debug/shapes/avoidance/3d/enable_agents_radius");
-	MOVE_PROJECT_SETTING_2("debug/shapes/avoidance/enable_obstacles_radius", "debug/shapes/avoidance/2d/enable_obstacles_radius", "debug/shapes/avoidance/2d/enable_obstacles_static");
-	MOVE_PROJECT_SETTING_2("debug/shapes/avoidance/enable_obstacles_radius", "debug/shapes/avoidance/3d/enable_obstacles_radius", "debug/shapes/avoidance/3d/enable_obstacles_static");
-#undef MOVE_PROJECT_SETTING_1
-#undef MOVE_PROJECT_SETTING_2
-#endif // DISABLE_DEPRECATED
-
-	debug_navigation_edge_connection_color = GLOBAL_DEF("debug/shapes/navigation/3d/edge_connection_color", Color(1.0, 0.0, 1.0, 1.0));
-	debug_navigation_geometry_edge_color = GLOBAL_DEF("debug/shapes/navigation/3d/geometry_edge_color", Color(0.5, 1.0, 1.0, 1.0));
-	debug_navigation_geometry_face_color = GLOBAL_DEF("debug/shapes/navigation/3d/geometry_face_color", Color(0.5, 1.0, 1.0, 0.4));
-	debug_navigation_geometry_edge_disabled_color = GLOBAL_DEF("debug/shapes/navigation/3d/geometry_edge_disabled_color", Color(0.5, 0.5, 0.5, 1.0));
-	debug_navigation_geometry_face_disabled_color = GLOBAL_DEF("debug/shapes/navigation/3d/geometry_face_disabled_color", Color(0.5, 0.5, 0.5, 0.4));
-	debug_navigation_link_connection_color = GLOBAL_DEF("debug/shapes/navigation/3d/link_connection_color", Color(1.0, 0.5, 1.0, 1.0));
-	debug_navigation_link_connection_disabled_color = GLOBAL_DEF("debug/shapes/navigation/3d/link_connection_disabled_color", Color(0.5, 0.5, 0.5, 1.0));
-	debug_navigation_agent_path_color = GLOBAL_DEF("debug/shapes/navigation/3d/agent_path_color", Color(1.0, 0.0, 0.0, 1.0));
-
-	debug_navigation_enable_edge_connections = GLOBAL_DEF("debug/shapes/navigation/3d/enable_edge_connections", true);
-	debug_navigation_enable_edge_connections_xray = GLOBAL_DEF("debug/shapes/navigation/3d/enable_edge_connections_xray", true);
-	debug_navigation_enable_edge_lines = GLOBAL_DEF("debug/shapes/navigation/3d/enable_edge_lines", true);
-	debug_navigation_enable_edge_lines_xray = GLOBAL_DEF("debug/shapes/navigation/3d/enable_edge_lines_xray", true);
-	debug_navigation_enable_geometry_face_random_color = GLOBAL_DEF("debug/shapes/navigation/3d/enable_geometry_face_random_color", true);
-	debug_navigation_enable_link_connections = GLOBAL_DEF("debug/shapes/navigation/3d/enable_link_connections", true);
-	debug_navigation_enable_link_connections_xray = GLOBAL_DEF("debug/shapes/navigation/3d/enable_link_connections_xray", true);
-
-	debug_navigation_enable_agent_paths = GLOBAL_DEF("debug/shapes/navigation/3d/enable_agent_paths", true);
-	debug_navigation_enable_agent_paths_xray = GLOBAL_DEF("debug/shapes/navigation/3d/enable_agent_paths_xray", true);
-	debug_navigation_agent_path_point_size = GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "debug/shapes/navigation/3d/agent_path_point_size", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), 4.0);
-
-	debug_navigation_avoidance_agents_radius_color = GLOBAL_DEF("debug/shapes/avoidance/3d/agents_radius_color", Color(1.0, 1.0, 0.0, 0.25));
-	debug_navigation_avoidance_obstacles_radius_color = GLOBAL_DEF("debug/shapes/avoidance/3d/obstacles_radius_color", Color(1.0, 0.5, 0.0, 0.25));
-	debug_navigation_avoidance_static_obstacle_pushin_face_color = GLOBAL_DEF("debug/shapes/avoidance/3d/obstacles_static_face_pushin_color", Color(1.0, 0.0, 0.0, 0.0));
-	debug_navigation_avoidance_static_obstacle_pushin_edge_color = GLOBAL_DEF("debug/shapes/avoidance/3d/obstacles_static_edge_pushin_color", Color(1.0, 0.0, 0.0, 1.0));
-	debug_navigation_avoidance_static_obstacle_pushout_face_color = GLOBAL_DEF("debug/shapes/avoidance/3d/obstacles_static_face_pushout_color", Color(1.0, 1.0, 0.0, 0.5));
-	debug_navigation_avoidance_static_obstacle_pushout_edge_color = GLOBAL_DEF("debug/shapes/avoidance/3d/obstacles_static_edge_pushout_color", Color(1.0, 1.0, 0.0, 1.0));
-	debug_navigation_avoidance_enable_agents_radius = GLOBAL_DEF("debug/shapes/avoidance/3d/enable_agents_radius", true);
-	debug_navigation_avoidance_enable_obstacles_radius = GLOBAL_DEF("debug/shapes/avoidance/3d/enable_obstacles_radius", true);
-	debug_navigation_avoidance_enable_obstacles_static = GLOBAL_DEF("debug/shapes/avoidance/3d/enable_obstacles_static", true);
-
 	if (Engine::get_singleton()->is_editor_hint()) {
 		// enable NavigationServer3D when in Editor or else navigation mesh edge connections are invisible
 		// on runtime tests SceneTree has "Visible Navigation" set and main iteration takes care of this
-		set_debug_enabled(true);
-		set_debug_navigation_enabled(true);
-		set_debug_avoidance_enabled(true);
+		NavigationServer3DDebug::get_singleton()->set_debug_enabled(true);
+		NavigationServer3DDebug::get_singleton()->set_debug_navigation_enabled(true);
+		NavigationServer3DDebug::get_singleton()->set_debug_avoidance_enabled(true);
 	}
 #endif // DEBUG_ENABLED
 }
 
 NavigationServer3D::~NavigationServer3D() {
+#ifdef DEBUG_ENABLED
+	memdelete(debug);
+	debug = nullptr;
+#endif // DEBUG_ENABLED
+
 	singleton = nullptr;
 
 	RWLockWrite write_lock(geometry_parser_rwlock);
@@ -399,27 +322,33 @@ void NavigationServer3D::source_geometry_parser_set_callback(RID p_parser, const
 
 void NavigationServer3D::set_debug_enabled(bool p_enabled) {
 #ifdef DEBUG_ENABLED
-	if (debug_enabled != p_enabled) {
-		debug_dirty = true;
-	}
-
-	debug_enabled = p_enabled;
-
-	if (debug_dirty) {
-		navigation_debug_dirty = true;
-		callable_mp(this, &NavigationServer3D::_emit_navigation_debug_changed_signal).call_deferred();
-
-		avoidance_debug_dirty = true;
-		callable_mp(this, &NavigationServer3D::_emit_avoidance_debug_changed_signal).call_deferred();
-	}
+	NavigationServer3DDebug::get_singleton()->set_debug_enabled(p_enabled);
 #endif // DEBUG_ENABLED
 }
 
 bool NavigationServer3D::get_debug_enabled() const {
-	return debug_enabled;
+#ifdef DEBUG_ENABLED
+	return NavigationServer3DDebug::get_singleton()->get_debug_enabled();
+#else
+	return false;
+#endif // DEBUG_ENABLED
 }
 
 #ifdef DEBUG_ENABLED
+void NavigationServer3D::emit_navigation_debug_changed() {
+	if (!navigation_debug_dirty) {
+		navigation_debug_dirty = true;
+		callable_mp(this, &NavigationServer3D::_emit_navigation_debug_changed_signal).call_deferred();
+	}
+}
+
+void NavigationServer3D::emit_avoidance_debug_changed() {
+	if (!avoidance_debug_dirty) {
+		avoidance_debug_dirty = true;
+		callable_mp(this, &NavigationServer3D::_emit_avoidance_debug_changed_signal).call_deferred();
+	}
+}
+
 void NavigationServer3D::_emit_navigation_debug_changed_signal() {
 	if (navigation_debug_dirty) {
 		navigation_debug_dirty = false;
@@ -435,602 +364,30 @@ void NavigationServer3D::_emit_avoidance_debug_changed_signal() {
 }
 #endif // DEBUG_ENABLED
 
+void NavigationServer3D::register_settings() {
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/3d/default_cell_size", PROPERTY_HINT_RANGE, NavigationDefaults3D::NAV_MESH_CELL_SIZE_HINT), NavigationDefaults3D::NAV_MESH_CELL_SIZE);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/3d/default_cell_height", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater"), NavigationDefaults3D::NAV_MESH_CELL_HEIGHT);
+	GLOBAL_DEF("navigation/3d/default_up", Vector3(0, 1, 0));
+	GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "navigation/3d/merge_rasterizer_cell_scale", PROPERTY_HINT_RANGE, "0.001,1,0.001,or_greater"), 1.0);
+	GLOBAL_DEF("navigation/3d/use_edge_connections", true);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/3d/default_edge_connection_margin", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), NavigationDefaults3D::EDGE_CONNECTION_MARGIN);
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::FLOAT, "navigation/3d/default_link_connection_radius", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), NavigationDefaults3D::LINK_CONNECTION_RADIUS);
+
+	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &NavigationServer3D::update_from_settings));
+
 #ifdef DEBUG_ENABLED
-Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_geometry_face_material() {
-	if (debug_navigation_geometry_face_material.is_valid()) {
-		return debug_navigation_geometry_face_material;
-	}
-
-	bool enabled_geometry_face_random_color = get_debug_navigation_enable_geometry_face_random_color();
-
-	Ref<StandardMaterial3D> face_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
-	face_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-	face_material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
-	face_material->set_albedo(get_debug_navigation_geometry_face_color());
-	face_material->set_cull_mode(StandardMaterial3D::CULL_DISABLED);
-	face_material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-	if (enabled_geometry_face_random_color) {
-		face_material->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
-		face_material->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
-	}
-
-	debug_navigation_geometry_face_material = face_material;
-
-	return debug_navigation_geometry_face_material;
-}
-
-Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_geometry_edge_material() {
-	if (debug_navigation_geometry_edge_material.is_valid()) {
-		return debug_navigation_geometry_edge_material;
-	}
-
-	bool enabled_edge_lines_xray = get_debug_navigation_enable_edge_lines_xray();
-
-	Ref<StandardMaterial3D> line_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
-	line_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-	line_material->set_albedo(get_debug_navigation_geometry_edge_color());
-	line_material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-	if (enabled_edge_lines_xray) {
-		line_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
-	}
-
-	debug_navigation_geometry_edge_material = line_material;
-
-	return debug_navigation_geometry_edge_material;
-}
-
-Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_geometry_face_disabled_material() {
-	if (debug_navigation_geometry_face_disabled_material.is_valid()) {
-		return debug_navigation_geometry_face_disabled_material;
-	}
-
-	Ref<StandardMaterial3D> face_disabled_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
-	face_disabled_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-	face_disabled_material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
-	face_disabled_material->set_albedo(get_debug_navigation_geometry_face_disabled_color());
-	face_disabled_material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-
-	debug_navigation_geometry_face_disabled_material = face_disabled_material;
-
-	return debug_navigation_geometry_face_disabled_material;
-}
-
-Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_geometry_edge_disabled_material() {
-	if (debug_navigation_geometry_edge_disabled_material.is_valid()) {
-		return debug_navigation_geometry_edge_disabled_material;
-	}
-
-	bool enabled_edge_lines_xray = get_debug_navigation_enable_edge_lines_xray();
-
-	Ref<StandardMaterial3D> line_disabled_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
-	line_disabled_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-	line_disabled_material->set_albedo(get_debug_navigation_geometry_edge_disabled_color());
-	line_disabled_material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-	if (enabled_edge_lines_xray) {
-		line_disabled_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
-	}
-
-	debug_navigation_geometry_edge_disabled_material = line_disabled_material;
-
-	return debug_navigation_geometry_edge_disabled_material;
-}
-
-Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_edge_connections_material() {
-	if (debug_navigation_edge_connections_material.is_valid()) {
-		return debug_navigation_edge_connections_material;
-	}
-
-	bool enabled_edge_connections_xray = get_debug_navigation_enable_edge_connections_xray();
-
-	Ref<StandardMaterial3D> edge_connections_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
-	edge_connections_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-	edge_connections_material->set_albedo(get_debug_navigation_edge_connection_color());
-	edge_connections_material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-	if (enabled_edge_connections_xray) {
-		edge_connections_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
-	}
-	edge_connections_material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MAX - 2);
-
-	debug_navigation_edge_connections_material = edge_connections_material;
-
-	return debug_navigation_edge_connections_material;
-}
-
-Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_link_connections_material() {
-	if (debug_navigation_link_connections_material.is_valid()) {
-		return debug_navigation_link_connections_material;
-	}
-
-	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
-	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-	material->set_albedo(debug_navigation_link_connection_color);
-	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-	if (debug_navigation_enable_link_connections_xray) {
-		material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
-	}
-	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MAX - 2);
-
-	debug_navigation_link_connections_material = material;
-	return debug_navigation_link_connections_material;
-}
-
-Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_link_connections_disabled_material() {
-	if (debug_navigation_link_connections_disabled_material.is_valid()) {
-		return debug_navigation_link_connections_disabled_material;
-	}
-
-	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
-	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-	material->set_albedo(debug_navigation_link_connection_disabled_color);
-	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-	if (debug_navigation_enable_link_connections_xray) {
-		material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
-	}
-	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MAX - 2);
-
-	debug_navigation_link_connections_disabled_material = material;
-	return debug_navigation_link_connections_disabled_material;
-}
-
-Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_agent_path_line_material() {
-	if (debug_navigation_agent_path_line_material.is_valid()) {
-		return debug_navigation_agent_path_line_material;
-	}
-
-	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
-	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-
-	material->set_albedo(debug_navigation_agent_path_color);
-	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-	if (debug_navigation_enable_agent_paths_xray) {
-		material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
-	}
-	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MAX - 2);
-
-	debug_navigation_agent_path_line_material = material;
-	return debug_navigation_agent_path_line_material;
-}
-
-Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_agent_path_point_material() {
-	if (debug_navigation_agent_path_point_material.is_valid()) {
-		return debug_navigation_agent_path_point_material;
-	}
-
-	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
-	material->set_albedo(debug_navigation_agent_path_color);
-	material->set_flag(StandardMaterial3D::FLAG_USE_POINT_SIZE, true);
-	material->set_point_size(debug_navigation_agent_path_point_size);
-	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-	if (debug_navigation_enable_agent_paths_xray) {
-		material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
-	}
-	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MAX - 2);
-
-	debug_navigation_agent_path_point_material = material;
-	return debug_navigation_agent_path_point_material;
-}
-
-Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_avoidance_agents_radius_material() {
-	if (debug_navigation_avoidance_agents_radius_material.is_valid()) {
-		return debug_navigation_avoidance_agents_radius_material;
-	}
-
-	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
-	material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
-	material->set_cull_mode(StandardMaterial3D::CULL_DISABLED);
-	material->set_albedo(debug_navigation_avoidance_agents_radius_color);
-	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MIN + 2);
-
-	debug_navigation_avoidance_agents_radius_material = material;
-	return debug_navigation_avoidance_agents_radius_material;
-}
-
-Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_avoidance_obstacles_radius_material() {
-	if (debug_navigation_avoidance_obstacles_radius_material.is_valid()) {
-		return debug_navigation_avoidance_obstacles_radius_material;
-	}
-
-	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
-	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-	material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
-	material->set_cull_mode(StandardMaterial3D::CULL_DISABLED);
-	material->set_albedo(debug_navigation_avoidance_obstacles_radius_color);
-	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MIN + 2);
-
-	debug_navigation_avoidance_obstacles_radius_material = material;
-	return debug_navigation_avoidance_obstacles_radius_material;
-}
-
-Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_avoidance_static_obstacle_pushin_face_material() {
-	if (debug_navigation_avoidance_static_obstacle_pushin_face_material.is_valid()) {
-		return debug_navigation_avoidance_static_obstacle_pushin_face_material;
-	}
-
-	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
-	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-	material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
-	material->set_cull_mode(StandardMaterial3D::CULL_DISABLED);
-	material->set_albedo(debug_navigation_avoidance_static_obstacle_pushin_face_color);
-	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MIN + 2);
-
-	debug_navigation_avoidance_static_obstacle_pushin_face_material = material;
-	return debug_navigation_avoidance_static_obstacle_pushin_face_material;
-}
-
-Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_avoidance_static_obstacle_pushout_face_material() {
-	if (debug_navigation_avoidance_static_obstacle_pushout_face_material.is_valid()) {
-		return debug_navigation_avoidance_static_obstacle_pushout_face_material;
-	}
-
-	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
-	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-	material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
-	material->set_cull_mode(StandardMaterial3D::CULL_DISABLED);
-	material->set_albedo(debug_navigation_avoidance_static_obstacle_pushout_face_color);
-	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MIN + 2);
-
-	debug_navigation_avoidance_static_obstacle_pushout_face_material = material;
-	return debug_navigation_avoidance_static_obstacle_pushout_face_material;
-}
-
-Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_avoidance_static_obstacle_pushin_edge_material() {
-	if (debug_navigation_avoidance_static_obstacle_pushin_edge_material.is_valid()) {
-		return debug_navigation_avoidance_static_obstacle_pushin_edge_material;
-	}
-
-	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
-	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-	//material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
-	//material->set_cull_mode(StandardMaterial3D::CULL_DISABLED);
-	material->set_albedo(debug_navigation_avoidance_static_obstacle_pushin_edge_color);
-	//material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MIN + 2);
-	material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
-
-	debug_navigation_avoidance_static_obstacle_pushin_edge_material = material;
-	return debug_navigation_avoidance_static_obstacle_pushin_edge_material;
-}
-
-Ref<StandardMaterial3D> NavigationServer3D::get_debug_navigation_avoidance_static_obstacle_pushout_edge_material() {
-	if (debug_navigation_avoidance_static_obstacle_pushout_edge_material.is_valid()) {
-		return debug_navigation_avoidance_static_obstacle_pushout_edge_material;
-	}
-
-	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
-	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
-	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
-	///material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
-	//material->set_cull_mode(StandardMaterial3D::CULL_DISABLED);
-	material->set_albedo(debug_navigation_avoidance_static_obstacle_pushout_edge_color);
-	//material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MIN + 2);
-	material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
-
-	debug_navigation_avoidance_static_obstacle_pushout_edge_material = material;
-	return debug_navigation_avoidance_static_obstacle_pushout_edge_material;
-}
-
-void NavigationServer3D::set_debug_navigation_edge_connection_color(const Color &p_color) {
-	debug_navigation_edge_connection_color = p_color;
-	if (debug_navigation_edge_connections_material.is_valid()) {
-		debug_navigation_edge_connections_material->set_albedo(debug_navigation_edge_connection_color);
-	}
-}
-
-Color NavigationServer3D::get_debug_navigation_edge_connection_color() const {
-	return debug_navigation_edge_connection_color;
-}
-
-void NavigationServer3D::set_debug_navigation_geometry_edge_color(const Color &p_color) {
-	debug_navigation_geometry_edge_color = p_color;
-	if (debug_navigation_geometry_edge_material.is_valid()) {
-		debug_navigation_geometry_edge_material->set_albedo(debug_navigation_geometry_edge_color);
-	}
-}
-
-Color NavigationServer3D::get_debug_navigation_geometry_edge_color() const {
-	return debug_navigation_geometry_edge_color;
-}
-
-void NavigationServer3D::set_debug_navigation_geometry_face_color(const Color &p_color) {
-	debug_navigation_geometry_face_color = p_color;
-	if (debug_navigation_geometry_face_material.is_valid()) {
-		debug_navigation_geometry_face_material->set_albedo(debug_navigation_geometry_face_color);
-	}
-}
-
-Color NavigationServer3D::get_debug_navigation_geometry_face_color() const {
-	return debug_navigation_geometry_face_color;
-}
-
-void NavigationServer3D::set_debug_navigation_geometry_edge_disabled_color(const Color &p_color) {
-	debug_navigation_geometry_edge_disabled_color = p_color;
-	if (debug_navigation_geometry_edge_disabled_material.is_valid()) {
-		debug_navigation_geometry_edge_disabled_material->set_albedo(debug_navigation_geometry_edge_disabled_color);
-	}
-}
-
-Color NavigationServer3D::get_debug_navigation_geometry_edge_disabled_color() const {
-	return debug_navigation_geometry_edge_disabled_color;
-}
-
-void NavigationServer3D::set_debug_navigation_geometry_face_disabled_color(const Color &p_color) {
-	debug_navigation_geometry_face_disabled_color = p_color;
-	if (debug_navigation_geometry_face_disabled_material.is_valid()) {
-		debug_navigation_geometry_face_disabled_material->set_albedo(debug_navigation_geometry_face_disabled_color);
-	}
-}
-
-Color NavigationServer3D::get_debug_navigation_geometry_face_disabled_color() const {
-	return debug_navigation_geometry_face_disabled_color;
-}
-
-void NavigationServer3D::set_debug_navigation_link_connection_color(const Color &p_color) {
-	debug_navigation_link_connection_color = p_color;
-	if (debug_navigation_link_connections_material.is_valid()) {
-		debug_navigation_link_connections_material->set_albedo(debug_navigation_link_connection_color);
-	}
-}
-
-Color NavigationServer3D::get_debug_navigation_link_connection_color() const {
-	return debug_navigation_link_connection_color;
-}
-
-void NavigationServer3D::set_debug_navigation_link_connection_disabled_color(const Color &p_color) {
-	debug_navigation_link_connection_disabled_color = p_color;
-	if (debug_navigation_link_connections_disabled_material.is_valid()) {
-		debug_navigation_link_connections_disabled_material->set_albedo(debug_navigation_link_connection_disabled_color);
-	}
-}
-
-Color NavigationServer3D::get_debug_navigation_link_connection_disabled_color() const {
-	return debug_navigation_link_connection_disabled_color;
-}
-
-void NavigationServer3D::set_debug_navigation_agent_path_point_size(real_t p_point_size) {
-	debug_navigation_agent_path_point_size = MAX(0.1, p_point_size);
-	if (debug_navigation_agent_path_point_material.is_valid()) {
-		debug_navigation_agent_path_point_material->set_point_size(debug_navigation_agent_path_point_size);
-	}
-}
-
-real_t NavigationServer3D::get_debug_navigation_agent_path_point_size() const {
-	return debug_navigation_agent_path_point_size;
-}
-
-void NavigationServer3D::set_debug_navigation_agent_path_color(const Color &p_color) {
-	debug_navigation_agent_path_color = p_color;
-	if (debug_navigation_agent_path_line_material.is_valid()) {
-		debug_navigation_agent_path_line_material->set_albedo(debug_navigation_agent_path_color);
-	}
-	if (debug_navigation_agent_path_point_material.is_valid()) {
-		debug_navigation_agent_path_point_material->set_albedo(debug_navigation_agent_path_color);
-	}
-}
-
-Color NavigationServer3D::get_debug_navigation_agent_path_color() const {
-	return debug_navigation_agent_path_color;
-}
-
-void NavigationServer3D::set_debug_navigation_enable_edge_connections(const bool p_value) {
-	debug_navigation_enable_edge_connections = p_value;
-	navigation_debug_dirty = true;
-	callable_mp(this, &NavigationServer3D::_emit_navigation_debug_changed_signal).call_deferred();
-}
-
-bool NavigationServer3D::get_debug_navigation_enable_edge_connections() const {
-	return debug_navigation_enable_edge_connections;
-}
-
-void NavigationServer3D::set_debug_navigation_enable_edge_connections_xray(const bool p_value) {
-	debug_navigation_enable_edge_connections_xray = p_value;
-	if (debug_navigation_edge_connections_material.is_valid()) {
-		debug_navigation_edge_connections_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, debug_navigation_enable_edge_connections_xray);
-	}
-}
-
-bool NavigationServer3D::get_debug_navigation_enable_edge_connections_xray() const {
-	return debug_navigation_enable_edge_connections_xray;
-}
-
-void NavigationServer3D::set_debug_navigation_enable_edge_lines(const bool p_value) {
-	debug_navigation_enable_edge_lines = p_value;
-	navigation_debug_dirty = true;
-	callable_mp(this, &NavigationServer3D::_emit_navigation_debug_changed_signal).call_deferred();
-}
-
-bool NavigationServer3D::get_debug_navigation_enable_edge_lines() const {
-	return debug_navigation_enable_edge_lines;
-}
-
-void NavigationServer3D::set_debug_navigation_enable_edge_lines_xray(const bool p_value) {
-	debug_navigation_enable_edge_lines_xray = p_value;
-	if (debug_navigation_geometry_edge_material.is_valid()) {
-		debug_navigation_geometry_edge_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, debug_navigation_enable_edge_lines_xray);
-	}
-}
-
-bool NavigationServer3D::get_debug_navigation_enable_edge_lines_xray() const {
-	return debug_navigation_enable_edge_lines_xray;
-}
-
-void NavigationServer3D::set_debug_navigation_enable_geometry_face_random_color(const bool p_value) {
-	debug_navigation_enable_geometry_face_random_color = p_value;
-	navigation_debug_dirty = true;
-	callable_mp(this, &NavigationServer3D::_emit_navigation_debug_changed_signal).call_deferred();
-}
-
-bool NavigationServer3D::get_debug_navigation_enable_geometry_face_random_color() const {
-	return debug_navigation_enable_geometry_face_random_color;
-}
-
-void NavigationServer3D::set_debug_navigation_enable_link_connections(const bool p_value) {
-	debug_navigation_enable_link_connections = p_value;
-	navigation_debug_dirty = true;
-	callable_mp(this, &NavigationServer3D::_emit_navigation_debug_changed_signal).call_deferred();
-}
-
-bool NavigationServer3D::get_debug_navigation_enable_link_connections() const {
-	return debug_navigation_enable_link_connections;
-}
-
-void NavigationServer3D::set_debug_navigation_enable_link_connections_xray(const bool p_value) {
-	debug_navigation_enable_link_connections_xray = p_value;
-	if (debug_navigation_link_connections_material.is_valid()) {
-		debug_navigation_link_connections_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, debug_navigation_enable_link_connections_xray);
-	}
-}
-
-bool NavigationServer3D::get_debug_navigation_enable_link_connections_xray() const {
-	return debug_navigation_enable_link_connections_xray;
-}
-
-void NavigationServer3D::set_debug_navigation_avoidance_enable_agents_radius(const bool p_value) {
-	debug_navigation_avoidance_enable_agents_radius = p_value;
-	avoidance_debug_dirty = true;
-	callable_mp(this, &NavigationServer3D::_emit_avoidance_debug_changed_signal).call_deferred();
-}
-
-bool NavigationServer3D::get_debug_navigation_avoidance_enable_agents_radius() const {
-	return debug_navigation_avoidance_enable_agents_radius;
-}
-
-void NavigationServer3D::set_debug_navigation_avoidance_enable_obstacles_radius(const bool p_value) {
-	debug_navigation_avoidance_enable_obstacles_radius = p_value;
-	avoidance_debug_dirty = true;
-	callable_mp(this, &NavigationServer3D::_emit_avoidance_debug_changed_signal).call_deferred();
-}
-
-bool NavigationServer3D::get_debug_navigation_avoidance_enable_obstacles_radius() const {
-	return debug_navigation_avoidance_enable_obstacles_radius;
-}
-
-void NavigationServer3D::set_debug_navigation_avoidance_enable_obstacles_static(const bool p_value) {
-	debug_navigation_avoidance_enable_obstacles_static = p_value;
-	avoidance_debug_dirty = true;
-	callable_mp(this, &NavigationServer3D::_emit_avoidance_debug_changed_signal).call_deferred();
-}
-
-bool NavigationServer3D::get_debug_navigation_avoidance_enable_obstacles_static() const {
-	return debug_navigation_avoidance_enable_obstacles_static;
-}
-
-void NavigationServer3D::set_debug_navigation_avoidance_agents_radius_color(const Color &p_color) {
-	debug_navigation_avoidance_agents_radius_color = p_color;
-	if (debug_navigation_avoidance_agents_radius_material.is_valid()) {
-		debug_navigation_avoidance_agents_radius_material->set_albedo(debug_navigation_avoidance_agents_radius_color);
-	}
-}
-
-Color NavigationServer3D::get_debug_navigation_avoidance_agents_radius_color() const {
-	return debug_navigation_avoidance_agents_radius_color;
-}
-
-void NavigationServer3D::set_debug_navigation_avoidance_obstacles_radius_color(const Color &p_color) {
-	debug_navigation_avoidance_obstacles_radius_color = p_color;
-	if (debug_navigation_avoidance_obstacles_radius_material.is_valid()) {
-		debug_navigation_avoidance_obstacles_radius_material->set_albedo(debug_navigation_avoidance_obstacles_radius_color);
-	}
-}
-
-Color NavigationServer3D::get_debug_navigation_avoidance_obstacles_radius_color() const {
-	return debug_navigation_avoidance_obstacles_radius_color;
-}
-
-void NavigationServer3D::set_debug_navigation_avoidance_static_obstacle_pushin_face_color(const Color &p_color) {
-	debug_navigation_avoidance_static_obstacle_pushin_face_color = p_color;
-	if (debug_navigation_avoidance_static_obstacle_pushin_face_material.is_valid()) {
-		debug_navigation_avoidance_static_obstacle_pushin_face_material->set_albedo(debug_navigation_avoidance_static_obstacle_pushin_face_color);
-	}
-}
-
-Color NavigationServer3D::get_debug_navigation_avoidance_static_obstacle_pushin_face_color() const {
-	return debug_navigation_avoidance_static_obstacle_pushin_face_color;
-}
-
-void NavigationServer3D::set_debug_navigation_avoidance_static_obstacle_pushout_face_color(const Color &p_color) {
-	debug_navigation_avoidance_static_obstacle_pushout_face_color = p_color;
-	if (debug_navigation_avoidance_static_obstacle_pushout_face_material.is_valid()) {
-		debug_navigation_avoidance_static_obstacle_pushout_face_material->set_albedo(debug_navigation_avoidance_static_obstacle_pushout_face_color);
-	}
-}
-
-Color NavigationServer3D::get_debug_navigation_avoidance_static_obstacle_pushout_face_color() const {
-	return debug_navigation_avoidance_static_obstacle_pushout_face_color;
-}
-
-void NavigationServer3D::set_debug_navigation_avoidance_static_obstacle_pushin_edge_color(const Color &p_color) {
-	debug_navigation_avoidance_static_obstacle_pushin_edge_color = p_color;
-	if (debug_navigation_avoidance_static_obstacle_pushin_edge_material.is_valid()) {
-		debug_navigation_avoidance_static_obstacle_pushin_edge_material->set_albedo(debug_navigation_avoidance_static_obstacle_pushin_edge_color);
-	}
-}
-
-Color NavigationServer3D::get_debug_navigation_avoidance_static_obstacle_pushin_edge_color() const {
-	return debug_navigation_avoidance_static_obstacle_pushin_edge_color;
-}
-
-void NavigationServer3D::set_debug_navigation_avoidance_static_obstacle_pushout_edge_color(const Color &p_color) {
-	debug_navigation_avoidance_static_obstacle_pushout_edge_color = p_color;
-	if (debug_navigation_avoidance_static_obstacle_pushout_edge_material.is_valid()) {
-		debug_navigation_avoidance_static_obstacle_pushout_edge_material->set_albedo(debug_navigation_avoidance_static_obstacle_pushout_edge_color);
-	}
-}
-
-Color NavigationServer3D::get_debug_navigation_avoidance_static_obstacle_pushout_edge_color() const {
-	return debug_navigation_avoidance_static_obstacle_pushout_edge_color;
-}
-
-void NavigationServer3D::set_debug_navigation_enable_agent_paths(const bool p_value) {
-	if (debug_navigation_enable_agent_paths != p_value) {
-		debug_dirty = true;
-	}
-
-	debug_navigation_enable_agent_paths = p_value;
-
-	if (debug_dirty) {
-		callable_mp(this, &NavigationServer3D::_emit_navigation_debug_changed_signal).call_deferred();
-	}
-}
-
-bool NavigationServer3D::get_debug_navigation_enable_agent_paths() const {
-	return debug_navigation_enable_agent_paths;
-}
-
-void NavigationServer3D::set_debug_navigation_enable_agent_paths_xray(const bool p_value) {
-	debug_navigation_enable_agent_paths_xray = p_value;
-	if (debug_navigation_agent_path_line_material.is_valid()) {
-		debug_navigation_agent_path_line_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, debug_navigation_enable_agent_paths_xray);
-	}
-	if (debug_navigation_agent_path_point_material.is_valid()) {
-		debug_navigation_agent_path_point_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, debug_navigation_enable_agent_paths_xray);
-	}
-}
-
-bool NavigationServer3D::get_debug_navigation_enable_agent_paths_xray() const {
-	return debug_navigation_enable_agent_paths_xray;
-}
-
-void NavigationServer3D::set_debug_navigation_enabled(bool p_enabled) {
-	debug_navigation_enabled = p_enabled;
-	navigation_debug_dirty = true;
-	callable_mp(this, &NavigationServer3D::_emit_navigation_debug_changed_signal).call_deferred();
-}
-
-bool NavigationServer3D::get_debug_navigation_enabled() const {
-	return debug_navigation_enabled;
-}
-
-void NavigationServer3D::set_debug_avoidance_enabled(bool p_enabled) {
-	debug_avoidance_enabled = p_enabled;
-	avoidance_debug_dirty = true;
-	callable_mp(this, &NavigationServer3D::_emit_avoidance_debug_changed_signal).call_deferred();
-}
-
-bool NavigationServer3D::get_debug_avoidance_enabled() const {
-	return debug_avoidance_enabled;
-}
-
+	NavigationServer3DDebug::get_singleton()->register_settings();
 #endif // DEBUG_ENABLED
+}
+
+void NavigationServer3D::update_from_settings() {
+#ifdef DEBUG_ENABLED
+	NavigationServer3DDebug::get_singleton()->update_from_settings();
+	if (ProjectSettings::get_singleton()->check_changed_settings_in_group("debug/shapes/navigation/3d")) {
+		navigation_debug_dirty = true;
+		callable_mp(this, &NavigationServer3D::_emit_navigation_debug_changed_signal).call_deferred();
+		avoidance_debug_dirty = true;
+		callable_mp(this, &NavigationServer3D::_emit_avoidance_debug_changed_signal).call_deferred();
+	}
+#endif // DEBUG_ENABLED
+}

--- a/servers/navigation_3d/navigation_server_3d.h
+++ b/servers/navigation_3d/navigation_server_3d.h
@@ -33,7 +33,11 @@
 #include "core/object/ref_counted.h"
 #include "core/os/rw_lock.h"
 #include "core/templates/rid_owner.h"
-#include "scene/resources/material.h"
+#include "core/variant/type_info.h"
+
+#ifdef DEBUG_ENABLED
+class NavigationServer3DDebug;
+#endif // DEBUG_ENABLED
 
 class Node;
 class NavigationMesh;
@@ -348,178 +352,24 @@ protected:
 	static void _bind_compatibility_methods();
 #endif
 
-private:
-	bool debug_enabled = false;
-
 #ifdef DEBUG_ENABLED
-	bool debug_dirty = true;
+public:
+	void emit_navigation_debug_changed();
+	void emit_avoidance_debug_changed();
 
-	bool debug_navigation_enabled = false;
-	bool navigation_debug_dirty = true;
+private:
+	NavigationServer3DDebug *debug = nullptr;
+
+	bool navigation_debug_dirty = false;
 	void _emit_navigation_debug_changed_signal();
 
-	bool debug_avoidance_enabled = false;
-	bool avoidance_debug_dirty = true;
+	bool avoidance_debug_dirty = false;
 	void _emit_avoidance_debug_changed_signal();
-
-	Color debug_navigation_edge_connection_color = Color(1.0, 0.0, 1.0, 1.0);
-	Color debug_navigation_geometry_edge_color = Color(0.5, 1.0, 1.0, 1.0);
-	Color debug_navigation_geometry_face_color = Color(0.5, 1.0, 1.0, 0.4);
-	Color debug_navigation_geometry_edge_disabled_color = Color(0.5, 0.5, 0.5, 1.0);
-	Color debug_navigation_geometry_face_disabled_color = Color(0.5, 0.5, 0.5, 0.4);
-	Color debug_navigation_link_connection_color = Color(1.0, 0.5, 1.0, 1.0);
-	Color debug_navigation_link_connection_disabled_color = Color(0.5, 0.5, 0.5, 1.0);
-	Color debug_navigation_agent_path_color = Color(1.0, 0.0, 0.0, 1.0);
-
-	real_t debug_navigation_agent_path_point_size = 4.0;
-
-	Color debug_navigation_avoidance_agents_radius_color = Color(1.0, 1.0, 0.0, 0.25);
-	Color debug_navigation_avoidance_obstacles_radius_color = Color(1.0, 0.5, 0.0, 0.25);
-
-	Color debug_navigation_avoidance_static_obstacle_pushin_face_color = Color(1.0, 0.0, 0.0, 0.0);
-	Color debug_navigation_avoidance_static_obstacle_pushout_face_color = Color(1.0, 1.0, 0.0, 0.5);
-	Color debug_navigation_avoidance_static_obstacle_pushin_edge_color = Color(1.0, 0.0, 0.0, 1.0);
-	Color debug_navigation_avoidance_static_obstacle_pushout_edge_color = Color(1.0, 1.0, 0.0, 1.0);
-
-	bool debug_navigation_enable_edge_connections = true;
-	bool debug_navigation_enable_edge_connections_xray = true;
-	bool debug_navigation_enable_edge_lines = true;
-	bool debug_navigation_enable_edge_lines_xray = true;
-	bool debug_navigation_enable_geometry_face_random_color = true;
-	bool debug_navigation_enable_link_connections = true;
-	bool debug_navigation_enable_link_connections_xray = true;
-	bool debug_navigation_enable_agent_paths = true;
-	bool debug_navigation_enable_agent_paths_xray = true;
-
-	bool debug_navigation_avoidance_enable_agents_radius = true;
-	bool debug_navigation_avoidance_enable_obstacles_radius = true;
-	bool debug_navigation_avoidance_enable_obstacles_static = true;
-
-	Ref<StandardMaterial3D> debug_navigation_geometry_edge_material;
-	Ref<StandardMaterial3D> debug_navigation_geometry_face_material;
-	Ref<StandardMaterial3D> debug_navigation_geometry_edge_disabled_material;
-	Ref<StandardMaterial3D> debug_navigation_geometry_face_disabled_material;
-	Ref<StandardMaterial3D> debug_navigation_edge_connections_material;
-	Ref<StandardMaterial3D> debug_navigation_link_connections_material;
-	Ref<StandardMaterial3D> debug_navigation_link_connections_disabled_material;
-	Ref<StandardMaterial3D> debug_navigation_avoidance_agents_radius_material;
-	Ref<StandardMaterial3D> debug_navigation_avoidance_obstacles_radius_material;
-
-	Ref<StandardMaterial3D> debug_navigation_avoidance_static_obstacle_pushin_face_material;
-	Ref<StandardMaterial3D> debug_navigation_avoidance_static_obstacle_pushout_face_material;
-	Ref<StandardMaterial3D> debug_navigation_avoidance_static_obstacle_pushin_edge_material;
-	Ref<StandardMaterial3D> debug_navigation_avoidance_static_obstacle_pushout_edge_material;
-
-	Ref<StandardMaterial3D> debug_navigation_agent_path_line_material;
-	Ref<StandardMaterial3D> debug_navigation_agent_path_point_material;
+#endif // DEBUG_ENABLED
 
 public:
-	void set_debug_navigation_enabled(bool p_enabled);
-	bool get_debug_navigation_enabled() const;
-
-	void set_debug_avoidance_enabled(bool p_enabled);
-	bool get_debug_avoidance_enabled() const;
-
-	void set_debug_navigation_edge_connection_color(const Color &p_color);
-	Color get_debug_navigation_edge_connection_color() const;
-
-	void set_debug_navigation_geometry_edge_color(const Color &p_color);
-	Color get_debug_navigation_geometry_edge_color() const;
-
-	void set_debug_navigation_geometry_face_color(const Color &p_color);
-	Color get_debug_navigation_geometry_face_color() const;
-
-	void set_debug_navigation_geometry_edge_disabled_color(const Color &p_color);
-	Color get_debug_navigation_geometry_edge_disabled_color() const;
-
-	void set_debug_navigation_geometry_face_disabled_color(const Color &p_color);
-	Color get_debug_navigation_geometry_face_disabled_color() const;
-
-	void set_debug_navigation_link_connection_color(const Color &p_color);
-	Color get_debug_navigation_link_connection_color() const;
-
-	void set_debug_navigation_link_connection_disabled_color(const Color &p_color);
-	Color get_debug_navigation_link_connection_disabled_color() const;
-
-	void set_debug_navigation_agent_path_color(const Color &p_color);
-	Color get_debug_navigation_agent_path_color() const;
-
-	void set_debug_navigation_avoidance_agents_radius_color(const Color &p_color);
-	Color get_debug_navigation_avoidance_agents_radius_color() const;
-
-	void set_debug_navigation_avoidance_obstacles_radius_color(const Color &p_color);
-	Color get_debug_navigation_avoidance_obstacles_radius_color() const;
-
-	void set_debug_navigation_avoidance_static_obstacle_pushin_face_color(const Color &p_color);
-	Color get_debug_navigation_avoidance_static_obstacle_pushin_face_color() const;
-
-	void set_debug_navigation_avoidance_static_obstacle_pushout_face_color(const Color &p_color);
-	Color get_debug_navigation_avoidance_static_obstacle_pushout_face_color() const;
-
-	void set_debug_navigation_avoidance_static_obstacle_pushin_edge_color(const Color &p_color);
-	Color get_debug_navigation_avoidance_static_obstacle_pushin_edge_color() const;
-
-	void set_debug_navigation_avoidance_static_obstacle_pushout_edge_color(const Color &p_color);
-	Color get_debug_navigation_avoidance_static_obstacle_pushout_edge_color() const;
-
-	void set_debug_navigation_enable_edge_connections(const bool p_value);
-	bool get_debug_navigation_enable_edge_connections() const;
-
-	void set_debug_navigation_enable_edge_connections_xray(const bool p_value);
-	bool get_debug_navigation_enable_edge_connections_xray() const;
-
-	void set_debug_navigation_enable_edge_lines(const bool p_value);
-	bool get_debug_navigation_enable_edge_lines() const;
-
-	void set_debug_navigation_enable_edge_lines_xray(const bool p_value);
-	bool get_debug_navigation_enable_edge_lines_xray() const;
-
-	void set_debug_navigation_enable_geometry_face_random_color(const bool p_value);
-	bool get_debug_navigation_enable_geometry_face_random_color() const;
-
-	void set_debug_navigation_enable_link_connections(const bool p_value);
-	bool get_debug_navigation_enable_link_connections() const;
-
-	void set_debug_navigation_enable_link_connections_xray(const bool p_value);
-	bool get_debug_navigation_enable_link_connections_xray() const;
-
-	void set_debug_navigation_enable_agent_paths(const bool p_value);
-	bool get_debug_navigation_enable_agent_paths() const;
-
-	void set_debug_navigation_enable_agent_paths_xray(const bool p_value);
-	bool get_debug_navigation_enable_agent_paths_xray() const;
-
-	void set_debug_navigation_agent_path_point_size(real_t p_point_size);
-	real_t get_debug_navigation_agent_path_point_size() const;
-
-	void set_debug_navigation_avoidance_enable_agents_radius(const bool p_value);
-	bool get_debug_navigation_avoidance_enable_agents_radius() const;
-
-	void set_debug_navigation_avoidance_enable_obstacles_radius(const bool p_value);
-	bool get_debug_navigation_avoidance_enable_obstacles_radius() const;
-
-	void set_debug_navigation_avoidance_enable_obstacles_static(const bool p_value);
-	bool get_debug_navigation_avoidance_enable_obstacles_static() const;
-
-	Ref<StandardMaterial3D> get_debug_navigation_geometry_face_material();
-	Ref<StandardMaterial3D> get_debug_navigation_geometry_edge_material();
-	Ref<StandardMaterial3D> get_debug_navigation_geometry_face_disabled_material();
-	Ref<StandardMaterial3D> get_debug_navigation_geometry_edge_disabled_material();
-	Ref<StandardMaterial3D> get_debug_navigation_edge_connections_material();
-	Ref<StandardMaterial3D> get_debug_navigation_link_connections_material();
-	Ref<StandardMaterial3D> get_debug_navigation_link_connections_disabled_material();
-
-	Ref<StandardMaterial3D> get_debug_navigation_agent_path_line_material();
-	Ref<StandardMaterial3D> get_debug_navigation_agent_path_point_material();
-
-	Ref<StandardMaterial3D> get_debug_navigation_avoidance_agents_radius_material();
-	Ref<StandardMaterial3D> get_debug_navigation_avoidance_obstacles_radius_material();
-
-	Ref<StandardMaterial3D> get_debug_navigation_avoidance_static_obstacle_pushin_face_material();
-	Ref<StandardMaterial3D> get_debug_navigation_avoidance_static_obstacle_pushout_face_material();
-	Ref<StandardMaterial3D> get_debug_navigation_avoidance_static_obstacle_pushin_edge_material();
-	Ref<StandardMaterial3D> get_debug_navigation_avoidance_static_obstacle_pushout_edge_material();
-#endif // DEBUG_ENABLED
+	void register_settings();
+	void update_from_settings();
 };
 
 VARIANT_ENUM_CAST(NavigationServer3D::ProcessInfo);

--- a/servers/navigation_3d/navigation_server_3d_debug.cpp
+++ b/servers/navigation_3d/navigation_server_3d_debug.cpp
@@ -1,0 +1,743 @@
+/**************************************************************************/
+/*  navigation_server_3d_debug.cpp                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifdef DEBUG_ENABLED
+
+#include "navigation_server_3d_debug.h"
+
+#include "core/config/project_settings.h"
+#include "scene/resources/material.h"
+#include "servers/navigation_3d/navigation_server_3d.h"
+
+NavigationServer3DDebug *NavigationServer3DDebug::singleton = nullptr;
+
+NavigationServer3DDebug *NavigationServer3DDebug::get_singleton() {
+	return singleton;
+}
+
+NavigationServer3DDebug::NavigationServer3DDebug() {
+	ERR_FAIL_COND(singleton != nullptr);
+	singleton = this;
+}
+
+NavigationServer3DDebug::~NavigationServer3DDebug() {
+	if (singleton == this) {
+		singleton = nullptr;
+	}
+}
+
+void NavigationServer3DDebug::register_settings() {
+#ifndef DISABLE_DEPRECATED
+#define MOVE_PROJECT_SETTING_1(m_old_setting, m_new_setting) \
+	if (!ProjectSettings::get_singleton()->has_setting(m_new_setting) && ProjectSettings::get_singleton()->has_setting(m_old_setting)) { \
+		Variant value = GLOBAL_GET(m_old_setting); \
+		ProjectSettings::get_singleton()->set_setting(m_new_setting, value); \
+		ProjectSettings::get_singleton()->clear(m_old_setting); \
+	}
+#define MOVE_PROJECT_SETTING_2(m_old_setting, m_new_setting_1, m_new_setting_2) \
+	if ((!ProjectSettings::get_singleton()->has_setting(m_new_setting_1) || !ProjectSettings::get_singleton()->has_setting(m_new_setting_2)) && \
+			ProjectSettings::get_singleton()->has_setting(m_old_setting)) { \
+		Variant value = GLOBAL_GET(m_old_setting); \
+		if (!ProjectSettings::get_singleton()->has_setting(m_new_setting_1)) { \
+			ProjectSettings::get_singleton()->set_setting(m_new_setting_1, value); \
+		} \
+		if (!ProjectSettings::get_singleton()->has_setting(m_new_setting_2)) { \
+			ProjectSettings::get_singleton()->set_setting(m_new_setting_2, value); \
+		} \
+		ProjectSettings::get_singleton()->clear(m_old_setting); \
+	}
+	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/edge_connection_color", "debug/shapes/navigation/2d/edge_connection_color", "debug/shapes/navigation/3d/edge_connection_color");
+	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/geometry_edge_color", "debug/shapes/navigation/2d/geometry_edge_color", "debug/shapes/navigation/3d/geometry_edge_color");
+	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/geometry_face_color", "debug/shapes/navigation/2d/geometry_face_color", "debug/shapes/navigation/3d/geometry_face_color");
+	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/geometry_edge_disabled_color", "debug/shapes/navigation/2d/geometry_edge_disabled_color", "debug/shapes/navigation/3d/geometry_edge_disabled_color");
+	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/geometry_face_disabled_color", "debug/shapes/navigation/2d/geometry_face_disabled_color", "debug/shapes/navigation/3d/geometry_face_disabled_color");
+	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/link_connection_color", "debug/shapes/navigation/2d/link_connection_color", "debug/shapes/navigation/3d/link_connection_color");
+	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/link_connection_disabled_color", "debug/shapes/navigation/2d/link_connection_disabled_color", "debug/shapes/navigation/3d/link_connection_disabled_color");
+	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/agent_path_color", "debug/shapes/navigation/2d/agent_path_color", "debug/shapes/navigation/3d/agent_path_color");
+
+	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/enable_edge_connections", "debug/shapes/navigation/2d/enable_edge_connections", "debug/shapes/navigation/3d/enable_edge_connections");
+	MOVE_PROJECT_SETTING_1("debug/shapes/navigation/enable_edge_connections_xray", "debug/shapes/navigation/3d/enable_edge_connections_xray");
+	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/enable_edge_lines", "debug/shapes/navigation/2d/enable_edge_lines", "debug/shapes/navigation/3d/enable_edge_lines");
+	MOVE_PROJECT_SETTING_1("debug/shapes/navigation/enable_edge_lines_xray", "debug/shapes/navigation/3d/enable_edge_lines_xray");
+	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/enable_geometry_face_random_color", "debug/shapes/navigation/2d/enable_geometry_face_random_color", "debug/shapes/navigation/3d/enable_geometry_face_random_color");
+	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/enable_link_connections", "debug/shapes/navigation/2d/enable_link_connections", "debug/shapes/navigation/3d/enable_link_connections");
+	MOVE_PROJECT_SETTING_1("debug/shapes/navigation/enable_link_connections_xray", "debug/shapes/navigation/3d/enable_link_connections_xray");
+
+	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/enable_agent_paths", "debug/shapes/navigation/2d/enable_agent_paths", "debug/shapes/navigation/3d/enable_agent_paths");
+	MOVE_PROJECT_SETTING_1("debug/shapes/navigation/enable_agent_paths_xray", "debug/shapes/navigation/3d/enable_agent_paths_xray");
+	MOVE_PROJECT_SETTING_2("debug/shapes/navigation/agent_path_point_size", "debug/shapes/navigation/2d/agent_path_point_size", "debug/shapes/navigation/3d/agent_path_point_size");
+
+	MOVE_PROJECT_SETTING_2("debug/shapes/avoidance/agents_radius_color", "debug/shapes/avoidance/2d/agents_radius_color", "debug/shapes/avoidance/3d/agents_radius_color");
+	MOVE_PROJECT_SETTING_2("debug/shapes/avoidance/obstacles_radius_color", "debug/shapes/avoidance/2d/obstacles_radius_color", "debug/shapes/avoidance/3d/obstacles_radius_color");
+	MOVE_PROJECT_SETTING_2("debug/shapes/avoidance/obstacles_static_face_pushin_color", "debug/shapes/avoidance/2d/obstacles_static_face_pushin_color", "debug/shapes/avoidance/3d/obstacles_static_face_pushin_color");
+	MOVE_PROJECT_SETTING_2("debug/shapes/avoidance/obstacles_static_edge_pushin_color", "debug/shapes/avoidance/2d/obstacles_static_edge_pushin_color", "debug/shapes/avoidance/3d/obstacles_static_edge_pushin_color");
+	MOVE_PROJECT_SETTING_2("debug/shapes/avoidance/obstacles_static_face_pushout_color", "debug/shapes/avoidance/2d/obstacles_static_face_pushout_color", "debug/shapes/avoidance/3d/obstacles_static_face_pushout_color");
+	MOVE_PROJECT_SETTING_2("debug/shapes/avoidance/obstacles_static_edge_pushout_color", "debug/shapes/avoidance/2d/obstacles_static_edge_pushout_color", "debug/shapes/avoidance/3d/obstacles_static_edge_pushout_color");
+	MOVE_PROJECT_SETTING_2("debug/shapes/avoidance/enable_agents_radius", "debug/shapes/avoidance/2d/enable_agents_radius", "debug/shapes/avoidance/3d/enable_agents_radius");
+	MOVE_PROJECT_SETTING_2("debug/shapes/avoidance/enable_obstacles_radius", "debug/shapes/avoidance/2d/enable_obstacles_radius", "debug/shapes/avoidance/2d/enable_obstacles_static");
+	MOVE_PROJECT_SETTING_2("debug/shapes/avoidance/enable_obstacles_radius", "debug/shapes/avoidance/3d/enable_obstacles_radius", "debug/shapes/avoidance/3d/enable_obstacles_static");
+#undef MOVE_PROJECT_SETTING_1
+#undef MOVE_PROJECT_SETTING_2
+#endif // DISABLE_DEPRECATED
+
+	debug_navigation_edge_connection_color = GLOBAL_DEF("debug/shapes/navigation/3d/edge_connection_color", Color(1.0, 0.0, 1.0, 1.0));
+	debug_navigation_geometry_edge_color = GLOBAL_DEF("debug/shapes/navigation/3d/geometry_edge_color", Color(0.5, 1.0, 1.0, 1.0));
+	debug_navigation_geometry_face_color = GLOBAL_DEF("debug/shapes/navigation/3d/geometry_face_color", Color(0.5, 1.0, 1.0, 0.4));
+	debug_navigation_geometry_edge_disabled_color = GLOBAL_DEF("debug/shapes/navigation/3d/geometry_edge_disabled_color", Color(0.5, 0.5, 0.5, 1.0));
+	debug_navigation_geometry_face_disabled_color = GLOBAL_DEF("debug/shapes/navigation/3d/geometry_face_disabled_color", Color(0.5, 0.5, 0.5, 0.4));
+	debug_navigation_link_connection_color = GLOBAL_DEF("debug/shapes/navigation/3d/link_connection_color", Color(1.0, 0.5, 1.0, 1.0));
+	debug_navigation_link_connection_disabled_color = GLOBAL_DEF("debug/shapes/navigation/3d/link_connection_disabled_color", Color(0.5, 0.5, 0.5, 1.0));
+	debug_navigation_agent_path_color = GLOBAL_DEF("debug/shapes/navigation/3d/agent_path_color", Color(1.0, 0.0, 0.0, 1.0));
+
+	debug_navigation_enable_edge_connections = GLOBAL_DEF("debug/shapes/navigation/3d/enable_edge_connections", true);
+	debug_navigation_enable_edge_connections_xray = GLOBAL_DEF("debug/shapes/navigation/3d/enable_edge_connections_xray", true);
+	debug_navigation_enable_edge_lines = GLOBAL_DEF("debug/shapes/navigation/3d/enable_edge_lines", true);
+	debug_navigation_enable_edge_lines_xray = GLOBAL_DEF("debug/shapes/navigation/3d/enable_edge_lines_xray", true);
+	debug_navigation_enable_geometry_face_random_color = GLOBAL_DEF("debug/shapes/navigation/3d/enable_geometry_face_random_color", true);
+	debug_navigation_enable_link_connections = GLOBAL_DEF("debug/shapes/navigation/3d/enable_link_connections", true);
+	debug_navigation_enable_link_connections_xray = GLOBAL_DEF("debug/shapes/navigation/3d/enable_link_connections_xray", true);
+
+	debug_navigation_enable_agent_paths = GLOBAL_DEF("debug/shapes/navigation/3d/enable_agent_paths", true);
+	debug_navigation_enable_agent_paths_xray = GLOBAL_DEF("debug/shapes/navigation/3d/enable_agent_paths_xray", true);
+	debug_navigation_agent_path_point_size = GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "debug/shapes/navigation/3d/agent_path_point_size", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), 4.0);
+
+	debug_navigation_avoidance_agents_radius_color = GLOBAL_DEF("debug/shapes/avoidance/3d/agents_radius_color", Color(1.0, 1.0, 0.0, 0.25));
+	debug_navigation_avoidance_obstacles_radius_color = GLOBAL_DEF("debug/shapes/avoidance/3d/obstacles_radius_color", Color(1.0, 0.5, 0.0, 0.25));
+	debug_navigation_avoidance_static_obstacle_pushin_face_color = GLOBAL_DEF("debug/shapes/avoidance/3d/obstacles_static_face_pushin_color", Color(1.0, 0.0, 0.0, 0.0));
+	debug_navigation_avoidance_static_obstacle_pushin_edge_color = GLOBAL_DEF("debug/shapes/avoidance/3d/obstacles_static_edge_pushin_color", Color(1.0, 0.0, 0.0, 1.0));
+	debug_navigation_avoidance_static_obstacle_pushout_face_color = GLOBAL_DEF("debug/shapes/avoidance/3d/obstacles_static_face_pushout_color", Color(1.0, 1.0, 0.0, 0.5));
+	debug_navigation_avoidance_static_obstacle_pushout_edge_color = GLOBAL_DEF("debug/shapes/avoidance/3d/obstacles_static_edge_pushout_color", Color(1.0, 1.0, 0.0, 1.0));
+	debug_navigation_avoidance_enable_agents_radius = GLOBAL_DEF("debug/shapes/avoidance/3d/enable_agents_radius", true);
+	debug_navigation_avoidance_enable_obstacles_radius = GLOBAL_DEF("debug/shapes/avoidance/3d/enable_obstacles_radius", true);
+	debug_navigation_avoidance_enable_obstacles_static = GLOBAL_DEF("debug/shapes/avoidance/3d/enable_obstacles_static", true);
+}
+
+void NavigationServer3DDebug::update_from_settings() {
+	if (!ProjectSettings::get_singleton()->check_changed_settings_in_group("debug/shapes/navigation/3d")) {
+		return;
+	}
+	set_debug_navigation_edge_connection_color(GLOBAL_GET("debug/shapes/navigation/3d/edge_connection_color"));
+	set_debug_navigation_geometry_edge_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_edge_color"));
+	set_debug_navigation_geometry_face_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_face_color"));
+	set_debug_navigation_geometry_edge_disabled_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_edge_disabled_color"));
+	set_debug_navigation_geometry_face_disabled_color(GLOBAL_GET("debug/shapes/navigation/3d/geometry_face_disabled_color"));
+	set_debug_navigation_enable_edge_connections(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_connections"));
+	set_debug_navigation_enable_edge_connections_xray(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_connections_xray"));
+	set_debug_navigation_enable_edge_lines(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_lines"));
+	set_debug_navigation_enable_edge_lines_xray(GLOBAL_GET("debug/shapes/navigation/3d/enable_edge_lines_xray"));
+	set_debug_navigation_enable_geometry_face_random_color(GLOBAL_GET("debug/shapes/navigation/3d/enable_geometry_face_random_color"));
+}
+
+void NavigationServer3DDebug::set_debug_enabled(bool p_enabled) {
+	debug_enabled = p_enabled;
+	NavigationServer3D::get_singleton()->emit_navigation_debug_changed();
+	NavigationServer3D::get_singleton()->emit_avoidance_debug_changed();
+}
+
+bool NavigationServer3DDebug::get_debug_enabled() const {
+	return debug_enabled;
+}
+
+Ref<StandardMaterial3D> NavigationServer3DDebug::get_debug_navigation_geometry_face_material() {
+	if (debug_navigation_geometry_face_material.is_valid()) {
+		return debug_navigation_geometry_face_material;
+	}
+
+	bool enabled_geometry_face_random_color = get_debug_navigation_enable_geometry_face_random_color();
+
+	Ref<StandardMaterial3D> face_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	face_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	face_material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+	face_material->set_albedo(get_debug_navigation_geometry_face_color());
+	face_material->set_cull_mode(StandardMaterial3D::CULL_DISABLED);
+	face_material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+	if (enabled_geometry_face_random_color) {
+		face_material->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
+		face_material->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
+	}
+
+	debug_navigation_geometry_face_material = face_material;
+
+	return debug_navigation_geometry_face_material;
+}
+
+Ref<StandardMaterial3D> NavigationServer3DDebug::get_debug_navigation_geometry_edge_material() {
+	if (debug_navigation_geometry_edge_material.is_valid()) {
+		return debug_navigation_geometry_edge_material;
+	}
+
+	bool enabled_edge_lines_xray = get_debug_navigation_enable_edge_lines_xray();
+
+	Ref<StandardMaterial3D> line_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	line_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	line_material->set_albedo(get_debug_navigation_geometry_edge_color());
+	line_material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+	if (enabled_edge_lines_xray) {
+		line_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
+	}
+
+	debug_navigation_geometry_edge_material = line_material;
+
+	return debug_navigation_geometry_edge_material;
+}
+
+Ref<StandardMaterial3D> NavigationServer3DDebug::get_debug_navigation_geometry_face_disabled_material() {
+	if (debug_navigation_geometry_face_disabled_material.is_valid()) {
+		return debug_navigation_geometry_face_disabled_material;
+	}
+
+	Ref<StandardMaterial3D> face_disabled_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	face_disabled_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	face_disabled_material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+	face_disabled_material->set_albedo(get_debug_navigation_geometry_face_disabled_color());
+	face_disabled_material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+
+	debug_navigation_geometry_face_disabled_material = face_disabled_material;
+
+	return debug_navigation_geometry_face_disabled_material;
+}
+
+Ref<StandardMaterial3D> NavigationServer3DDebug::get_debug_navigation_geometry_edge_disabled_material() {
+	if (debug_navigation_geometry_edge_disabled_material.is_valid()) {
+		return debug_navigation_geometry_edge_disabled_material;
+	}
+
+	bool enabled_edge_lines_xray = get_debug_navigation_enable_edge_lines_xray();
+
+	Ref<StandardMaterial3D> line_disabled_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	line_disabled_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	line_disabled_material->set_albedo(get_debug_navigation_geometry_edge_disabled_color());
+	line_disabled_material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+	if (enabled_edge_lines_xray) {
+		line_disabled_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
+	}
+
+	debug_navigation_geometry_edge_disabled_material = line_disabled_material;
+
+	return debug_navigation_geometry_edge_disabled_material;
+}
+
+Ref<StandardMaterial3D> NavigationServer3DDebug::get_debug_navigation_edge_connections_material() {
+	if (debug_navigation_edge_connections_material.is_valid()) {
+		return debug_navigation_edge_connections_material;
+	}
+
+	bool enabled_edge_connections_xray = get_debug_navigation_enable_edge_connections_xray();
+
+	Ref<StandardMaterial3D> edge_connections_material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	edge_connections_material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	edge_connections_material->set_albedo(get_debug_navigation_edge_connection_color());
+	edge_connections_material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+	if (enabled_edge_connections_xray) {
+		edge_connections_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
+	}
+	edge_connections_material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MAX - 2);
+
+	debug_navigation_edge_connections_material = edge_connections_material;
+
+	return debug_navigation_edge_connections_material;
+}
+
+Ref<StandardMaterial3D> NavigationServer3DDebug::get_debug_navigation_link_connections_material() {
+	if (debug_navigation_link_connections_material.is_valid()) {
+		return debug_navigation_link_connections_material;
+	}
+
+	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	material->set_albedo(debug_navigation_link_connection_color);
+	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+	if (debug_navigation_enable_link_connections_xray) {
+		material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
+	}
+	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MAX - 2);
+
+	debug_navigation_link_connections_material = material;
+	return debug_navigation_link_connections_material;
+}
+
+Ref<StandardMaterial3D> NavigationServer3DDebug::get_debug_navigation_link_connections_disabled_material() {
+	if (debug_navigation_link_connections_disabled_material.is_valid()) {
+		return debug_navigation_link_connections_disabled_material;
+	}
+
+	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	material->set_albedo(debug_navigation_link_connection_disabled_color);
+	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+	if (debug_navigation_enable_link_connections_xray) {
+		material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
+	}
+	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MAX - 2);
+
+	debug_navigation_link_connections_disabled_material = material;
+	return debug_navigation_link_connections_disabled_material;
+}
+
+Ref<StandardMaterial3D> NavigationServer3DDebug::get_debug_navigation_agent_path_line_material() {
+	if (debug_navigation_agent_path_line_material.is_valid()) {
+		return debug_navigation_agent_path_line_material;
+	}
+
+	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+
+	material->set_albedo(debug_navigation_agent_path_color);
+	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+	if (debug_navigation_enable_agent_paths_xray) {
+		material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
+	}
+	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MAX - 2);
+
+	debug_navigation_agent_path_line_material = material;
+	return debug_navigation_agent_path_line_material;
+}
+
+Ref<StandardMaterial3D> NavigationServer3DDebug::get_debug_navigation_agent_path_point_material() {
+	if (debug_navigation_agent_path_point_material.is_valid()) {
+		return debug_navigation_agent_path_point_material;
+	}
+
+	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	material->set_albedo(debug_navigation_agent_path_color);
+	material->set_flag(StandardMaterial3D::FLAG_USE_POINT_SIZE, true);
+	material->set_point_size(debug_navigation_agent_path_point_size);
+	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+	if (debug_navigation_enable_agent_paths_xray) {
+		material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
+	}
+	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MAX - 2);
+
+	debug_navigation_agent_path_point_material = material;
+	return debug_navigation_agent_path_point_material;
+}
+
+Ref<StandardMaterial3D> NavigationServer3DDebug::get_debug_navigation_avoidance_agents_radius_material() {
+	if (debug_navigation_avoidance_agents_radius_material.is_valid()) {
+		return debug_navigation_avoidance_agents_radius_material;
+	}
+
+	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+	material->set_cull_mode(StandardMaterial3D::CULL_DISABLED);
+	material->set_albedo(debug_navigation_avoidance_agents_radius_color);
+	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MIN + 2);
+
+	debug_navigation_avoidance_agents_radius_material = material;
+	return debug_navigation_avoidance_agents_radius_material;
+}
+
+Ref<StandardMaterial3D> NavigationServer3DDebug::get_debug_navigation_avoidance_obstacles_radius_material() {
+	if (debug_navigation_avoidance_obstacles_radius_material.is_valid()) {
+		return debug_navigation_avoidance_obstacles_radius_material;
+	}
+
+	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+	material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+	material->set_cull_mode(StandardMaterial3D::CULL_DISABLED);
+	material->set_albedo(debug_navigation_avoidance_obstacles_radius_color);
+	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MIN + 2);
+
+	debug_navigation_avoidance_obstacles_radius_material = material;
+	return debug_navigation_avoidance_obstacles_radius_material;
+}
+
+Ref<StandardMaterial3D> NavigationServer3DDebug::get_debug_navigation_avoidance_static_obstacle_pushin_face_material() {
+	if (debug_navigation_avoidance_static_obstacle_pushin_face_material.is_valid()) {
+		return debug_navigation_avoidance_static_obstacle_pushin_face_material;
+	}
+
+	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+	material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+	material->set_cull_mode(StandardMaterial3D::CULL_DISABLED);
+	material->set_albedo(debug_navigation_avoidance_static_obstacle_pushin_face_color);
+	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MIN + 2);
+
+	debug_navigation_avoidance_static_obstacle_pushin_face_material = material;
+	return debug_navigation_avoidance_static_obstacle_pushin_face_material;
+}
+
+Ref<StandardMaterial3D> NavigationServer3DDebug::get_debug_navigation_avoidance_static_obstacle_pushout_face_material() {
+	if (debug_navigation_avoidance_static_obstacle_pushout_face_material.is_valid()) {
+		return debug_navigation_avoidance_static_obstacle_pushout_face_material;
+	}
+
+	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+	material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
+	material->set_cull_mode(StandardMaterial3D::CULL_DISABLED);
+	material->set_albedo(debug_navigation_avoidance_static_obstacle_pushout_face_color);
+	material->set_render_priority(StandardMaterial3D::RENDER_PRIORITY_MIN + 2);
+
+	debug_navigation_avoidance_static_obstacle_pushout_face_material = material;
+	return debug_navigation_avoidance_static_obstacle_pushout_face_material;
+}
+
+Ref<StandardMaterial3D> NavigationServer3DDebug::get_debug_navigation_avoidance_static_obstacle_pushin_edge_material() {
+	if (debug_navigation_avoidance_static_obstacle_pushin_edge_material.is_valid()) {
+		return debug_navigation_avoidance_static_obstacle_pushin_edge_material;
+	}
+
+	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+	material->set_albedo(debug_navigation_avoidance_static_obstacle_pushin_edge_color);
+	material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
+
+	debug_navigation_avoidance_static_obstacle_pushin_edge_material = material;
+	return debug_navigation_avoidance_static_obstacle_pushin_edge_material;
+}
+
+Ref<StandardMaterial3D> NavigationServer3DDebug::get_debug_navigation_avoidance_static_obstacle_pushout_edge_material() {
+	if (debug_navigation_avoidance_static_obstacle_pushout_edge_material.is_valid()) {
+		return debug_navigation_avoidance_static_obstacle_pushout_edge_material;
+	}
+
+	Ref<StandardMaterial3D> material = Ref<StandardMaterial3D>(memnew(StandardMaterial3D));
+	material->set_shading_mode(StandardMaterial3D::SHADING_MODE_UNSHADED);
+	material->set_flag(StandardMaterial3D::FLAG_DISABLE_FOG, true);
+	material->set_albedo(debug_navigation_avoidance_static_obstacle_pushout_edge_color);
+	material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, true);
+
+	debug_navigation_avoidance_static_obstacle_pushout_edge_material = material;
+	return debug_navigation_avoidance_static_obstacle_pushout_edge_material;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_edge_connection_color(const Color &p_color) {
+	debug_navigation_edge_connection_color = p_color;
+	if (debug_navigation_edge_connections_material.is_valid()) {
+		debug_navigation_edge_connections_material->set_albedo(debug_navigation_edge_connection_color);
+	}
+}
+
+Color NavigationServer3DDebug::get_debug_navigation_edge_connection_color() const {
+	return debug_navigation_edge_connection_color;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_geometry_edge_color(const Color &p_color) {
+	debug_navigation_geometry_edge_color = p_color;
+	if (debug_navigation_geometry_edge_material.is_valid()) {
+		debug_navigation_geometry_edge_material->set_albedo(debug_navigation_geometry_edge_color);
+	}
+}
+
+Color NavigationServer3DDebug::get_debug_navigation_geometry_edge_color() const {
+	return debug_navigation_geometry_edge_color;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_geometry_face_color(const Color &p_color) {
+	debug_navigation_geometry_face_color = p_color;
+	if (debug_navigation_geometry_face_material.is_valid()) {
+		debug_navigation_geometry_face_material->set_albedo(debug_navigation_geometry_face_color);
+	}
+}
+
+Color NavigationServer3DDebug::get_debug_navigation_geometry_face_color() const {
+	return debug_navigation_geometry_face_color;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_geometry_edge_disabled_color(const Color &p_color) {
+	debug_navigation_geometry_edge_disabled_color = p_color;
+	if (debug_navigation_geometry_edge_disabled_material.is_valid()) {
+		debug_navigation_geometry_edge_disabled_material->set_albedo(debug_navigation_geometry_edge_disabled_color);
+	}
+}
+
+Color NavigationServer3DDebug::get_debug_navigation_geometry_edge_disabled_color() const {
+	return debug_navigation_geometry_edge_disabled_color;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_geometry_face_disabled_color(const Color &p_color) {
+	debug_navigation_geometry_face_disabled_color = p_color;
+	if (debug_navigation_geometry_face_disabled_material.is_valid()) {
+		debug_navigation_geometry_face_disabled_material->set_albedo(debug_navigation_geometry_face_disabled_color);
+	}
+}
+
+Color NavigationServer3DDebug::get_debug_navigation_geometry_face_disabled_color() const {
+	return debug_navigation_geometry_face_disabled_color;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_link_connection_color(const Color &p_color) {
+	debug_navigation_link_connection_color = p_color;
+	if (debug_navigation_link_connections_material.is_valid()) {
+		debug_navigation_link_connections_material->set_albedo(debug_navigation_link_connection_color);
+	}
+}
+
+Color NavigationServer3DDebug::get_debug_navigation_link_connection_color() const {
+	return debug_navigation_link_connection_color;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_link_connection_disabled_color(const Color &p_color) {
+	debug_navigation_link_connection_disabled_color = p_color;
+	if (debug_navigation_link_connections_disabled_material.is_valid()) {
+		debug_navigation_link_connections_disabled_material->set_albedo(debug_navigation_link_connection_disabled_color);
+	}
+}
+
+Color NavigationServer3DDebug::get_debug_navigation_link_connection_disabled_color() const {
+	return debug_navigation_link_connection_disabled_color;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_agent_path_point_size(float p_point_size) {
+	debug_navigation_agent_path_point_size = MAX(0.1, p_point_size);
+	if (debug_navigation_agent_path_point_material.is_valid()) {
+		debug_navigation_agent_path_point_material->set_point_size(debug_navigation_agent_path_point_size);
+	}
+}
+
+float NavigationServer3DDebug::get_debug_navigation_agent_path_point_size() const {
+	return debug_navigation_agent_path_point_size;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_agent_path_color(const Color &p_color) {
+	debug_navigation_agent_path_color = p_color;
+	if (debug_navigation_agent_path_line_material.is_valid()) {
+		debug_navigation_agent_path_line_material->set_albedo(debug_navigation_agent_path_color);
+	}
+	if (debug_navigation_agent_path_point_material.is_valid()) {
+		debug_navigation_agent_path_point_material->set_albedo(debug_navigation_agent_path_color);
+	}
+}
+
+Color NavigationServer3DDebug::get_debug_navigation_agent_path_color() const {
+	return debug_navigation_agent_path_color;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_enable_edge_connections(const bool p_value) {
+	debug_navigation_enable_edge_connections = p_value;
+	NavigationServer3D::get_singleton()->emit_navigation_debug_changed();
+}
+
+bool NavigationServer3DDebug::get_debug_navigation_enable_edge_connections() const {
+	return debug_navigation_enable_edge_connections;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_enable_edge_connections_xray(const bool p_value) {
+	debug_navigation_enable_edge_connections_xray = p_value;
+	if (debug_navigation_edge_connections_material.is_valid()) {
+		debug_navigation_edge_connections_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, debug_navigation_enable_edge_connections_xray);
+	}
+}
+
+bool NavigationServer3DDebug::get_debug_navigation_enable_edge_connections_xray() const {
+	return debug_navigation_enable_edge_connections_xray;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_enable_edge_lines(const bool p_value) {
+	debug_navigation_enable_edge_lines = p_value;
+	NavigationServer3D::get_singleton()->emit_navigation_debug_changed();
+}
+
+bool NavigationServer3DDebug::get_debug_navigation_enable_edge_lines() const {
+	return debug_navigation_enable_edge_lines;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_enable_edge_lines_xray(const bool p_value) {
+	debug_navigation_enable_edge_lines_xray = p_value;
+	if (debug_navigation_geometry_edge_material.is_valid()) {
+		debug_navigation_geometry_edge_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, debug_navigation_enable_edge_lines_xray);
+	}
+}
+
+bool NavigationServer3DDebug::get_debug_navigation_enable_edge_lines_xray() const {
+	return debug_navigation_enable_edge_lines_xray;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_enable_geometry_face_random_color(const bool p_value) {
+	debug_navigation_enable_geometry_face_random_color = p_value;
+	NavigationServer3D::get_singleton()->emit_navigation_debug_changed();
+}
+
+bool NavigationServer3DDebug::get_debug_navigation_enable_geometry_face_random_color() const {
+	return debug_navigation_enable_geometry_face_random_color;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_enable_link_connections(const bool p_value) {
+	debug_navigation_enable_link_connections = p_value;
+	NavigationServer3D::get_singleton()->emit_navigation_debug_changed();
+}
+
+bool NavigationServer3DDebug::get_debug_navigation_enable_link_connections() const {
+	return debug_navigation_enable_link_connections;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_enable_link_connections_xray(const bool p_value) {
+	debug_navigation_enable_link_connections_xray = p_value;
+	if (debug_navigation_link_connections_material.is_valid()) {
+		debug_navigation_link_connections_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, debug_navigation_enable_link_connections_xray);
+	}
+}
+
+bool NavigationServer3DDebug::get_debug_navigation_enable_link_connections_xray() const {
+	return debug_navigation_enable_link_connections_xray;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_avoidance_enable_agents_radius(const bool p_value) {
+	debug_navigation_avoidance_enable_agents_radius = p_value;
+	NavigationServer3D::get_singleton()->emit_avoidance_debug_changed();
+}
+
+bool NavigationServer3DDebug::get_debug_navigation_avoidance_enable_agents_radius() const {
+	return debug_navigation_avoidance_enable_agents_radius;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_avoidance_enable_obstacles_radius(const bool p_value) {
+	debug_navigation_avoidance_enable_obstacles_radius = p_value;
+	NavigationServer3D::get_singleton()->emit_avoidance_debug_changed();
+}
+
+bool NavigationServer3DDebug::get_debug_navigation_avoidance_enable_obstacles_radius() const {
+	return debug_navigation_avoidance_enable_obstacles_radius;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_avoidance_enable_obstacles_static(const bool p_value) {
+	debug_navigation_avoidance_enable_obstacles_static = p_value;
+	NavigationServer3D::get_singleton()->emit_avoidance_debug_changed();
+}
+
+bool NavigationServer3DDebug::get_debug_navigation_avoidance_enable_obstacles_static() const {
+	return debug_navigation_avoidance_enable_obstacles_static;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_avoidance_agents_radius_color(const Color &p_color) {
+	debug_navigation_avoidance_agents_radius_color = p_color;
+	if (debug_navigation_avoidance_agents_radius_material.is_valid()) {
+		debug_navigation_avoidance_agents_radius_material->set_albedo(debug_navigation_avoidance_agents_radius_color);
+	}
+}
+
+Color NavigationServer3DDebug::get_debug_navigation_avoidance_agents_radius_color() const {
+	return debug_navigation_avoidance_agents_radius_color;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_avoidance_obstacles_radius_color(const Color &p_color) {
+	debug_navigation_avoidance_obstacles_radius_color = p_color;
+	if (debug_navigation_avoidance_obstacles_radius_material.is_valid()) {
+		debug_navigation_avoidance_obstacles_radius_material->set_albedo(debug_navigation_avoidance_obstacles_radius_color);
+	}
+}
+
+Color NavigationServer3DDebug::get_debug_navigation_avoidance_obstacles_radius_color() const {
+	return debug_navigation_avoidance_obstacles_radius_color;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_avoidance_static_obstacle_pushin_face_color(const Color &p_color) {
+	debug_navigation_avoidance_static_obstacle_pushin_face_color = p_color;
+	if (debug_navigation_avoidance_static_obstacle_pushin_face_material.is_valid()) {
+		debug_navigation_avoidance_static_obstacle_pushin_face_material->set_albedo(debug_navigation_avoidance_static_obstacle_pushin_face_color);
+	}
+}
+
+Color NavigationServer3DDebug::get_debug_navigation_avoidance_static_obstacle_pushin_face_color() const {
+	return debug_navigation_avoidance_static_obstacle_pushin_face_color;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_avoidance_static_obstacle_pushout_face_color(const Color &p_color) {
+	debug_navigation_avoidance_static_obstacle_pushout_face_color = p_color;
+	if (debug_navigation_avoidance_static_obstacle_pushout_face_material.is_valid()) {
+		debug_navigation_avoidance_static_obstacle_pushout_face_material->set_albedo(debug_navigation_avoidance_static_obstacle_pushout_face_color);
+	}
+}
+
+Color NavigationServer3DDebug::get_debug_navigation_avoidance_static_obstacle_pushout_face_color() const {
+	return debug_navigation_avoidance_static_obstacle_pushout_face_color;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_avoidance_static_obstacle_pushin_edge_color(const Color &p_color) {
+	debug_navigation_avoidance_static_obstacle_pushin_edge_color = p_color;
+	if (debug_navigation_avoidance_static_obstacle_pushin_edge_material.is_valid()) {
+		debug_navigation_avoidance_static_obstacle_pushin_edge_material->set_albedo(debug_navigation_avoidance_static_obstacle_pushin_edge_color);
+	}
+}
+
+Color NavigationServer3DDebug::get_debug_navigation_avoidance_static_obstacle_pushin_edge_color() const {
+	return debug_navigation_avoidance_static_obstacle_pushin_edge_color;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_avoidance_static_obstacle_pushout_edge_color(const Color &p_color) {
+	debug_navigation_avoidance_static_obstacle_pushout_edge_color = p_color;
+	if (debug_navigation_avoidance_static_obstacle_pushout_edge_material.is_valid()) {
+		debug_navigation_avoidance_static_obstacle_pushout_edge_material->set_albedo(debug_navigation_avoidance_static_obstacle_pushout_edge_color);
+	}
+}
+
+Color NavigationServer3DDebug::get_debug_navigation_avoidance_static_obstacle_pushout_edge_color() const {
+	return debug_navigation_avoidance_static_obstacle_pushout_edge_color;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_enable_agent_paths(const bool p_value) {
+	debug_navigation_enable_agent_paths = p_value;
+	NavigationServer3D::get_singleton()->emit_navigation_debug_changed();
+}
+
+bool NavigationServer3DDebug::get_debug_navigation_enable_agent_paths() const {
+	return debug_navigation_enable_agent_paths;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_enable_agent_paths_xray(const bool p_value) {
+	debug_navigation_enable_agent_paths_xray = p_value;
+	if (debug_navigation_agent_path_line_material.is_valid()) {
+		debug_navigation_agent_path_line_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, debug_navigation_enable_agent_paths_xray);
+	}
+	if (debug_navigation_agent_path_point_material.is_valid()) {
+		debug_navigation_agent_path_point_material->set_flag(StandardMaterial3D::FLAG_DISABLE_DEPTH_TEST, debug_navigation_enable_agent_paths_xray);
+	}
+}
+
+bool NavigationServer3DDebug::get_debug_navigation_enable_agent_paths_xray() const {
+	return debug_navigation_enable_agent_paths_xray;
+}
+
+void NavigationServer3DDebug::set_debug_navigation_enabled(bool p_enabled) {
+	debug_navigation_enabled = p_enabled;
+	NavigationServer3D::get_singleton()->emit_navigation_debug_changed();
+}
+
+bool NavigationServer3DDebug::get_debug_navigation_enabled() const {
+	return debug_navigation_enabled;
+}
+
+void NavigationServer3DDebug::set_debug_avoidance_enabled(bool p_enabled) {
+	debug_avoidance_enabled = p_enabled;
+	NavigationServer3D::get_singleton()->emit_avoidance_debug_changed();
+}
+
+bool NavigationServer3DDebug::get_debug_avoidance_enabled() const {
+	return debug_avoidance_enabled;
+}
+
+#endif // DEBUG_ENABLED

--- a/servers/navigation_3d/navigation_server_3d_debug.h
+++ b/servers/navigation_3d/navigation_server_3d_debug.h
@@ -1,0 +1,217 @@
+/**************************************************************************/
+/*  navigation_server_3d_debug.h                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef DEBUG_ENABLED
+
+#include "core/math/color.h"
+#include "core/object/ref_counted.h"
+
+class StandardMaterial3D;
+
+class NavigationServer3DDebug {
+	static NavigationServer3DDebug *singleton;
+
+	bool debug_enabled = false;
+	bool debug_navigation_enabled = false;
+	bool debug_avoidance_enabled = false;
+
+	Color debug_navigation_edge_connection_color;
+	Color debug_navigation_geometry_edge_color;
+	Color debug_navigation_geometry_face_color;
+	Color debug_navigation_geometry_edge_disabled_color;
+	Color debug_navigation_geometry_face_disabled_color;
+	Color debug_navigation_link_connection_color;
+	Color debug_navigation_link_connection_disabled_color;
+	Color debug_navigation_agent_path_color;
+
+	float debug_navigation_agent_path_point_size = 4.0;
+
+	Color debug_navigation_avoidance_agents_radius_color;
+	Color debug_navigation_avoidance_obstacles_radius_color;
+
+	Color debug_navigation_avoidance_static_obstacle_pushin_face_color;
+	Color debug_navigation_avoidance_static_obstacle_pushout_face_color;
+	Color debug_navigation_avoidance_static_obstacle_pushin_edge_color;
+	Color debug_navigation_avoidance_static_obstacle_pushout_edge_color;
+
+	bool debug_navigation_enable_edge_connections = true;
+	bool debug_navigation_enable_edge_connections_xray = true;
+	bool debug_navigation_enable_edge_lines = true;
+	bool debug_navigation_enable_edge_lines_xray = true;
+	bool debug_navigation_enable_geometry_face_random_color = true;
+	bool debug_navigation_enable_link_connections = true;
+	bool debug_navigation_enable_link_connections_xray = true;
+	bool debug_navigation_enable_agent_paths = true;
+	bool debug_navigation_enable_agent_paths_xray = true;
+
+	bool debug_navigation_avoidance_enable_agents_radius = true;
+	bool debug_navigation_avoidance_enable_obstacles_radius = true;
+	bool debug_navigation_avoidance_enable_obstacles_static = true;
+
+	Ref<StandardMaterial3D> debug_navigation_geometry_edge_material;
+	Ref<StandardMaterial3D> debug_navigation_geometry_face_material;
+	Ref<StandardMaterial3D> debug_navigation_geometry_edge_disabled_material;
+	Ref<StandardMaterial3D> debug_navigation_geometry_face_disabled_material;
+	Ref<StandardMaterial3D> debug_navigation_edge_connections_material;
+	Ref<StandardMaterial3D> debug_navigation_link_connections_material;
+	Ref<StandardMaterial3D> debug_navigation_link_connections_disabled_material;
+	Ref<StandardMaterial3D> debug_navigation_avoidance_agents_radius_material;
+	Ref<StandardMaterial3D> debug_navigation_avoidance_obstacles_radius_material;
+
+	Ref<StandardMaterial3D> debug_navigation_avoidance_static_obstacle_pushin_face_material;
+	Ref<StandardMaterial3D> debug_navigation_avoidance_static_obstacle_pushout_face_material;
+	Ref<StandardMaterial3D> debug_navigation_avoidance_static_obstacle_pushin_edge_material;
+	Ref<StandardMaterial3D> debug_navigation_avoidance_static_obstacle_pushout_edge_material;
+
+	Ref<StandardMaterial3D> debug_navigation_agent_path_line_material;
+	Ref<StandardMaterial3D> debug_navigation_agent_path_point_material;
+
+public:
+	static NavigationServer3DDebug *get_singleton();
+
+	void set_debug_enabled(bool p_enabled);
+	bool get_debug_enabled() const;
+
+	void register_settings();
+	void update_from_settings();
+
+	void set_debug_navigation_enabled(bool p_enabled);
+	bool get_debug_navigation_enabled() const;
+
+	void set_debug_avoidance_enabled(bool p_enabled);
+	bool get_debug_avoidance_enabled() const;
+
+	void set_debug_navigation_edge_connection_color(const Color &p_color);
+	Color get_debug_navigation_edge_connection_color() const;
+
+	void set_debug_navigation_geometry_edge_color(const Color &p_color);
+	Color get_debug_navigation_geometry_edge_color() const;
+
+	void set_debug_navigation_geometry_face_color(const Color &p_color);
+	Color get_debug_navigation_geometry_face_color() const;
+
+	void set_debug_navigation_geometry_edge_disabled_color(const Color &p_color);
+	Color get_debug_navigation_geometry_edge_disabled_color() const;
+
+	void set_debug_navigation_geometry_face_disabled_color(const Color &p_color);
+	Color get_debug_navigation_geometry_face_disabled_color() const;
+
+	void set_debug_navigation_link_connection_color(const Color &p_color);
+	Color get_debug_navigation_link_connection_color() const;
+
+	void set_debug_navigation_link_connection_disabled_color(const Color &p_color);
+	Color get_debug_navigation_link_connection_disabled_color() const;
+
+	void set_debug_navigation_agent_path_color(const Color &p_color);
+	Color get_debug_navigation_agent_path_color() const;
+
+	void set_debug_navigation_avoidance_agents_radius_color(const Color &p_color);
+	Color get_debug_navigation_avoidance_agents_radius_color() const;
+
+	void set_debug_navigation_avoidance_obstacles_radius_color(const Color &p_color);
+	Color get_debug_navigation_avoidance_obstacles_radius_color() const;
+
+	void set_debug_navigation_avoidance_static_obstacle_pushin_face_color(const Color &p_color);
+	Color get_debug_navigation_avoidance_static_obstacle_pushin_face_color() const;
+
+	void set_debug_navigation_avoidance_static_obstacle_pushout_face_color(const Color &p_color);
+	Color get_debug_navigation_avoidance_static_obstacle_pushout_face_color() const;
+
+	void set_debug_navigation_avoidance_static_obstacle_pushin_edge_color(const Color &p_color);
+	Color get_debug_navigation_avoidance_static_obstacle_pushin_edge_color() const;
+
+	void set_debug_navigation_avoidance_static_obstacle_pushout_edge_color(const Color &p_color);
+	Color get_debug_navigation_avoidance_static_obstacle_pushout_edge_color() const;
+
+	void set_debug_navigation_enable_edge_connections(const bool p_value);
+	bool get_debug_navigation_enable_edge_connections() const;
+
+	void set_debug_navigation_enable_edge_connections_xray(const bool p_value);
+	bool get_debug_navigation_enable_edge_connections_xray() const;
+
+	void set_debug_navigation_enable_edge_lines(const bool p_value);
+	bool get_debug_navigation_enable_edge_lines() const;
+
+	void set_debug_navigation_enable_edge_lines_xray(const bool p_value);
+	bool get_debug_navigation_enable_edge_lines_xray() const;
+
+	void set_debug_navigation_enable_geometry_face_random_color(const bool p_value);
+	bool get_debug_navigation_enable_geometry_face_random_color() const;
+
+	void set_debug_navigation_enable_link_connections(const bool p_value);
+	bool get_debug_navigation_enable_link_connections() const;
+
+	void set_debug_navigation_enable_link_connections_xray(const bool p_value);
+	bool get_debug_navigation_enable_link_connections_xray() const;
+
+	void set_debug_navigation_enable_agent_paths(const bool p_value);
+	bool get_debug_navigation_enable_agent_paths() const;
+
+	void set_debug_navigation_enable_agent_paths_xray(const bool p_value);
+	bool get_debug_navigation_enable_agent_paths_xray() const;
+
+	void set_debug_navigation_agent_path_point_size(float p_point_size);
+	float get_debug_navigation_agent_path_point_size() const;
+
+	void set_debug_navigation_avoidance_enable_agents_radius(const bool p_value);
+	bool get_debug_navigation_avoidance_enable_agents_radius() const;
+
+	void set_debug_navigation_avoidance_enable_obstacles_radius(const bool p_value);
+	bool get_debug_navigation_avoidance_enable_obstacles_radius() const;
+
+	void set_debug_navigation_avoidance_enable_obstacles_static(const bool p_value);
+	bool get_debug_navigation_avoidance_enable_obstacles_static() const;
+
+	Ref<StandardMaterial3D> get_debug_navigation_geometry_face_material();
+	Ref<StandardMaterial3D> get_debug_navigation_geometry_edge_material();
+	Ref<StandardMaterial3D> get_debug_navigation_geometry_face_disabled_material();
+	Ref<StandardMaterial3D> get_debug_navigation_geometry_edge_disabled_material();
+	Ref<StandardMaterial3D> get_debug_navigation_edge_connections_material();
+	Ref<StandardMaterial3D> get_debug_navigation_link_connections_material();
+	Ref<StandardMaterial3D> get_debug_navigation_link_connections_disabled_material();
+
+	Ref<StandardMaterial3D> get_debug_navigation_agent_path_line_material();
+	Ref<StandardMaterial3D> get_debug_navigation_agent_path_point_material();
+
+	Ref<StandardMaterial3D> get_debug_navigation_avoidance_agents_radius_material();
+	Ref<StandardMaterial3D> get_debug_navigation_avoidance_obstacles_radius_material();
+
+	Ref<StandardMaterial3D> get_debug_navigation_avoidance_static_obstacle_pushin_face_material();
+	Ref<StandardMaterial3D> get_debug_navigation_avoidance_static_obstacle_pushout_face_material();
+	Ref<StandardMaterial3D> get_debug_navigation_avoidance_static_obstacle_pushin_edge_material();
+	Ref<StandardMaterial3D> get_debug_navigation_avoidance_static_obstacle_pushout_edge_material();
+
+	NavigationServer3DDebug();
+	~NavigationServer3DDebug();
+};
+
+#endif // DEBUG_ENABLED


### PR DESCRIPTION
Moves NavigationServer debug to dedicated files.

Aka shrinks the actual NavigationServer files down to tiny because half or more of the files was just debug yada, especially for the NavigationServer3D that had to include rendering due to material include.

Tested with `template_debug_or_release` and `disable_navigation_2d_or_3d` builds.