### PR TITLE
Core: Add `--color`/`--no-color` CLI arguments

### DIFF
--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -34,6 +34,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/object/script_backtrace.h"
+#include "core/os/os.h"
 #include "core/os/time.h"
 #include "core/string/regex.h"
 #include "core/templates/rb_set.h"
@@ -57,21 +58,14 @@ void Logger::log_error(const char *p_function, const char *p_file, int p_line, c
 		return;
 	}
 
-	const char *err_type = error_type_string(p_type);
+	const char *err_details = p_rationale && *p_rationale ? p_rationale : p_code;
 
-	const char *err_details;
-	if (p_rationale && *p_rationale) {
-		err_details = p_rationale;
-	} else {
-		err_details = p_code;
-	}
-
-	logf_error("%s: %s\n", err_type, err_details);
-	logf_error("   at: %s (%s:%i)\n", p_function, p_file, p_line);
+	logf_error("%s: %s\n", error_type_string(p_type), err_details);
+	logf_error("%sat: %s (%s:%i)\n", error_type_indent(p_type), p_function, p_file, p_line);
 
 	for (const Ref<ScriptBacktrace> &backtrace : p_script_backtraces) {
 		if (!backtrace->is_empty()) {
-			logf_error("%s\n", backtrace->format(3).utf8().get_data());
+			logf_error("%s\n", backtrace->format(strlen(error_type_indent(p_type))).utf8().get_data());
 		}
 	}
 }
@@ -223,6 +217,62 @@ void StdLogger::logv(const char *p_format, va_list p_list, bool p_err) {
 			// Don't always flush when printing stdout to avoid performance
 			// issues when `print()` is spammed in release builds.
 			fflush(stdout);
+		}
+	}
+}
+
+void StdLogger::log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, bool p_editor_notify, ErrorType p_type, const Vector<Ref<ScriptBacktrace>> &p_script_backtraces) {
+	if (!should_log(true)) {
+		return;
+	}
+
+	constexpr const char GRAY[] = "\u001b[0;90m";
+	constexpr const char RED[] = "\u001b[0;31m";
+	constexpr const char RED_BOLD[] = "\u001b[1;31m";
+	constexpr const char YELLOW[] = "\u001b[0;33m";
+	constexpr const char YELLOW_BOLD[] = "\u001b[1;33m";
+	constexpr const char MAGENTA[] = "\u001b[0;35m";
+	constexpr const char MAGENTA_BOLD[] = "\u001b[1;35m";
+	constexpr const char CYAN[] = "\u001b[0;36m";
+	constexpr const char CYAN_BOLD[] = "\u001b[1;36m";
+	constexpr const char RESET[] = "\u001b[0m";
+
+	const char *bold_color = "";
+	const char *normal_color = "";
+	const char *gray_color = "";
+	const char *reset_color = "";
+
+	if (OS::get_singleton() && OS::get_singleton()->is_stderr_color()) {
+		gray_color = GRAY;
+		reset_color = RESET;
+		switch (p_type) {
+			case ERR_WARNING:
+				bold_color = YELLOW_BOLD;
+				normal_color = YELLOW;
+				break;
+			case ERR_SCRIPT:
+				bold_color = MAGENTA_BOLD;
+				normal_color = MAGENTA;
+				break;
+			case ERR_SHADER:
+				bold_color = CYAN_BOLD;
+				normal_color = CYAN;
+				break;
+			case ERR_ERROR:
+				bold_color = RED_BOLD;
+				normal_color = RED;
+				break;
+		}
+	}
+
+	const char *err_details = p_rationale && *p_rationale ? p_rationale : p_code;
+
+	logf_error("%s%s:%s %s\n", bold_color, error_type_string(p_type), normal_color, err_details);
+	logf_error("%s%sat: %s (%s:%i)%s\n", gray_color, error_type_indent(p_type), p_function, p_file, p_line, reset_color);
+
+	for (const Ref<ScriptBacktrace> &backtrace : p_script_backtraces) {
+		if (!backtrace->is_empty()) {
+			logf_error("%s%s%s\n", gray_color, backtrace->format(strlen(error_type_indent(p_type))).utf8().get_data(), reset_color);
 		}
 	}
 }

