### PR TITLE
Editor Settings: Fix crash when setting `3D Navigation Scheme` in Project Manager

### DIFF
--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -175,14 +175,16 @@ void EditorSettingsDialog::update_3d_navigation_preset() {
 		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/pan_mouse_button", (int)set_pan_mouse_button);
 		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/zoom_mouse_button", (int)set_zoom_mouse_button);
 		EditorSettings::get_singleton()->set_manually("editors/3d/navigation/emulate_3_button_mouse", set_3_button_mouse);
-		_set_shortcut_input("spatial_editor/viewport_orbit_modifier_1", orbit_mod_key_1);
-		_set_shortcut_input("spatial_editor/viewport_orbit_modifier_2", orbit_mod_key_2);
-		_set_shortcut_input("spatial_editor/viewport_pan_modifier_1", pan_mod_key_1);
-		_set_shortcut_input("spatial_editor/viewport_pan_modifier_2", pan_mod_key_2);
-		_set_shortcut_input("spatial_editor/viewport_zoom_modifier_1", zoom_mod_key_1);
-		_set_shortcut_input("spatial_editor/viewport_zoom_modifier_2", zoom_mod_key_2);
-		_set_shortcut_input("spatial_editor/viewport_orbit_snap_modifier_1", orbit_snap_mod_key_1);
-		_set_shortcut_input("spatial_editor/viewport_orbit_snap_modifier_2", orbit_snap_mod_key_2);
+		if (!EditorSettingsDialog::get_singleton()->_is_in_project_manager()) {
+			_set_shortcut_input("spatial_editor/viewport_orbit_modifier_1", orbit_mod_key_1);
+			_set_shortcut_input("spatial_editor/viewport_orbit_modifier_2", orbit_mod_key_2);
+			_set_shortcut_input("spatial_editor/viewport_pan_modifier_1", pan_mod_key_1);
+			_set_shortcut_input("spatial_editor/viewport_pan_modifier_2", pan_mod_key_2);
+			_set_shortcut_input("spatial_editor/viewport_zoom_modifier_1", zoom_mod_key_1);
+			_set_shortcut_input("spatial_editor/viewport_zoom_modifier_2", zoom_mod_key_2);
+			_set_shortcut_input("spatial_editor/viewport_orbit_snap_modifier_1", orbit_snap_mod_key_1);
+			_set_shortcut_input("spatial_editor/viewport_orbit_snap_modifier_2", orbit_snap_mod_key_2);
+		}
 	}
 }
 
@@ -193,6 +195,7 @@ void EditorSettingsDialog::_set_shortcut_input(const String &p_name, Ref<InputEv
 	}
 
 	Ref<Shortcut> sc = EditorSettings::get_singleton()->get_shortcut(p_name);
+	ERR_FAIL_COND(sc.is_null());
 	sc->set_events(sc_events);
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/121861

## Why does it crash

The shortcuts are not registered in the Project Manager, so when we retrieve the Shortcut via `EditorSettings::get_singleton()->get_shortcut(p_name);`, it returns an empty `Ref`, but we don't check for `null,` so we end up calling `null->set_events(...)`, which crashes in a milion diffrent ways.

## Fix

I added two lines of defense:

1. `NULL` check to `Ref<Shortcut> sc = EditorSettings::get_singleton()->get_shortcut(p_name)`
2. Don't call `_set_shortcut_input` if in the Project Manager

## Additional information

This only fixes the crash, but not the behavior - key modifiers don't show up in the Project Manager (to be clear: this problem existed before this PR)

<img width="598" height="256" alt="image" src="https://github.com/user-attachments/assets/c2e6e9a4-65cf-453a-a749-e7efc4cb5967" />

<img width="688" height="262" alt="image" src="https://github.com/user-attachments/assets/16afa7ba-0218-451f-8e2e-6aa5671bcd7b" />

No AI was used.