### PR TITLE
Add core level `WeakRef` to make weak `Object` references easier and safer. Fix a few potential `EditorInspector` crashes.

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2356,4 +2356,33 @@ void EngineDebugger::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear_breakpoints"), &EngineDebugger::clear_breakpoints);
 }
 
+Variant WeakRef::get_ref() const {
+	if (ref.is_null()) {
+		return Variant();
+	}
+
+	Object *obj = ObjectDB::get_instance(ref);
+	if (!obj) {
+		return Variant();
+	}
+	RefCounted *r = cast_to<RefCounted>(obj);
+	if (r) {
+		return Ref<RefCounted>(r);
+	}
+
+	return obj;
+}
+
+void WeakRef::set_obj(Object *p_object) {
+	ref = p_object ? p_object->get_instance_id() : ObjectID();
+}
+
+void WeakRef::set_ref(const Ref<RefCounted> &p_ref) {
+	ref = p_ref.is_valid() ? p_ref->get_instance_id() : ObjectID();
+}
+
+void WeakRef::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_ref"), &WeakRef::get_ref);
+}
+
 } // namespace CoreBind

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -696,6 +696,20 @@ public:
 	~EngineDebugger();
 };
 
+class WeakRef : public RefCounted {
+	GDCLASS(WeakRef, RefCounted);
+
+	ObjectID ref;
+
+protected:
+	static void _bind_methods();
+
+public:
+	Variant get_ref() const;
+	void set_obj(Object *p_object);
+	void set_ref(const Ref<RefCounted> &p_ref);
+};
+
 } // namespace CoreBind
 
 VARIANT_ENUM_CAST(CoreBind::Logger::ErrorType);

--- a/core/object/ref_counted.cpp
+++ b/core/object/ref_counted.cpp
@@ -133,32 +133,3 @@ RefCounted::RefCounted() :
 	refcount_init.init();
 	dereference_count.set(0);
 }
-
-Variant WeakRef::get_ref() const {
-	if (ref.is_null()) {
-		return Variant();
-	}
-
-	Object *obj = ObjectDB::get_instance(ref);
-	if (!obj) {
-		return Variant();
-	}
-	RefCounted *r = cast_to<RefCounted>(obj);
-	if (r) {
-		return Ref<RefCounted>(r);
-	}
-
-	return obj;
-}
-
-void WeakRef::set_obj(Object *p_object) {
-	ref = p_object ? p_object->get_instance_id() : ObjectID();
-}
-
-void WeakRef::set_ref(const Ref<RefCounted> &p_ref) {
-	ref = p_ref.is_valid() ? p_ref->get_instance_id() : ObjectID();
-}
-
-void WeakRef::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_ref"), &WeakRef::get_ref);
-}

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -238,20 +238,6 @@ void postinitialize_handler(Ref<T> &p_object) {
 	postinitialize_handler(p_object.ptr());
 }
 
-class WeakRef : public RefCounted {
-	GDCLASS(WeakRef, RefCounted);
-
-	ObjectID ref;
-
-protected:
-	static void _bind_methods();
-
-public:
-	Variant get_ref() const;
-	void set_obj(Object *p_object);
-	void set_ref(const Ref<RefCounted> &p_ref);
-};
-
 // Zero-constructing Ref initializes reference to nullptr (and thus empty).
 template <typename T>
 struct is_zero_constructible<Ref<T>> : std::true_type {};

