### PR TITLE
Restrict editor minimum size to screen size

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -179,6 +179,7 @@
 #include "servers/audio/audio_server.h"
 #include "servers/audio/audio_server_enums.h"
 #include "servers/display/display_server.h"
+#include "servers/display/display_server_enums.h"
 #include "servers/navigation_2d/navigation_server_2d.h"
 #include "servers/navigation_3d/navigation_server_3d.h"
 #include "servers/rendering/rendering_device.h"
@@ -8518,9 +8519,13 @@ EditorNode::EditorNode() {
 	// Define a minimum window size to prevent UI elements from overlapping or being cut off.
 	Window *w = Object::cast_to<Window>(SceneTree::get_singleton()->get_root());
 	if (w) {
-		const Size2 minimum_size = Size2(1024, 600) * EDSCALE;
-		w->set_min_size(minimum_size); // Calling it this early doesn't sync the property with DS.
-		DisplayServer::get_singleton()->window_set_min_size(minimum_size);
+		const Size2 display_size = DisplayServer::get_singleton()->screen_get_usable_rect(DisplayServerEnums::SCREEN_OF_MAIN_WINDOW).size;
+		const real_t smallest_display_dimension = display_size.width < display_size.height ? display_size.width : display_size.height;
+		const Size2 editor_minimum_size = Size2(1024, 600) * EDSCALE;
+		// Ensure the minimum size is not larger than the display size to avoid issues on smaller screens.
+		const Size2 computed_minimum_size = editor_minimum_size.minf(smallest_display_dimension);
+		w->set_min_size(computed_minimum_size); // Calling it this early doesn't sync the property with DS.
+		DisplayServer::get_singleton()->window_set_min_size(computed_minimum_size);
 	}
 
 	FileDialog::set_default_show_hidden_files(EDITOR_GET("filesystem/file_dialog/show_hidden_files"));


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121854 

The `EditorNode` could report a minimum size greater than the screen size, which, as the editor now gets an update that it should have always been getting, would result in the screen going over the edge in portrait mode on mobile devices.
This clamps the reported size to the screen size, preventing it from being too big.

## Additional information

Somehow this does not fix (space word) https://github.com/godotengine/godot/issues/118237, which I would assume is due to Android reporting a size too wide for itself? 
I'm hardly knowledgeable about Android's back-end, so take that explanation with a grain of salt.

I should note that this introduces a theoretical issue, whereby using a screen size smaller than the `EditorNode`'s true computed minimum size (which isn't technically the one being clamped in this PR, which is larger), without having the same space-saving settings as the Android Editor does in distraction-free mode, would result in some elements being clipped off the edge... So don't try to run desktop Godot on CRT I guess? 

AI Disclosure: GitHub Copilot chat helped me identify the root cause; all code is written by me.