### PR TITLE
Extend `AudioStreamEditor` editor plugin support

### DIFF
--- a/editor/audio/audio_stream_editor_plugin.cpp
+++ b/editor/audio/audio_stream_editor_plugin.cpp
@@ -35,9 +35,13 @@
 #include "editor/editor_string_names.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/resources/audio/audio_stream_randomizer.h"
 #include "scene/resources/audio/audio_stream_wav.h"
 #include "servers/rendering/rendering_server.h"
 
+#include "modules/interactive_music/audio_stream_playlist.h"
+#include "modules/interactive_music/audio_stream_synchronized.h"
+#include "modules/mp3/audio_stream_mp3.h"
 // AudioStreamEditor
 
 void AudioStreamEditor::_notification(int p_what) {
@@ -80,6 +84,9 @@ void AudioStreamEditor::_draw_preview() {
 	if (width <= 0) {
 		return; // No points to draw.
 	}
+	if (_stream_empty) {
+		return;
+	}
 
 	Rect2 rect = _preview->get_rect();
 
@@ -109,13 +116,6 @@ void AudioStreamEditor::_preview_changed(ObjectID p_which) {
 	if (stream.is_valid() && stream->get_instance_id() == p_which) {
 		_preview->queue_redraw();
 	}
-}
-
-void AudioStreamEditor::_stream_changed() {
-	if (!is_visible()) {
-		return;
-	}
-	queue_redraw();
 }
 
 void AudioStreamEditor::_play() {
@@ -155,6 +155,9 @@ void AudioStreamEditor::_draw_indicator() {
 	if (stream.is_null()) {
 		return;
 	}
+	if (_stream_empty) {
+		return;
+	}
 
 	Rect2 rect = _preview->get_rect();
 	float len = stream->get_length();
@@ -162,10 +165,7 @@ void AudioStreamEditor::_draw_indicator() {
 	const Color col = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
 	Ref<Texture2D> icon = get_editor_theme_icon(SNAME("TimelineIndicator"));
 	_indicator->draw_line(Point2(ofs_x, 0), Point2(ofs_x, rect.size.height), col, Math::round(2 * EDSCALE));
-	_indicator->draw_texture(
-			icon,
-			Point2(ofs_x - icon->get_width() * 0.5, 0),
-			col);
+	_indicator->draw_texture(icon, Point2(ofs_x - icon->get_width() * 0.5, 0), col);
 
 	_current_label->set_text(String::num(_current, 2).pad_decimals(2) + " /");
 }
@@ -207,12 +207,36 @@ void AudioStreamEditor::set_stream(const Ref<AudioStream> &p_stream) {
 	stream->connect_changed(callable_mp(this, &AudioStreamEditor::_stream_changed));
 
 	_player->set_stream(stream);
+
+	_stream_changed();
+}
+
+void AudioStreamEditor::_stream_changed() {
+	if (!is_visible()) {
+		return;
+	}
+
 	_current = 0;
+	_stream_empty = stream->get_length() <= 0;
 
-	String text = String::num(stream->get_length(), 2).pad_decimals(2) + "s";
-	_duration_label->set_text(text);
+	_play_button->set_disabled(_stream_empty);
+	_stop_button->set_disabled(_stream_empty);
 
-	queue_redraw();
+	if (_stream_empty) {
+		_duration_label->set_text(TTR("No Audio"));
+		if (_indicator->is_connected(SceneStringName(gui_input), callable_mp(this, &AudioStreamEditor::_on_input_indicator))) {
+			_indicator->disconnect(SceneStringName(gui_input), callable_mp(this, &AudioStreamEditor::_on_input_indicator));
+		}
+		_current_label->set_text("");
+	} else {
+		String text = String::num(stream->get_length(), 2).pad_decimals(2) + "s";
+		_duration_label->set_text(text);
+		if (!_indicator->is_connected(SceneStringName(gui_input), callable_mp(this, &AudioStreamEditor::_on_input_indicator))) {
+			_indicator->connect(SceneStringName(gui_input), callable_mp(this, &AudioStreamEditor::_on_input_indicator));
+		}
+	}
+	_preview->queue_redraw();
+	_indicator->queue_redraw();
 }
 
 AudioStreamEditor::AudioStreamEditor() {
@@ -234,7 +258,6 @@ AudioStreamEditor::AudioStreamEditor() {
 	_indicator = memnew(Control);
 	_indicator->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	_indicator->connect(SceneStringName(draw), callable_mp(this, &AudioStreamEditor::_draw_indicator));
-	_indicator->connect(SceneStringName(gui_input), callable_mp(this, &AudioStreamEditor::_on_input_indicator));
 	_preview->add_child(_indicator);
 
 	HBoxContainer *hbox = memnew(HBoxContainer);
@@ -269,7 +292,25 @@ AudioStreamEditor::AudioStreamEditor() {
 // EditorInspectorPluginAudioStream
 
 bool EditorInspectorPluginAudioStream::can_handle(Object *p_object) {
-	return Object::cast_to<AudioStreamWAV>(p_object) != nullptr;
+	if (Object::cast_to<AudioStreamWAV>(p_object)) {
+		return true;
+	}
+	if (Object::cast_to<AudioStreamMP3>(p_object)) {
+		return true;
+	}
+	if (Object::cast_to<AudioStreamSynchronized>(p_object)) {
+		return true;
+	}
+	if (Object::cast_to<AudioStreamPlaylist>(p_object)) {
+		return true;
+	}
+	if (Object::cast_to<AudioStreamRandomizer>(p_object)) {
+		return true;
+	}
+	if (p_object->is_class("AudioStreamOggVorbis")) {
+		return true;
+	}
+	return false;
 }
 
 void EditorInspectorPluginAudioStream::parse_begin(Object *p_object) {

--- a/editor/audio/audio_stream_editor_plugin.h
+++ b/editor/audio/audio_stream_editor_plugin.h
@@ -54,6 +54,7 @@ class AudioStreamEditor : public ColorRect {
 	float _current = 0;
 	bool _dragging = false;
 	bool _pausing = false;
+	bool _stream_empty = false;
 
 protected:
 	void _notification(int p_what);

--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -52,6 +52,14 @@ void AudioStreamInteractive::set_clip_count(int p_count) {
 	AudioServer::get_singleton()->lock();
 
 	if (p_count < clip_count) {
+		for (int i = p_count; i < clip_count; i++) {
+			clips[i].stream.unref();
+			clips[i].name = "";
+			clips[i].auto_advance = AUTO_ADVANCE_DISABLED;
+			clips[i].auto_advance_next_clip = 0;
+		}
+	}
+	if (p_count < clip_count) {
 		// Removing should stop players.
 		version++;
 	}

--- a/modules/interactive_music/audio_stream_playlist.cpp
+++ b/modules/interactive_music/audio_stream_playlist.cpp
@@ -31,6 +31,7 @@
 #include "audio_stream_playlist.h"
 
 #include "core/math/math_funcs.h"
+#include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "servers/audio/audio_server.h"
 
@@ -47,12 +48,30 @@ void AudioStreamPlaylist::set_list_stream(int p_stream_index, Ref<AudioStream> p
 	ERR_FAIL_COND(p_stream == this);
 	ERR_FAIL_INDEX(p_stream_index, MAX_STREAMS);
 
+	Ref<AudioStream> old_stream = audio_streams[p_stream_index];
+	if (old_stream.is_valid()) {
+		old_stream->disconnect_changed(callable_mp((Resource *)this, &Resource::emit_changed));
+	}
+	if (p_stream.is_valid()) {
+		p_stream->connect_changed(callable_mp((Resource *)this, &Resource::emit_changed));
+	}
+
 	AudioServer::get_singleton()->lock();
 	audio_streams[p_stream_index] = p_stream;
 	for (AudioStreamPlaybackPlaylist *E : playbacks) {
 		E->_update_playback_instances();
 	}
 	AudioServer::get_singleton()->unlock();
+
+	if (!pending_emit_changed) {
+		pending_emit_changed = true;
+		callable_mp(this, &AudioStreamPlaylist::emit_pending_changed).call_deferred();
+	}
+}
+
+void AudioStreamPlaylist::emit_pending_changed() {
+	pending_emit_changed = false;
+	emit_changed();
 }
 
 Ref<AudioStream> AudioStreamPlaylist::get_list_stream(int p_stream_index) const {
@@ -92,9 +111,18 @@ double AudioStreamPlaylist::get_length() const {
 void AudioStreamPlaylist::set_stream_count(int p_count) {
 	ERR_FAIL_COND(p_count < 0 || p_count > MAX_STREAMS);
 	AudioServer::get_singleton()->lock();
+	if (p_count < stream_count) {
+		for (int i = p_count; i < stream_count; i++) {
+			audio_streams[i].unref();
+		}
+	}
 	stream_count = p_count;
 	AudioServer::get_singleton()->unlock();
 	notify_property_list_changed();
+	if (!pending_emit_changed) {
+		pending_emit_changed = true;
+		callable_mp(this, &AudioStreamPlaylist::emit_pending_changed).call_deferred();
+	}
 }
 
 int AudioStreamPlaylist::get_stream_count() const {

--- a/modules/interactive_music/audio_stream_playlist.h
+++ b/modules/interactive_music/audio_stream_playlist.h
@@ -53,6 +53,9 @@ private:
 	Ref<AudioStream> audio_streams[MAX_STREAMS];
 	HashSet<AudioStreamPlaybackPlaylist *> playbacks;
 
+	bool pending_emit_changed = false;
+	void emit_pending_changed();
+
 public:
 	virtual double get_bpm() const override;
 	void set_stream_count(int p_count);

--- a/modules/interactive_music/audio_stream_synchronized.cpp
+++ b/modules/interactive_music/audio_stream_synchronized.cpp
@@ -31,6 +31,7 @@
 #include "audio_stream_synchronized.h"
 
 #include "core/math/math_funcs.h"
+#include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "servers/audio/audio_server.h"
 
@@ -50,12 +51,30 @@ void AudioStreamSynchronized::set_sync_stream(int p_stream_index, Ref<AudioStrea
 	ERR_FAIL_COND(p_stream == this);
 	ERR_FAIL_INDEX(p_stream_index, MAX_STREAMS);
 
+	Ref<AudioStream> old_stream = audio_streams[p_stream_index];
+	if (old_stream.is_valid()) {
+		old_stream->disconnect_changed(callable_mp((Resource *)this, &Resource::emit_changed));
+	}
+	if (p_stream.is_valid()) {
+		p_stream->connect_changed(callable_mp((Resource *)this, &Resource::emit_changed));
+	}
+
 	AudioServer::get_singleton()->lock();
 	audio_streams[p_stream_index] = p_stream;
 	for (AudioStreamPlaybackSynchronized *E : playbacks) {
 		E->_update_playback_instances();
 	}
 	AudioServer::get_singleton()->unlock();
+
+	if (!pending_emit_changed) {
+		pending_emit_changed = true;
+		callable_mp(this, &AudioStreamSynchronized::emit_pending_changed).call_deferred();
+	}
+}
+
+void AudioStreamSynchronized::emit_pending_changed() {
+	pending_emit_changed = false;
+	emit_changed();
 }
 
 Ref<AudioStream> AudioStreamSynchronized::get_sync_stream(int p_stream_index) const {
@@ -132,9 +151,19 @@ double AudioStreamSynchronized::get_length() const {
 void AudioStreamSynchronized::set_stream_count(int p_count) {
 	ERR_FAIL_COND(p_count < 0 || p_count > MAX_STREAMS);
 	AudioServer::get_singleton()->lock();
+	if (p_count < stream_count) {
+		for (int i = p_count; i < stream_count; i++) {
+			audio_streams[i].unref();
+			audio_stream_volume_db[i] = 0.0f;
+		}
+	}
 	stream_count = p_count;
 	AudioServer::get_singleton()->unlock();
 	notify_property_list_changed();
+	if (!pending_emit_changed) {
+		pending_emit_changed = true;
+		callable_mp(this, &AudioStreamSynchronized::emit_pending_changed).call_deferred();
+	}
 }
 
 int AudioStreamSynchronized::get_stream_count() const {

--- a/modules/interactive_music/audio_stream_synchronized.h
+++ b/modules/interactive_music/audio_stream_synchronized.h
@@ -50,6 +50,9 @@ private:
 	float audio_stream_volume_db[MAX_STREAMS] = {};
 	HashSet<AudioStreamPlaybackSynchronized *> playbacks;
 
+	bool pending_emit_changed = false;
+	void emit_pending_changed();
+
 public:
 	virtual double get_bpm() const override;
 	virtual int get_beat_count() const override;

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -512,7 +512,9 @@ double AudioStreamOggVorbis::get_loop_offset() const {
 }
 
 double AudioStreamOggVorbis::get_length() const {
-	ERR_FAIL_COND_V(packet_sequence.is_null(), 0);
+	if (packet_sequence.is_null()) {
+		return 0;
+	}
 	return packet_sequence->get_length();
 }
 

--- a/scene/resources/audio/audio_stream_randomizer.cpp
+++ b/scene/resources/audio/audio_stream_randomizer.cpp
@@ -30,6 +30,7 @@
 
 #include "audio_stream_randomizer.h"
 
+#include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 
 void AudioStreamRandomizer::add_stream(int p_index, Ref<AudioStream> p_stream, float p_weight) {
@@ -69,8 +70,26 @@ void AudioStreamRandomizer::remove_stream(int p_index) {
 
 void AudioStreamRandomizer::set_stream(int p_index, Ref<AudioStream> p_stream) {
 	ERR_FAIL_INDEX(p_index, audio_stream_pool.size());
+
+	Ref<AudioStream> old_stream = audio_stream_pool[p_index].stream;
+	if (old_stream.is_valid()) {
+		old_stream->disconnect_changed(callable_mp((Resource *)this, &Resource::emit_changed));
+	}
+	if (p_stream.is_valid()) {
+		p_stream->connect_changed(callable_mp((Resource *)this, &Resource::emit_changed));
+	}
+
 	audio_stream_pool.write[p_index].stream = p_stream;
-	emit_signal(CoreStringName(changed));
+
+	if (!pending_emit_changed) {
+		pending_emit_changed = true;
+		callable_mp(this, &AudioStreamRandomizer::emit_pending_changed).call_deferred();
+	}
+}
+
+void AudioStreamRandomizer::emit_pending_changed() {
+	pending_emit_changed = false;
+	emit_changed();
 }
 
 Ref<AudioStream> AudioStreamRandomizer::get_stream(int p_index) const {

--- a/scene/resources/audio/audio_stream_randomizer.h
+++ b/scene/resources/audio/audio_stream_randomizer.h
@@ -68,6 +68,9 @@ private:
 	Ref<AudioStream> last_playback = nullptr;
 	PlaybackMode playback_mode = PLAYBACK_RANDOM_NO_REPEATS;
 
+	bool pending_emit_changed = false;
+	void emit_pending_changed();
+
 protected:
 	static void _bind_methods();
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

As mentioned in several issues, proposals, and related pull requests, the built-in audio editor plugin `EditorInspectorPluginAudioStream` currently only supports `AudioStreamWAV` and does not provide preview support for other audio stream types such as `AudioStreamMP3`, `AudioStreamPlaylist`...

---

## Solution
This PR adds preview support for additional audio stream types, including `AudioStreamMP3`, `AudioStreamOggVorbis`, `AudioStreamSynchronized`, `AudioStreamRandomizer`, and `AudioStreamPlaylist`.

Some changes were required to support more complex stream types, for example `AudioStreamSynchronized` can contain other `AudioStreamSynchronized` instances recursively, so a notification system was added to propagate changes to the editor plugin whenever audio streams are added or removed internally.

---

## Demonstration

[The video showing the feature](https://github.com/user-attachments/assets/173e6af7-f0b8-4904-b822-f71c1a7fc446)

---

## Related discussion

### Godot Proposals
* https://github.com/godotengine/godot-proposals/issues/14661
* https://github.com/godotengine/godot-proposals/issues/14348
* https://github.com/godotengine/godot-proposals/issues/14356
* https://github.com/godotengine/godot-proposals/issues/14296

### Pull Request
* https://github.com/godotengine/godot/pull/116623
* https://github.com/godotengine/godot/pull/117394
* https://github.com/godotengine/godot/pull/121882

