### PR TITLE
Change all `TileSet` and `TileSet.TileShape` references in tests to `Mesh` and `Mesh.ArrayType` to prevent module dependency

### DIFF
--- a/modules/gdscript/tests/scripts/analyzer/errors/enum_declaration_and_usage.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/enum_declaration_and_usage.gd
@@ -12,16 +12,16 @@ func test():
 
 	print(Side.NOT_EXIST) # Global.
 	print(Vector3.Axis.NOT_EXIST) # Built-in.
-	print(TileSet.TileShape.NOT_EXIST) # Native.
+	print(Mesh.ArrayType.NOT_EXIST) # Native.
 	print(CustomEnum.NOT_EXIST) # Custom.
 
 	print(Side.size()) # Global.
 	print(Vector3.Axis.size()) # Built-in.
-	print(TileSet.TileShape.size()) # Native.
+	print(Mesh.ArrayType.size()) # Native.
 
 	Side.clear() # Global.
 	Vector3.Axis.clear() # Built-in.
-	TileSet.TileShape.clear() # Native.
+	Mesh.ArrayType.clear() # Native.
 	CustomEnum.clear() # Custom.
 
 	var enum_type = CustomEnum

--- a/modules/gdscript/tests/scripts/analyzer/errors/enum_declaration_and_usage.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/enum_declaration_and_usage.out
@@ -6,7 +6,7 @@ GDTEST_ANALYZER_ERROR
 >> ERROR at line 11: Type "ProcessMode" in base "Node" cannot be used on its own.
 >> ERROR at line 13: Cannot find member "NOT_EXIST" in base "Side".
 >> ERROR at line 14: Cannot find member "NOT_EXIST" in base "Vector3.Axis".
->> ERROR at line 15: Cannot find member "NOT_EXIST" in base "TileSet.TileShape".
+>> ERROR at line 15: Cannot find member "NOT_EXIST" in base "Mesh.ArrayType".
 >> ERROR at line 16: Cannot find member "NOT_EXIST" in base "enum_declaration_and_usage.gd.CustomEnum".
 >> ERROR at line 18: Global enum "Side" cannot be used on its own.
 >> ERROR at line 18: The native enum "Side" does not behave like Dictionary and does not have methods of its own.
@@ -14,8 +14,8 @@ GDTEST_ANALYZER_ERROR
 >> ERROR at line 19: Type "Axis" in base "Vector3" cannot be used on its own.
 >> ERROR at line 19: Native class Vector3.Axis used in script doesn't exist or isn't exposed.
 >> ERROR at line 19: Static function "size()" not found in base "Variant".
->> ERROR at line 20: Type "TileShape" in base "TileSet" cannot be used on its own.
->> ERROR at line 20: Native class TileSet.TileShape used in script doesn't exist or isn't exposed.
+>> ERROR at line 20: Type "ArrayType" in base "Mesh" cannot be used on its own.
+>> ERROR at line 20: Native class Mesh.ArrayType used in script doesn't exist or isn't exposed.
 >> ERROR at line 20: Static function "size()" not found in base "Variant".
 >> ERROR at line 22: Global enum "Side" cannot be used on its own.
 >> ERROR at line 22: The native enum "Side" does not behave like Dictionary and does not have methods of its own.
@@ -23,8 +23,8 @@ GDTEST_ANALYZER_ERROR
 >> ERROR at line 23: Type "Axis" in base "Vector3" cannot be used on its own.
 >> ERROR at line 23: Native class Vector3.Axis used in script doesn't exist or isn't exposed.
 >> ERROR at line 23: Static function "clear()" not found in base "Variant".
->> ERROR at line 24: Type "TileShape" in base "TileSet" cannot be used on its own.
->> ERROR at line 24: Native class TileSet.TileShape used in script doesn't exist or isn't exposed.
+>> ERROR at line 24: Type "ArrayType" in base "Mesh" cannot be used on its own.
+>> ERROR at line 24: Native class Mesh.ArrayType used in script doesn't exist or isn't exposed.
 >> ERROR at line 24: Static function "clear()" not found in base "Variant".
 >> ERROR at line 25: Cannot call non-const Dictionary function "clear()" on enum "CustomEnum".
 >> ERROR at line 28: Cannot call non-const Dictionary function "clear()" on enum "CustomEnum".

--- a/modules/gdscript/tests/scripts/analyzer/errors/not_found_member.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/not_found_member.gd
@@ -1,2 +1,2 @@
 func test():
-	TileSet.this_does_not_exist # Does not exist
+	Mesh.this_does_not_exist # Does not exist

--- a/modules/gdscript/tests/scripts/analyzer/errors/not_found_member.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/not_found_member.out
@@ -1,2 +1,2 @@
 GDTEST_ANALYZER_ERROR
->> ERROR at line 2: Cannot find member "this_does_not_exist" in base "TileSet".
+>> ERROR at line 2: Cannot find member "this_does_not_exist" in base "Mesh".

--- a/modules/gdscript/tests/scripts/analyzer/features/enum_native_access_types.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/enum_native_access_types.gd
@@ -1,19 +1,19 @@
-func print_enum(e: TileSet.TileShape) -> TileSet.TileShape:
+func print_enum(e: Mesh.ArrayType) -> Mesh.ArrayType:
 	print(e)
 	return e
 
 func test():
-	var v: TileSet.TileShape
-	v = TileSet.TILE_SHAPE_SQUARE
+	var v: Mesh.ArrayType
+	v = Mesh.ARRAY_VERTEX
 	v = print_enum(v)
-	v = print_enum(TileSet.TILE_SHAPE_SQUARE)
-	v = TileSet.TileShape.TILE_SHAPE_SQUARE
+	v = print_enum(Mesh.ARRAY_VERTEX)
+	v = Mesh.ArrayType.ARRAY_VERTEX
 	v = print_enum(v)
-	v = print_enum(TileSet.TileShape.TILE_SHAPE_SQUARE)
+	v = print_enum(Mesh.ArrayType.ARRAY_VERTEX)
 
-	v = TileSet.TILE_SHAPE_ISOMETRIC
+	v = Mesh.ARRAY_NORMAL
 	v = print_enum(v)
-	v = print_enum(TileSet.TILE_SHAPE_ISOMETRIC)
-	v = TileSet.TileShape.TILE_SHAPE_ISOMETRIC
+	v = print_enum(Mesh.ARRAY_NORMAL)
+	v = Mesh.ArrayType.ARRAY_NORMAL
 	v = print_enum(v)
-	v = print_enum(TileSet.TileShape.TILE_SHAPE_ISOMETRIC)
+	v = print_enum(Mesh.ArrayType.ARRAY_NORMAL)


### PR DESCRIPTION


<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #121921

## Additional information

Let me know if something else other than `Mesh.ArrayType` should be used, but otherwise I think it's pretty core so it probably won't be moved to a module anytime soon.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
