### PR TITLE
Add theme items to define scroll margins in `ScrollContainer`

### DIFF
--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -146,6 +146,18 @@
 		<theme_item name="scrollbar_h_separation" data_type="constant" type="int" default="0">
 			The space between the ScrollContainer's vertical scroll bar and its content, in pixels. No space will be added when the content's minimum size is larger than the ScrollContainer's size.
 		</theme_item>
+		<theme_item name="scrollbar_margin_bottom" data_type="constant" type="int" default="-1">
+			The bottom margin of the horizontal scrollbar. When negative, uses [theme_item panel]'s bottom margin.
+		</theme_item>
+		<theme_item name="scrollbar_margin_left" data_type="constant" type="int" default="-1">
+			The left margin of the horizontal scrollbar. When negative, uses [theme_item panel]'s left margin.
+		</theme_item>
+		<theme_item name="scrollbar_margin_right" data_type="constant" type="int" default="-1">
+			The right margin of the horizontal scrollbar. When negative, uses [theme_item panel]'s right margin.
+		</theme_item>
+		<theme_item name="scrollbar_margin_top" data_type="constant" type="int" default="-1">
+			The top margin of the horizontal scrollbar. When negative, uses [theme_item panel]'s top margin.
+		</theme_item>
 		<theme_item name="scrollbar_v_separation" data_type="constant" type="int" default="0">
 			The space between the ScrollContainer's horizontal scroll bar and its content, in pixels. No space will be added when the content's minimum size is larger than the ScrollContainer's size.
 		</theme_item>

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1682,6 +1682,11 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_stylebox(SceneStringName(panel), "ScrollContainer", p_config.base_empty_style);
 		p_theme->set_stylebox("focus", "ScrollContainer", p_config.focus_style);
 
+		p_theme->set_constant("scrollbar_margin_left", "ScrollContainer", 0);
+		p_theme->set_constant("scrollbar_margin_top", "ScrollContainer", 0);
+		p_theme->set_constant("scrollbar_margin_right", "ScrollContainer", 0);
+		p_theme->set_constant("scrollbar_margin_bottom", "ScrollContainer", 0);
+
 		// Scroll hints.
 		p_theme->set_color("scroll_hint_vertical_color", "ScrollContainer", Color(0, 0, 0, p_config.dark_theme ? 1.0 : 0.5));
 		p_theme->set_color("scroll_hint_horizontal_color", "ScrollContainer", Color(0, 0, 0, p_config.dark_theme ? 1.0 : 0.5));

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -344,18 +344,32 @@ void ScrollContainer::_update_scrollbar_position() {
 	Size2 hmin = h_scroll->is_visible() ? h_scroll->get_bound_minimum_size() : Size2();
 	Size2 vmin = v_scroll->is_visible() ? v_scroll->get_bound_minimum_size() : Size2();
 
-	int lmar = is_layout_rtl() ? margins.size.x : margins.position.x;
-	int rmar = is_layout_rtl() ? margins.position.x : margins.size.x;
+	int left_margin = 0;
+	if (theme_cache.scrollbar_margin_left < 0) {
+		left_margin = is_layout_rtl() ? margins.size.x : margins.position.x;
+	} else {
+		left_margin = theme_cache.scrollbar_margin_left;
+	}
 
-	h_scroll->set_anchor_and_offset(SIDE_LEFT, ANCHOR_BEGIN, lmar);
-	h_scroll->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, -rmar - vmin.width);
-	h_scroll->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -hmin.height - margins.size.y);
-	h_scroll->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -margins.size.y);
+	int right_margin = 0;
+	if (theme_cache.scrollbar_margin_right < 0) {
+		right_margin = is_layout_rtl() ? margins.position.x : margins.size.x;
+	} else {
+		right_margin = theme_cache.scrollbar_margin_right;
+	}
 
-	v_scroll->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -vmin.width - rmar);
-	v_scroll->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, -rmar);
-	v_scroll->set_anchor_and_offset(SIDE_TOP, ANCHOR_BEGIN, margins.position.y);
-	v_scroll->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -hmin.height - margins.size.y);
+	int top_margin = theme_cache.scrollbar_margin_top < 0 ? margins.position.y : theme_cache.scrollbar_margin_top;
+	int bottom_margin = theme_cache.scrollbar_margin_bottom < 0 ? theme_cache.panel_style->get_margin(SIDE_BOTTOM) : theme_cache.scrollbar_margin_bottom;
+
+	h_scroll->set_anchor_and_offset(SIDE_LEFT, ANCHOR_BEGIN, left_margin);
+	h_scroll->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, -right_margin - vmin.width);
+	h_scroll->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -hmin.height - bottom_margin);
+	h_scroll->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -bottom_margin);
+
+	v_scroll->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -vmin.width - right_margin);
+	v_scroll->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, -right_margin);
+	v_scroll->set_anchor_and_offset(SIDE_TOP, ANCHOR_BEGIN, top_margin);
+	v_scroll->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -hmin.height - bottom_margin);
 
 	_updating_scrollbars = false;
 }
