### PR TITLE
GDScript: Remove second `UNTYPED_DECLARATION` warning for rest parameters

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1825,9 +1825,6 @@ void GDScriptAnalyzer::resolve_function_signature(GDScriptParser::FunctionNode *
 			inferred_type.kind = GDScriptParser::DataType::BUILTIN;
 			inferred_type.builtin_type = Variant::ARRAY;
 			p_function->rest_parameter->type_constraint = inferred_type;
-#ifdef DEBUG_ENABLED
-			parser->push_warning(p_function->rest_parameter, GDScriptWarning::UNTYPED_DECLARATION, "Parameter", p_function->rest_parameter->identifier->name);
-#endif
 		}
 #ifdef DEBUG_ENABLED
 		is_shadowing(p_function->rest_parameter->identifier, "function parameter", true);

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -542,6 +542,18 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 		ERR_FAIL_V_MSG(result, "\nCould not load source code for: '" + source_file + "'");
 	}
 
+#ifdef DEBUG_ENABLED
+	// Allows us to enable the UNTYPED_DECLARATION and INFERRED_DECLARATION
+	// warnings for specific tests by including a comment.
+	const String sc = script->get_source_code();
+	const String untyped_declaration_path = GDScriptWarning::get_setting_path_from_code(GDScriptWarning::UNTYPED_DECLARATION);
+	const String inferred_declaration_path = GDScriptWarning::get_setting_path_from_code(GDScriptWarning::INFERRED_DECLARATION);
+
+	ProjectSettings::get_singleton()->set_setting(untyped_declaration_path, (int)(sc.contains("# enable UNTYPED_DECLARATION") ? GDScriptWarning::WARN : GDScriptWarning::IGNORE));
+	ProjectSettings::get_singleton()->set_setting(inferred_declaration_path, (int)(sc.contains("# enable INFERRED_DECLARATION") ? GDScriptWarning::WARN : GDScriptWarning::IGNORE));
+	GDScriptParser::update_project_settings();
+#endif // DEBUG_ENABLED
+
 	// Test parsing.
 	GDScriptParser parser;
 	if (tokenizer_mode == TOKENIZER_TEXT) {

--- a/modules/gdscript/tests/scripts/analyzer/warnings/untyped_declaration.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/untyped_declaration.gd
@@ -1,0 +1,10 @@
+# enable UNTYPED_DECLARATION
+
+func test() -> void:
+    pass
+
+func regular_function(_arg) -> void:
+    pass
+
+func vararg_function(..._var_args) -> void:
+    pass

--- a/modules/gdscript/tests/scripts/analyzer/warnings/untyped_declaration.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/untyped_declaration.out
@@ -1,0 +1,3 @@
+GDTEST_OK
+~~ WARNING at line 6: (UNTYPED_DECLARATION) Parameter "_arg" has no static type.
+~~ WARNING at line 9: (UNTYPED_DECLARATION) Parameter "_var_args" has no static type.


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #121838

## Additional information

From my investigation, it appears that the code in `GDScriptAnalyzer::resolve_assignable` already handles rest parameters in function definitions and produces `UNTYPED_DECLARATION` for them, so the creation of an `UNTYPED_DECLARATION` warning in `GDScriptAnalyzer::resolve_function_signature` for rest parameters specifically isn't necessary.

With this PR, the test case produces only one warning for the single rest parameter, as expected:

<img width="597" height="239" alt="CleanShot 2026-07-27 at 15 37 51@2x" src="https://github.com/user-attachments/assets/6580718b-1778-4093-9ee6-361d75e8088c" />


<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
