### PR TITLE
Optimize Gizmo updates

### DIFF
--- a/core/math/triangle_mesh.cpp
+++ b/core/math/triangle_mesh.cpp
@@ -522,6 +522,14 @@ Vector<Face3> TriangleMesh::get_faces() const {
 	return faces;
 }
 
+AABB TriangleMesh::get_aabb() const {
+	if (!valid) {
+		return AABB();
+	}
+
+	return bvh[bvh.size() - 1].aabb;
+}
+
 bool TriangleMesh::create_from_faces(const Vector<Vector3> &p_faces) {
 	create(p_faces);
 	return is_valid();

--- a/core/math/triangle_mesh.h
+++ b/core/math/triangle_mesh.h
@@ -87,6 +87,7 @@ public:
 	bool intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, Vector3 &r_point, Vector3 &r_normal, int32_t *r_surf_index = nullptr, int32_t *r_face_index = nullptr) const;
 	bool inside_convex_shape(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count, Vector3 p_scale = Vector3(1, 1, 1)) const;
 	Vector<Face3> get_faces() const;
+	AABB get_aabb() const;
 
 	const Vector<Triangle> &get_triangles() const { return triangles; }
 	const Vector<Vector3> &get_vertices() const { return vertices; }

--- a/editor/scene/3d/node_3d_editor_gizmos.cpp
+++ b/editor/scene/3d/node_3d_editor_gizmos.cpp
@@ -254,6 +254,10 @@ void EditorNode3DGizmo::add_mesh(const Ref<Mesh> &p_mesh, const Ref<Material> &p
 void EditorNode3DGizmo::_update_bvh() {
 	ERR_FAIL_NULL(spatial_node);
 
+	if (hidden && !gizmo_plugin->is_selectable_when_hidden()) {
+		return;
+	}
+
 	Transform3D transform = spatial_node->get_global_transform();
 
 	float effective_icon_size = selectable_icon_size > 0.0f ? selectable_icon_size : 0.0f;
@@ -267,11 +271,7 @@ void EditorNode3DGizmo::_update_bvh() {
 	if (!collision_meshes.is_empty()) {
 		for (Ref<TriangleMesh> collision_mesh : collision_meshes) {
 			if (collision_mesh.is_valid()) {
-				for (const Face3 &face : collision_mesh->get_faces()) {
-					aabb.expand_to(transform.xform(face.vertex[0]));
-					aabb.expand_to(transform.xform(face.vertex[1]));
-					aabb.expand_to(transform.xform(face.vertex[2]));
-				}
+				aabb.merge_with(transform.xform(collision_mesh->get_aabb()));
 			}
 		}
 	}
@@ -803,7 +803,7 @@ void EditorNode3DGizmo::create() {
 
 	bvh_node_id = Node3DEditor::get_singleton()->insert_gizmo_bvh_node(
 			spatial_node,
-			AABB(spatial_node->get_position(), Vector3(0, 0, 0)));
+			AABB(spatial_node->get_global_position(), Vector3(0, 0, 0)));
 
 	transform();
 }
@@ -839,11 +839,17 @@ void EditorNode3DGizmo::free() {
 }
 
 void EditorNode3DGizmo::set_hidden(bool p_hidden) {
+	if (hidden == p_hidden) {
+		return;
+	}
+
 	hidden = p_hidden;
 	int layer = hidden ? 0 : 1 << Node3DEditorViewport::GIZMO_EDIT_LAYER;
 	for (int i = 0; i < instances.size(); ++i) {
 		RS::get_singleton()->instance_set_layer_mask(instances[i].instance, layer);
 	}
+
+	_update_bvh();
 }
 
 void EditorNode3DGizmo::set_plugin(EditorNode3DGizmoPlugin *p_plugin) {

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -2458,6 +2458,14 @@ void Node3DEditor::_notification(int p_what) {
 			_finish_indicators();
 		} break;
 
+		case NOTIFICATION_PROCESS: {
+			if (gizmo_bvh_needs_optimization) {
+				// Only call this once per frame and only call when dirty. This is very expensive.
+				gizmo_bvh.optimize_incremental(1);
+				gizmo_bvh_needs_optimization = false;
+			}
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			_update_theme();
 			_update_gizmos_menu_theme();
@@ -4079,7 +4087,7 @@ DynamicBVH::ID Node3DEditor::insert_gizmo_bvh_node(Node3D *p_node, const AABB &p
 
 void Node3DEditor::update_gizmo_bvh_node(DynamicBVH::ID p_id, const AABB &p_aabb) {
 	gizmo_bvh.update(p_id, p_aabb);
-	gizmo_bvh.optimize_incremental(1);
+	gizmo_bvh_needs_optimization = true;
 }
 
 void Node3DEditor::remove_gizmo_bvh_node(DynamicBVH::ID p_id) {

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -137,6 +137,7 @@ private:
 	bool current_hover_gizmo_handle_secondary;
 
 	DynamicBVH gizmo_bvh;
+	bool gizmo_bvh_needs_optimization = true;
 
 	real_t snap_translate_value = 0;
 	real_t snap_rotate_value = 0;


### PR DESCRIPTION
This does two major optimizations for gizmos:
1. Defer `optimize_incremental()` to only be called at most once per frame for Node3DEditor BVH. Previously it was called any time any gizmo was updated. `optimize_incremental()` is an expensive operation and should only be done once all updates have finished
2. Use the existing TriangleMesh AABB instead of transforming every vertex and re-calculating the AABB. This was extremely expensive for big meshes. (I looked into this at the request of @tdaven who has been having issues with the performance here)

A bonus optimization, I switched to using the global position of the node when originally inserting into the BVH. This helps avoid collisions at insertion time (and is technically more correct, since it makes no sense to use the local position).

In the MRP in https://github.com/godotengine/godot/issues/107123, the time spent updating the BVH goes from 9.2 seconds to 1.8 seconds with no change in behaviour (combined with https://github.com/godotengine/godot/pull/109514, loading that scene becomes instant).

I also tested loading a single very large mesh and measured an improvement of about 100 ms in the BVH update function (140ms->40ms). But I would like to see if it benefits @tdaven's game even more. Since I struggled to make an MRP that really stressed that part of the function 

## What problem(s) does this PR solve?

- Fixes a major performance regression from https://github.com/godotengine/godot/pull/94553
- Fixes: https://github.com/godotengine/godot/issues/107123

## Additional information

Supersedes: https://github.com/godotengine/godot/pull/98590
Kind of a follow up to https://github.com/godotengine/godot/pull/96934 since it addresses many of the performance issues that https://github.com/godotengine/godot/pull/96934 solved for PlaneMesh.