@@ -474,17 +488,29 @@ void ScrollContainer::_reposition_children() {
 	size -= margins.position + margins.size;
 	Point2 ofs = margins.position;
 
-	bool rtl = is_layout_rtl();
-	bool reserve_vscroll = _is_v_scroll_visible() || vertical_scroll_mode == SCROLL_MODE_RESERVE;
-
 	if (_is_h_scroll_visible() || horizontal_scroll_mode == SCROLL_MODE_RESERVE) {
-		size.y -= h_scroll->get_minimum_size().y + theme_cache.scrollbar_v_separation;
+		int height = h_scroll->get_minimum_size().y + theme_cache.scrollbar_v_separation;
+		if (theme_cache.scrollbar_margin_bottom >= 0) {
+			int scroll_margin = theme_cache.scrollbar_margin_bottom + height;
+			if (scroll_margin > margins.size.height) {
+				height = scroll_margin - margins.size.height;
+			}
+		}
+
+		size.height -= height;
 	}
 
-	if (reserve_vscroll) {
-		int width = v_scroll->get_minimum_size().x + theme_cache.scrollbar_h_separation;
-		size.x -= width;
-		if (rtl) {
+	if (_is_v_scroll_visible() || vertical_scroll_mode == SCROLL_MODE_RESERVE) {
+		int width = v_scroll->get_minimum_size().width + theme_cache.scrollbar_h_separation;
+		if (theme_cache.scrollbar_margin_right >= 0) {
+			int scroll_margin = theme_cache.scrollbar_margin_right + width;
+			if (scroll_margin > margins.size.width) {
+				width = scroll_margin - margins.size.width;
+			}
+		}
+
+		size.width -= width;
+		if (is_layout_rtl()) {
 			ofs.x += width;
 		}
 	}
@@ -1024,6 +1050,10 @@ void ScrollContainer::_bind_methods() {
 	BIND_ENUM_CONSTANT(SCROLL_HINT_MODE_TOP_AND_LEFT);
 	BIND_ENUM_CONSTANT(SCROLL_HINT_MODE_BOTTOM_AND_RIGHT);
 
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ScrollContainer, scrollbar_margin_left);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ScrollContainer, scrollbar_margin_top);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ScrollContainer, scrollbar_margin_right);
+	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ScrollContainer, scrollbar_margin_bottom);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ScrollContainer, scrollbar_h_separation);
 	BIND_THEME_ITEM(Theme::DATA_TYPE_CONSTANT, ScrollContainer, scrollbar_v_separation);
 

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -105,6 +105,10 @@ private:
 		Color scroll_hint_vertical_color;
 		Color scroll_hint_horizontal_color;
 
+		int scrollbar_margin_left = -1;
+		int scrollbar_margin_top = -1;
+		int scrollbar_margin_right = -1;
+		int scrollbar_margin_bottom = -1;
 		int scrollbar_h_separation = 0;
 		int scrollbar_v_separation = 0;
 	} theme_cache;

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -668,6 +668,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_icon("scroll_hint_horizontal", "ScrollContainer", icons["scroll_hint_horizontal"]);
 	theme->set_color("scroll_hint_vertical_color", "ScrollContainer", Color(0, 0, 0));
 	theme->set_color("scroll_hint_horizontal_color", "ScrollContainer", Color(0, 0, 0));
+	theme->set_constant("scrollbar_margin_left", "ScrollContainer", -1);
+	theme->set_constant("scrollbar_margin_top", "ScrollContainer", -1);
+	theme->set_constant("scrollbar_margin_right", "ScrollContainer", -1);
+	theme->set_constant("scrollbar_margin_bottom", "ScrollContainer", -1);
 
 	// Virtual Joystick
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

This is #121480 but for `ScrollContainer`, it adds theme item constants to offset the scrollbars. Just like the PR for `ItemList`, it allows those scrolls to better align with the rest of the ones in the editor.