### PR TITLE
Tree: Fix CELL_MODE_RANGE auto-tooltip showing all comma-separated options

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2236,28 +2236,12 @@ void Tree::update_item_cell(TreeItem *p_item, int p_col) const {
 
 	p_item->cells.write[p_col].text_buf->clear();
 	if (p_item->cells[p_col].mode == TreeItem::CELL_MODE_RANGE) {
+		if (!p_item->cells[p_col].text.is_empty() && !p_item->cells[p_col].editable) {
+			return;
+		}
+		valtext = _get_range_cell_text(p_item->cells[p_col]);
 		if (!p_item->cells[p_col].text.is_empty()) {
-			if (!p_item->cells[p_col].editable) {
-				return;
-			}
-
-			int option = (int)p_item->cells[p_col].val;
-
-			valtext = p_item->atr(p_col, ETR("(Other)"));
-			Vector<String> strings = p_item->cells[p_col].text.split(",");
-			for (int j = 0; j < strings.size(); j++) {
-				int value = j;
-				if (!strings[j].get_slicec(':', 1).is_empty()) {
-					value = strings[j].get_slicec(':', 1).to_int();
-				}
-				if (option == value) {
-					valtext = p_item->atr(p_col, strings[j].get_slicec(':', 0));
-					break;
-				}
-			}
-
-		} else {
-			valtext = String::num(p_item->cells[p_col].val, Math::range_step_decimals(p_item->cells[p_col].step));
+			valtext = p_item->atr(p_col, valtext);
 		}
 	} else {
 		// Don't auto translate if it's in string mode and editable, as the text can be changed to anything by the user.
@@ -3642,6 +3626,28 @@ void Tree::_update_value_editor(const TreeItem::Cell &p_cell) {
 	value_editor->set_value(p_cell.val);
 	value_editor->set_exp_ratio(p_cell.expr);
 	updating_value_editor = false;
+}
+
+String Tree::_get_range_cell_text(const TreeItem::Cell &p_cell) const {
+	if (p_cell.text.is_empty()) {
+		return String::num(p_cell.val, Math::range_step_decimals(p_cell.step));
+	}
+
+	int option = (int)p_cell.val;
+	String valtext = ETR("(Other)");
+	Vector<String> strings = p_cell.text.split(",");
+
+	for (int j = 0; j < strings.size(); j++) {
+		int value = j;
+		if (!strings[j].get_slicec(':', 1).is_empty()) {
+			value = strings[j].get_slicec(':', 1).to_int();
+		}
+		if (option == value) {
+			valtext = strings[j].get_slicec(':', 0);
+			break;
+		}
+	}
+	return valtext;
 }
 
 void Tree::popup_select(int p_option) {
@@ -7277,6 +7283,9 @@ String Tree::get_tooltip(const Point2 &p_pos) const {
 	if (it) {
 		const String item_tooltip = it->get_tooltip_text(col);
 		if (enable_auto_tooltip && item_tooltip.is_empty()) {
+			if (it->cells[col].mode == TreeItem::CELL_MODE_RANGE) {
+				return _get_range_cell_text(it->cells[col]);
+			}
 			return it->get_text(col);
 		}
 		return item_tooltip;

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -610,6 +610,7 @@ private:
 	void value_editor_changed(double p_value);
 	void _update_popup_menu(const TreeItem::Cell &p_cell);
 	void _update_value_editor(const TreeItem::Cell &p_cell);
+	String _get_range_cell_text(const TreeItem::Cell &p_cell) const;
 
 	void popup_select(int p_option);
 


### PR DESCRIPTION
Refactor range cell text resolution into a `_get_range_cell_text` helper method. Use this helper in `get_tooltip` to display only the selected option label, and update `update_item_cell` to eliminate duplicated logic.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #121888

`Tree` cells in `CELL_MODE_RANGE` store their options as a comma-separated string in the `text` field (e.g., `"Has,Many,Options"`). When auto-tooltip is enabled and no explicit tooltip is set, the tooltip fallback previously returned `it->get_text(col)`. This resulted in the tooltip displaying the full raw comma-separated string containing all options, rather than only the active selection.

## Additional information

This PR introduces a private `_get_range_cell_text()` helper method on `Tree` that resolves the individual selected option label from a range cell's text.

Key changes:
- Extracted the range text resolution logic directly from `update_item_cell()` into `_get_range_cell_text()`, consolidating the string parsing into a single reusable helper.
- Updated the tooltip fallback in `get_tooltip()` to use this helper for `CELL_MODE_RANGE` cells, so tooltips display only the selected option's label (or `"(Other)"` / numeric fallbacks) instead of the full comma-separated string.

### AI Disclosure

AI was used to assist in locating relevant methods during codebase exploration, to review the code changes against the rest of the codebase, and to format this PR description. All code changes were manually reviewed, compiled, and verified locally.

### Visual Comparison

| Before | After |
| :---: | :---: |
| ![Before](https://github.com/user-attachments/assets/15c0eef1-df7d-42d0-8f77-66dbb30335e0) | ![After](https://github.com/user-attachments/assets/d66dcbeb-e37f-4877-abeb-3843eecbc20c) |