### PR TITLE
[3.x] mbedTLS: Always use Godot's OS as entropy source

### DIFF
--- a/core/crypto/crypto_core.cpp
+++ b/core/crypto/crypto_core.cpp
@@ -30,14 +30,27 @@
 
 #include "crypto_core.h"
 
+#include "core/os/os.h"
+
 #include <mbedtls/aes.h>
 #include <mbedtls/base64.h>
+#include <mbedtls/entropy.h>
 #include <mbedtls/md5.h>
 #include <mbedtls/sha1.h>
 #include <mbedtls/sha256.h>
 #if MBEDTLS_VERSION_MAJOR >= 3
 #include <mbedtls/compat-2.x.h>
 #endif
+
+extern "C" {
+int mbedtls_hardware_poll(void *p_data, unsigned char *r_buffer, size_t p_len, size_t *r_len) {
+	*r_len = 0;
+	Error err = OS::get_singleton()->get_entropy(r_buffer, p_len);
+	ERR_FAIL_COND_V(err, MBEDTLS_ERR_ENTROPY_SOURCE_FAILED);
+	*r_len = p_len;
+	return 0;
+}
+}
 
 // MD5
 CryptoCore::MD5Context::MD5Context() {

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -266,6 +266,8 @@ public:
 	virtual String get_current_tablet_driver() const { return ""; };
 	virtual void set_current_tablet_driver(const String &p_driver){};
 
+	virtual Error get_entropy(uint8_t *r_buffer, int p_bytes) = 0; // Should return cryptographically-safe random bytes.
+
 	virtual PoolStringArray get_connected_midi_inputs();
 	virtual void open_midi_inputs();
 	virtual void close_midi_inputs();

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -49,6 +49,7 @@
 #include <android/input.h>
 #include <core/os/keyboard.h>
 #include <dlfcn.h>
+#include <stdlib.h>
 
 #include "java_godot_io_wrapper.h"
 #include "java_godot_wrapper.h"
@@ -762,6 +763,11 @@ Error OS_Android::kill(const ProcessID &p_pid) {
 		return OK;
 	}
 	return OS_Unix::kill(p_pid);
+}
+
+Error OS_Android::get_entropy(uint8_t *r_buffer, int p_bytes) {
+	arc4random_buf(r_buffer, p_bytes);
+	return OK;
 }
 
 OS_Android::~OS_Android() {

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -220,6 +220,8 @@ public:
 	virtual Error execute(const String &p_path, const List<String> &p_arguments, bool p_blocking = true, ProcessID *r_child_id = nullptr, String *r_pipe = nullptr, int *r_exitcode = nullptr, bool read_stderr = false, Mutex *p_pipe_mutex = nullptr, bool p_open_console = false);
 	virtual Error kill(const ProcessID &p_pid);
 
+	virtual Error get_entropy(uint8_t *r_buffer, int p_bytes);
+
 	virtual void benchmark_begin_measure(const String &p_what);
 	virtual void benchmark_end_measure(const String &p_what);
 	virtual void benchmark_dump();

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -105,6 +105,8 @@ public:
 
 	void start();
 
+	virtual Error get_entropy(uint8_t *r_buffer, int p_bytes);
+
 	virtual bool tts_is_speaking() const;
 	virtual bool tts_is_paused() const;
 	virtual Array tts_get_voices() const;

--- a/platform/iphone/os_iphone.mm
+++ b/platform/iphone/os_iphone.mm
@@ -89,6 +89,11 @@ OSIPhone *OSIPhone::get_singleton() {
 	return (OSIPhone *)OS::get_singleton();
 };
 
+Error OSIPhone::get_entropy(uint8_t *r_buffer, int p_bytes) {
+	int status = SecRandomCopyBytes(kSecRandomDefault, p_bytes, r_buffer);
+	return status == errSecSuccess ? OK : FAILED;
+}
+
 bool OSIPhone::tts_is_speaking() const {
 	ERR_FAIL_COND_V_MSG(!tts, false, "Enable the \"audio/general/text_to_speech\" project setting to use text-to-speech.");
 	ERR_FAIL_COND_V(!tts, false);

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -65,6 +65,18 @@ void OS_JavaScript::request_quit_callback() {
 	}
 }
 
+Error OS_JavaScript::get_entropy(uint8_t *r_buffer, int p_bytes) {
+	int left = p_bytes;
+	int ofs = 0;
+	do {
+		int chunk = MIN(left, 256);
+		ERR_FAIL_COND_V(getentropy(r_buffer + ofs, chunk), FAILED);
+		left -= chunk;
+		ofs += chunk;
+	} while (left > 0);
+	return OK;
+}
+
 bool OS_JavaScript::tts_is_speaking() const {
 	ERR_FAIL_COND_V_MSG(!tts, false, "Enable the \"audio/general/text_to_speech\" project setting to use text-to-speech.");
 	return godot_js_tts_is_speaking();

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -151,6 +151,8 @@ public:
 	// Override return type to make writing static callbacks less tedious.
 	static OS_JavaScript *get_singleton();
 
+	Error get_entropy(uint8_t *r_buffer, int p_bytes);
+
 	virtual bool tts_is_speaking() const;
 	virtual bool tts_is_paused() const;
 	virtual Array tts_get_voices() const;

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -213,6 +213,8 @@ def configure(env):
             "CoreMedia",
             "-framework",
             "CoreVideo",
+            "-framework",
+            "Security",
         ]
     )
     env.Append(LIBS=["pthread"])

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -195,6 +195,8 @@ protected:
 public:
 	static OS_OSX *singleton;
 