--- a/core/io/logger.h
+++ b/core/io/logger.h
@@ -99,6 +99,7 @@ public:
 class StdLogger : public Logger {
 public:
 	virtual void logv(const char *p_format, va_list p_list, bool p_err) override _PRINTF_FORMAT_ATTRIBUTE_2_0;
+	virtual void log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, bool p_editor_notify = false, ErrorType p_type = ERR_ERROR, const Vector<Ref<ScriptBacktrace>> &p_script_backtraces = {}) override;
 	virtual ~StdLogger() {}
 };
 

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -192,6 +192,26 @@ bool OS::is_stdout_debug_enabled() const {
 	return _debug_stdout;
 }
 
+bool OS::is_stdout_color() const {
+	if (_color_override != 0) {
+		return _color_override > 0;
+	} else if (has_environment("NO_COLOR")) {
+		return false;
+	} else {
+		return has_environment("FORCE_COLOR") || has_environment("CI") || get_stdout_type() == OS::STD_HANDLE_CONSOLE;
+	}
+}
+
+bool OS::is_stderr_color() const {
+	if (_color_override != 0) {
+		return _color_override > 0;
+	} else if (has_environment("NO_COLOR")) {
+		return false;
+	} else {
+		return has_environment("FORCE_COLOR") || has_environment("CI") || get_stderr_type() == OS::STD_HANDLE_CONSOLE;
+	}
+}
+
 bool OS::is_stdout_enabled() const {
 	return _stdout_enabled;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -86,6 +86,7 @@ private:
 	bool _delta_smoothing_enabled = false;
 	bool _verbose_stdout = false;
 	bool _debug_stdout = false;
+	int _color_override = 0;
 	String _local_clipboard;
 	// Assume success by default, all failure cases need to set EXIT_FAILURE explicitly.
 	int _exit_code = EXIT_SUCCESS;
@@ -285,6 +286,9 @@ public:
 
 	bool is_stdout_verbose() const;
 	bool is_stdout_debug_enabled() const;
+
+	bool is_stdout_color() const;
+	bool is_stderr_color() const;
 
 	bool is_stdout_enabled() const;
 	bool is_stderr_enabled() const;

--- a/core/string/print_string.cpp
+++ b/core/string/print_string.cpp
@@ -117,6 +117,9 @@ void __print_line_rich(const String &p_string) {
 	// Support of those ANSI escape codes varies across terminal emulators,
 	// especially for italic and strikethrough.
 
+	const bool color = OS::get_singleton()->is_stdout_color();
+	const String url_begin = color ? "\u001b]8;;" : "";
+	const String url_end = color ? "\u001b\\" : "";
 	String output;
 	int pos = 0;
 	bool in_named_url = false;
@@ -145,40 +148,40 @@ void __print_line_rich(const String &p_string) {
 
 		String tag = p_string.substr(brk_pos + 1, brk_end - brk_pos - 1);
 		if (tag == "b") {
-			output += "\u001b[1m";
+			output += color ? "\u001b[1m" : "";
 		} else if (tag == "/b") {
-			output += "\u001b[22m";
+			output += color ? "\u001b[22m" : "";
 		} else if (tag == "i") {
-			output += "\u001b[3m";
+			output += color ? "\u001b[3m" : "";
 		} else if (tag == "/i") {
-			output += "\u001b[23m";
+			output += color ? "\u001b[23m" : "";
 		} else if (tag == "u") {
-			output += "\u001b[4m";
+			output += color ? "\u001b[4m" : "";
 		} else if (tag == "/u") {
-			output += "\u001b[24m";
+			output += color ? "\u001b[24m" : "";
 		} else if (tag == "s") {
-			output += "\u001b[9m";
+			output += color ? "\u001b[9m" : "";
 		} else if (tag == "/s") {
-			output += "\u001b[29m";
+			output += color ? "\u001b[29m" : "";
 		} else if (tag == "indent") {
 			output += "    ";
 		} else if (tag == "/indent") {
 			output += "";
 		} else if (tag == "code") {
-			output += "\u001b[2m";
+			output += color ? "\u001b[2m" : "";
 		} else if (tag == "/code") {
-			output += "\u001b[22m";
+			output += color ? "\u001b[22m" : "";
 		} else if (tag.begins_with("url=")) {
 			// Support named URLs using OSC 8 escape codes:
 			// <https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda>
 			in_named_url = true;
 			const String url_link = tag.substr(strlen("url="));
-			output += vformat("\u001b]8;;%s\u001b\\", url_link);
+			output += vformat("%s%s%s", url_begin, url_link, url_end);
 		} else if (tag == "url") {
 			output += "";
 		} else if (tag == "/url") {
 			if (in_named_url) {
-				output += "\u001b]8;;\u001b\\";
+				output += vformat("%s%s", url_begin, url_end);
 				in_named_url = false;
 			} else {
 				// While it's legal to close an URL that was never opened using OSC 8 escape codes,
@@ -196,7 +199,9 @@ void __print_line_rich(const String &p_string) {
 			output += "";
 		} else if (tag.begins_with("color=")) {
 			String color_name = tag.trim_prefix("color=");
-			if (color_name == "black") {
+			if (!color) {
+				// No-op.
+			} else if (color_name == "black") {
 				output += "\u001b[30m";
 			} else if (color_name == "red") {
 				output += "\u001b[91m";
@@ -227,10 +232,12 @@ void __print_line_rich(const String &p_string) {
 				output += vformat("\u001b[38;2;%d;%d;%dm", c.r * 255, c.g * 255, c.b * 255);
 			}
 		} else if (tag == "/color") {
-			output += "\u001b[39m";
+			output += color ? "\u001b[39m" : "";
 		} else if (tag.begins_with("bgcolor=")) {
 			String color_name = tag.trim_prefix("bgcolor=");
-			if (color_name == "black") {
+			if (!color) {
+				// No-op.
+			} else if (color_name == "black") {
 				output += "\u001b[40m";
 			} else if (color_name == "red") {
 				output += "\u001b[101m";
@@ -261,10 +268,12 @@ void __print_line_rich(const String &p_string) {
 				output += vformat("\u001b[48;2;%d;%d;%dm", c.r * 255, c.g * 255, c.b * 255);
 			}
 		} else if (tag == "/bgcolor") {
-			output += "\u001b[49m";
+			output += color ? "\u001b[49m" : "";
 		} else if (tag.begins_with("fgcolor=")) {
 			String color_name = tag.trim_prefix("fgcolor=");
-			if (color_name == "black") {
+			if (!color) {
+				// No-op.
+			} else if (color_name == "black") {
 				output += "\u001b[30;40m";
 			} else if (color_name == "red") {
 				output += "\u001b[91;101m";
@@ -295,13 +304,13 @@ void __print_line_rich(const String &p_string) {
 				output += vformat("\u001b[38;2;%d;%d;%d;48;2;%d;%d;%dm", c.r * 255, c.g * 255, c.b * 255, c.r * 255, c.g * 255, c.b * 255);
 			}
 		} else if (tag == "/fgcolor") {
-			output += "\u001b[39;49m";
+			output += color ? "\u001b[39;49m" : "";
 		} else {
 			output += "[";
 			pos = brk_pos + 1;
 		}
 	}
-	output += "\u001b[0m"; // Reset.
+	output += color ? "\u001b[0m" : ""; // Reset.
 
 	if (!CoreGlobals::print_ready) {
 		__print_fallback(output, false, false);

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -1222,65 +1222,6 @@ String OS_Unix::expand_path(const String &p_path) const {
 	return path;
 }
 
-void UnixTerminalLogger::log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, bool p_editor_notify, ErrorType p_type, const Vector<Ref<ScriptBacktrace>> &p_script_backtraces) {
-	if (!should_log(true)) {
-		return;
-	}
-
-	const char *err_details;
-	if (p_rationale && p_rationale[0]) {
-		err_details = p_rationale;
-	} else {
-		err_details = p_code;
-	}
-
-	// Disable color codes if stdout is not a TTY.
-	// This prevents Godot from writing ANSI escape codes when redirecting
-	// stdout and stderr to a file.
-	const bool tty = isatty(fileno(stdout));
-	const char *gray = tty ? "\E[0;90m" : "";
-	const char *red = tty ? "\E[0;91m" : "";
-	const char *red_bold = tty ? "\E[1;31m" : "";
-	const char *yellow = tty ? "\E[0;93m" : "";
-	const char *yellow_bold = tty ? "\E[1;33m" : "";
-	const char *magenta = tty ? "\E[0;95m" : "";
-	const char *magenta_bold = tty ? "\E[1;35m" : "";
-	const char *cyan = tty ? "\E[0;96m" : "";
-	const char *cyan_bold = tty ? "\E[1;36m" : "";
-	const char *reset = tty ? "\E[0m" : "";
-
-	const char *bold_color;
-	const char *normal_color;
-	switch (p_type) {
-		case ERR_WARNING:
-			bold_color = yellow_bold;
-			normal_color = yellow;
-			break;
-		case ERR_SCRIPT:
-			bold_color = magenta_bold;
-			normal_color = magenta;
-			break;
-		case ERR_SHADER:
-			bold_color = cyan_bold;
-			normal_color = cyan;
-			break;
-		case ERR_ERROR:
-		default:
-			bold_color = red_bold;
-			normal_color = red;
-			break;
-	}
-
-	logf_error("%s%s:%s %s\n", bold_color, error_type_string(p_type), normal_color, err_details);
-	logf_error("%s%sat: %s (%s:%i)%s\n", gray, error_type_indent(p_type), p_function, p_file, p_line, reset);
-
-	for (const Ref<ScriptBacktrace> &backtrace : p_script_backtraces) {
-		if (!backtrace->is_empty()) {
-			logf_error("%s%s%s\n", gray, backtrace->format(strlen(error_type_indent(p_type))).utf8().get_data(), reset);
-		}
-	}
-}
-
 UnixTerminalLogger::~UnixTerminalLogger() {}
 
 OS_Unix::OS_Unix() {

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -144,7 +144,6 @@ public:
 
 class UnixTerminalLogger : public StdLogger {
 public:
-	virtual void log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, bool p_editor_notify = false, ErrorType p_type = ERR_ERROR, const Vector<Ref<ScriptBacktrace>> &p_script_backtraces = {}) override;
 	virtual ~UnixTerminalLogger();
 };
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -373,16 +373,17 @@ void finalize_theme_db() {
 #define MAIN_PRINT(m_txt)
 #endif
 
-void Main::print_header(bool p_rich) {
+void Main::print_header() {
+	const bool color = OS::get_singleton()->is_stdout_color();
 	if (GODOT_VERSION_TIMESTAMP > 0) {
 		// Version timestamp available.
-		if (p_rich) {
+		if (color) {
 			Engine::get_singleton()->print_header_rich("\u001b[38;5;39m" + String(GODOT_VERSION_NAME) + "\u001b[0m v" + get_full_version_string() + " (" + Time::get_singleton()->get_datetime_string_from_unix_time(GODOT_VERSION_TIMESTAMP, true) + " UTC) - \u001b[4m" + String(GODOT_VERSION_WEBSITE));
 		} else {
 			Engine::get_singleton()->print_header(String(GODOT_VERSION_NAME) + " v" + get_full_version_string() + " (" + Time::get_singleton()->get_datetime_string_from_unix_time(GODOT_VERSION_TIMESTAMP, true) + " UTC) - " + String(GODOT_VERSION_WEBSITE));
 		}
 	} else {
-		if (p_rich) {
+		if (color) {
 			Engine::get_singleton()->print_header_rich("\u001b[38;5;39m" + String(GODOT_VERSION_NAME) + "\u001b[0m v" + get_full_version_string() + " - \u001b[4m" + String(GODOT_VERSION_WEBSITE));
 		} else {
 			Engine::get_singleton()->print_header(String(GODOT_VERSION_NAME) + " v" + get_full_version_string() + " - " + String(GODOT_VERSION_WEBSITE));
@@ -395,7 +396,10 @@ void Main::print_header(bool p_rich) {
  * automatically added at the end.
  */
 void Main::print_help_copyright(const char *p_notice) {
-	OS::get_singleton()->print("\u001b[90m%s\u001b[0m\n", p_notice);
+	const bool color = OS::get_singleton()->is_stdout_color();
+	const char *gray_color = color ? "\u001b[90m" : "";
+	const char *reset_color = color ? "\u001b[0m" : "";
+	OS::get_singleton()->print("%s%s%s\n", gray_color, p_notice, reset_color);
 }
 
 /**
@@ -403,7 +407,10 @@ void Main::print_help_copyright(const char *p_notice) {
  * automatically added at beginning and at the end.
  */
 void Main::print_help_title(const char *p_title) {
-	OS::get_singleton()->print("\n\u001b[1;93m%s:\u001b[0m\n", p_title);
+	const bool color = OS::get_singleton()->is_stdout_color();
+	const char *title_color = color ? "\u001b[1;93m" : "";
+	const char *reset_color = color ? "\u001b[0m" : "";
+	OS::get_singleton()->print("\n%s%s%s\n", title_color, p_title, reset_color);
 }
 
 /**
@@ -411,12 +418,14 @@ void Main::print_help_title(const char *p_title) {
  * This color replacement must be done *after* calling `rpad()` for the length padding to be done correctly.
  */
 String Main::format_help_option(const char *p_option) {
-	return (String(p_option)
-					.rpad(OPTION_COLUMN_LENGTH)
-					.replace("[", "\u001b[96m[")
-					.replace("]", "]\u001b[0m")
-					.replace("<", "\u001b[95m<")
-					.replace(">", ">\u001b[0m"));
+	String option = String(p_option).rpad(OPTION_COLUMN_LENGTH);
+	if (OS::get_singleton()->is_stdout_color()) {
+		option = option.replace("[", "\u001b[96m[")
+						 .replace("]", "]\u001b[0m")
+						 .replace("<", "\u001b[95m<")
+						 .replace(">", ">\u001b[0m");
+	}
+	return option;
 }
 
 /**
@@ -427,48 +436,61 @@ String Main::format_help_option(const char *p_option) {
  * support in editor.
  */
 void Main::print_help_option(const char *p_option, const char *p_description, CLIOptionAvailability p_availability) {
+	const bool color = OS::get_singleton()->is_stdout_color();
 	const bool option_empty = (p_option && !p_option[0]);
 	if (!option_empty) {
 		const char *availability_badge = "";
 		switch (p_availability) {
 			case CLI_OPTION_AVAILABILITY_EDITOR:
-				availability_badge = "\u001b[1;91mE";
+				availability_badge = color ? "\u001b[1;91mE" : "E";
 				break;
 			case CLI_OPTION_AVAILABILITY_TEMPLATE_DEBUG:
-				availability_badge = "\u001b[1;94mD";
+				availability_badge = color ? "\u001b[1;94mD" : "D";
 				break;
 			case CLI_OPTION_AVAILABILITY_TEMPLATE_UNSAFE:
-				availability_badge = "\u001b[1;93mX";
+				availability_badge = color ? "\u001b[1;93mX" : "X";
 				break;
 			case CLI_OPTION_AVAILABILITY_TEMPLATE_RELEASE:
-				availability_badge = "\u001b[1;92mR";
+				availability_badge = color ? "\u001b[1;92mR" : "R";
 				break;
 			case CLI_OPTION_AVAILABILITY_HIDDEN:
 				// Use for multiline option names (but not when the option name is empty).
 				availability_badge = " ";
 				break;
 		}
+		const char *option_color = color ? "\u001b[92m" : "";
+		const char *reset_color = color ? "\u001b[0m" : "";
 		OS::get_singleton()->print(
-				"  \u001b[92m%s  %s\u001b[0m  %s",
+				"  %s%s  %s%s  %s",
+				option_color,
 				format_help_option(p_option).utf8().ptr(),
 				availability_badge,
+				reset_color,
 				p_description);
 	} else {
 		// Make continuation lines for descriptions faint if the option name is empty.
+		const char *initial_color = color ? "\u001b[92m" : "";
+		const char *reset_color = color ? "\u001b[0m" : "";
+		const char *faint_color = color ? "\u001b[90m" : "";
 		OS::get_singleton()->print(
-				"  \u001b[92m%s   \u001b[0m  \u001b[90m%s",
+				"  %s%s   %s  %s%s",
+				initial_color,
 				format_help_option(p_option).utf8().ptr(),
+				reset_color,
+				faint_color,
 				p_description);
 	}
 }
 
 void Main::print_help(const char *p_binary) {
-	print_header(true);
+	const bool color = OS::get_singleton()->is_stdout_color();
+
+	print_header();
 	print_help_copyright("Free and open source software under the terms of the MIT license.");
 	print_help_copyright("(c) 2014-present Godot Engine contributors. (c) 2007-present Juan Linietsky, Ariel Manzur.");
 
 	print_help_title("Usage");
-	OS::get_singleton()->print("  %s \u001b[96m[options] [path to \"project.godot\" file]\u001b[0m\n", p_binary);
+	OS::get_singleton()->print("  %s %s[options] [path to \"project.godot\" file]%s\n", p_binary, color ? "\u001b[96m" : "", color ? "\u001b[0m" : "");
 
 #if defined(TOOLS_ENABLED)
 	print_help_title("Option legend (this build = editor)");
@@ -478,15 +500,15 @@ void Main::print_help(const char *p_binary) {
 	print_help_title("Option legend (this build = release export template)");
 #endif
 
-	OS::get_singleton()->print("  \u001b[1;92mR\u001b[0m  Available in editor builds, debug export templates and release export templates.\n");
+	OS::get_singleton()->print("  %sR%s  Available in editor builds, debug export templates and release export templates.\n", color ? "\u001b[1;92m" : "", color ? "\u001b[0m" : "");
 #ifdef DEBUG_ENABLED
-	OS::get_singleton()->print("  \u001b[1;94mD\u001b[0m  Available in editor builds and debug export templates only.\n");
+	OS::get_singleton()->print("  %sD%s  Available in editor builds and debug export templates only.\n", color ? "\u001b[1;94m" : "", color ? "\u001b[0m" : "");
 #endif
 #if defined(OVERRIDE_PATH_ENABLED)
-	OS::get_singleton()->print("  \u001b[1;93mX\u001b[0m  Only available in editor builds, and export templates compiled with `disable_path_overrides=false`.\n");
+	OS::get_singleton()->print("  %sX%s  Only available in editor builds, and export templates compiled with `disable_path_overrides=false`.\n", color ? "\u001b[1;93m" : "", color ? "\u001b[0m" : "");
 #endif
 #ifdef TOOLS_ENABLED
-	OS::get_singleton()->print("  \u001b[1;91mE\u001b[0m  Only available in editor builds.\n");
+	OS::get_singleton()->print("  %sE%s  Only available in editor builds.\n", color ? "\u001b[1;91m" : "", color ? "\u001b[0m" : "");
 #endif
 
 	print_help_title("General options");
@@ -494,6 +516,7 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("--version", "Display the version string.\n");
 	print_help_option("-v, --verbose", "Use verbose stdout mode.\n");
 	print_help_option("--quiet", "Quiet mode, silences stdout messages. Errors are still displayed.\n");
+	print_help_option("--color, --no-color", "Overrides standard color detection to force on/off colored output.\n");
 	print_help_option("--no-header", "Do not print engine version and rendering driver/method header on startup.\n");
 
 	print_help_title("Run options");
@@ -1140,8 +1163,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (arg == "-h" || arg == "--help" || arg == "/?") { // display help
 
 			show_help = true;
-			exit_err = ERR_HELP; // Hack to force an early exit in `main()` with a success code.
-			goto error;
 
 		} else if (arg == "--version") {
 			print_line(get_full_version_string());
@@ -1154,6 +1175,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (arg == "-q" || arg == "--quiet") { // quieter output
 
 			quiet_stdout = true;
+
+		} else if (arg == "--color" || arg == "--no-color") {
+			OS::get_singleton()->_color_override = arg == "--color" ? 1 : -1;
 
 		} else if (arg == "--no-header") {
 			Engine::get_singleton()->_print_header = false;
@@ -2000,6 +2024,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		}
 
 		I = N;
+	}
+
+	if (show_help) {
+		exit_err = ERR_HELP;
+		goto error; // Hack to force an early exit in `main()` with a success code.
 	}
 
 #ifdef TOOLS_ENABLED
@@ -2881,7 +2910,7 @@ error:
 	args.clear();
 	main_args.clear();
 
-	if (show_help) {
+	if (show_help && exit_err == ERR_HELP) {
 		print_help(execpath);
 	}
 
@@ -2950,7 +2979,7 @@ Error Main::setup2(bool p_show_boot_logo) {
 	set_current_thread_safe_for_nodes(true);
 
 	// Don't use rich formatting to prevent ANSI escape codes from being written to log files.
-	print_header(false);
+	print_header();
 
 #ifdef TOOLS_ENABLED
 	int accessibility_mode_editor = 0;

--- a/main/main.h
+++ b/main/main.h
@@ -45,7 +45,7 @@ class Main {
 		CLI_OPTION_AVAILABILITY_HIDDEN,
 	};
 
-	static void print_header(bool p_rich);
+	static void print_header();
 	static void print_help_copyright(const char *p_notice);
 	static void print_help_title(const char *p_title);
 	static void print_help_option(const char *p_option, const char *p_description, CLIOptionAvailability p_availability = CLI_OPTION_AVAILABILITY_TEMPLATE_RELEASE);

--- a/misc/utility/color.py
+++ b/misc/utility/color.py
@@ -11,13 +11,13 @@ from typing import Final
 
 IS_CI: Final[bool] = bool(os.environ.get("CI"))
 NO_COLOR: Final[bool] = bool(os.environ.get("NO_COLOR"))
-CLICOLOR_FORCE: Final[bool] = bool(os.environ.get("CLICOLOR_FORCE"))
+FORCE_COLOR: Final[bool] = bool(os.environ.get("FORCE_COLOR"))
 STDOUT_TTY: Final[bool] = bool(sys.stdout.isatty())
 STDERR_TTY: Final[bool] = bool(sys.stderr.isatty())
 
 
-_STDOUT_ORIGINAL: Final[bool] = False if NO_COLOR else CLICOLOR_FORCE or IS_CI or STDOUT_TTY
-_STDERR_ORIGINAL: Final[bool] = False if NO_COLOR else CLICOLOR_FORCE or IS_CI or STDERR_TTY
+_STDOUT_ORIGINAL: Final[bool] = False if NO_COLOR else FORCE_COLOR or IS_CI or STDOUT_TTY
+_STDERR_ORIGINAL: Final[bool] = False if NO_COLOR else FORCE_COLOR or IS_CI or STDERR_TTY
 _stdout_override: bool = _STDOUT_ORIGINAL
 _stderr_override: bool = _STDERR_ORIGINAL
 
@@ -35,7 +35,7 @@ def force_stdout_color(value: bool) -> None:
     Explicitly set `stdout` support for ANSI escape codes.
     If environment overrides exist, does nothing.
     """
-    if not NO_COLOR or not CLICOLOR_FORCE:
+    if not NO_COLOR or not FORCE_COLOR:
         global _stdout_override
         _stdout_override = value
 
@@ -45,7 +45,7 @@ def force_stderr_color(value: bool) -> None:
     Explicitly set `stderr` support for ANSI escape codes.
     If environment overrides exist, does nothing.
     """
-    if not NO_COLOR or not CLICOLOR_FORCE:
+    if not NO_COLOR or not FORCE_COLOR:
         global _stderr_override
         _stderr_override = value
 

--- a/platform/windows/windows_terminal_logger.cpp
+++ b/platform/windows/windows_terminal_logger.cpp
@@ -74,67 +74,6 @@ void WindowsTerminalLogger::logv(const char *p_format, va_list p_list, bool p_er
 #endif
 }
 
-void WindowsTerminalLogger::log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, bool p_editor_notify, ErrorType p_type, const Vector<Ref<ScriptBacktrace>> &p_script_backtraces) {
-	if (!should_log(true)) {
-		return;
-	}
-
-	HANDLE hCon = GetStdHandle(STD_OUTPUT_HANDLE);
-	if (OS::get_singleton()->get_stdout_type() != OS::STD_HANDLE_CONSOLE || !hCon || hCon == INVALID_HANDLE_VALUE) {
-		StdLogger::log_error(p_function, p_file, p_line, p_code, p_rationale, p_editor_notify, p_type, p_script_backtraces);
-	} else {
-		CONSOLE_SCREEN_BUFFER_INFO sbi; //original
-		GetConsoleScreenBufferInfo(hCon, &sbi);
-
-		WORD current_bg = sbi.wAttributes & (BACKGROUND_RED | BACKGROUND_GREEN | BACKGROUND_BLUE | BACKGROUND_INTENSITY);
-
-		uint32_t basecol = 0;
-		switch (p_type) {
-			case ERR_WARNING:
-				basecol = FOREGROUND_RED | FOREGROUND_GREEN;
-				break;
-			case ERR_SCRIPT:
-				basecol = FOREGROUND_RED | FOREGROUND_BLUE;
-				break;
-			case ERR_SHADER:
-				basecol = FOREGROUND_GREEN | FOREGROUND_BLUE;
-				break;
-			case ERR_ERROR:
-			default:
-				basecol = FOREGROUND_RED;
-				break;
-		}
-
-		basecol |= current_bg;
-
-		SetConsoleTextAttribute(hCon, basecol | FOREGROUND_INTENSITY);
-		logf_error("%s:", error_type_string(p_type));
-
-		SetConsoleTextAttribute(hCon, basecol);
-		if (p_rationale && p_rationale[0]) {
-			logf_error(" %s\n", p_rationale);
-		} else {
-			logf_error(" %s\n", p_code);
-		}
-
-		// `FOREGROUND_INTENSITY` alone results in gray text.
-		SetConsoleTextAttribute(hCon, FOREGROUND_INTENSITY);
-		if (p_rationale && p_rationale[0]) {
-			logf_error("%sat: (%s:%i)\n", error_type_indent(p_type), p_file, p_line);
-		} else {
-			logf_error("%sat: %s (%s:%i)\n", error_type_indent(p_type), p_function, p_file, p_line);
-		}
-
-		for (const Ref<ScriptBacktrace> &backtrace : p_script_backtraces) {
-			if (!backtrace->is_empty()) {
-				logf_error("%s\n", backtrace->format(strlen(error_type_indent(p_type))).utf8().get_data());
-			}
-		}
-
-		SetConsoleTextAttribute(hCon, sbi.wAttributes);
-	}
-}
-
 WindowsTerminalLogger::~WindowsTerminalLogger() {}
 
 #endif // WINDOWS_ENABLED

--- a/platform/windows/windows_terminal_logger.h
+++ b/platform/windows/windows_terminal_logger.h
@@ -37,7 +37,6 @@
 class WindowsTerminalLogger : public StdLogger {
 public:
 	virtual void logv(const char *p_format, va_list p_list, bool p_err) override;
-	virtual void log_error(const char *p_function, const char *p_file, int p_line, const char *p_code, const char *p_rationale, bool p_editor_notify = false, ErrorType p_type = ERR_ERROR, const Vector<Ref<ScriptBacktrace>> &p_script_backtraces = {}) override;
 	virtual ~WindowsTerminalLogger();
 };
 

--- a/tests/test_macros.cpp
+++ b/tests/test_macros.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #define DOCTEST_CONFIG_IMPLEMENT
+#define DOCTEST_CONFIG_COLORS_ANSI
 #include "test_macros.h"
 
 HashMap<String, TestFunc> *test_commands = nullptr;


### PR DESCRIPTION
- Supersedes #77261
- Supersedes #100724

## What problem(s) does this PR solve?

As of now, our engine output fails to fully utilize context-sensitive data made possible by #91201, resulting in colorized output either not showing up when desired, or appearing when inappropriate. This is a straightforward implementation that gives `StdLogger::log_error` and `--help` basic support for knowing when to output color. Passing `--color` or `--no-color` will forcibly enable or disable colored output respectively, regardless of where that output is being directed.

## Additional information

Detects environment variables `NO_COLOR`[^1] and `FORCE_COLOR`[^2] to unilaterally disable or enable colors respectively, assuming no override cli was passed. This mostly mirrors how our `colors.py` is setup, though that's also been tweaked as `CLICOLOR_FORCE`[^3] is now considered deprecated. Similarly, `CI` is no longer inherently recognized to force colors on, so the GHA scripts now have `FORCE_COLOR` assigned as environment variables.

This is very much a hacked-on solution for the existing system, as anything beyond this would require a much more involved curation and detection of ANSI codeblocks. Ideally, we'd be able to parse and filter out disabled ANSI immediately prior to output being printed, instead of this manual approach that's largely isolated to error outputs and `--help`.

Also adds `DOCTEST_CONFIG_COLORS_ANSI` to `tests/test_macros.cpp` in order to also have colored output for doctest on Windows. This is the reasonable extent I can do for doctest atm, as anything more seems like it'd necessitate a more involved shakeup of how the tests are setup to begin with.

[^1]: https://no-color.org/
[^2]: https://force-color.org/
[^3]: https://bixense.com/clicolors/