### PR TITLE
Android: Resume render thread on activity resume

### DIFF
--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotGLRenderView.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotGLRenderView.java
@@ -123,6 +123,7 @@ class GodotGLRenderView extends GLSurfaceView implements GodotRenderView {
 			godotRenderer.onActivityResumed();
 			GodotLib.focusin();
 		});
+		resumeGLThread();
 	}
 
 	@Override

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotVulkanRenderView.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotVulkanRenderView.java
@@ -113,6 +113,7 @@ class GodotVulkanRenderView extends VkSurfaceView implements GodotRenderView {
 			mRenderer.onVkResume();
 			GodotLib.focusin();
 		});
+		resumeRenderThread();
 	}
 
 	@Override


### PR DESCRIPTION
Fixes a regression in the Android Editor where closing the game window left the editor's render thread paused. This occurred because `onActivityPaused` was invoked when the game window was opened, causing the renderer to pause.