### PR TITLE
Style: Auto-inherit parent config in `clang_format_glsl.yml`

### DIFF
--- a/misc/utility/clang_format_glsl.yml
+++ b/misc/utility/clang_format_glsl.yml
@@ -1,48 +1,12 @@
 # GLSL-specific rules.
-# The rules should be the same as .clang-format, except those explicitly mentioned.
-BasedOnStyle: LLVM
-AccessModifierOffset: -4
+# The rules will be the same as .clang-format, except those explicitly mentioned.
+BasedOnStyle: InheritParentConfig
+# `uniform` and `buffer` not recognized as object-like containers.
+RemoveSemicolon: false
+# NOTE: This is a duplicated value from the main config to work around a bug in clang-format when
+#  inheriting a parent config. This value changed to a boolean in v22, and automatically resolves
+#  "DontAlign" to "false". However, it does *not* perform this resolution in an inherited file,
+#  which causes the value to fallback to the LLVM value: "true". When comparing `--dump-config`
+#  outputs, this is the only instance of this happening, but future major version bumps should
+#  ratify this as well.
 AlignAfterOpenBracket: DontAlign
-AlignOperands: DontAlign
-AlignTrailingComments:
-  Kind: Never
-  OverEmptyLines: 0
-AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortFunctionsOnASingleLine: Inline
-AttributeMacros:
-  - _ALWAYS_INLINE_
-  - _FORCE_INLINE_
-  - _NO_INLINE_
-BreakConstructorInitializers: AfterColon
-ColumnLimit: 0
-ConstructorInitializerIndentWidth: 8
-ContinuationIndentWidth: 8
-Cpp11BracedListStyle: false
-IncludeCategories:
-  - Regex: ^".*"$
-    Priority: 1
-  - Regex: ^<.*\.h>$
-    Priority: 2
-  - Regex: ^<.*>$
-    Priority: 3
-IndentCaseLabels: true
-IndentWidth: 4
-InsertBraces: true
-JavaImportGroups:
-  - org.godotengine
-  - android
-  - androidx
-  - com.android
-  - com.google
-  - java
-  - javax
-KeepEmptyLinesAtTheStartOfBlocks: false
-ObjCBlockIndentWidth: 4
-PackConstructorInitializers: NextLine
-RemoveSemicolon: false # Differs from base .clang-format
-SpacesInLineCommentPrefix:
-  Minimum: 0
-  Maximum: -1
-Standard: c++20
-TabWidth: 4
-UseTab: Always

--- a/servers/rendering/renderer_rd/shaders/effects/octmap_filter.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/octmap_filter.glsl
@@ -225,8 +225,8 @@ void main() {
 	}
 
 #ifdef USE_TEXTURE_ARRAY
-#define IMAGE_STORE(x)                             \
-	imageStore(x, ivec2(id), color);               \
+#define IMAGE_STORE(x) \
+	imageStore(x, ivec2(id), color); \
 	imageStore(x, ivec2(id) + ivec2(1, 0), color); \
 	imageStore(x, ivec2(id) + ivec2(0, 1), color); \
 	imageStore(x, ivec2(id) + ivec2(1, 1), color)

