### PR TITLE
Fix crash when failing to open log file for writing

### DIFF
--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -161,6 +161,7 @@ void RotatedFileLogger::rotate_file() {
 	}
 
 	file = FileAccess::open(base_path, FileAccess::WRITE);
+	ERR_FAIL_COND_MSG(file.is_null(), "Failed to open log file for writing: " + base_path);
 	file->detach_from_objectdb(); // Note: This FileAccess instance will exist longer than ObjectDB, therefore can't be registered in ObjectDB.
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR fixes a crash when Godot can't write to the log file opened in `RotatedFileLogger::rotate_file()`.

## Additional information

I encountered this problem when a sandboxed AI tried to run Godot, and then Godot immediately crashed because it couldn't write the log file. After the crash was identified, no AI was used to make this PR.

This PR should be cherry-picked to all supported branches, it's a very straightforward fix.