### PR TITLE
Don't defer `child_entered_tree` in `ScriptEditor`

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -2191,10 +2191,6 @@ void ScriptEditor::_connect_to_scene() {
 }
 
 void ScriptEditor::_connect_to_scene_recursive(Node *p_current, Node *p_base) {
-	if (p_current != p_base && p_current->get_owner() != p_base) {
-		return;
-	}
-
 	_queue_update_list();
 	const Callable update_callable = callable_mp(this, &ScriptEditor::_queue_update_list);
 	if (p_current->is_connected(CoreStringName(script_changed), update_callable)) {
@@ -2202,7 +2198,7 @@ void ScriptEditor::_connect_to_scene_recursive(Node *p_current, Node *p_base) {
 	}
 	p_current->connect(CoreStringName(script_changed), update_callable);
 	p_current->connect(SceneStringName(tree_exited), update_callable);
-	p_current->connect(SNAME("child_entered_tree"), callable_mp(this, &ScriptEditor::_connect_to_scene_recursive).bind(p_base), CONNECT_DEFERRED);
+	p_current->connect(SNAME("child_entered_tree"), callable_mp(this, &ScriptEditor::_connect_to_scene_recursive).bind(p_base));
 
 	for (Node *child : p_current->iterate_children()) {
 		_connect_to_scene_recursive(child, p_base);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes https://github.com/godotengine/godot/issues/123436

- Hopefully fixes https://github.com/godotengine/godot/issues/121681

Haven't been able to reproduce it.

- Should also fix the crash in https://github.com/godotengine/godot/pull/121401

## Additional information

It seems happening was the `child_entered_tree` argument was deleted and then unusable by the time the deferred call happened.

It was deferred in the first place because `get_owner` isn't set yet. It's fine to remove this check. This means editable children are connected to the signal, but it doesn't change behavior because `_find_scripts` is where it actually checks for the script and it still has the check.

