### PR TITLE
Android Editor: Expand Portrait Mode support and fix related issues

### DIFF
--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -2271,6 +2271,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	library_message = memnew(Label);
 	library_message->set_focus_mode(FOCUS_ACCESSIBILITY);
 	library_message->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	library_message->set_autowrap_mode(TextServer::AUTOWRAP_WORD);
 	library_message_box->add_child(library_message);
 
 	library_message_button = memnew(Button);

--- a/editor/gui/touch_actions_panel.cpp
+++ b/editor/gui/touch_actions_panel.cpp
@@ -99,6 +99,7 @@ void TouchActionsPanel::_screen_orientation_changed(int p_new_orientation) {
 	portrait_mode = p_new_orientation == 1;
 
 	if (is_floating) {
+		set_position(EDITOR_DEF(portrait_mode ? "_touch_actions_panel_portrait_pos" : "_touch_actions_panel_position", Point2(100, 480)));
 		return;
 	}
 
@@ -194,7 +195,7 @@ void TouchActionsPanel::_on_drag_handle_gui_input(const Ref<InputEvent> &p_event
 		} else {
 			if (dragging) {
 				dragging = false;
-				EditorSettings::get_singleton()->set("_touch_actions_panel_position", get_position());
+				EditorSettings::get_singleton()->set(portrait_mode ? "_touch_actions_panel_portrait_pos" : "_touch_actions_panel_position", get_position());
 				EditorSettings::get_singleton()->save();
 			}
 		}
@@ -203,7 +204,7 @@ void TouchActionsPanel::_on_drag_handle_gui_input(const Ref<InputEvent> &p_event
 	Ref<InputEventMouseMotion> mouse_motion_event = p_event;
 	if (dragging && mouse_motion_event.is_valid()) {
 		Vector2 new_position = get_position() + mouse_motion_event->get_relative();
-		const float margin = 25.0;
+		const float margin = 15.0;
 		Vector2 parent_size = get_parent_area_size();
 		Vector2 panel_size = get_size();
 		new_position = new_position.clamp(Vector2(margin, margin), parent_size - panel_size - Vector2(margin, margin));
@@ -256,7 +257,7 @@ TouchActionsPanel::TouchActionsPanel(bool p_floating) {
 		panel_style->set_content_margin_all(12);
 		add_theme_style_override(SceneStringName(panel), panel_style);
 
-		set_position(EDITOR_DEF("_touch_actions_panel_position", Point2(100, 480)));
+		set_position(EDITOR_DEF(portrait_mode ? "_touch_actions_panel_portrait_pos" : "_touch_actions_panel_position", Point2(100, 480)));
 	}
 
 	box = memnew(BoxContainer);

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -187,6 +187,7 @@ void ProjectManager::_build_icon_type_cache(Ref<Theme> p_theme) {
 // Hides certain parts of the Project Manager when window width gets smaller than combined_minimum_size.
 void ProjectManager::_update_compact_mode(bool p_reset_threshold) {
 	if (p_reset_threshold) {
+		project_list_sidebar->show();
 		compact_mode_threshold = root_container->get_combined_minimum_size().width;
 	}
 
@@ -195,7 +196,10 @@ void ProjectManager::_update_compact_mode(bool p_reset_threshold) {
 }
 
 void ProjectManager::_update_size_limits() {
-	const Size2 minimum_size = Size2(480, 300) * EDSCALE;
+	const Size2 default_minimum_size = Size2(720, 450) * EDSCALE;
+	const Size2 display_size = DisplayServer::get_singleton()->screen_get_usable_rect(DisplayServerEnums::SCREEN_OF_MAIN_WINDOW).size;
+	const real_t smallest_display_dimension = display_size.width < display_size.height ? display_size.width : display_size.height;
+	const Size2 minimum_size = default_minimum_size.minf(smallest_display_dimension);
 
 	// Define a minimum window size to prevent UI elements from overlapping or being cut off.
 	Window *w = Object::cast_to<Window>(SceneTree::get_singleton()->get_root());
@@ -1637,6 +1641,7 @@ ProjectManager::ProjectManager() {
 			project_list->connect(ProjectList::SIGNAL_SELECTION_CHANGED, callable_mp(this, &ProjectManager::_update_project_buttons));
 			project_list->connect(ProjectList::SIGNAL_PROJECT_ASK_OPEN, callable_mp(this, &ProjectManager::_open_selected_projects_check_recovery_mode));
 			project_list->connect(ProjectList::SIGNAL_MENU_OPTION_SELECTED, callable_mp(this, &ProjectManager::_project_list_menu_option));
+			project_list->connect(SceneStringName(minimum_size_changed), callable_mp(this, &ProjectManager::_update_compact_mode).bind(true));
 
 			// Empty project list placeholder.
 			{

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -3249,11 +3249,13 @@ Node3DEditor::Node3DEditor() {
 	toolbar_margin->add_child(main_flow);
 
 	// Main toolbars.
-	HBoxContainer *main_menu_hbox = memnew(HBoxContainer);
-	main_flow->add_child(main_menu_hbox);
+	// Split into separate `HBoxContainer` so they can wrap onto multiple lines as the window width decreases (the parent is a `FlowContainer`).
+	// These are not grouped by any particular criteria. Only some of the end children are grouped separately, based on their separators.
+	HBoxContainer *tool_button_hbox = memnew(HBoxContainer);
+	main_flow->add_child(tool_button_hbox);
 
 	tool_button[TOOL_MODE_TRANSFORM] = memnew(Button);
-	main_menu_hbox->add_child(tool_button[TOOL_MODE_TRANSFORM]);
+	tool_button_hbox->add_child(tool_button[TOOL_MODE_TRANSFORM]);
 	tool_button[TOOL_MODE_TRANSFORM]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_TRANSFORM]->set_theme_type_variation(SceneStringName(FlatButton));
 	tool_button[TOOL_MODE_TRANSFORM]->set_pressed(true);
@@ -3263,7 +3265,7 @@ Node3DEditor::Node3DEditor() {
 	tool_button[TOOL_MODE_TRANSFORM]->set_accessibility_name(TTRC("Transform Mode"));
 
 	tool_button[TOOL_MODE_MOVE] = memnew(Button);
-	main_menu_hbox->add_child(tool_button[TOOL_MODE_MOVE]);
+	tool_button_hbox->add_child(tool_button[TOOL_MODE_MOVE]);
 	tool_button[TOOL_MODE_MOVE]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_MOVE]->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	tool_button[TOOL_MODE_MOVE]->set_theme_type_variation(SceneStringName(FlatButton));
@@ -3274,7 +3276,7 @@ Node3DEditor::Node3DEditor() {
 	tool_button[TOOL_MODE_MOVE]->set_accessibility_name(TTRC("Move Mode"));
 
 	tool_button[TOOL_MODE_ROTATE] = memnew(Button);
-	main_menu_hbox->add_child(tool_button[TOOL_MODE_ROTATE]);
+	tool_button_hbox->add_child(tool_button[TOOL_MODE_ROTATE]);
 	tool_button[TOOL_MODE_ROTATE]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_ROTATE]->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	tool_button[TOOL_MODE_ROTATE]->set_theme_type_variation(SceneStringName(FlatButton));
@@ -3284,7 +3286,7 @@ Node3DEditor::Node3DEditor() {
 	tool_button[TOOL_MODE_ROTATE]->set_accessibility_name(TTRC("Rotate Mode"));
 
 	tool_button[TOOL_MODE_SCALE] = memnew(Button);
-	main_menu_hbox->add_child(tool_button[TOOL_MODE_SCALE]);
+	tool_button_hbox->add_child(tool_button[TOOL_MODE_SCALE]);
 	tool_button[TOOL_MODE_SCALE]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_SCALE]->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	tool_button[TOOL_MODE_SCALE]->set_theme_type_variation(SceneStringName(FlatButton));
@@ -3294,7 +3296,7 @@ Node3DEditor::Node3DEditor() {
 	tool_button[TOOL_MODE_SCALE]->set_accessibility_name(TTRC("Scale Mode"));
 
 	tool_button[TOOL_MODE_SELECT] = memnew(Button);
-	main_menu_hbox->add_child(tool_button[TOOL_MODE_SELECT]);
+	tool_button_hbox->add_child(tool_button[TOOL_MODE_SELECT]);
 	tool_button[TOOL_MODE_SELECT]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_SELECT]->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	tool_button[TOOL_MODE_SELECT]->set_theme_type_variation(SceneStringName(FlatButton));
@@ -3303,10 +3305,10 @@ Node3DEditor::Node3DEditor() {
 	tool_button[TOOL_MODE_SELECT]->set_shortcut_context(this);
 	tool_button[TOOL_MODE_SELECT]->set_accessibility_name(TTRC("Select Mode"));
 
-	main_menu_hbox->add_child(memnew(VSeparator));
+	tool_button_hbox->add_child(memnew(VSeparator));
 
 	tool_button[TOOL_MODE_LIST_SELECT] = memnew(Button);
-	main_menu_hbox->add_child(tool_button[TOOL_MODE_LIST_SELECT]);
+	tool_button_hbox->add_child(tool_button[TOOL_MODE_LIST_SELECT]);
 	tool_button[TOOL_MODE_LIST_SELECT]->set_toggle_mode(true);
 	tool_button[TOOL_MODE_LIST_SELECT]->set_theme_type_variation(SceneStringName(FlatButton));
 	tool_button[TOOL_MODE_LIST_SELECT]->connect(SceneStringName(pressed), callable_mp(this, &Node3DEditor::_menu_item_pressed).bind(MENU_TOOL_LIST_SELECT));
@@ -3314,7 +3316,7 @@ Node3DEditor::Node3DEditor() {
 	tool_button[TOOL_MODE_LIST_SELECT]->set_accessibility_name(TTRC("Show List of Selectable Nodes"));
 
 	tool_button[TOOL_LOCK_SELECTED] = memnew(Button);
-	main_menu_hbox->add_child(tool_button[TOOL_LOCK_SELECTED]);
+	tool_button_hbox->add_child(tool_button[TOOL_LOCK_SELECTED]);
 	tool_button[TOOL_LOCK_SELECTED]->set_theme_type_variation(SceneStringName(FlatButton));
 	tool_button[TOOL_LOCK_SELECTED]->connect(SceneStringName(pressed), callable_mp(this, &Node3DEditor::_menu_item_pressed).bind(MENU_LOCK_SELECTED));
 	tool_button[TOOL_LOCK_SELECTED]->set_tooltip_text(TTRC("Lock selected node, preventing selection and movement."));
@@ -3323,7 +3325,7 @@ Node3DEditor::Node3DEditor() {
 	tool_button[TOOL_LOCK_SELECTED]->set_accessibility_name(TTRC("Lock"));
 
 	tool_button[TOOL_UNLOCK_SELECTED] = memnew(Button);
-	main_menu_hbox->add_child(tool_button[TOOL_UNLOCK_SELECTED]);
+	tool_button_hbox->add_child(tool_button[TOOL_UNLOCK_SELECTED]);
 	tool_button[TOOL_UNLOCK_SELECTED]->set_theme_type_variation(SceneStringName(FlatButton));
 	tool_button[TOOL_UNLOCK_SELECTED]->connect(SceneStringName(pressed), callable_mp(this, &Node3DEditor::_menu_item_pressed).bind(MENU_UNLOCK_SELECTED));
 	tool_button[TOOL_UNLOCK_SELECTED]->set_tooltip_text(TTRC("Unlock selected node, allowing selection and movement."));
@@ -3332,7 +3334,7 @@ Node3DEditor::Node3DEditor() {
 	tool_button[TOOL_UNLOCK_SELECTED]->set_accessibility_name(TTRC("Unlock"));
 
 	tool_button[TOOL_GROUP_SELECTED] = memnew(Button);
-	main_menu_hbox->add_child(tool_button[TOOL_GROUP_SELECTED]);
+	tool_button_hbox->add_child(tool_button[TOOL_GROUP_SELECTED]);
 	tool_button[TOOL_GROUP_SELECTED]->set_theme_type_variation(SceneStringName(FlatButton));
 	tool_button[TOOL_GROUP_SELECTED]->connect(SceneStringName(pressed), callable_mp(this, &Node3DEditor::_menu_item_pressed).bind(MENU_GROUP_SELECTED));
 	tool_button[TOOL_GROUP_SELECTED]->set_tooltip_text(TTRC("Groups the selected node with its children. This selects the parent when any child node is clicked in 2D and 3D view."));
@@ -3341,7 +3343,7 @@ Node3DEditor::Node3DEditor() {
 	tool_button[TOOL_GROUP_SELECTED]->set_accessibility_name(TTRC("Group"));
 
 	tool_button[TOOL_UNGROUP_SELECTED] = memnew(Button);
-	main_menu_hbox->add_child(tool_button[TOOL_UNGROUP_SELECTED]);
+	tool_button_hbox->add_child(tool_button[TOOL_UNGROUP_SELECTED]);
 	tool_button[TOOL_UNGROUP_SELECTED]->set_theme_type_variation(SceneStringName(FlatButton));
 	tool_button[TOOL_UNGROUP_SELECTED]->connect(SceneStringName(pressed), callable_mp(this, &Node3DEditor::_menu_item_pressed).bind(MENU_UNGROUP_SELECTED));
 	tool_button[TOOL_UNGROUP_SELECTED]->set_tooltip_text(TTRC("Ungroups the selected node from its children. Child nodes will be individual items in 2D and 3D view."));
@@ -3350,7 +3352,7 @@ Node3DEditor::Node3DEditor() {
 	tool_button[TOOL_UNGROUP_SELECTED]->set_accessibility_name(TTRC("Ungroup"));
 
 	tool_button[TOOL_RULER] = memnew(Button);
-	main_menu_hbox->add_child(tool_button[TOOL_RULER]);
+	tool_button_hbox->add_child(tool_button[TOOL_RULER]);
 	tool_button[TOOL_RULER]->set_toggle_mode(true);
 	tool_button[TOOL_RULER]->set_theme_type_variation("FlatButton");
 	tool_button[TOOL_RULER]->connect(SceneStringName(pressed), callable_mp(this, &Node3DEditor::_menu_item_pressed).bind(MENU_RULER));
@@ -3358,10 +3360,10 @@ Node3DEditor::Node3DEditor() {
 	tool_button[TOOL_RULER]->set_shortcut(ED_SHORTCUT("spatial_editor/measure", TTRC("Ruler Mode"), Key::M));
 	tool_button[TOOL_RULER]->set_accessibility_name(TTRC("Ruler Mode"));
 
-	main_menu_hbox->add_child(memnew(VSeparator));
+	tool_button_hbox->add_child(memnew(VSeparator));
 
 	tool_option_button[TOOL_OPT_LOCAL_COORDS] = memnew(Button);
-	main_menu_hbox->add_child(tool_option_button[TOOL_OPT_LOCAL_COORDS]);
+	tool_button_hbox->add_child(tool_option_button[TOOL_OPT_LOCAL_COORDS]);
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_toggle_mode(true);
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_theme_type_variation(SceneStringName(FlatButton));
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->connect(SceneStringName(toggled), callable_mp(this, &Node3DEditor::_menu_item_toggled).bind(MENU_TOOL_LOCAL_COORDS));
@@ -3370,7 +3372,7 @@ Node3DEditor::Node3DEditor() {
 	tool_option_button[TOOL_OPT_LOCAL_COORDS]->set_accessibility_name(TTRC("Use Local Space"));
 
 	tool_option_button[TOOL_OPT_USE_SNAP] = memnew(Button);
-	main_menu_hbox->add_child(tool_option_button[TOOL_OPT_USE_SNAP]);
+	tool_button_hbox->add_child(tool_option_button[TOOL_OPT_USE_SNAP]);
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_toggle_mode(true);
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_theme_type_variation(SceneStringName(FlatButton));
 	tool_option_button[TOOL_OPT_USE_SNAP]->connect(SceneStringName(toggled), callable_mp(this, &Node3DEditor::_menu_item_toggled).bind(MENU_TOOL_USE_SNAP));
@@ -3379,7 +3381,7 @@ Node3DEditor::Node3DEditor() {
 	tool_option_button[TOOL_OPT_USE_SNAP]->set_accessibility_name(TTRC("Use Snap"));
 
 	tool_option_button[TOOL_OPT_USE_TRACKBALL] = memnew(Button);
-	main_menu_hbox->add_child(tool_option_button[TOOL_OPT_USE_TRACKBALL]);
+	tool_button_hbox->add_child(tool_option_button[TOOL_OPT_USE_TRACKBALL]);
 	tool_option_button[TOOL_OPT_USE_TRACKBALL]->set_toggle_mode(true);
 	tool_option_button[TOOL_OPT_USE_TRACKBALL]->set_theme_type_variation(SceneStringName(FlatButton));
 	tool_option_button[TOOL_OPT_USE_TRACKBALL]->connect(SceneStringName(toggled), callable_mp(this, &Node3DEditor::_menu_item_toggled).bind(MENU_TOOL_USE_TRACKBALL));
@@ -3388,7 +3390,7 @@ Node3DEditor::Node3DEditor() {
 	tool_option_button[TOOL_OPT_USE_TRACKBALL]->set_accessibility_name(TTRC("Use Trackball"));
 
 	tool_option_button[TOOL_OPT_PRESERVE_CHILDREN_TRANSFORM] = memnew(Button);
-	main_menu_hbox->add_child(tool_option_button[TOOL_OPT_PRESERVE_CHILDREN_TRANSFORM]);
+	tool_button_hbox->add_child(tool_option_button[TOOL_OPT_PRESERVE_CHILDREN_TRANSFORM]);
 	tool_option_button[TOOL_OPT_PRESERVE_CHILDREN_TRANSFORM]->set_toggle_mode(true);
 	tool_option_button[TOOL_OPT_PRESERVE_CHILDREN_TRANSFORM]->set_theme_type_variation(SceneStringName(FlatButton));
 	tool_option_button[TOOL_OPT_PRESERVE_CHILDREN_TRANSFORM]->connect(SceneStringName(toggled), callable_mp(this, &Node3DEditor::_menu_item_toggled).bind(MENU_TOOL_PRESERVE_CHILDREN_TRANSFORM));
@@ -3397,7 +3399,11 @@ Node3DEditor::Node3DEditor() {
 	tool_option_button[TOOL_OPT_PRESERVE_CHILDREN_TRANSFORM]->set_accessibility_name(TTRC("Preserve Children Transform"));
 	tool_option_button[TOOL_OPT_PRESERVE_CHILDREN_TRANSFORM]->set_tooltip_text(TTRC("When enabled, transforming a node will preserve the global transform of its children.\nThis also applies when editing transform properties in the Inspector."));
 
-	main_menu_hbox->add_child(memnew(VSeparator));
+	tool_button_hbox->add_child(memnew(VSeparator));
+
+	HBoxContainer *environment_hbox = memnew(HBoxContainer);
+	main_flow->add_child(environment_hbox);
+
 	sun_button = memnew(Button);
 	sun_button->set_tooltip_text(TTRC("Toggle preview sunlight.\nIf a DirectionalLight3D node is added to the scene, preview sunlight is disabled."));
 	sun_button->set_toggle_mode(true);
@@ -3407,7 +3413,7 @@ Node3DEditor::Node3DEditor() {
 	// Preview is enabled by default - ensure this applies on editor startup when there is no state yet.
 	sun_button->set_pressed(true);
 
-	main_menu_hbox->add_child(sun_button);
+	environment_hbox->add_child(sun_button);
 
 	environ_button = memnew(Button);
 	environ_button->set_tooltip_text(TTRC("Toggle preview environment.\nIf a WorldEnvironment node is added to the scene, preview environment is disabled."));
@@ -3418,16 +3424,19 @@ Node3DEditor::Node3DEditor() {
 	// Preview is enabled by default - ensure this applies on editor startup when there is no state yet.
 	environ_button->set_pressed(true);
 
-	main_menu_hbox->add_child(environ_button);
+	environment_hbox->add_child(environ_button);
 
 	sun_environ_settings = memnew(Button);
 	sun_environ_settings->set_tooltip_text(TTRC("Edit Sun and Environment settings."));
 	sun_environ_settings->set_theme_type_variation(SceneStringName(FlatButton));
 	sun_environ_settings->connect(SceneStringName(pressed), callable_mp(this, &Node3DEditor::_sun_environ_settings_pressed));
 
-	main_menu_hbox->add_child(sun_environ_settings);
+	environment_hbox->add_child(sun_environ_settings);
 
-	main_menu_hbox->add_child(memnew(VSeparator));
+	environment_hbox->add_child(memnew(VSeparator));
+
+	HBoxContainer *transform_view_hbox = memnew(HBoxContainer);
+	main_flow->add_child(transform_view_hbox);
 
 	// Drag and drop support;
 	preview_node = memnew(Node3D);
@@ -3469,7 +3478,7 @@ Node3DEditor::Node3DEditor() {
 	transform_menu->set_text(TTRC("Transform"));
 	transform_menu->set_switch_on_hover(true);
 	transform_menu->set_shortcut_context(this);
-	main_menu_hbox->add_child(transform_menu);
+	transform_view_hbox->add_child(transform_menu);
 
 	p = transform_menu->get_popup();
 	p->add_shortcut(ED_SHORTCUT("spatial_editor/snap_to_floor", TTRC("Snap Object to Floor"), Key::PAGEDOWN), MENU_SNAP_TO_FLOOR);
@@ -3499,9 +3508,9 @@ Node3DEditor::Node3DEditor() {
 	view_layout_menu->set_text(TTRC("View"));
 	view_layout_menu->set_switch_on_hover(true);
 	view_layout_menu->set_shortcut_context(this);
-	main_menu_hbox->add_child(view_layout_menu);
+	transform_view_hbox->add_child(view_layout_menu);
 
-	main_menu_hbox->add_child(memnew(VSeparator));
+	transform_view_hbox->add_child(memnew(VSeparator));
 
 	context_toolbar_panel = memnew(PanelContainer);
 	context_toolbar_hbox = memnew(HBoxContainer);

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -5753,9 +5753,11 @@ CanvasItemEditor::CanvasItemEditor() {
 	toolbar_margin->add_child(main_flow);
 
 	// Main toolbars.
-	HBoxContainer *main_menu_hbox = memnew(HBoxContainer);
-	main_menu_hbox->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
-	main_flow->add_child(main_menu_hbox);
+	// Split into separate `HBoxContainer` so they can wrap onto multiple lines as the window width decreases (the parent is a `FlowContainer`).
+	// These are not grouped by any particular criteria. Only some of the end children are grouped separately, based on their separators.
+	HBoxContainer *tool_button_hbox = memnew(HBoxContainer);
+	tool_button_hbox->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
+	main_flow->add_child(tool_button_hbox);
 
 	bottom_split = memnew(VSplitContainer);
 	add_child(bottom_split);
@@ -5870,7 +5872,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	select_button = memnew(Button);
 	select_button->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	select_button->set_theme_type_variation(SceneStringName(FlatButton));
-	main_menu_hbox->add_child(select_button);
+	tool_button_hbox->add_child(select_button);
 	select_button->set_toggle_mode(true);
 	select_button->connect(SceneStringName(pressed), callable_mp(this, &CanvasItemEditor::_button_tool_select).bind(TOOL_SELECT));
 	select_button->set_pressed(true);
@@ -5880,18 +5882,18 @@ CanvasItemEditor::CanvasItemEditor() {
 
 	scene_paint_button = memnew(Button);
 	scene_paint_button->set_theme_type_variation(SceneStringName(FlatButton));
-	main_menu_hbox->add_child(scene_paint_button);
+	tool_button_hbox->add_child(scene_paint_button);
 	scene_paint_button->set_toggle_mode(true);
 	scene_paint_button->connect(SceneStringName(pressed), callable_mp(this, &CanvasItemEditor::_button_tool_select).bind(TOOL_SCENE_PAINT));
 	scene_paint_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/scene_paint_mode", TTRC("Scene Paint Mode"), Key::B, true));
 	scene_paint_button->set_shortcut_context(this);
 	scene_paint_button->set_accessibility_name(TTRC("Scene Paint Mode"));
 
-	main_menu_hbox->add_child(memnew(VSeparator));
+	tool_button_hbox->add_child(memnew(VSeparator));
 
 	move_button = memnew(Button);
 	move_button->set_theme_type_variation(SceneStringName(FlatButton));
-	main_menu_hbox->add_child(move_button);
+	tool_button_hbox->add_child(move_button);
 	move_button->set_toggle_mode(true);
 	move_button->connect(SceneStringName(pressed), callable_mp(this, &CanvasItemEditor::_button_tool_select).bind(TOOL_MOVE));
 	move_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/move_mode", TTRC("Move Mode"), Key::W, true));
@@ -5900,7 +5902,7 @@ CanvasItemEditor::CanvasItemEditor() {
 
 	rotate_button = memnew(Button);
 	rotate_button->set_theme_type_variation(SceneStringName(FlatButton));
-	main_menu_hbox->add_child(rotate_button);
+	tool_button_hbox->add_child(rotate_button);
 	rotate_button->set_toggle_mode(true);
 	rotate_button->connect(SceneStringName(pressed), callable_mp(this, &CanvasItemEditor::_button_tool_select).bind(TOOL_ROTATE));
 	rotate_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/rotate_mode", TTRC("Rotate Mode"), Key::E, true));
@@ -5909,18 +5911,18 @@ CanvasItemEditor::CanvasItemEditor() {
 
 	scale_button = memnew(Button);
 	scale_button->set_theme_type_variation(SceneStringName(FlatButton));
-	main_menu_hbox->add_child(scale_button);
+	tool_button_hbox->add_child(scale_button);
 	scale_button->set_toggle_mode(true);
 	scale_button->connect(SceneStringName(pressed), callable_mp(this, &CanvasItemEditor::_button_tool_select).bind(TOOL_SCALE));
 	scale_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/scale_mode", TTRC("Scale Mode"), Key::R, true));
 	scale_button->set_shortcut_context(this);
 	scale_button->set_accessibility_name(TTRC("Scale Mode"));
 
-	main_menu_hbox->add_child(memnew(VSeparator));
+	tool_button_hbox->add_child(memnew(VSeparator));
 
 	list_select_button = memnew(Button);
 	list_select_button->set_theme_type_variation(SceneStringName(FlatButton));
-	main_menu_hbox->add_child(list_select_button);
+	tool_button_hbox->add_child(list_select_button);
 	list_select_button->set_toggle_mode(true);
 	list_select_button->connect(SceneStringName(pressed), callable_mp(this, &CanvasItemEditor::_button_tool_select).bind(TOOL_LIST_SELECT));
 	list_select_button->set_accessibility_name(TTRC("List Selectable Nodes"));
@@ -5928,14 +5930,14 @@ CanvasItemEditor::CanvasItemEditor() {
 	pivot_button = memnew(Button);
 	pivot_button->set_tooltip_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	pivot_button->set_theme_type_variation(SceneStringName(FlatButton));
-	main_menu_hbox->add_child(pivot_button);
+	tool_button_hbox->add_child(pivot_button);
 	pivot_button->set_toggle_mode(true);
 	pivot_button->connect(SceneStringName(pressed), callable_mp(this, &CanvasItemEditor::_button_tool_select).bind(TOOL_EDIT_PIVOT));
 	pivot_button->set_accessibility_name(TTRC("Change Pivot"));
 
 	pan_button = memnew(Button);
 	pan_button->set_theme_type_variation(SceneStringName(FlatButton));
-	main_menu_hbox->add_child(pan_button);
+	tool_button_hbox->add_child(pan_button);
 	pan_button->set_toggle_mode(true);
 	pan_button->connect(SceneStringName(pressed), callable_mp(this, &CanvasItemEditor::_button_tool_select).bind(TOOL_PAN));
 	pan_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/pan_mode", TTRC("Pan Mode"), Key::G));
@@ -5944,18 +5946,18 @@ CanvasItemEditor::CanvasItemEditor() {
 
 	ruler_button = memnew(Button);
 	ruler_button->set_theme_type_variation(SceneStringName(FlatButton));
-	main_menu_hbox->add_child(ruler_button);
+	tool_button_hbox->add_child(ruler_button);
 	ruler_button->set_toggle_mode(true);
 	ruler_button->connect(SceneStringName(pressed), callable_mp(this, &CanvasItemEditor::_button_tool_select).bind(TOOL_RULER));
 	ruler_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/ruler_mode", TTRC("Ruler Mode"), Key::M));
 	ruler_button->set_shortcut_context(this);
 	ruler_button->set_accessibility_name(TTRC("Ruler Mode"));
 
-	main_menu_hbox->add_child(memnew(VSeparator));
+	tool_button_hbox->add_child(memnew(VSeparator));
 
 	local_space_button = memnew(Button);
 	local_space_button->set_theme_type_variation(SceneStringName(FlatButton));
-	main_menu_hbox->add_child(local_space_button);
+	tool_button_hbox->add_child(local_space_button);
 	local_space_button->set_toggle_mode(true);
 	local_space_button->set_pressed_no_signal(true);
 	local_space_button->connect(SceneStringName(toggled), callable_mp(this, &CanvasItemEditor::_button_toggle_local_space));
@@ -5965,7 +5967,7 @@ CanvasItemEditor::CanvasItemEditor() {
 
 	smart_snap_button = memnew(Button);
 	smart_snap_button->set_theme_type_variation(SceneStringName(FlatButton));
-	main_menu_hbox->add_child(smart_snap_button);
+	tool_button_hbox->add_child(smart_snap_button);
 	smart_snap_button->set_toggle_mode(true);
 	smart_snap_button->connect(SceneStringName(toggled), callable_mp(this, &CanvasItemEditor::_button_toggle_smart_snap));
 	smart_snap_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/use_smart_snap", TTRC("Use Smart Snap"), KeyModifierMask::SHIFT | Key::S));
@@ -5973,7 +5975,7 @@ CanvasItemEditor::CanvasItemEditor() {
 
 	grid_snap_button = memnew(Button);
 	grid_snap_button->set_theme_type_variation(SceneStringName(FlatButton));
-	main_menu_hbox->add_child(grid_snap_button);
+	tool_button_hbox->add_child(grid_snap_button);
 	grid_snap_button->set_toggle_mode(true);
 	grid_snap_button->connect(SceneStringName(toggled), callable_mp(this, &CanvasItemEditor::_button_toggle_grid_snap));
 	grid_snap_button->set_shortcut(ED_SHORTCUT("canvas_item_editor/use_grid_snap", TTRC("Use Grid Snap"), KeyModifierMask::SHIFT | Key::G));
@@ -5983,7 +5985,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	snap_config_menu->set_flat(false);
 	snap_config_menu->set_theme_type_variation("FlatMenuButton");
 	snap_config_menu->set_shortcut_context(this);
-	main_menu_hbox->add_child(snap_config_menu);
+	tool_button_hbox->add_child(snap_config_menu);
 	snap_config_menu->set_h_size_flags(SIZE_SHRINK_END);
 	snap_config_menu->set_tooltip_text(TTRC("Snapping Options"));
 	snap_config_menu->set_switch_on_hover(true);
@@ -6010,12 +6012,16 @@ CanvasItemEditor::CanvasItemEditor() {
 	p->add_separator();
 	p->add_shortcut(ED_SHORTCUT("canvas_item_editor/configure_snap", TTRC("Configure Snap...")), SNAP_CONFIGURE);
 
-	main_menu_hbox->add_child(memnew(VSeparator));
+	tool_button_hbox->add_child(memnew(VSeparator));
+
+	HBoxContainer *selection_control_hbox = memnew(HBoxContainer);
+	selection_control_hbox->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
+	main_flow->add_child(selection_control_hbox);
 
 	lock_button = memnew(Button);
 	lock_button->set_theme_type_variation(SceneStringName(FlatButton));
 	lock_button->set_accessibility_name(TTRC("Lock"));
-	main_menu_hbox->add_child(lock_button);
+	selection_control_hbox->add_child(lock_button);
 
 	lock_button->connect(SceneStringName(pressed), callable_mp(this, &CanvasItemEditor::_popup_callback).bind(LOCK_SELECTED));
 	lock_button->set_tooltip_text(TTRC("Lock selected node, preventing selection and movement."));
@@ -6025,7 +6031,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	unlock_button = memnew(Button);
 	unlock_button->set_accessibility_name(TTRC("Unlock"));
 	unlock_button->set_theme_type_variation(SceneStringName(FlatButton));
-	main_menu_hbox->add_child(unlock_button);
+	selection_control_hbox->add_child(unlock_button);
 	unlock_button->connect(SceneStringName(pressed), callable_mp(this, &CanvasItemEditor::_popup_callback).bind(UNLOCK_SELECTED));
 	unlock_button->set_tooltip_text(TTRC("Unlock selected node, allowing selection and movement."));
 	// Define the shortcut globally (without a context) so that it works if the Scene tree dock is currently focused.
@@ -6034,7 +6040,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	group_button = memnew(Button);
 	group_button->set_accessibility_name(TTRC("Group"));
 	group_button->set_theme_type_variation(SceneStringName(FlatButton));
-	main_menu_hbox->add_child(group_button);
+	selection_control_hbox->add_child(group_button);
 	group_button->connect(SceneStringName(pressed), callable_mp(this, &CanvasItemEditor::_popup_callback).bind(GROUP_SELECTED));
 	group_button->set_tooltip_text(TTRC("Groups the selected node with its children. This causes the parent to be selected when any child node is clicked in 2D and 3D view."));
 	// Define the shortcut globally (without a context) so that it works if the Scene tree dock is currently focused.
@@ -6043,19 +6049,23 @@ CanvasItemEditor::CanvasItemEditor() {
 	ungroup_button = memnew(Button);
 	ungroup_button->set_accessibility_name(TTRC("Ungroup"));
 	ungroup_button->set_theme_type_variation(SceneStringName(FlatButton));
-	main_menu_hbox->add_child(ungroup_button);
+	selection_control_hbox->add_child(ungroup_button);
 	ungroup_button->connect(SceneStringName(pressed), callable_mp(this, &CanvasItemEditor::_popup_callback).bind(UNGROUP_SELECTED));
 	ungroup_button->set_tooltip_text(TTRC("Ungroups the selected node from its children. Child nodes will be individual items in 2D and 3D view."));
 	// Define the shortcut globally (without a context) so that it works if the Scene tree dock is currently focused.
 	ungroup_button->set_shortcut(ED_GET_SHORTCUT("editor/ungroup_selected_nodes"));
 
-	main_menu_hbox->add_child(memnew(VSeparator));
+	selection_control_hbox->add_child(memnew(VSeparator));
+
+	HBoxContainer *skeleton_menu_hbox = memnew(HBoxContainer);
+	skeleton_menu_hbox->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
+	main_flow->add_child(skeleton_menu_hbox);
 
 	skeleton_menu = memnew(MenuButton);
 	skeleton_menu->set_flat(false);
 	skeleton_menu->set_theme_type_variation("FlatMenuButton");
 	skeleton_menu->set_shortcut_context(this);
-	main_menu_hbox->add_child(skeleton_menu);
+	skeleton_menu_hbox->add_child(skeleton_menu);
 	skeleton_menu->set_tooltip_text(TTRC("Skeleton Options"));
 	skeleton_menu->set_switch_on_hover(true);
 
@@ -6066,7 +6076,11 @@ CanvasItemEditor::CanvasItemEditor() {
 	p->add_shortcut(ED_SHORTCUT("canvas_item_editor/skeleton_make_bones", TTRC("Make Bone2D Node(s) from Node(s)"), KeyModifierMask::CMD_OR_CTRL | KeyModifierMask::SHIFT | Key::B), SKELETON_MAKE_BONES);
 	p->connect(SceneStringName(id_pressed), callable_mp(this, &CanvasItemEditor::_popup_callback));
 
-	main_menu_hbox->add_child(memnew(VSeparator));
+	skeleton_menu_hbox->add_child(memnew(VSeparator));
+
+	HBoxContainer *view_menu_hbox = memnew(HBoxContainer);
+	view_menu_hbox->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
+	main_flow->add_child(view_menu_hbox);
 
 	view_menu = memnew(MenuButton);
 	view_menu->set_flat(false);
@@ -6075,7 +6089,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	view_menu->set_text(TTRC("View"));
 	view_menu->set_switch_on_hover(true);
 	view_menu->set_shortcut_context(this);
-	main_menu_hbox->add_child(view_menu);
+	view_menu_hbox->add_child(view_menu);
 
 	p = view_menu->get_popup();
 	p->connect(SceneStringName(id_pressed), callable_mp(this, &CanvasItemEditor::_popup_callback));
@@ -6135,7 +6149,7 @@ CanvasItemEditor::CanvasItemEditor() {
 
 	p->add_submenu_node_item(TTRC("Preview Translation"), memnew(EditorTranslationPreviewMenu));
 
-	main_menu_hbox->add_child(memnew(VSeparator));
+	view_menu_hbox->add_child(memnew(VSeparator));
 
 	// Contextual toolbars.
 	context_toolbar_panel = memnew(PanelContainer);

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -2080,8 +2080,7 @@ void ScriptEditor::_notification(int p_what) {
 			}
 
 			virtual_keyboard_spacer->set_custom_minimum_size(Size2(0, spacer_height));
-			EditorSceneTabs::get_singleton()->set_visible(!kb_height);
-			menu_hb->set_visible(!kb_visible);
+			EditorSceneTabs::get_singleton()->set_visible(!kb_visible);
 		} break;
 #endif
 		case NOTIFICATION_APPLICATION_FOCUS_IN: {
@@ -4029,7 +4028,7 @@ void ScriptEditor::_update_code_editor_zoom_factor(CodeTextEditor *p_code_text_e
 }
 
 void ScriptEditor::_floating_state_changed(bool p_floating) {
-	make_floating->set_visible(!p_floating);
+	make_floating->set_visible(!p_floating && !make_floating->is_disabled());
 	is_floating = p_floating;
 }
 

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -236,6 +236,11 @@ void EditorSettingsDialog::popup_edit_settings() {
 		saved_size = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "editor_settings", Rect2());
 	}
 
+#ifdef ANDROID_ENABLED
+	// The Android Editor's aspect ratio may change when the device orientation changes, and `saved_size` may correspond to a different orientation (example, a very small width if it was last opened in portrait mode).
+	// Always reset the popup size so that it covers most of the available area.
+	popup_centered_clamped(Size2(900, 700) * EDSCALE, 0.8);
+#else
 	if (saved_size != Rect2()) {
 		popup(saved_size);
 	} else if (_is_in_project_manager()) {
@@ -243,6 +248,7 @@ void EditorSettingsDialog::popup_edit_settings() {
 	} else {
 		popup_centered_clamped(Size2(900, 700) * EDSCALE, 0.8);
 	}
+#endif
 
 	_focus_current_search_box();
 }

--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -54,12 +54,18 @@ void ProjectSettingsEditor::connect_filesystem_dock_signals(FileSystemDock *p_fs
 
 void ProjectSettingsEditor::popup_project_settings(bool p_clear_filter) {
 	// Restore valid window bounds or pop up at default size.
+#ifdef ANDROID_ENABLED
+	// The Android Editor's aspect ratio may change when the device orientation changes, and `saved_size` may correspond to a different orientation (example, a very small width if it was last opened in portrait mode).
+	// Always reset the popup size so that it covers most of the available area.
+	popup_centered_clamped(Size2(1200, 700) * EDSCALE, 0.8);
+#else
 	Rect2 saved_size = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "project_settings", Rect2());
 	if (saved_size != Rect2()) {
 		popup(saved_size);
 	} else {
 		popup_centered_clamped(Size2(1200, 700) * EDSCALE, 0.8);
 	}
+#endif
 
 	_add_feature_overrides();
 	general_settings_inspector->update_category_list();

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1140,7 +1140,7 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 		Ref<StyleBoxFlat> grabber_hl_style = p_config.base_style->duplicate();
 		grabber_hl_style->set_bg_color(p_config.mono_color * Color(1, 1, 1, 0.5));
 
-		int scroll_margin = EDSCALE_RND(p_config.enable_touch_optimizations ? 10 : 3);
+		int scroll_margin = EDSCALE_RND(p_config.enable_touch_optimizations ? 13 : 3);
 
 		// HScrollBar.
 

--- a/platform/android/editor/editor_utils_jni.cpp
+++ b/platform/android/editor/editor_utils_jni.cpp
@@ -101,10 +101,9 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_EditorUtils_runSc
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_EditorUtils_orientationChanged(JNIEnv *p_env, jclass, jboolean p_portrait) {
 #ifdef TOOLS_ENABLED
 	if (EditorNode::get_singleton() != nullptr) {
-		EditorTitleBar *title_bar = EditorNode::get_singleton()->get_title_bar();
-		if (title_bar != nullptr) {
+		if (EditorRunBar::get_singleton() != nullptr) {
 			// TODO: Enable for portrait once the title bar width is optimized.
-			title_bar->set_visible(!p_portrait);
+			EditorRunBar::get_singleton()->set_visible(!p_portrait);
 		}
 
 		if (ScriptEditor::get_singleton() != nullptr && EDITOR_GET("text_editor/appearance/minimap/show_minimap")) {

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -947,19 +947,19 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 		}
 
 		if (!isLargeScreen) {
-			toggleScriptEditorOrientation()
+			toggleEditorOrientation()
 		}
 	}
 
 	override fun onDistractionFreeModeChanged(enabled: Boolean) {
 		distractionFreeModeEnabled = enabled
 		if (!isLargeScreen) {
-			toggleScriptEditorOrientation()
+			toggleEditorOrientation()
 		}
 	}
 
-	private fun toggleScriptEditorOrientation() {
-		if (activeWorkspace == SCRIPT_WORKSPACE && distractionFreeModeEnabled) {
+	private fun toggleEditorOrientation() {
+		if (distractionFreeModeEnabled) {
 			changingOrientationAllowed = true
 			requestedOrientation = ActivityInfo.SCREEN_ORIENTATION_USER
 		} else if (changingOrientationAllowed) {

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/embed/EmbeddedGodotGame.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/embed/EmbeddedGodotGame.kt
@@ -31,9 +31,12 @@
 package org.godotengine.editor.embed
 
 import android.content.pm.ActivityInfo
+import android.content.res.Configuration
+import android.content.res.Configuration.ORIENTATION_PORTRAIT
 import android.graphics.Color
 import android.graphics.Point
 import android.os.Bundle
+import android.util.Log
 import android.util.Rational
 import android.view.Gravity
 import android.view.MotionEvent
@@ -58,8 +61,12 @@ class EmbeddedGodotGame : GodotGame() {
 		private const val PREFS_NAME = "embedded_game_window_prefs"
 		private const val KEY_X = "embedded_window_x"
 		private const val KEY_Y = "embedded_window_y"
+		private const val KEY_X_PORTRAIT = "embedded_window_portrait_x"
+		private const val KEY_Y_PORTRAIT = "embedded_window_portrait_y"
 		private const val KEY_WIDTH = "embedded_window_width"
 		private const val KEY_HEIGHT = "embedded_window_height"
+		private const val KEY_WIDTH_PORTRAIT = "embedded_window_portrait_width"
+		private const val KEY_HEIGHT_PORTRAIT = "embedded_window_portrait_height"
 		private const val KEY_FREE_RESIZE = "is_free_resize"
 
 		private const val RESIZE_THRESHOLD = 80f
@@ -76,6 +83,7 @@ class EmbeddedGodotGame : GodotGame() {
 	private var layoutHeightInPx = 0
 	private var isFullscreen = false
 	private var gameRequestedOrientation = ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+	private var currentOrientation = Configuration.ORIENTATION_UNDEFINED
 
 	private var resizingEnabled = false
 	private var isResizing = false
@@ -92,15 +100,7 @@ class EmbeddedGodotGame : GodotGame() {
 	private val lockAspectRatioCheckBox: CheckBox by lazy { findViewById(R.id.lockAspectRatioCheckBox) }
 	private val cornerHandles = mutableListOf<View>()
 
-	private val screenBounds: android.graphics.Rect by lazy {
-		if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
-			windowManager.currentWindowMetrics.bounds
-		} else {
-			val size = Point()
-			windowManager.defaultDisplay.getRealSize(size)
-			android.graphics.Rect(0, 0, size.x, size.y)
-		}
-	}
+	private lateinit var screenBounds: android.graphics.Rect
 
 	private val maxAllowedWidth: Int get() = (screenBounds.width() * MAX_SCREEN_PERCENT).toInt()
 	private val maxAllowedHeight: Int get() = (screenBounds.height() * MAX_SCREEN_PERCENT).toInt()
@@ -122,6 +122,9 @@ class EmbeddedGodotGame : GodotGame() {
 
 		setFinishOnTouchOutside(false)
 
+		currentOrientation = applicationContext.resources.configuration.orientation
+		screenBounds = calculateScreenBounds()
+
 		val layoutParams = window.attributes
 		layoutParams.flags = layoutParams.flags or FLAG_NOT_TOUCH_MODAL or FLAG_WATCH_OUTSIDE_TOUCH
 		layoutParams.flags = layoutParams.flags and FLAG_DIM_BEHIND.inv()
@@ -134,6 +137,31 @@ class EmbeddedGodotGame : GodotGame() {
 	}
 
 	override fun getGodotAppLayout() = R.layout.godot_embedded_game_layout
+
+	override fun onConfigurationChanged(newConfig: Configuration) {
+		super.onConfigurationChanged(newConfig)
+		if (currentOrientation != newConfig.orientation) {
+			currentOrientation = newConfig.orientation
+			screenBounds = calculateScreenBounds()
+
+			if (!isFullscreen) {
+				// Update Game Window size and position
+				val layoutParams = window.attributes
+				loadWindowBounds(window.attributes)
+				window.attributes = layoutParams
+			}
+		}
+	}
+
+	private fun calculateScreenBounds(): android.graphics.Rect {
+		return if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.R) {
+			windowManager.currentWindowMetrics.bounds
+		} else {
+			val size = Point()
+			windowManager.defaultDisplay.getRealSize(size)
+			android.graphics.Rect(0, 0, size.x, size.y)
+		}
+	}
 
 	private fun setupOverlayUI() {
 		lockAspectRatioCheckBox.isChecked = !isFreeResize
@@ -342,11 +370,12 @@ class EmbeddedGodotGame : GodotGame() {
 		val layoutParams = window.attributes
 		layoutWidthInPx = layoutParams.width
 		layoutHeightInPx = layoutParams.height
+		Log.d("test", currentOrientation.toString())
 		getSharedPreferences(PREFS_NAME, MODE_PRIVATE).edit().apply {
-			putInt(KEY_X, layoutParams.x)
-			putInt(KEY_Y, layoutParams.y)
-			putInt(KEY_WIDTH, layoutParams.width)
-			putInt(KEY_HEIGHT, layoutParams.height)
+			putInt(if (currentOrientation == ORIENTATION_PORTRAIT) KEY_X_PORTRAIT else KEY_X, layoutParams.x)
+			putInt(if (currentOrientation == ORIENTATION_PORTRAIT) KEY_Y_PORTRAIT else KEY_Y, layoutParams.y)
+			putInt(if (currentOrientation == ORIENTATION_PORTRAIT) KEY_WIDTH_PORTRAIT else KEY_WIDTH, layoutParams.width)
+			putInt(if (currentOrientation == ORIENTATION_PORTRAIT) KEY_HEIGHT_PORTRAIT else KEY_HEIGHT, layoutParams.height)
 			putBoolean(KEY_FREE_RESIZE, isFreeResize)
 			apply()
 		}
@@ -358,10 +387,15 @@ class EmbeddedGodotGame : GodotGame() {
 	private fun loadWindowBounds(layoutParams: WindowManager.LayoutParams) {
 		val prefs = getSharedPreferences(PREFS_NAME, MODE_PRIVATE)
 		isFreeResize = prefs.getBoolean(KEY_FREE_RESIZE, false)
-		layoutWidthInPx = prefs.getInt(KEY_WIDTH, defaultWidthInPx)
-		layoutHeightInPx = prefs.getInt(KEY_HEIGHT, defaultHeightInPx)
-		layoutParams.x = prefs.getInt(KEY_X, screenBounds.width() - layoutWidthInPx)
-		layoutParams.y = prefs.getInt(KEY_Y, screenBounds.height() - layoutHeightInPx)
+		if (currentOrientation == ORIENTATION_PORTRAIT) {
+			layoutWidthInPx = prefs.getInt(KEY_WIDTH_PORTRAIT, defaultHeightInPx)
+			layoutHeightInPx = prefs.getInt(KEY_HEIGHT_PORTRAIT, defaultWidthInPx)
+		} else {
+			layoutWidthInPx = prefs.getInt(KEY_WIDTH, defaultWidthInPx)
+			layoutHeightInPx = prefs.getInt(KEY_HEIGHT, defaultHeightInPx)
+		}
+		layoutParams.x = prefs.getInt(if (currentOrientation == ORIENTATION_PORTRAIT) KEY_X_PORTRAIT else KEY_X, screenBounds.width() - layoutWidthInPx)
+		layoutParams.y = prefs.getInt(if (currentOrientation == ORIENTATION_PORTRAIT) KEY_Y_PORTRAIT else KEY_Y, screenBounds.height() - layoutHeightInPx)
 		layoutParams.width = layoutWidthInPx
 		layoutParams.height = layoutHeightInPx
 		lockedAspectRatio = layoutParams.width.toFloat() / layoutParams.height.toFloat().coerceAtLeast(1f)

--- a/platform/android/java/editor/src/main/res/layout/godot_editor_layout.xml
+++ b/platform/android/java/editor/src/main/res/layout/godot_editor_layout.xml
@@ -22,8 +22,10 @@
 
 		<androidx.constraintlayout.widget.ConstraintLayout
 			android:id="@+id/embedded_game_view_container"
-			android:layout_width="@dimen/embed_game_window_default_width"
-			android:layout_height="@dimen/embed_game_window_default_height"
+			android:maxWidth="@dimen/embed_game_window_default_width"
+			android:maxHeight="@dimen/embed_game_window_default_height"
+			android:layout_width="match_parent"
+			android:layout_height="match_parent"
 			android:background="@drawable/game_menu_message_bg"
 			android:layout_gravity="bottom|end">
 

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -87,8 +87,8 @@ private:
 
 public:
 	static const char *ANDROID_EXEC_PATH;
-	static const int DEFAULT_WINDOW_WIDTH = 800;
-	static const int DEFAULT_WINDOW_HEIGHT = 600;
+	static const int DEFAULT_WINDOW_WIDTH = 760;
+	static const int DEFAULT_WINDOW_HEIGHT = 570;
 
 #ifdef TOOLS_ENABLED
 	Error sign_apk(const String &p_input_path, const String &p_output_path, const String &p_keystore_path, const String &p_keystore_user, const String &p_keystore_password);


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/121387

- This PR expands portrait mode support to small devices (smart phones), when `distraction free mode` is enabled.
- TouchActionsPanel caches different position in portrait and landscape, so when you switch from landscape to portrait it stays in the oplace where you last kept it in portrait.
- Fixes Android Game window orientation handling.
- Increases default scale by 5% on Android.
- Improves 3D and 2D workspace toolbar to better resize to small window width.
- Enables EditorTitleBar in portrait, and now only EditorRunBar is hidden.
- Fixed the Project Manager resize issue and the compact threshold is now refreshed when the ProjectList size changes.
- On Android, Project Manager and Editor Settings now always calculate their popup window size instead of caching it, ensuring they open at the maximum size when switching between portrait and landscape.
- Fixes https://github.com/godotengine/godot/issues/121485
- Fixes https://github.com/godotengine/godot/issues/122083
- Fixes https://github.com/godotengine/godot-proposals/issues/15208