### PR TITLE
Add editor settings option to toggle editor mode auto switch

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1015,6 +1015,9 @@
 		<member name="interface/editor/behavior/automatically_open_screenshots" type="bool" setter="" getter="">
 			If [code]true[/code], automatically opens screenshots with the default program associated to [code].png[/code] files after a screenshot is taken using the [b]Editor &gt; Take Screenshot[/b] action.
 		</member>
+		<member name="interface/editor/behavior/enable_editor_mode_auto_switch" type="bool" setter="" getter="">
+			If [code]true[/code], editor modes in the top bar automatically switch when selecting different node types in the scene tree.
+		</member>
 		<member name="interface/editor/behavior/import_resources_when_unfocused" type="bool" setter="" getter="">
 			If [code]true[/code], (re)imports resources even if the editor window is unfocused or minimized. If [code]false[/code], resources are only (re)imported when the editor window is focused. This can be set to [code]true[/code] to speed up iteration by starting the import process earlier when saving files in the project folder. This also allows getting visual feedback on changes without having to click the editor window, which is useful with multi-monitor setups. The downside of setting this to [code]true[/code] is that it increases idle CPU usage and may steal CPU time from other applications when importing resources.
 		</member>

--- a/editor/editor_main_screen.cpp
+++ b/editor/editor_main_screen.cpp
@@ -237,6 +237,11 @@ EditorPlugin *EditorMainScreen::get_plugin_by_name(const String &p_plugin_name) 
 }
 
 bool EditorMainScreen::can_auto_switch_screens() const {
+	// No switching if editor setting is toggled off
+	if (!EditorSettings::get_singleton()->get_setting("interface/editor/behavior/enable_editor_mode_auto_switch")) {
+		return false;
+	}
+
 	if (selected_plugin == nullptr) {
 		return true;
 	}

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -546,6 +546,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("interface/editor/input/mouse_extra_buttons_navigate_history", true);
 	_initial_set("interface/editor/behavior/save_each_scene_on_quit", true, true); // Regression
 	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/behavior/save_on_focus_loss", false, "")
+	EDITOR_SETTING_BASIC(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/behavior/enable_editor_mode_auto_switch", true, "")
 	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/appearance/accept_dialog_cancel_ok_buttons", 0,
 			vformat("Auto (%s),Cancel First,OK First", DisplayServer::get_singleton()->get_swap_cancel_ok() ? "OK First" : "Cancel First"),
 			PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);


### PR DESCRIPTION
Links to:
Closes https://github.com/godotengine/godot-proposals/issues/14651
Closes https://github.com/godotengine/godot-proposals/issues/13901

PR adds editor settings option to turn off auto switching of the editor mode in the top bar when selecting nodes in the scene tree.

Default behaviour remains as it was, where selecting a node will change the mode. Toggling the option off will prevent the main viewport from being manipulated by the engine.

<img width="1892" height="1182" alt="image" src="https://github.com/user-attachments/assets/f2338329-f90b-4bb3-b75e-009ade469327" />

<img width="874" height="153" alt="image" src="https://github.com/user-attachments/assets/45f7743f-0ed2-4b84-9bfc-11a66620fbc7" />

AI Disclosure: No AI was used to make this PR