### PR TITLE
Fix hang when Video RAM resource type is unknown

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -497,7 +497,7 @@ void ScriptEditorDebugger::_msg_servers_memory_usage(uint64_t p_thread_id, const
 		// If it does not have a theme icon, just go up the inheritance tree until we find one.
 		if (!has_theme_icon(type, EditorStringName(EditorIcons))) {
 			StringName base_type = type;
-			while (base_type != "Resource" || base_type != "") {
+			while (base_type != "Resource" && !base_type.is_empty()) {
 				base_type = ClassDB::get_parent_class(base_type);
 				if (has_theme_icon(base_type, EditorStringName(EditorIcons))) {
 					type = base_type;


### PR DESCRIPTION
## What problem(s) does this PR solve?

The editor could hang indefinitely while processing Video RAM usage data if a reported resource type had no editor icon and was unknown to `ClassDB`.

The parent-class loop used `||` for its two termination conditions, so it continued after reaching an empty class name, small oversight nothing big.

- Fixes #121930

## Additional information
here is a video of it working as intended now using the MRP in issue #121930, just by looking at the code you can tell what was wrong


https://github.com/user-attachments/assets/87d1b052-170a-4ec2-a0e9-b0689d471b11