--- a/core/object/weak_ref.h
+++ b/core/object/weak_ref.h
@@ -1,0 +1,84 @@
+/**************************************************************************/
+/*  weak_ref.h                                                            */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/object.h"
+
+/**
+ * Holds a reference to an Object without owning it.
+ * Use `get_validated_object()` to access the object.
+ *
+ * For documentation, see:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/object_class.html#object-ownership-and-casting
+ */
+template <typename T>
+class WeakRef {
+	ObjectID _object_id;
+
+public:
+	/// Safely get the validated object. Returns `nullptr` if the WeakRef was null, or the object was
+	/// already freed.
+	/// Note: This function is not free, so if you need to access the object many times, cache it in a
+	///       T * temporarily. If there's any risk of the object being freed, use `get_validated_object()`
+	///       again.
+	_ALWAYS_INLINE_ T *get_validated_object() {
+		return _object_id.is_valid() ? Object::cast_to<T>(ObjectDB::get_instance(_object_id)) : nullptr;
+	}
+
+	_ALWAYS_INLINE_ bool is_null() const { return _object_id.is_null(); }
+
+	_ALWAYS_INLINE_ ObjectID get_object_id() const { return _object_id; }
+
+	bool operator==(const Object *p_object) const { return p_object ? p_object->get_instance_id() == _object_id : _object_id.is_null(); }
+	bool operator!=(const Object *p_object) const { return p_object ? p_object->get_instance_id() != _object_id : _object_id.is_valid(); }
+
+	void operator=(T *p_object) {
+		_object_id = p_object ? p_object->get_instance_id() : ObjectID();
+	}
+
+	WeakRef() = default;
+	WeakRef(const WeakRef<T> &p_ref) = default;
+
+	WeakRef(ObjectID p_object_id) :
+			_object_id(p_object_id) {}
+
+	WeakRef(T *p_object) :
+			_object_id(p_object ? p_object->get_instance_id() : ObjectID()) {}
+};
+
+template <typename T>
+bool operator==(const Object *p_object, WeakRef<T> p_ref) {
+	return p_ref == p_object;
+}
+template <typename T>
+bool operator!=(const Object *p_object, WeakRef<T> p_ref) {
+	return p_ref != p_object;
+}

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -147,7 +147,7 @@ void register_core_types() {
 
 	GDREGISTER_CLASS(Object);
 	GDREGISTER_CLASS(RefCounted);
-	GDREGISTER_CLASS(WeakRef);
+	GDREGISTER_CLASS(CoreBind::WeakRef);
 	GDREGISTER_CLASS(Resource);
 
 	GDREGISTER_CLASS(Time);

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -30,6 +30,7 @@
 
 #include "variant_utility.h"
 
+#include "core/core_bind.h"
 #include "core/io/marshalls.h"
 #include "core/object/ref_counted.h"
 #include "core/os/os.h"
@@ -816,14 +817,14 @@ Variant VariantUtilityFunctions::weakref(const Variant &p_obj, Callable::CallErr
 	if (p_obj.get_type() == Variant::OBJECT) {
 		r_error.error = Callable::CallError::CALL_OK;
 		if (p_obj.is_ref_counted()) {
-			Ref<WeakRef> wref = memnew(WeakRef);
+			Ref<CoreBind::WeakRef> wref = memnew(CoreBind::WeakRef);
 			Ref<RefCounted> r = p_obj;
 			if (r.is_valid()) {
 				wref->set_ref(r);
 			}
 			return wref;
 		} else {
-			Ref<WeakRef> wref = memnew(WeakRef);
+			Ref<CoreBind::WeakRef> wref = memnew(CoreBind::WeakRef);
 			Object *o = p_obj.get_validated_object();
 			if (o) {
 				wref->set_obj(o);
@@ -832,7 +833,7 @@ Variant VariantUtilityFunctions::weakref(const Variant &p_obj, Callable::CallErr
 		}
 	} else if (p_obj.get_type() == Variant::NIL) {
 		r_error.error = Callable::CallError::CALL_OK;
-		Ref<WeakRef> wref = memnew(WeakRef);
+		Ref<CoreBind::WeakRef> wref = memnew(CoreBind::WeakRef);
 		return wref;
 	} else {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -147,6 +147,7 @@ bool EditorInspector::_resource_properties_matches(const Ref<Resource> &p_resour
 			continue;
 		}
 
+		Object *object = object_ref.get_validated_object();
 		if (p.name.begins_with("metadata/") && bool(object->call(SNAME("_hide_metadata_from_inspector")))) {
 			// Hide metadata from inspector if required.
 			continue;
@@ -4187,6 +4188,7 @@ void EditorInspector::_parse_added_editors(VBoxContainer *p_current_vbox, Editor
 		}
 
 		if (ep) {
+			Object *object = object_ref.get_validated_object();
 			ep->object = object;
 			ep->connect("property_changed", callable_mp(this, &EditorInspector::_property_changed).bind(false));
 			ep->connect("property_keyed", callable_mp(this, &EditorInspector::_property_keyed));
@@ -4256,6 +4258,7 @@ bool EditorInspector::_is_property_disabled_by_feature_profile(const StringName 
 		return false;
 	}
 
+	Object *object = object_ref.get_validated_object();
 	StringName class_name = object->get_class();
 
 	while (class_name != StringName()) {
@@ -4288,6 +4291,7 @@ void EditorInspector::_add_section_in_tree(EditorInspectorSection *p_section, VB
 }
 
 void EditorInspector::update_tree() {
+	Object *object = object_ref.get_validated_object();
 	if (!object) {
 		return;
 	}
@@ -5388,7 +5392,7 @@ void EditorInspector::_clear(bool p_hide_plugins) {
 }
 
 Object *EditorInspector::get_edited_object() {
-	return object;
+	return object_ref.get_validated_object();
 }
 
 Object *EditorInspector::get_next_edited_object() {
@@ -5396,13 +5400,15 @@ Object *EditorInspector::get_next_edited_object() {
 }
 
 void EditorInspector::edit(Object *p_object) {
-	if (object == p_object) {
+	if (object_ref == p_object) {
 		return;
 	}
 
+	Object *object = object_ref.get_validated_object();
+
 	next_object = p_object; // Some plugins need to know the next edited object when clearing the inspector.
-	if (object) {
-		if (likely(Variant(object).get_validated_object())) {
+	if (!object_ref.is_null()) {
+		if (likely(object)) {
 			object->disconnect(CoreStringName(property_list_changed), callable_mp(this, &EditorInspector::_changed_callback));
 		}
 		_clear();
@@ -5410,6 +5416,7 @@ void EditorInspector::edit(Object *p_object) {
 	per_array_page.clear();
 
 	object = p_object;
+	object_ref = p_object;
 
 	if (object) {
 		update_scroll_request = 0; //reset
@@ -5636,7 +5643,7 @@ void EditorInspector::_page_change_request(int p_new_page, const StringName &p_a
 }
 
 void EditorInspector::_edit_request_change(Object *p_object, const String &p_property) {
-	if (object != p_object) { //may be undoing/redoing for a non edited object, so ignore
+	if (object_ref != p_object) { //may be undoing/redoing for a non edited object, so ignore
 		return;
 	}
 
@@ -5652,6 +5659,9 @@ void EditorInspector::_edit_request_change(Object *p_object, const String &p_pro
 }
 
 void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bool p_refresh_all, const String &p_changed_field) {
+	Object *object = object_ref.get_validated_object();
+	ERR_FAIL_NULL(object);
+
 	if (autoclear && editor_property_map.has(p_name)) {
 		for (EditorProperty *E : editor_property_map[p_name]) {
 			if (E->is_checkable()) {
@@ -5832,6 +5842,7 @@ void EditorInspector::_multiple_properties_changed(const Vector<String> &p_paths
 }
 
 void EditorInspector::_property_keyed(const String &p_path, bool p_advance) {
+	Object *object = object_ref.get_validated_object();
 	if (!object) {
 		return;
 	}
@@ -5843,6 +5854,7 @@ void EditorInspector::_property_keyed(const String &p_path, bool p_advance) {
 }
 
 void EditorInspector::_property_deleted(const String &p_path) {
+	Object *object = object_ref.get_validated_object();
 	if (!object) {
 		return;
 	}
@@ -5863,6 +5875,7 @@ void EditorInspector::_property_deleted(const String &p_path) {
 }
 
 void EditorInspector::_property_keyed_with_value(const String &p_path, const Variant &p_value, bool p_advance) {
+	Object *object = object_ref.get_validated_object();
 	if (!object) {
 		return;
 	}
@@ -5874,6 +5887,7 @@ void EditorInspector::_property_keyed_with_value(const String &p_path, const Var
 }
 
 void EditorInspector::_property_checked(const String &p_path, bool p_checked) {
+	Object *object = object_ref.get_validated_object();
 	if (!object) {
 		return;
 	}
@@ -5915,6 +5929,7 @@ void EditorInspector::_property_checked(const String &p_path, bool p_checked) {
 }
 
 void EditorInspector::_property_pinned(const String &p_path, bool p_pinned) {
+	Object *object = object_ref.get_validated_object();
 	if (!object) {
 		return;
 	}
@@ -5962,7 +5977,7 @@ void EditorInspector::_resource_selected(const String &p_path, Ref<Resource> p_r
 }
 
 void EditorInspector::_node_removed(Node *p_node) {
-	if (p_node == object) {
+	if (p_node == object_ref) {
 		edit(nullptr);
 	}
 }
@@ -5974,6 +5989,9 @@ void EditorInspector::_update_current_favorites() {
 	}
 
 	HashMap<String, PackedStringArray> favorites = EditorSettings::get_singleton()->get_favorite_properties();
+
+	Object *object = object_ref.get_validated_object();
+	ERR_FAIL_NULL(object);
 
 	// Fetch script properties.
 	Ref<Script> scr = object->get_script();
@@ -6031,6 +6049,7 @@ void EditorInspector::_update_current_favorites() {
 }
 
 void EditorInspector::_set_property_favorited(const String &p_path, bool p_favorited) {
+	Object *object = object_ref.get_validated_object();
 	if (!object) {
 		return;
 	}
@@ -6119,6 +6138,9 @@ void EditorInspector::_clear_current_favorites() {
 	current_favorites.clear();
 
 	HashMap<String, PackedStringArray> favorites = EditorSettings::get_singleton()->get_favorite_properties();
+
+	Object *object = object_ref.get_validated_object();
+	ERR_FAIL_NULL(object);
 
 	Ref<Script> scr = object->get_script();
 	if (scr.is_valid()) {
@@ -6258,7 +6280,8 @@ void EditorInspector::_notification(int p_what) {
 
 void EditorInspector::_changed_callback() {
 	//this is called when property change is notified via notify_property_list_changed()
-	if (object != nullptr) {
+	Object *object = object_ref.get_validated_object();
+	if (object) {
 		_update_current_favorites();
 		_edit_request_change(object, String());
 	}
@@ -6269,6 +6292,7 @@ void EditorInspector::_vscroll_changed(double p_offset) {
 		return;
 	}
 
+	Object *object = object_ref.get_validated_object();
 	if (object) {
 		scroll_cache[object->get_instance_id()] = p_offset;
 	}
@@ -6328,6 +6352,9 @@ void EditorInspector::_show_add_meta_dialog() {
 		add_child(add_meta_dialog);
 	}
 
+	Object *object = object_ref.get_validated_object();
+	ERR_FAIL_NULL(object);
+
 	StringName dialog_title;
 	Node *node = Object::cast_to<Node>(object);
 	// If object is derived from Node use node name, if derived from Resource use classname.
@@ -6339,6 +6366,9 @@ void EditorInspector::_show_add_meta_dialog() {
 }
 
 void EditorInspector::_add_meta_confirm() {
+	Object *object = object_ref.get_validated_object();
+	ERR_FAIL_NULL(object);
+
 	// Ensure metadata is unfolded when adding a new metadata.
 	object->editor_set_section_unfold("metadata", true);
 

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/object/weak_ref.h"
 #include "editor/inspector/editor_property_name_processor.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
@@ -801,7 +802,7 @@ private:
 	HashSet<StringName> pending;
 
 	void _clear(bool p_hide_plugins = true);
-	Object *object = nullptr;
+	WeakRef<Object> object_ref;
 	Object *next_object = nullptr;
 
 	//

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -38,6 +38,7 @@
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
+#include "core/core_bind.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
 #include "core/io/compression.h"
@@ -1430,7 +1431,7 @@ void godotsharp_weakref(Object *p_ptr, Ref<RefCounted> *r_weak_ref) {
 		return;
 	}
 
-	Ref<WeakRef> wref;
+	Ref<CoreBind::WeakRef> wref;
 	RefCounted *rc = Object::cast_to<RefCounted>(p_ptr);
 
 	if (rc) {

--- a/modules/objectdb_profiler/editor/snapshot_data.cpp
+++ b/modules/objectdb_profiler/editor/snapshot_data.cpp
@@ -276,7 +276,7 @@ void GameStateSnapshot::_get_rc_cycles(
 		}
 
 		SnapshotDataObject *next = objects[next_child.value];
-		if (next != nullptr && next->is_class(RefCounted::get_class_static()) && !next->is_class(WeakRef::get_class_static()) && !p_traversed_objs.has(next)) {
+		if (next != nullptr && next->is_class(RefCounted::get_class_static()) && !next->is_class("WeakRef") && !p_traversed_objs.has(next)) {
 			HashSet<SnapshotDataObject *> traversed_copy(p_traversed_objs);
 			if (p_obj != p_source_obj) {
 				traversed_copy.insert(p_obj);
@@ -309,7 +309,7 @@ void GameStateSnapshot::recompute_references() {
 	}
 
 	for (const KeyValue<ObjectID, SnapshotDataObject *> &obj : objects) {
-		if (!obj.value->is_class(RefCounted::get_class_static()) || obj.value->is_class(WeakRef::get_class_static())) {
+		if (!obj.value->is_class(RefCounted::get_class_static()) || obj.value->is_class("WeakRef")) {
 			continue;
 		}
 		LocalVector<String> cycles;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Follow-up to/includes https://github.com/godotengine/godot/pull/112470

There is currently no core endorsed way to hold a weak reference to an object.
However, this is often critical for the editor; basically anytime you hold a reference to a non-RefCounted object you don't own, you need a weak reference.

The [`Object` ownership guide](https://docs.godotengine.org/en/latest/engine_details/architecture/object_class.html#object-ownership-and-casting) currently awkwardly suggests storing an `ObjectID` which isn't very convenient.

## Additional information

I opted against storing `T *` for fast access (which `CoreBind::WeakRef` and `Variant` do) because it's inherently unsafe. Those two storing `T *` directly is probably directly causing (rare) crashes.

I also fixed a potential crashes in `EditorInspector` to demonstrate the need and how to use it.