### PR TITLE
`GDScriptNativeClass`: replace class name with `GDType`

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -66,19 +66,16 @@
 ///////////////////////////
 
 GDScriptNativeClass::GDScriptNativeClass(const StringName &p_name) {
-	name = p_name;
+	nc_gdtype = ClassDB::get_gdtype(p_name);
 }
 
 bool GDScriptNativeClass::_get(const StringName &p_name, Variant &r_ret) const {
-	bool ok;
-	int64_t v = ClassDB::get_integer_constant(name, p_name, &ok);
-
-	if (ok) {
-		r_ret = v;
+	if (const int64_t *v = nc_gdtype->get_integer_constant_map().getptr(p_name)) {
+		r_ret = *v;
 		return true;
 	}
 
-	MethodBind *method = ClassDB::get_method(name, p_name);
+	MethodBind *method = ClassDB::get_method(get_name(), p_name);
 	if (method && method->is_static()) {
 		// Native static method.
 		r_ret = Callable(this, p_name);
@@ -94,7 +91,7 @@ void GDScriptNativeClass::_bind_methods() {
 
 Variant GDScriptNativeClass::_new() {
 	Object *o = instantiate();
-	ERR_FAIL_NULL_V_MSG(o, Variant(), "Class type: '" + String(name) + "' is not instantiable.");
+	ERR_FAIL_NULL_V_MSG(o, Variant(), "Class type: '" + String(get_name()) + "' is not instantiable.");
 
 	RefCounted *rc = Object::cast_to<RefCounted>(o);
 	if (rc) {
@@ -105,7 +102,7 @@ Variant GDScriptNativeClass::_new() {
 }
 
 Object *GDScriptNativeClass::instantiate() {
-	return ClassDB::instantiate_no_placeholders(name);
+	return ClassDB::instantiate_no_placeholders(get_name());
 }
 
 Variant GDScriptNativeClass::callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
@@ -114,7 +111,7 @@ Variant GDScriptNativeClass::callp(const StringName &p_method, const Variant **p
 		return Object::callp(p_method, p_args, p_argcount, r_error);
 	}
 
-	MethodBind *method = ClassDB::get_method(name, p_method);
+	MethodBind *method = ClassDB::get_method(get_name(), p_method);
 	if (method && method->is_static()) {
 		// Native static method.
 		return method->call(nullptr, p_args, p_argcount, r_error);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -65,19 +65,17 @@
 ///////////////////////////
 
 GDScriptNativeClass::GDScriptNativeClass(const StringName &p_name) {
-	name = p_name;
+	nc_gdtype = ClassDB::get_gdtype(p_name);
 }
 
 bool GDScriptNativeClass::_get(const StringName &p_name, Variant &r_ret) const {
-	bool ok;
-	int64_t v = ClassDB::get_integer_constant(name, p_name, &ok);
-
-	if (ok) {
-		r_ret = v;
+	if (const int64_t *v = nc_gdtype->get_integer_constant_map().getptr(p_name)) {
+		r_ret = *v;
 		return true;
 	}
 
-	const MethodBind *method = ClassDB::get_method(name, p_name);
+	const MethodBind *const *cmethod = nc_gdtype->get_method_map().getptr(p_name);
+	const MethodBind *method = cmethod ? *cmethod : nullptr;
 	if (method && method->is_static()) {
 		// Native static method.
 		r_ret = Callable(this, p_name);
@@ -93,7 +91,7 @@ void GDScriptNativeClass::_bind_methods() {
 
 Variant GDScriptNativeClass::_new() {
 	Object *o = instantiate();
-	ERR_FAIL_NULL_V_MSG(o, Variant(), "Class type: '" + String(name) + "' is not instantiable.");
+	ERR_FAIL_NULL_V_MSG(o, Variant(), "Class type: '" + String(get_name()) + "' is not instantiable.");
 
 	RefCounted *rc = Object::cast_to<RefCounted>(o);
 	if (rc) {
@@ -104,7 +102,7 @@ Variant GDScriptNativeClass::_new() {
 }
 
 Object *GDScriptNativeClass::instantiate() {
-	return ClassDB::instantiate_no_placeholders(name);
+	return ClassDB::instantiate_no_placeholders(get_name());
 }
 
 Variant GDScriptNativeClass::callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
@@ -113,7 +111,8 @@ Variant GDScriptNativeClass::callp(const StringName &p_method, const Variant **p
 		return Object::callp(p_method, p_args, p_argcount, r_error);
 	}
 
-	const MethodBind *method = ClassDB::get_method(name, p_method);
+	const MethodBind *const *cmethod = nc_gdtype->get_method_map().getptr(p_method);
+	const MethodBind *method = cmethod ? *cmethod : nullptr;
 	if (method && method->is_static()) {
 		// Native static method.
 		return method->call(nullptr, p_args, p_argcount, r_error);

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -40,14 +40,15 @@
 class GDScriptNativeClass : public RefCounted {
 	GDCLASS(GDScriptNativeClass, RefCounted);
 
-	StringName name;
+	const GDType *nc_gdtype;
 
 protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	static void _bind_methods();
 
 public:
-	_FORCE_INLINE_ const StringName &get_name() const { return name; }
+	_FORCE_INLINE_ const GDType *get_native_gdtype() const { return nc_gdtype; }
+	_FORCE_INLINE_ const StringName &get_name() const { return nc_gdtype->get_name(); }
 	Variant _new();
 	Object *instantiate();
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -40,14 +40,15 @@
 class GDScriptNativeClass : public RefCounted {
 	GDCLASS(GDScriptNativeClass, RefCounted);
 
-	StringName name;
+	const GDType *nc_gdtype;
 
 protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	static void _bind_methods();
 
 public:
-	_FORCE_INLINE_ const StringName &get_name() const { return name; }
+	_FORCE_INLINE_ const GDType *get_type() const { return nc_gdtype; }
+	_FORCE_INLINE_ const StringName &get_name() const { return nc_gdtype->get_name(); }
 	Variant _new();
 	Object *instantiate();
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -347,7 +347,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 							scr = scr->base.ptr();
 						}
 
-						if (nc && (identifier == CoreStringName(free_) || ClassDB::has_signal(nc->get_name(), identifier) || ClassDB::has_method(nc->get_name(), identifier))) {
+						if (nc && (identifier == CoreStringName(free_) || nc->get_type()->get_signal_map().has(identifier) || ClassDB::has_method(nc->get_name(), identifier))) {
 							// Get like it was a property.
 							GDScriptCodeGenerator::Address temp = codegen.add_temporary(); // TODO: Get type here.
 							GDScriptCodeGenerator::Address self(GDScriptCodeGenerator::Address::SELF);
@@ -377,10 +377,8 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 						// Class C++ integer constant.
 						if (nc) {
-							bool success = false;
-							int64_t constant = ClassDB::get_integer_constant(nc->get_name(), identifier, &success);
-							if (success) {
-								return codegen.add_constant(constant);
+							if (const int64_t *constant = nc->get_type()->get_integer_constant_map().getptr(identifier)) {
+								return codegen.add_constant(*constant);
 							}
 						}
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -347,7 +347,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 							scr = scr->base.ptr();
 						}
 
-						if (nc && (identifier == CoreStringName(free_) || ClassDB::has_signal(nc->get_name(), identifier) || ClassDB::has_method(nc->get_name(), identifier))) {
+						if (nc && (identifier == CoreStringName(free_) || nc->get_native_gdtype()->get_signal_map().has(identifier) || nc->get_native_gdtype()->get_method_map().has(identifier))) {
 							// Get like it was a property.
 							GDScriptCodeGenerator::Address temp = codegen.add_temporary(); // TODO: Get type here.
 							GDScriptCodeGenerator::Address self(GDScriptCodeGenerator::Address::SELF);
@@ -377,10 +377,8 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 						// Class C++ integer constant.
 						if (nc) {
-							bool success = false;
-							int64_t constant = ClassDB::get_integer_constant(nc->get_name(), identifier, &success);
-							if (success) {
-								return codegen.add_constant(constant);
+							if (const int64_t *constant = nc->get_native_gdtype()->get_integer_constant_map().getptr(identifier)) {
+								return codegen.add_constant(*constant);
 							}
 						}
 
@@ -641,11 +639,12 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				} else {
 					if (callee->type == GDScriptParser::Node::IDENTIFIER) {
 						// Self function call.
-						if (ClassDB::has_method(codegen.script->native->get_name(), call->function_name)) {
+						if (codegen.script->native->get_native_gdtype()->get_method_map().has(call->function_name)) {
 							// Native method, use faster path.
 							GDScriptCodeGenerator::Address self;
 							self.mode = GDScriptCodeGenerator::Address::SELF;
-							const MethodBind *method = ClassDB::get_method(codegen.script->native->get_name(), call->function_name);
+							const MethodBind *const *cmethod = codegen.script->native->get_native_gdtype()->get_method_map().getptr(call->function_name);
+							const MethodBind *method = cmethod ? *cmethod : nullptr;
 
 							if (_can_use_validate_call(method, arguments)) {
 								// Exact arguments, use validated call.

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -2540,7 +2540,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					*dst = E->value->call(p_instance, (const Variant **)argptrs, argc, err);
 				} else if (gds->native.ptr()) {
 					if (*methodname != GDScriptLanguage::get_singleton()->strings._init) {
-						const MethodBind *mb = ClassDB::get_method(gds->native->get_name(), *methodname);
+						const MethodBind *const *cmb = gds->native->get_native_gdtype()->get_method_map().getptr(*methodname);
+						const MethodBind *mb = cmb ? *cmb : nullptr;
 						if (!mb) {
 							err.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
 						} else {


### PR DESCRIPTION
- Work towards https://github.com/godotengine/godot-proposals/issues/12323 on GDScript's side.

## What problem(s) does this PR solve?

Pretty much what I said in [this comment](https://github.com/godotengine/godot/pull/117599#issuecomment-5065833919).

`GDScriptNativeClass` currently relies on a class name, which is used for communication with `ClassDB` to get an integer constant, a method, or instantiation.

Instead of a class name, it's very easy to make it hold a `GDType`. The explanation is already there in the proposal, and it makes getting integer constants or methods a faster path.

<img width="734" height="524" alt="gdsnc_gdtype" src="https://github.com/user-attachments/assets/96aba50d-4ac6-4f6c-aea8-9680489fd560" />

And whenever the name is needed (for features still unsupported by `GDType`) you can still get it with `nc_gdtype->get_name()`.

## Additional information

Property maps (next big step after method maps) have little significance.

I'm also not sure if `GDScriptLanguage` initialization as a whole becomes a big bottleneck (each construction means a read lock + a look-up on `classes.getptr()`) to justify this or not. Although a hypothetical `ClassDB::get_gdtype_list()` could mitigate.