+	virtual Error get_entropy(uint8_t *r_buffer, int p_bytes);
+
 	virtual bool tts_is_speaking() const;
 	virtual bool tts_is_paused() const;
 	virtual Array tts_get_voices() const;

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1573,6 +1573,11 @@ int OS_OSX::get_current_video_driver() const {
 	return video_driver_index;
 }
 
+Error OS_OSX::get_entropy(uint8_t *r_buffer, int p_bytes) {
+	int status = SecRandomCopyBytes(kSecRandomDefault, p_bytes, r_buffer);
+	return status == errSecSuccess ? OK : FAILED;
+}
+
 bool OS_OSX::tts_is_speaking() const {
 	ERR_FAIL_COND_V_MSG(!tts, false, "Enable the \"audio/general/text_to_speech\" project setting to use text-to-speech.");
 	ERR_FAIL_COND_V(!tts, false);

--- a/platform/server/os_server.cpp
+++ b/platform/server/os_server.cpp
@@ -41,6 +41,18 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#ifdef __APPLE__
+#include <sys/random.h>
+#define UNIX_GET_ENTROPY
+#elif defined(__FreeBSD__) || defined(__OpenBSD__) || (defined(__GLIBC_MINOR__) && (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 26))
+// In <unistd.h>.
+// One day... (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 700)
+// https://publications.opengroup.org/standards/unix/c211
+#define UNIX_GET_ENTROPY
+#elif !defined(NO_URANDOM)
+#include <fcntl.h>
+#endif
+
 int OS_Server::get_video_driver_count() const {
 	return 1;
 }
@@ -110,6 +122,32 @@ void OS_Server::finalize() {
 	resource_loader_dummy.unref();
 
 	args.clear();
+}
+
+Error OS_Server::get_entropy(uint8_t *r_buffer, int p_bytes) {
+#if defined(UNIX_GET_ENTROPY)
+	int left = p_bytes;
+	int ofs = 0;
+	do {
+		int chunk = MIN(left, 256);
+		ERR_FAIL_COND_V(getentropy(r_buffer + ofs, chunk), FAILED);
+		left -= chunk;
+		ofs += chunk;
+	} while (left > 0);
+// Define this yourself if you don't want to fall back to /dev/urandom.
+#elif !defined(NO_URANDOM)
+	int r = open("/dev/urandom", O_RDONLY);
+	ERR_FAIL_COND_V(r < 0, FAILED);
+	int left = p_bytes;
+	do {
+		ssize_t ret = read(r, r_buffer, p_bytes);
+		ERR_FAIL_COND_V(ret <= 0, FAILED);
+		left -= ret;
+	} while (left > 0);
+#else
+	return ERR_UNAVAILABLE;
+#endif
+	return OK;
 }
 
 void OS_Server::set_mouse_show(bool p_show) {

--- a/platform/server/os_server.h
+++ b/platform/server/os_server.h
@@ -89,6 +89,8 @@ protected:
 public:
 	virtual String get_name() const;
 
+	virtual Error get_entropy(uint8_t *r_buffer, int p_bytes);
+
 	virtual void set_mouse_show(bool p_show);
 	virtual void set_mouse_grab(bool p_grab);
 	virtual bool is_mouse_grab_enabled() const;

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -372,6 +372,12 @@ void OS_UWP::finalize_core() {
 	NetSocketPosix::cleanup();
 }
 
+Error OS_UWP::get_entropy(uint8_t *r_buffer, int p_bytes) {
+	NTSTATUS status = BCryptGenRandom(nullptr, r_buffer, p_bytes, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+	ERR_FAIL_COND_V(status, FAILED);
+	return OK;
+}
+
 void OS_UWP::alert(const String &p_alert, const String &p_title) {
 	Platform::String ^ alert = ref new Platform::String(p_alert.c_str());
 	Platform::String ^ title = ref new Platform::String(p_title.c_str());

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -166,6 +166,8 @@ public:
 	// Event to send to the app wrapper
 	HANDLE mouse_mode_changed;
 
+	virtual Error get_entropy(uint8_t *r_buffer, int p_bytes);
+
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 	String get_stdin_string();
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1853,6 +1853,12 @@ void OS_Windows::finalize_core() {
 	NetSocketPosix::cleanup();
 }
 
+Error OS_Windows::get_entropy(uint8_t *r_buffer, int p_bytes) {
+	NTSTATUS status = BCryptGenRandom(nullptr, r_buffer, p_bytes, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+	ERR_FAIL_COND_V(status, FAILED);
+	return OK;
+}
+
 void OS_Windows::alert(const String &p_alert, const String &p_title) {
 	if (is_no_window_mode_enabled()) {
 		print_line("ALERT: " + p_title + ": " + p_alert);

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -437,6 +437,8 @@ protected:
 public:
 	LRESULT WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 
+	virtual Error get_entropy(uint8_t *r_buffer, int p_bytes);
+
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");
 	String get_stdin_string();
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -69,6 +69,15 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#if defined(__FreeBSD__) || defined(__OpenBSD__) || (defined(__GLIBC_MINOR__) && (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 26))
+// In <unistd.h>.
+// One day... (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 700)
+// https://publications.opengroup.org/standards/unix/c211
+#define UNIX_GET_ENTROPY
+#elif !defined(NO_URANDOM)
+#include <fcntl.h>
+#endif
+
 //stupid linux.h
 #ifdef KEY_TAB
 #undef KEY_TAB
@@ -105,6 +114,32 @@ static String get_atom_name(Display *p_disp, Atom p_atom) {
 	ret.parse_utf8(name);
 	XFree(name);
 	return ret;
+}
+
+Error OS_X11::get_entropy(uint8_t *r_buffer, int p_bytes) {
+#if defined(UNIX_GET_ENTROPY)
+	int left = p_bytes;
+	int ofs = 0;
+	do {
+		int chunk = MIN(left, 256);
+		ERR_FAIL_COND_V(getentropy(r_buffer + ofs, chunk), FAILED);
+		left -= chunk;
+		ofs += chunk;
+	} while (left > 0);
+// Define this yourself if you don't want to fall back to /dev/urandom.
+#elif !defined(NO_URANDOM)
+	int r = open("/dev/urandom", O_RDONLY);
+	ERR_FAIL_COND_V(r < 0, FAILED);
+	int left = p_bytes;
+	do {
+		ssize_t ret = read(r, r_buffer, p_bytes);
+		ERR_FAIL_COND_V(ret <= 0, FAILED);
+		left -= ret;
+	} while (left > 0);
+#else
+	return ERR_UNAVAILABLE;
+#endif
+	return OK;
 }
 
 #ifdef SPEECHD_ENABLED

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -263,6 +263,8 @@ protected:
 public:
 	virtual String get_name() const;
 
+	virtual Error get_entropy(uint8_t *r_buffer, int p_bytes);
+
 #ifdef SPEECHD_ENABLED
 	virtual bool tts_is_speaking() const;
 	virtual bool tts_is_paused() const;

--- a/thirdparty/mbedtls/include/godot_core_mbedtls_config.h
+++ b/thirdparty/mbedtls/include/godot_core_mbedtls_config.h
@@ -48,7 +48,10 @@
 #define MBEDTLS_SHA1_C
 #define MBEDTLS_SHA256_C
 #define MBEDTLS_PLATFORM_ZEROIZE_ALT
-#define MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
+
+// Custom entropy source.
+#define MBEDTLS_NO_PLATFORM_ENTROPY
+#define MBEDTLS_ENTROPY_HARDWARE_ALT
 
 // This is only to pass a check in the mbedtls check_config.h header, none of
 // the files we include as part of the core build uses it anyway, we already

--- a/thirdparty/mbedtls/include/godot_module_mbedtls_config.h
+++ b/thirdparty/mbedtls/include/godot_module_mbedtls_config.h
@@ -56,6 +56,10 @@
 #define GODOT_MBEDTLS_THREADING_ALT
 #endif
 
+// Custom entropy source.
+#define MBEDTLS_NO_PLATFORM_ENTROPY
+#define MBEDTLS_ENTROPY_HARDWARE_ALT
+
 #if !(defined(__linux__) && defined(__aarch64__))
 // ARMv8 hardware AES operations. Detection only possible on linux.
 // May technically be supported on some ARM32 arches but doesn't seem


### PR DESCRIPTION
Backport of #121759

Includes backport of OS::get_entropy from master (i.e. up to #121764 ).

See also ( https://github.com/godotengine/godot/pull/121759#issuecomment-5117830396 )