### PR TITLE
[Image] Fix leftover note in `Image::load_exr_from_buffer`

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -4488,7 +4488,7 @@ Error Image::load_exr_from_buffer(const Vector<uint8_t> &p_array) {
 	ERR_FAIL_NULL_V_MSG(
 			_exr_mem_loader_func,
 			ERR_UNAVAILABLE,
-			"The TinyEXR module isn't enabled. Recompile the Godot editor or export template binary with the `tinyexr_export_templates=yes` SCons option.");
+			"The TinyEXR module isn't enabled. Recompile the Godot editor or export template binary with the `module_tinyexr_enabled=yes` SCons option.");
 	return _load_from_buffer(p_array, _exr_mem_loader_func);
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

The configuration flag was never implemented.

## Additional information

Leftover from:
* https://github.com/godotengine/godot/pull/101255

No AI used.
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
