### PR TITLE
[Windows] Clean WinRT window data pointer when it is erased.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -7468,6 +7468,7 @@ void DisplayServerWindows::_destroy_window(DisplayServerEnums::WindowID p_window
 
 	if (has_winrt_queue) {
 		WinRTUtils::destroy_wd(wd.wrt_wd);
+		wd.wrt_wd = nullptr;
 	}
 	DestroyWindow(wd.hWnd);
 	windows.erase(p_window_id);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Seems like `DestroyWindow` can result in `_get_screen_hdr_data` call in some conditions (not reliably reproducible, so not sure when) and access deleted pointer when window is closed.