### PR TITLE
Wayland: Add an env var to disable native fifo

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -6179,6 +6179,10 @@ bool WaylandThread::window_is_suspended(DisplayServerEnums::WindowID p_window_id
 }
 
 bool WaylandThread::is_fifo_available() const {
+	if (OS::get_singleton()->get_environment("GODOT_WAYLAND_DISABLE_NATIVE_FIFO") == "1") {
+		return false;
+	}
+
 	return registry.wp_fifo_manager_name != 0;
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

This adds the ability to work around all sorts of FIFO issues (see below), like the (now fixed upstream) #114975 and likely #114986 (which smells like broken FIFO to me on Wayland, as #121712 works around it with mailbox).

## Additional information

Historically, we needed to manually throttle frames as otherwise they could get "stuck" when not presenting frames (e.g. window hidden). This got now solved (at least for Vulkan) with the `wp-fifo-v1` extension. If we detect that, we trust the compositor again.

Issue is, some drivers/compositors are broken or quirky and will still freeze clients in certain situations. Disabling "native fifo" by default would lower performance, and there's no reliable way of detecting broken implementations, so we need a workaround toggle.

This patch implements exactly that, through a `GODOT_WAYLAND_DISABLE_NATIVE_FIFO` environment variable.

---

Yes the patch is quite basic as we already got everything in the Wayland platform logic. The hardest part was the name! Feel free to propose a better one as I always pick the worst choice xD

I didn't feel like extra logging was necessary, as there's already a verbose "manually throttling frames with mailbox" message. I can add a warning perhaps if it was forced with native fifo available.

