### PR TITLE
Fix crash when setting the root Viewport's World3D to null

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4904,7 +4904,12 @@ void Viewport::set_world_3d(const Ref<World3D> &p_world_3d) {
 	}
 
 	if (is_inside_tree()) {
-		RenderingServer::get_singleton()->viewport_set_scenario(viewport, find_world_3d()->get_scenario());
+		const Ref<World3D> found_world_3d = find_world_3d();
+		if (found_world_3d.is_valid()) {
+			RenderingServer::get_singleton()->viewport_set_scenario(viewport, found_world_3d->get_scenario());
+		} else {
+			RenderingServer::get_singleton()->viewport_set_scenario(viewport, RID());
+		}
 	}
 
 	_update_audio_listener_3d();
@@ -4925,7 +4930,12 @@ void Viewport::_own_world_3d_changed() {
 	}
 
 	if (is_inside_tree()) {
-		RenderingServer::get_singleton()->viewport_set_scenario(viewport, find_world_3d()->get_scenario());
+		const Ref<World3D> found_world_3d = find_world_3d();
+		if (found_world_3d.is_valid()) {
+			RenderingServer::get_singleton()->viewport_set_scenario(viewport, found_world_3d->get_scenario());
+		} else {
+			RenderingServer::get_singleton()->viewport_set_scenario(viewport, RID());
+		}
 	}
 
 	_update_audio_listener_3d();
@@ -4960,7 +4970,12 @@ void Viewport::set_use_own_world_3d(bool p_use_own_world_3d) {
 	}
 
 	if (is_inside_tree()) {
-		RenderingServer::get_singleton()->viewport_set_scenario(viewport, find_world_3d()->get_scenario());
+		const Ref<World3D> found_world_3d = find_world_3d();
+		if (found_world_3d.is_valid()) {
+			RenderingServer::get_singleton()->viewport_set_scenario(viewport, found_world_3d->get_scenario());
+		} else {
+			RenderingServer::get_singleton()->viewport_set_scenario(viewport, RID());
+		}
 	}
 
 	_update_audio_listener_3d();


### PR DESCRIPTION
## What problem(s) does this PR solve?

Most of the code in `Viewport::set_world_3d` already handles the world being null by explicitly checking `.is_valid()`:

```cpp
if (own_world_3d.is_valid() && world_3d.is_valid()) {
	world_3d->disconnect_changed(callable_mp(this, &Viewport::_own_world_3d_changed));
}

world_3d = p_world_3d;

if (own_world_3d.is_valid()) {
	if (world_3d.is_valid()) {
		own_world_3d = world_3d->duplicate();
		world_3d->connect_changed(callable_mp(this, &Viewport::_own_world_3d_changed));
	} else {
		own_world_3d.instantiate();
	}
}
```

However, this code did not:

```cpp
if (is_inside_tree()) {
	RenderingServer::get_singleton()->viewport_set_scenario(viewport, find_world_3d()->get_scenario());
}
```

This uses `find_world_3d()`, which would work if itself or an ancestor viewport had a World3D, but will return null if none exists, such as when setting a null World3D on the root viewport. This PR fixes the crash by checking if the found world exists, and setting a null RID for the scenario if it does not exist.

```cpp
if (is_inside_tree()) {
	const Ref<World3D> found_world = find_world_3d();
	if (found_world.is_valid()) {
		RenderingServer::get_singleton()->viewport_set_scenario(viewport, found_world->get_scenario());
	} else {
		RenderingServer::get_singleton()->viewport_set_scenario(viewport, RID());
	}
}
```

## Additional information

I did not use AI to make this pull request.

This is probably another good one to cherry-pick to supported branches.