### PR TITLE
Fix PSSM shadows with 2 splits, blend enabled, and angular distance > 0

### DIFF
--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -2423,7 +2423,7 @@ void fragment_shader(in SceneData scene_data) {
 							blend_count++;
 						}
 
-						if (blend_count < blend_max) {
+						if (blend_count < blend_max && depth_z < directional_lights.data[i].shadow_split_offsets.w) {
 							vec4 v = vec4(vertex, 1.0);
 
 							BIAS_FUNC(v, 3)

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -816,7 +816,7 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 						Projection correction;
 						correction.set_depth_correction(false, true, false);
 						Projection matrix = correction * light_instance->shadow_transform[j].camera;
-						float split = light_instance->shadow_transform[MIN(limit, j)].split;
+						float split = j <= limit ? light_instance->shadow_transform[j].split : 0;
 
 						Projection bias;
 						bias.set_light_bias();
@@ -858,8 +858,8 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 					}
 
 					float fade_start = light->param[RSE::LIGHT_PARAM_SHADOW_FADE_START];
-					light_data.fade_from = -light_data.shadow_split_offsets[3] * MIN(fade_start, 0.999); //using 1.0 would break smoothstep
-					light_data.fade_to = -light_data.shadow_split_offsets[3];
+					light_data.fade_from = -light_data.shadow_split_offsets[limit] * MIN(fade_start, 0.999); //using 1.0 would break smoothstep
+					light_data.fade_to = -light_data.shadow_split_offsets[limit];
 				}
 
 				r_directional_light_count++;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/121851

## Additional information

When enabling blending and angular distance the shader was always reading at least 2 splits without checking if the shadow map had them.

Master:
<img width="2142" height="1200" alt="master" src="https://github.com/user-attachments/assets/8a1a0724-77ef-4f29-b1c5-bf22c55592e5" />

Fix:
<img width="2142" height="1200" alt="fix" src="https://github.com/user-attachments/assets/deb40144-a5c6-4208-be96-c91bc92ac00c" />
