### PR TITLE
Define `MIN`/`MAX`/`SIGN`/`CLAMP` as macros to avoid redeclaration by system headers

### DIFF
--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -145,31 +145,38 @@ static_assert(__cplusplus >= 201703L, "Minimum of C++17 required.");
 #define _LIFETIME_BOUND_
 #endif
 
-// Make room for our constexpr's below by overriding potential system-specific macros.
+template <typename T>
+constexpr const T gd_sign(const T p_value) {
+	return p_value > 0 ? +1.0f : (p_value < 0 ? -1.0f : 0.0f);
+}
+
+template <typename T, typename T2>
+constexpr auto gd_min(const T p_left, const T2 p_right) {
+	return p_left < p_right ? p_left : p_right;
+}
+
+template <typename T, typename T2>
+constexpr auto gd_max(const T p_left, const T2 p_right) {
+	return p_left > p_right ? p_left : p_right;
+}
+
+template <typename T, typename T2, typename T3>
+constexpr auto gd_clamp(const T p_value, const T2 p_min, const T3 p_max) {
+	return p_value < p_min ? p_min : (p_value > p_max ? p_max : p_value);
+}
+
+// Make room for our versions below.
 #undef SIGN
 #undef MIN
 #undef MAX
 #undef CLAMP
 
-template <typename T>
-constexpr const T SIGN(const T p_value) {
-	return p_value > 0 ? +1.0f : (p_value < 0 ? -1.0f : 0.0f);
-}
-
-template <typename T, typename T2>
-constexpr auto MIN(const T p_left, const T2 p_right) {
-	return p_left < p_right ? p_left : p_right;
-}
-
-template <typename T, typename T2>
-constexpr auto MAX(const T p_left, const T2 p_right) {
-	return p_left > p_right ? p_left : p_right;
-}
-
-template <typename T, typename T2, typename T3>
-constexpr auto CLAMP(const T p_value, const T2 p_min, const T3 p_max) {
-	return p_value < p_min ? p_min : (p_value > p_max ? p_max : p_value);
-}
+// Define these as macros. This prevents system headers from redeclaring
+// them with naive macros, which perform worse than the constexpr functions.
+#define SIGN(m_v) gd_sign((m_v))
+#define MIN(m_l, m_r) gd_min((m_l), (m_r))
+#define MAX(m_l, m_r) gd_max((m_l), (m_r))
+#define CLAMP(m_v, m_min, m_max) gd_clamp((m_v), (m_min), (m_max))
 
 // Like std::size, but without requiring any additional includes.
 template <typename T, size_t SIZE>

--- a/drivers/d3d12/godot_nir.h
+++ b/drivers/d3d12/godot_nir.h
@@ -38,12 +38,19 @@ GODOT_MSVC_WARNING_PUSH
 GODOT_MSVC_WARNING_IGNORE(4200) // "nonstandard extension used: zero-sized array in struct/union".
 GODOT_MSVC_WARNING_IGNORE(4806) // "'&': unsafe operation: no value of type 'bool' promoted to type 'uint32_t' can equal the given constant".
 
+// Mesa unconditionally defines CLAMP, colliding with ours.
+#undef CLAMP
+
 #include <nir_spirv.h>
 #include <nir_to_dxil.h>
 #include <spirv_to_dxil.h>
 extern "C" {
 #include <dxil_spirv_nir.h>
 }
+
+// Restore our CLAMP.
+#undef CLAMP
+#define CLAMP(m_v, m_min, m_max) gd_clamp((m_v), (m_min), (m_max))
 
 GODOT_GCC_WARNING_POP
 GODOT_CLANG_WARNING_POP


### PR DESCRIPTION
## What problem(s) does this PR solve?

Should fix https://github.com/godotengine/godot/pull/121832#issuecomment-5097332497

We've been fighting an uphill battle, with trying to undef `MIN`, `MAX` and the ilk to define our own functions instead.
Effectively, whether it works depends on whether system headers don't register the macros again over our functions.

Instead, I propose to _keep the macros defined_ and simply redirect them to our `constexpr` functions. This works because libraries usually guard their definitions under `#ifndef`, letting our macros win.

This should be more robust, with collisions failing loudly instead of silently overriding our functions (see https://github.com/godotengine/godot/actions/runs/30313861669/job/90135250825?pr=121840).
with the caveat that it won't be possible to use `MIN`, `MAX` etc. in `#if` macro expressions anymore the same way.
However, we should see if that actually does happen by build failures.

## Additional information

Another solution would be to move the functions to `Math::`, but that would require major amounts of code churn.