### PR TITLE
Core: Remove assignment in Variant Object destructor

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1443,7 +1443,11 @@ void Variant::_clear_internal() {
 			reinterpret_cast<NodePath *>(_data._mem)->~NodePath();
 		} break;
 		case OBJECT: {
-			_get_obj().unref();
+			// Mirrors ObjData::unref
+			const ObjData &objdata = _get_obj();
+			if (objdata.id.is_ref_counted() && static_cast<RefCounted *>(objdata.obj)->unreference()) {
+				memdelete(objdata.obj);
+			}
 		} break;
 		case RID: {
 			// Not much need probably.


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->
Sequel to #121834. <sub>This should have been combined but hindsight 20/20.</sub>

## What problem(s) does this PR solve?

- Optimizes  `Object` typed `Variant` destruction by not assigning an empty `ObjData`.

## Additional information

`Variant` `Object*` is used heavily in function calls. Currently the `Variant` destructor cleans up the pointer data which is unnecessary. I suspect this one is more difficult for the compiler to optimized out since it is scoped in an if branch within a function call.

Profiling of an empty GDScript function call in a loop.

```py
func fn():
    pass

for i in 1_000_000:
    fn()
```

Before:
<img width="514" height="281" alt="image" src="https://github.com/user-attachments/assets/46bbb43a-7fee-4559-badb-9be2290a340f" />

After:

<img width="508" height="302" alt="image" src="https://github.com/user-attachments/assets/f09518d3-f0a0-4666-b7ae-43af9922dcd6" />

-----

This does change the behaviour slightly. The only other call site of `_clear_internal` is in `VariantInternal::clear` which already does not zero out the `_data` for numeric types for example. 
Additionally it sets the `type = NIL` which would correctly be zeroed out if followed up with a call to `VariantInternal::initialize` or `VariantTypeChanger::change` for Object types.

### Future work

There are a few more cases that similarly call `unref` which zeroes a pointer.

In called destructor:
* `StringName`
* `NodePath`
* `Callable`
* `Dictionary`
* `Array`

Directly in `_clear_internal`
* `Transform2D`
* `AABB`
* `Basis`
* `Transform3D`
* `Projection`

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
