### PR TITLE
Fix right click to cancel on point drag for Polygon2D

### DIFF
--- a/editor/scene/2d/abstract_polygon_2d_editor.cpp
+++ b/editor/scene/2d/abstract_polygon_2d_editor.cpp
@@ -433,11 +433,21 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 						return true;
 					}
 				}
-			} else if (mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed() && !edited_point.valid()) {
-				const PosVertex closest = closest_point(gpoint);
+			} else if (mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed()) {
+				if (!edited_point.valid()) {
+					const PosVertex closest = closest_point(gpoint);
 
-				if (closest.valid()) {
-					remove_point(closest);
+					if (closest.valid()) {
+						remove_point(closest);
+						return true;
+					}
+				} else {
+					_set_polygon(edited_point.polygon, pre_move_edit);
+					edited_point = PosVertex();
+					hover_point = Vertex();
+					selected_point = Vertex();
+					edge_point = PosVertex();
+					canvas_item_editor->update_viewport();
 					return true;
 				}
 			}
@@ -493,6 +503,7 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 				}
 			} else if (mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed() && wip_active) {
 				_wip_cancel();
+				return true;
 			}
 		}
 


### PR DESCRIPTION

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/121914

## Additional information

[Screencast_20260730_095959.webm](https://github.com/user-attachments/assets/b3a578fc-9a4d-4f8b-babe-c6274e3fe331)

Also added so the context menu dont open when you right click to cancel while in create mode

[Screencast_20260730_095945.webm](https://github.com/user-attachments/assets/da65f9d2-7c4d-4c68-86d9-8e0b825ab963)
