### PR TITLE
Document inconsistent behavior of `NoiseTexture2D.get_image()`

### DIFF
--- a/doc/classes/Texture2D.xml
+++ b/doc/classes/Texture2D.xml
@@ -153,6 +153,7 @@
 			<return type="Image" />
 			<description>
 				Returns an [Image] that is a copy of data from this [Texture2D] (a new [Image] is created each time). [Image]s can be accessed and manipulated directly.
+				[b]Warning:[/b] For performance reasons, [NoiseTexture2D] will return a [i]shared instance[/i] of the image data. If you need to independently manipulate the data, create a copy first.
 				[b]Note:[/b] This will return [code]null[/code] if this [Texture2D] is invalid.
 				[b]Note:[/b] This will fetch the texture data from the GPU, which might cause performance problems when overused. Avoid calling [method get_image] every frame, especially on large textures.
 			</description>

--- a/modules/noise/doc_classes/NoiseTexture2D.xml
+++ b/modules/noise/doc_classes/NoiseTexture2D.xml
@@ -13,6 +13,7 @@
 		var image = texture.get_image()
 		var data = image.get_data()
 		[/codeblock]
+		Once the process has completed, [method Texture2D.get_image] will return a [i]shared instance[/i] of the image data. If you need to independently manipulate the data, create a copy first.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #121173, in a way

## Additional information

Following #121173 and a PR I opened to fix the implementation to match, #121174, there was a consensus (including on the RocketChat, as I recall) that the current implementation is best for performance and it was the documentation that should be updated instead.

This PR approaches the problem from that angle by adding notes to the `Texture2D` and `NoiseTexture2D` docs specifying that the latter's implementation of `get_image()` works differently from the rest of the subclasses.

For `Texture2D.get_image()` it adds the note:
> **Warning:** For performance reasons, `NoiseTexture2D` will return a _shared instance_ of the image data. If you need to independently manipulate the data, create a copy first.

For `NoiseTexture2D`'s class description, it adds:
> Once the process has completed, `Texture2D.get_image` will return a _shared instance_ of the image data. If you need to independently manipulate the data, create a copy first.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
