### PR TITLE
Add enumerate function (similar to python)

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -81,6 +81,30 @@
 				Converts a [param dictionary] (created with [method inst_to_dict]) back to an Object instance. Can be useful for deserializing.
 			</description>
 		</method>
+		<method name="enumerate">
+			<return type="Dictionary" />
+			<param index="0" name="var" type="Variant" />
+			<param index="1" name="start" type="int" default="0" />
+			<description>
+				Returns a dictionary with keys being indexes and values being what a normal for loop over the array would return. An optional parameter [param start] can be provided to start the keys at a different number, though the values will remain unchanged.
+				[codeblock]
+				var my_array = [7, 4, 9]
+				for pos, value in enumerate(my_array):
+					prints(pos, value)
+				# Result:
+				# 0 7
+				# 1 4
+				# 2 9
+
+				for pos, value in enumerate(my_array, 15):
+					prints(pos, value)
+				# Result:
+				# 15 7
+				# 16 4
+				# 17 9
+				[/codeblock]
+			</description>
+		</method>
 		<method name="get_stack">
 			<return type="Array" />
 			<description>

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -452,6 +452,92 @@ struct GDScriptUtilityFunctionsDefinitions {
 		}
 	}
 
+#define STANDARD_ASSIGN_KEYS_AND_VALUES(key_and_values, array_like, starting_number) \
+	for (int i = 0; i < array_like.size(); i++) { \
+		key_and_values[starting_number + i] = array_like[i]; \
+	} \
+	*r_ret = key_and_values;
+
+	static inline void enumerate(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+		DEBUG_VALIDATE_ARG_COUNT(1, 2);
+		Dictionary key_and_values;
+		int starting_number = 0;
+		if (p_arg_count == 2) {
+			DEBUG_VALIDATE_ARG_TYPE(1, Variant::INT);
+			starting_number = *p_args[1];
+		}
+
+		switch (p_args[0]->get_type()) {
+			case Variant::STRING:
+			case Variant::STRING_NAME: {
+				String d = *p_args[0];
+				for (int i = 0; i < d.length(); i++) {
+					key_and_values[starting_number + i] = d.get(i);
+				}
+				*r_ret = key_and_values;
+			} break;
+			case Variant::DICTIONARY: {
+				Dictionary d = *p_args[0];
+				int pos = 0;
+				for (const KeyValue<Variant, Variant> &kv : d) {
+					key_and_values[starting_number + pos] = kv.key;
+					pos += 1;
+				}
+				*r_ret = key_and_values;
+			} break;
+			case Variant::ARRAY: {
+				Array d = *p_args[0];
+				STANDARD_ASSIGN_KEYS_AND_VALUES(key_and_values, d, starting_number)
+			} break;
+			case Variant::PACKED_BYTE_ARRAY: {
+				Vector<uint8_t> d = *p_args[0];
+				STANDARD_ASSIGN_KEYS_AND_VALUES(key_and_values, d, starting_number)
+			} break;
+			case Variant::PACKED_INT32_ARRAY: {
+				Vector<int32_t> d = *p_args[0];
+				STANDARD_ASSIGN_KEYS_AND_VALUES(key_and_values, d, starting_number)
+			} break;
+			case Variant::PACKED_INT64_ARRAY: {
+				Vector<int64_t> d = *p_args[0];
+				STANDARD_ASSIGN_KEYS_AND_VALUES(key_and_values, d, starting_number)
+			} break;
+			case Variant::PACKED_FLOAT32_ARRAY: {
+				Vector<float> d = *p_args[0];
+				STANDARD_ASSIGN_KEYS_AND_VALUES(key_and_values, d, starting_number)
+			} break;
+			case Variant::PACKED_FLOAT64_ARRAY: {
+				Vector<double> d = *p_args[0];
+				STANDARD_ASSIGN_KEYS_AND_VALUES(key_and_values, d, starting_number)
+			} break;
+			case Variant::PACKED_STRING_ARRAY: {
+				Vector<String> d = *p_args[0];
+				STANDARD_ASSIGN_KEYS_AND_VALUES(key_and_values, d, starting_number)
+			} break;
+			case Variant::PACKED_VECTOR2_ARRAY: {
+				Vector<Vector2> d = *p_args[0];
+				STANDARD_ASSIGN_KEYS_AND_VALUES(key_and_values, d, starting_number)
+			} break;
+			case Variant::PACKED_VECTOR3_ARRAY: {
+				Vector<Vector3> d = *p_args[0];
+				STANDARD_ASSIGN_KEYS_AND_VALUES(key_and_values, d, starting_number)
+			} break;
+			case Variant::PACKED_COLOR_ARRAY: {
+				Vector<Color> d = *p_args[0];
+				STANDARD_ASSIGN_KEYS_AND_VALUES(key_and_values, d, starting_number)
+			} break;
+			case Variant::PACKED_VECTOR4_ARRAY: {
+				Vector<Vector4> d = *p_args[0];
+				STANDARD_ASSIGN_KEYS_AND_VALUES(key_and_values, d, starting_number)
+			} break;
+			default: {
+				*r_ret = vformat(RTR("Value of type '%s' can't be enumerated."), Variant::get_type_name(p_args[0]->get_type()));
+				r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
+				r_error.argument = 0;
+				r_error.expected = Variant::NIL;
+			} break;
+		}
+	}
+
 	static inline void is_instance_of(Variant *r_ret, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
 		DEBUG_VALIDATE_ARG_COUNT(2, 2);
 
@@ -588,6 +674,7 @@ void GDScriptUtilityFunctions::register_functions() {
 	REGISTER_FUNC( print_stack,    false, RET(NIL),           NOARGS,                                  false, varray(     ));
 	REGISTER_FUNC( get_stack,      false, RET(ARRAY),         NOARGS,                                  false, varray(     ));
 	REGISTER_FUNC( len,            true,  RET(INT),           ARGS( ARGVAR("var")                   ), false, varray(     ));
+	REGISTER_FUNC( enumerate,      true,  RET(DICTIONARY),    ARGS( ARGVAR("var"), ARG("start", INT)), false, varray(  0  ));
 	REGISTER_FUNC( is_instance_of, true,  RET(BOOL),          ARGS( ARGVAR("value"), ARGVAR("type") ), false, varray(     ));
 	/* clang-format on */
 }


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/7651 (which has **51 upvotes**)

Adds a gdscript utility function `enumerate`, similar to python (though here we return a dictionary since generators aren't in gdscript)

Builds on top of my other PR that adds `for key, value in dictionary` https://github.com/godotengine/godot/pull/121877 (credit for that one primarily goes to @rodrigodias4)

Copied from the docs I wrote:
Returns a dictionary with keys being indexes and values being what a normal for loop over the array would return. An optional parameter can be provided to start the keys at a different number, though the values will remain unchanged.
```gdscript
var my_array = [7, 4, 9]
for pos, value in enumerate(my_array):
	prints(pos, value)
# Result:
# 0 7
# 1 4
# 2 9

for pos, value in enumerate(my_array, 15):
	prints(pos, value)
# Result:
# 15 7
# 16 4
# 17 9
```

## Additional information

No AI was used for this PR

A lot of the code was copy paste for the packed types, so I wrote a macro. (First time I've made one in C++, if I did something wrong with the formatting, let me know).

Using enumerate to return a dictionary is slower/ uses more memory since the array contents is copied, stats at bottom.
```gdscript
var big_array = []
# Called when the node enters the scene tree for the first time.
func _ready() -> void:
    await get_tree().create_timer(1).timeout
    for i in range(100_000):
        big_array.append(i)
    
    await get_tree().process_frame
    await get_tree().process_frame
    await get_tree().process_frame
    add_nums1()
    await get_tree().process_frame
    await get_tree().process_frame
    add_nums2()
    await get_tree().process_frame
    await get_tree().process_frame
    add_nums3()

func add_nums1():
    var total = 0
    for x in big_array:
        total += x

func add_nums2():
    var total = 0
    for i in range(len(big_array)):
        total += big_array[i]

func add_nums3():
    var total = 0
    for k, v in enumerate(big_array):
        total += v
 ```

Time for 100_000 elements:
add_nums1: 15.32 ms
add_nums2: 19.15 ms
add_nums3: 73.01 ms

Though for 100 elements the difference is negligible:
add_nums1: 0.05 ms
add_nums2: 0.04 ms
add_nums3: 0.08 ms

(This was a single trial for each size, so your mileage may vary. I can add more stats if desired.)