### PR TITLE
CI: Install Perfetto for Android builds

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -67,6 +67,9 @@ jobs:
       - name: Download Swappy
         run: python ./misc/scripts/install_swappy_android.py
 
+      - name: Download Perfetto
+        run: python ./misc/scripts/install_perfetto.py
+
       - name: Compilation
         uses: ./.github/actions/godot-build
         with:


### PR DESCRIPTION
This has two effects:

- Prevent the warning about Perfetto not being installed on every build.
- Ensure the Perfetto install code gets tested on CI, as well as the relevant C++ codepaths.

Together with https://github.com/godotengine/godot/pull/121905, this silences all warnings that were printed on every build.

## Preview

On *Android / Editor* job:

### `master`

<img width="1133" height="117" alt="Image" src="https://github.com/user-attachments/assets/dde48053-9d14-4e15-b6a3-05a41f085943" />

### This PR

<img width="1133" height="63" alt="image" src="https://github.com/user-attachments/assets/abbb0fcb-c437-4e67-a321-ee15b935d6bc" />