--- a/servers/rendering/renderer_rd/shaders/environment/sdfgi_integrate.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sdfgi_integrate.glsl
@@ -292,9 +292,9 @@ void main() {
 
 		vec3 ray_dir2 = ray_dir * ray_dir;
 
-#define SH_ACCUM(m_idx, m_value)                       \
-	{                                                  \
-		vec3 l = light.rgb * (m_value);                \
+#define SH_ACCUM(m_idx, m_value) \
+	{ \
+		vec3 l = light.rgb * (m_value); \
 		sh_accum[probe_index].c[m_idx * 3 + 0] += l.r; \
 		sh_accum[probe_index].c[m_idx * 3 + 1] += l.g; \
 		sh_accum[probe_index].c[m_idx * 3 + 2] += l.b; \

--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog.glsl
@@ -43,7 +43,7 @@ layout(set = 1, binding = 1) volatile buffer emissive_only_map_buffer {
 	uint emissive_only_map[];
 };
 #else
-layout(r32ui, set = 1, binding = 1) uniform volatile uimage3D emissive_only_map;
+layout(r32ui, set = 1, binding = 1) volatile uniform uimage3D emissive_only_map;
 #endif
 
 layout(set = 1, binding = 2, std140) uniform SceneParams {
@@ -76,8 +76,8 @@ layout(set = 1, binding = 4) volatile buffer light_only_map_buffer {
 	uint light_only_map[];
 };
 #else
-layout(r32ui, set = 1, binding = 3) uniform volatile uimage3D density_only_map;
-layout(r32ui, set = 1, binding = 4) uniform volatile uimage3D light_only_map;
+layout(r32ui, set = 1, binding = 3) volatile uniform uimage3D density_only_map;
+layout(r32ui, set = 1, binding = 4) volatile uniform uimage3D light_only_map;
 #endif
 
 #ifdef MATERIAL_UNIFORMS_USED

--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
@@ -14,11 +14,10 @@ layout(local_size_x = 4, local_size_y = 4, local_size_z = 4) in;
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 #endif
 
+#include "../area_lights_inc.glsl"
 #include "../cluster_data_inc.glsl"
 #include "../light_data_inc.glsl"
 #include "../oct_inc.glsl"
-
-#include "../area_lights_inc.glsl"
 
 #define M_TAU 6.28318530718
 #define M_PI 3.14159265359

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -6,7 +6,6 @@
 
 /* Include half precision types. */
 #include "../half_inc.glsl"
-
 #include "scene_forward_clustered_inc.glsl"
 
 #define SHADER_IS_SRGB false
@@ -877,7 +876,6 @@ void main() {
 
 /* Include half precision types. */
 #include "../half_inc.glsl"
-
 #include "scene_forward_clustered_inc.glsl"
 
 /* Varyings */
@@ -1080,9 +1078,8 @@ layout(location = 2) out vec2 motion_vector;
 #define SPECULAR_SCHLICK_GGX
 #endif
 
-#include "../scene_forward_lights_inc.glsl"
-
 #include "../scene_forward_gi_inc.glsl"
+#include "../scene_forward_lights_inc.glsl"
 
 #endif //!defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED)
 
@@ -2346,10 +2343,10 @@ void fragment_shader(in SceneData scene_data) {
 					vec3 light_dir = directional_lights.data[i].direction;
 					vec3 base_normal_bias = geo_normal * (1.0 - max(0.0, dot(light_dir, -geo_normal)));
 
-#define BIAS_FUNC(m_var, m_idx)                                                                 \
-	m_var.xyz += light_dir * directional_lights.data[i].shadow_bias[m_idx];                     \
+#define BIAS_FUNC(m_var, m_idx) \
+	m_var.xyz += light_dir * directional_lights.data[i].shadow_bias[m_idx]; \
 	vec3 normal_bias = base_normal_bias * directional_lights.data[i].shadow_normal_bias[m_idx]; \
-	normal_bias -= light_dir * dot(light_dir, normal_bias);                                     \
+	normal_bias -= light_dir * dot(light_dir, normal_bias); \
 	m_var.xyz += normal_bias;
 
 					//version with soft shadows, more expensive

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1981,10 +1981,10 @@ void main() {
 					hvec3 light_dir = hvec3(directional_lights.data[i].direction);
 					hvec3 base_normal_bias = geo_normal * (half(1.0) - max(half(0.0), dot(light_dir, -geo_normal)));
 
-#define BIAS_FUNC(m_var, m_idx)                                                                        \
+#define BIAS_FUNC(m_var, m_idx) \
 	hvec3 normal_bias = base_normal_bias * half(directional_lights.data[i].shadow_normal_bias[m_idx]); \
-	normal_bias -= light_dir * dot(light_dir, normal_bias);                                            \
-	normal_bias += light_dir * half(directional_lights.data[i].shadow_bias[m_idx]);                    \
+	normal_bias -= light_dir * dot(light_dir, normal_bias); \
+	normal_bias += light_dir * half(directional_lights.data[i].shadow_bias[m_idx]); \
 	m_var.xyz += vec3(normal_bias);
 
 					if (depth_z < directional_lights.data[i].shadow_split_offsets.x) {


### PR DESCRIPTION
- Related: #121585

## What problem(s) does this PR solve?

Our clang-format rulesets have been slowly drifting over time, as the glsl-specific implementation required manual adjustments that didn't always occur. By changing the glsl-specific file's `BasedOnStyle` to `InheritParentConfig`, we can automatically pull all config options from the base `.clang-format` by default, meaning the only options that need to be specified are what explicitly deviates from said file (along with comments explaining said deviation).

## Additional information

No adjustments were made to the shader files beyond the new clang-format changes, meaning this should be much easier to integrate as-is compared to #121585.