### PR TITLE
Fix Open button incorrect state in FileDialog

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -1578,6 +1578,7 @@ void FileDialog::_invalidate() {
 	}
 
 	update_file_list();
+	get_ok_button()->set_disabled(_is_open_should_be_disabled());
 
 	if (ensure_visible_after_invalidating) {
 		file_list->ensure_current_is_visible();


### PR DESCRIPTION
Fixes issue where Open button in FileDialog would be disabled when file selection is correct. This happens in editor's "Open Scene" file dialog which has default file set.

The fix is updating disabled button properly when state is invalidated.

## What problem(s) does this PR solve?

- Partially addresses #115106 (fixes case 1)

## Additional information

Tested "Open Scene" dialog in editor in 4.7 and my PR.

<img width="1802" height="673" alt="image" src="https://github.com/user-attachments/assets/4d41977a-0c3e-4823-8a1d-e044cd3f7e5c" />