### PR TITLE
CI: Silence warning about Metal not being supported in macOS x86_64 builds

### DIFF
--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -81,7 +81,8 @@ jobs:
       - name: Compilation (x86_64)
         uses: ./.github/actions/godot-build
         with:
-          scons-flags: ${{ env.SCONS_FLAGS }} ${{ matrix.scons-flags }} arch=x86_64 vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }} accesskit=${{ steps.accesskit-sdk.outputs.ACCESSKIT_ENABLED }} angle=${{ steps.angle-sdk.outputs.ANGLE_ENABLED }}
+          # Silence warning about Metal not being supported in x86_64 builds using `metal=no`.
+          scons-flags: ${{ env.SCONS_FLAGS }} ${{ matrix.scons-flags }} arch=x86_64 vulkan=${{ steps.vulkan-sdk.outputs.VULKAN_ENABLED }} accesskit=${{ steps.accesskit-sdk.outputs.ACCESSKIT_ENABLED }} angle=${{ steps.angle-sdk.outputs.ANGLE_ENABLED }} metal=no
           platform: macos
           target: ${{ matrix.target }}
 


### PR DESCRIPTION
This silences one of the two warnings that are always printed on every build on CI, with the other warning being fixed by https://github.com/godotengine/godot/pull/121906.

## Preview

On *macOS / Template* job:

### `master`

<img width="1117" height="101" alt="Image" src="https://github.com/user-attachments/assets/55cad959-edb7-427d-bbf0-ccf6e295c4d7" />

### This PR

<img width="1133" height="101" alt="image" src="https://github.com/user-attachments/assets/e720e770-ace7-4540-979b-8a315eb9803a" />