### PR TITLE
Fix exported Packed*Array default values in the inspector

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -5497,12 +5497,8 @@ Variant GDScriptAnalyzer::make_subscript_reduced_value(GDScriptParser::Subscript
 
 Variant GDScriptAnalyzer::make_call_reduced_value(GDScriptParser::CallNode *p_call, bool &r_is_reduced) {
 	if (p_call->get_callee_type() == GDScriptParser::Node::IDENTIFIER) {
-		Variant::Type type = Variant::NIL;
-		if (p_call->function_name == SNAME("Array")) {
-			type = Variant::ARRAY;
-		} else if (p_call->function_name == SNAME("Dictionary")) {
-			type = Variant::DICTIONARY;
-		} else {
+		const Variant::Type type = GDScriptParser::get_builtin_type(p_call->function_name);
+		if (type == Variant::VARIANT_MAX) {
 			return Variant();
 		}
 
@@ -5748,6 +5744,17 @@ Variant GDScriptAnalyzer::make_variable_default_value(GDScriptParser::VariableNo
 		Variant initializer_value = make_expression_reduced_value(p_variable->initializer, is_initializer_value_reduced);
 		if (is_initializer_value_reduced) {
 			result = initializer_value;
+
+			GDScriptParser::DataType datatype = p_variable->type_constraint;
+			if (datatype.is_hard_type() && datatype.kind == GDScriptParser::DataType::BUILTIN && datatype.builtin_type != Variant::OBJECT && datatype.builtin_type != result.get_type()) {
+				const Variant *argptr = &initializer_value;
+				Variant converted_value;
+				Callable::CallError ce;
+				Variant::construct(datatype.builtin_type, converted_value, &argptr, 1, ce);
+				if (!ce.error) {
+					result = converted_value;
+				}
+			}
 		}
 	} else {
 		GDScriptParser::DataType datatype = p_variable->type_constraint;


### PR DESCRIPTION
Exported `Packed*Array` properties showed the wrong default in the editor.
With a default like `["something"]`, adding an element gave `<null>`. With
`PackedStringArray(["something"])`, the property showed as nil on a new node
or after a reset.

The editor takes these defaults from the GDScript analyzer. Two things went
wrong there:

- An array literal reduces to an untyped `Array`, and nothing converted it to
  the declared packed type. The inspector edited an `Array`, so resizing it
  appended `null` instead of an empty string.
- `make_call_reduced_value()` only handled the `Array()` and `Dictionary()`
  constructors. Every other builtin constructor reduced to nothing, so the
  default value ended up nil.

`make_call_reduced_value()` now looks the type up with `get_builtin_type()`,
so it handles all builtin constructors. `make_variable_default_value()` now
converts the reduced initializer to the variable's declared builtin type, the
same way `const` declarations already do.