### PR TITLE
demo: add elastic_out global math utility (practice / draft — do not merge)

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -585,6 +585,31 @@ constexpr float smoothstep(float p_from, float p_to, float p_s) {
 	return s * s * (3.0f - 2.0f * s);
 }
 
+// Elastic ease-out over [0, 1]: overshoots then settles at 1.
+// Same curve family as Tween.TRANS_ELASTIC / EASE_OUT, exposed as a standalone math utility.
+_ALWAYS_INLINE_ double elastic_out(double p_x) {
+	if (p_x <= 0.0) {
+		return 0.0;
+	}
+	if (p_x >= 1.0) {
+		return 1.0;
+	}
+	const double p = 0.3;
+	const double s = p / 4.0;
+	return pow(2.0, -10.0 * p_x) * sin((p_x - s) * (Math::TAU) / p) + 1.0;
+}
+_ALWAYS_INLINE_ float elastic_out(float p_x) {
+	if (p_x <= 0.0f) {
+		return 0.0f;
+	}
+	if (p_x >= 1.0f) {
+		return 1.0f;
+	}
+	const float p = 0.3f;
+	const float s = p / 4.0f;
+	return pow(2.0f, -10.0f * p_x) * sin((p_x - s) * (float)Math::TAU / p) + 1.0f;
+}
+
 constexpr double move_toward(double p_from, double p_to, double p_delta) {
 	return abs(p_to - p_from) <= p_delta ? p_to : p_from + SIGN(p_to - p_from) * p_delta;
 }

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -557,6 +557,10 @@ double VariantUtilityFunctions::smoothstep(double p_from, double p_to, double p_
 	return Math::smoothstep(p_from, p_to, p_step);
 }
 
+double VariantUtilityFunctions::elastic_out(double p_x) {
+	return Math::elastic_out(p_x);
+}
+
 double VariantUtilityFunctions::move_toward(double p_from, double p_to, double p_delta) {
 	return Math::move_toward(p_from, p_to, p_delta);
 }
@@ -1704,6 +1708,7 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(remap, sarray("value", "istart", "istop", "ostart", "ostop"), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDR(smoothstep, sarray("from", "to", "x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(elastic_out, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(move_toward, sarray("from", "to", "delta"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(rotate_toward, sarray("from", "to", "delta"), Variant::UTILITY_FUNC_TYPE_MATH);
 

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -94,6 +94,7 @@ struct VariantUtilityFunctions {
 	static double inverse_lerp(double p_from, double p_to, double p_weight);
 	static double remap(double p_value, double p_istart, double p_istop, double p_ostart, double p_ostop);
 	static double smoothstep(double p_from, double p_to, double p_val);
+	static double elastic_out(double p_x);
 	static double move_toward(double p_from, double p_to, double p_delta);
 	static double rotate_toward(double p_from, double p_to, double p_delta);
 	static double deg_to_rad(double p_angle_deg);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1269,6 +1269,20 @@
 				[url=https://raw.githubusercontent.com/godotengine/godot-docs/master/img/smoothstep_range.webp]Smoothstep() return values with positive, zero, and negative ranges[/url]
 			</description>
 		</method>
+		<method name="elastic_out" keywords="ease,interpolate">
+			<return type="float" />
+			<param index="0" name="x" type="float" />
+			<description>
+				Returns an elastic ease-out value for [param x] in the range [code][0, 1][/code]. Values outside that range are clamped: [code]x &lt;= 0[/code] returns [code]0[/code], and [code]x &gt;= 1[/code] returns [code]1[/code].
+				The curve overshoots past [code]1[/code] and settles, matching the feel of [code]Tween.TRANS_ELASTIC[/code] with [code]Tween.EASE_OUT[/code]. Combine with [method lerpf] for custom motion without creating a [Tween].
+				[codeblock]
+				elastic_out(0.0) # Returns 0.0
+				elastic_out(1.0) # Returns 1.0
+				var y = lerpf(0.0, 100.0, elastic_out(t))
+				[/codeblock]
+				See also [method ease] and [method smoothstep].
+			</description>
+		</method>
 		<method name="snapped">
 			<return type="Variant" />
 			<param index="0" name="x" type="Variant" />

--- a/tests/core/math/test_math_funcs.cpp
+++ b/tests/core/math/test_math_funcs.cpp
@@ -492,6 +492,16 @@ TEST_CASE_TEMPLATE("[Math] smoothstep", T, float, double) {
 	CHECK(Math::smoothstep((T)0.0, (T)2.0, (T)2.0) == doctest::Approx((T)1.0));
 }
 
+TEST_CASE_TEMPLATE("[Math] elastic_out", T, float, double) {
+	CHECK(Math::elastic_out((T)0.0) == doctest::Approx((T)0.0));
+	CHECK(Math::elastic_out((T)-0.5) == doctest::Approx((T)0.0));
+	CHECK(Math::elastic_out((T)1.0) == doctest::Approx((T)1.0));
+	CHECK(Math::elastic_out((T)1.5) == doctest::Approx((T)1.0));
+	// Mid-curve overshoots above 1.0 before settling.
+	CHECK(Math::elastic_out((T)0.5) > (T)1.0);
+	CHECK(Math::elastic_out((T)0.25) != Math::elastic_out((T)0.75));
+}
+
 TEST_CASE("[Math] ease") {
 	CHECK(Math::ease(0.1, 1.0) == doctest::Approx(0.1));
 	CHECK(Math::ease(0.1, 2.0) == doctest::Approx(0.01));


### PR DESCRIPTION
## Summary
- **DRAFT PRACTICE PR — please ignore / do not review or merge.** Fork + PR flow test for a Cursor enablement session.
- Adds `elastic_out(x)` as a GlobalScope math utility (elastic ease-out overshoot), following the existing `smoothstep` / `ease` binding pattern.
- Includes Math impl, VariantUtilityFunctions + FUNCBINDR, `@GlobalScope.xml` docs, and doctest coverage.

## Test plan
- [ ] `scons -j14 target=editor tests=yes vulkan=no accesskit=no angle=no`
- [ ] `./bin/godot.* --headless --test`
- [ ] GDScript: `elastic_out(0)==0`, `elastic_out(1)==1`, `elastic_out(0.5)>1`


Made with [Cursor](https://cursor.com)