### PR TITLE
3D: Fix camera drifting away when piloting it while in follow mode

### DIFF
--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -3556,7 +3556,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 				_disable_follow_mode();
 			}
 
-			if (focused_node_id.is_valid() && get_selected_count() > 0 && times_focused_consecutively >= 2 && times_focused_consecutively % 2 == 0) {
+			if (focused_node_id.is_valid() && get_selected_count() > 0 && times_focused_consecutively >= 2 && times_focused_consecutively % 2 == 0 && !previewing_camera) {
 				Node *focused_node = ObjectDB::get_instance<Node>(focused_node_id);
 				if (focused_node) {
 					follow_mode->set_text(vformat(TTR("Following %s"), focused_node->get_name()));
@@ -4873,6 +4873,7 @@ void Node3DEditorViewport::_toggle_camera_preview(bool p_activate) {
 	_update_navigation_controls_visibility();
 
 	if (!p_activate) {
+		times_focused_consecutively = pre_preview_times_focused_consecutively;
 		_pilot_commit_undo_session();
 		previewing->disconnect(SceneStringName(tree_exiting), callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
 		previewing->disconnect(CoreStringName(property_list_changed), callable_mp(this, &Node3DEditorViewport::_preview_camera_property_changed));
@@ -4892,6 +4893,7 @@ void Node3DEditorViewport::_toggle_camera_preview(bool p_activate) {
 		surface->queue_redraw();
 
 	} else {
+		pre_preview_times_focused_consecutively = times_focused_consecutively;
 		previewing = preview;
 		previewing->connect(SceneStringName(tree_exiting), callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
 		previewing->connect(CoreStringName(property_list_changed), callable_mp(this, &Node3DEditorViewport::_preview_camera_property_changed));
@@ -5348,6 +5350,9 @@ void Node3DEditorViewport::reset() {
 }
 
 void Node3DEditorViewport::focus_selection() {
+	if (previewing_camera) {
+		return;
+	}
 	Vector3 center;
 	int count = 0;
 

--- a/editor/scene/3d/node_3d_editor_viewport.h
+++ b/editor/scene/3d/node_3d_editor_viewport.h
@@ -470,6 +470,7 @@ private:
 
 	bool previewing_camera = false;
 	bool previewing_cinema = false;
+	int pre_preview_times_focused_consecutively = 0;
 	int times_focused_consecutively = 0;
 	bool pilot_preview_enabled = false;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121821

## Additional information

It is physically impossible to follow and pilot a 3D Camera at the same time. Doing so causes the viewport cursor position to acquire an offset relative to the camera's actual position, resulting in an infinite interpolation loop as the camera continuously tries and fails to catch up to the cursor.

This can be easily proven by zooming in while in follow mode before hitting the pilot button, as this will make the drifting slow as the cursor has a smaller offset that results in a smaller interpolation.

The fix is to disable follow mode before entering pilot mode, while saving the times consecutively focused, in order to restore the follow mode if there was one, after toggling off pilot mode.
