### PR TITLE
Fix regressions to the Android editor introduced by #121670

### DIFF
--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotGLRenderView.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotGLRenderView.java
@@ -108,7 +108,6 @@ class GodotGLRenderView extends GLSurfaceView implements GodotRenderView {
 			// Pause the renderer
 			godotRenderer.onActivityPaused();
 		});
-		pauseGLThread();
 	}
 
 	@Override

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotVulkanRenderView.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotVulkanRenderView.java
@@ -93,7 +93,6 @@ class GodotVulkanRenderView extends VkSurfaceView implements GodotRenderView {
 			// Pause the renderer
 			mRenderer.onVkPause();
 		});
-		pauseRenderThread();
 	}
 
 	@Override

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/vulkan/VkRenderer.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/vulkan/VkRenderer.kt
@@ -57,6 +57,22 @@ internal class VkRenderer {
 
 	private val pluginRegistry: GodotPluginRegistry = GodotPluginRegistry.getPluginRegistry()
 
+	internal var initialized = false
+		private set
+	private var rendererResumed = false
+
+	internal fun initialize(): Boolean {
+		if (!initialized) {
+			// Check the app is resumed to initialize the renderer.
+			if (rendererResumed) {
+				Log.v(TAG, "Initializing renderer...")
+				initialized = true
+			}
+		}
+
+		return initialized
+	}
+
 	/**
 	 * Called when the surface is created and signals the beginning of rendering.
 	 */
@@ -94,6 +110,7 @@ internal class VkRenderer {
 	 */
 	fun onVkResume() {
 		Log.v(TAG, "Renderer resumed")
+		rendererResumed = true
 		GodotLib.onRendererResumed()
 	}
 
@@ -102,6 +119,7 @@ internal class VkRenderer {
 	 */
 	fun onVkPause() {
 		Log.v(TAG, "Renderer paused")
+		rendererResumed = false
 		GodotLib.onRendererPaused()
 	}
 

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/vulkan/VkThread.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/vulkan/VkThread.kt
@@ -59,8 +59,6 @@ internal class VkThread(private val vkSurfaceView: VkSurfaceView, private val vk
 
 	private var shouldExit = false
 	private var exited = false
-	private var rendererInitialized = false
-	private var rendererResumed = false
 	private var resumed = false
 	private var surfaceChanged = false
 	private var hasSurface = false
@@ -202,7 +200,7 @@ internal class VkThread(private val vkSurfaceView: VkSurfaceView, private val vk
 							return
 						}
 
-						// Check for events and execute them outside of the loop if found to avoid
+						// Check for events and execute them outside the loop if found to avoid
 						// blocking the thread lifecycle by holding onto the lock.
 						if (eventQueue.isNotEmpty()) {
 							event = eventQueue.removeAt(0)
@@ -210,28 +208,21 @@ internal class VkThread(private val vkSurfaceView: VkSurfaceView, private val vk
 						}
 
 						if (readyToDraw) {
-							if (!rendererResumed) {
-								rendererResumed = true
-								vkRenderer.onVkResume()
-
-								if (!rendererInitialized) {
-									rendererInitialized = true
+							if (!vkRenderer.initialized) {
+								if (vkRenderer.initialize()) {
 									vkRenderer.onVkSurfaceCreated(vkSurfaceView.holder.surface)
 								}
 							}
 
-							if (surfaceChanged) {
-								vkRenderer.onVkSurfaceChanged(vkSurfaceView.holder.surface, width, height)
-								surfaceChanged = false
-							}
+							if (vkRenderer.initialized) {
+								if (surfaceChanged) {
+									vkRenderer.onVkSurfaceChanged(vkSurfaceView.holder.surface, width, height)
+									surfaceChanged = false
+								}
 
-							// Break out of the loop so drawing can occur without holding onto the lock.
-							break
-						} else if (rendererResumed) {
-							// If we aren't ready to draw but are resumed, that means we either lost a surface
-							// or the app was paused.
-							rendererResumed = false
-							vkRenderer.onVkPause()
+								// Break out of the loop so drawing can occur without holding onto the lock.
+								break
+							}
 						}
 						// We only reach this state if we are not ready to draw and have no queued events, so
 						// we wait.


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

This reverts the core fix added in https://github.com/godotengine/godot/pull/121670 and provides another approach for resolving the same issue. 

The root cause of the issue was that we were attempting to initialize the `DisplayServer` when the screen was off and the surface was being destroyed. 
To prevent this, the new approach ensures that the app is resumed before we attempt to initialize. Post initialization, we are free to continue rendering as usual.

- Closes # https://github.com/godotengine/godot/issues/89069

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
