### PR TITLE
GDScript: Cover not validated native static calls in the test suite

### DIFF
--- a/modules/gdscript/tests/scripts/runtime/features/call_native_static_method.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/call_native_static_method.gd
@@ -1,0 +1,18 @@
+func run(param):
+	# Validated native static call with return value.
+	print(FileAccess.file_exists("some_file"))
+
+	# Validated native static call without return value.
+	Node.print_orphan_nodes()
+
+	# Not validated native static call with return value.
+	@warning_ignore("unsafe_call_argument")
+	print(FileAccess.file_exists(param))
+
+	# Not validated native static call without return value.
+	FileDialog.set_favorite_list([param])
+	print(FileDialog.get_favorite_list())
+	FileDialog.set_favorite_list([])
+
+func test():
+	run("some_file")

--- a/modules/gdscript/tests/scripts/runtime/features/call_native_static_method.out
+++ b/modules/gdscript/tests/scripts/runtime/features/call_native_static_method.out
@@ -1,0 +1,4 @@
+GDTEST_OK
+false
+false
+["some_file/"]

--- a/modules/gdscript/tests/scripts/runtime/features/call_native_static_method_validated.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/call_native_static_method_validated.gd
@@ -1,6 +1,0 @@
-func test():
-	# Validated native static call with return value.
-	print(FileAccess.file_exists("some_file"))
-
-	# Validated native static call without return value.
-	Node.print_orphan_nodes()

--- a/modules/gdscript/tests/scripts/runtime/features/call_native_static_method_validated.out
+++ b/modules/gdscript/tests/scripts/runtime/features/call_native_static_method_validated.out
@@ -1,2 +1,0 @@
-GDTEST_OK
-false


### PR DESCRIPTION
## What problem(s) does this PR solve?

Ensures that `GDScriptByteCodeGenerator::write_call_native_static` is covered by our tests.