### PR TITLE
Fix exclusive fullscreen being toggled back to fullscreen with built-in shortcut

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -713,8 +713,8 @@
 			[b]Note:[/b] This property is implemented only on macOS and Windows.
 		</member>
 		<member name="mode" type="int" setter="set_mode" getter="get_mode" enum="Window.Mode" default="0">
-			Set's the window's current mode.
-			[b]Note:[/b] Fullscreen mode is not exclusive full screen on Windows and Linux.
+			The window's current mode.
+			[b]Note:[/b] Fullscreen mode is not exclusive fullscreen on Windows and Linux. Use [constant Window.MODE_EXCLUSIVE_FULLSCREEN] to achieve exclusive fullscreen on those platforms.
 			[b]Note:[/b] This method only works with native windows, i.e. the main window and [Window]-derived nodes when [member Viewport.gui_embed_subwindows] is disabled in the main viewport.
 		</member>
 		<member name="mouse_passthrough" type="bool" setter="set_flag" getter="get_flag" default="false">
@@ -939,7 +939,7 @@
 			[b]On Android:[/b] This enables immersive mode.
 			[b]On Windows:[/b] Depending on video driver, full screen transition might cause screens to go black for a moment.
 			[b]On macOS:[/b] A new desktop is used to display the running project. Exclusive full screen mode prevents Dock and Menu from showing up when the mouse pointer is hovering the edge of the screen.
-			[b]On Linux (X11):[/b] Exclusive full screen mode bypasses compositor.
+			[b]On Linux (X11):[/b] Exclusive full screen mode bypasses compositor, which results in improved performance and decreased input lag.
 			[b]On Linux (Wayland):[/b] Equivalent to [constant MODE_FULLSCREEN].
 			[b]Note:[/b] Regardless of the platform, enabling full screen will change the window size to match the monitor's size. Therefore, make sure your project supports [url=$DOCS_URL/tutorials/rendering/multiple_resolutions.html]multiple resolutions[/url] when enabling full screen mode.
 		</constant>

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -2036,10 +2036,11 @@ void Window::_window_input(const Ref<InputEvent> &p_ev) {
 
 	if (fullscreen_shortcut_enabled && p_ev->is_action_pressed("ui_toggle_fullscreen")) {
 		if (mode == MODE_FULLSCREEN || mode == MODE_EXCLUSIVE_FULLSCREEN) {
-			set_mode(toggle_fullscreen_previous_mode);
+			toggle_fullscreen_previous_fullscreen_mode = mode;
+			set_mode(toggle_fullscreen_previous_windowed_mode);
 		} else {
-			toggle_fullscreen_previous_mode = mode;
-			set_mode(MODE_FULLSCREEN);
+			toggle_fullscreen_previous_windowed_mode = mode;
+			set_mode(toggle_fullscreen_previous_fullscreen_mode);
 		}
 	}
 
@@ -3734,6 +3735,13 @@ Window::Window() {
 
 	theme_owner = memnew(ThemeOwner(this));
 	RS::get_singleton()->viewport_set_update_mode(get_viewport_rid(), RSE::VIEWPORT_UPDATE_DISABLED);
+
+	// Ensure the built-in fullscreen toggle switches back to the intended mode if the project starts in fullscreen.
+	if (GLOBAL_GET_CACHED(DisplayServerEnums::WindowMode, "display/window/size/mode") == DisplayServerEnums::WindowMode::WINDOW_MODE_EXCLUSIVE_FULLSCREEN) {
+		toggle_fullscreen_previous_fullscreen_mode = MODE_EXCLUSIVE_FULLSCREEN;
+	} else {
+		toggle_fullscreen_previous_fullscreen_mode = MODE_FULLSCREEN;
+	}
 }
 
 Window::~Window() {

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -127,7 +127,8 @@ private:
 	mutable Size2i max_size;
 	mutable Vector<Vector2> mpath;
 	mutable Mode mode = MODE_WINDOWED;
-	mutable Mode toggle_fullscreen_previous_mode = mode;
+	mutable Mode toggle_fullscreen_previous_windowed_mode = mode;
+	mutable Mode toggle_fullscreen_previous_fullscreen_mode = MODE_FULLSCREEN;
 	mutable bool flags[FLAG_MAX] = {};
 	bool visible = true;
 	bool focused = false;


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/39708.

If the project is configured to use exclusive fullscreen or if it was changed to exclusive fullscreen by code, toggling back and forth between windowed and fullscreen by pressing <kbd>Alt + Enter</kbd> will now select the exclusive fullscreen mode as intended.

**Testing project:** [test_fullscreen_toggle.zip](https://github.com/user-attachments/files/30483347/test_fullscreen_toggle.zip)

## Preview

*Look at the window mode label in the top-left corner.*

### Before

https://github.com/user-attachments/assets/cd5fb55a-e7aa-408c-908d-2d09159d5837

### After

https://github.com/user-attachments/assets/ee01b21e-199a-4e9e-9d5f-4d554a997bf7