### PR TITLE
Fix `SignalsDock` tree not updating

### DIFF
--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -1470,6 +1470,12 @@ void ConnectionsDock::_close() {
 	hide();
 }
 
+void ConnectionsDock::_changed_callback() {
+	if (selected_object != nullptr) {
+		update_tree();
+	}
+}
+
 void ConnectionsDock::_connect_pressed() {
 	TreeItem *item = tree->get_selected();
 	if (!item) {
@@ -1527,8 +1533,16 @@ void ConnectionsDock::set_object(Object *p_object) {
 		select_an_object->hide();
 		holder->show();
 	}
+	if (selected_object != nullptr && likely(Variant(selected_object).get_validated_object())) {
+		selected_object->disconnect(CoreStringName(property_list_changed), callable_mp(this, &ConnectionsDock::_changed_callback));
+	}
+
 	selected_object = p_object;
 	is_editing_resource = (Object::cast_to<Resource>(selected_object) != nullptr);
+
+	if (selected_object != nullptr) {
+		selected_object->connect(CoreStringName(property_list_changed), callable_mp(this, &ConnectionsDock::_changed_callback));
+	}
 	update_tree();
 }
 

--- a/editor/scene/connections_dialog.h
+++ b/editor/scene/connections_dialog.h
@@ -274,6 +274,8 @@ class ConnectionsDock : public VBoxContainer {
 	void _tree_gui_input(const Ref<InputEvent> &p_event);
 	void _close();
 
+	void _changed_callback();
+
 protected:
 	void _connect_pressed();
 	void _notification(int p_what);

--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -49,7 +49,7 @@ void ScriptEditorBase::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("name_changed"));
 
 	// First use in TextEditorBase.
-	ADD_SIGNAL(MethodInfo("edited_script_changed"));
+	ADD_SIGNAL(MethodInfo("_validation_updated"));
 	ADD_SIGNAL(MethodInfo("search_in_files_requested", PropertyInfo(Variant::STRING, "text")));
 	ClassDB::bind_method(D_METHOD("add_syntax_highlighter", "highlighter"), &ScriptEditorBase::add_syntax_highlighter);
 	ClassDB::bind_method(D_METHOD("get_base_editor"), &ScriptEditorBase::get_base_editor);
@@ -66,6 +66,7 @@ void ScriptEditorBase::_bind_methods() {
 #ifndef DISABLE_DEPRECATED
 	ADD_SIGNAL(MethodInfo("request_save_history"));
 	ADD_SIGNAL(MethodInfo("request_save_previous_state", PropertyInfo(Variant::DICTIONARY, "state")));
+	ADD_SIGNAL(MethodInfo("edited_script_changed"));
 #endif
 }
 
@@ -563,7 +564,7 @@ void TextEditorBase::_load_theme_settings() {
 }
 
 void TextEditorBase::_validate_script() {
-	emit_signal(SNAME("edited_script_changed"));
+	emit_signal(SNAME("_validation_updated"));
 }
 
 void TextEditorBase::_saved_update() {

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -49,7 +49,6 @@
 #include "editor/doc/editor_help_search.h"
 #include "editor/docks/filesystem_dock.h"
 #include "editor/docks/inspector_dock.h"
-#include "editor/docks/signals_dock.h"
 #include "editor/editor_interface.h"
 #include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
@@ -2449,9 +2448,7 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 	seb->edited_file_data.last_modified_time = FileAccess::get_modified_time(p_resource->get_path());
 
 	seb->connect("name_changed", callable_mp(this, &ScriptEditor::_update_filenames));
-	if (this == script_editor) {
-		seb->connect("edited_script_changed", callable_mp(this, &ScriptEditor::_script_changed));
-	}
+	seb->connect("_validation_updated", callable_mp(this, &ScriptEditor::_validation_updated));
 
 	if (TextEditorBase *teb = Object::cast_to<TextEditorBase>(seb)) {
 		// Syntax highlighting.
@@ -3890,9 +3887,7 @@ void ScriptEditor::register_create_script_editor_function(CreateScriptEditorFunc
 	script_editor_funcs[script_editor_func_count++] = p_func;
 }
 
-void ScriptEditor::_script_changed() {
-	SignalsDock::get_singleton()->update_lists();
-
+void ScriptEditor::_validation_updated() {
 	document_list->update_list();
 
 	document_outline->update_outline();

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -424,7 +424,7 @@ class ScriptEditor : public PanelContainer {
 	void _update_history_pos(int p_new_pos);
 	void _update_modified_scripts_for_external_editor(Ref<Script> p_for_script = Ref<Script>());
 
-	void _script_changed();
+	void _validation_updated();
 	int file_dialog_option;
 	void _file_dialog_action(const String &p_file);
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Fixes a regression from https://github.com/godotengine/godot/pull/116490
Shader editor document list error icon was not being updated immediately on validation, I forgot to remove the if statement so the signal connects for shaders too.
<img width="202" height="25" alt="image" src="https://github.com/user-attachments/assets/22e035a9-7eb0-43b1-bef2-b03e0dfe3881" />

Also updated the signal and function name.

- Fixes https://github.com/godotengine/godot/issues/37783

The SignalsDock tree was updating when any script validation updated, not just the one in cares about.
It was not updating when script attached/detached.
It was not updating when external editor changed the signals.
(These weren't part of the regression, I just happened to fix them when trying to find a better place for the Signals update from ScriptEditor).

## Additional information

Copied the signal connection logic from EditorInspector, not sure if this needs the `get_validated_object`, but I figured its safer to have it.

There is still one use of `SignalsDock::update_lists()` in C# code so I didn't remove it. Not sure if it is still needed or not since IDK why it was updating for the inspector too.