### PR TITLE
Use a dedicated thread for the thread renderer, rather than a ThreadPool thread

### DIFF
--- a/core/templates/command_queue_mt.h
+++ b/core/templates/command_queue_mt.h
@@ -115,6 +115,7 @@ class CommandQueueMT {
 	uint32_t sync_tail = 0;
 	uint32_t sync_awaiters = 0;
 	WorkerThreadPool::TaskID pump_task_id = WorkerThreadPool::INVALID_TASK_ID;
+	ConditionVariable command_cond_var;
 	uint64_t flush_read_ptr = 0;
 	std::atomic<bool> pending{ false };
 
@@ -137,6 +138,7 @@ class CommandQueueMT {
 		MutexLock mlock(mutex);
 		create_command<T>(std::forward<Args>(p_args)...);
 
+		command_cond_var.notify_one();
 		if (pump_task_id != WorkerThreadPool::INVALID_TASK_ID) {
 			WorkerThreadPool::get_singleton()->notify_yield_over(pump_task_id);
 		}
@@ -264,8 +266,11 @@ public:
 	}
 
 	void wait_and_flush() {
-		ERR_FAIL_COND(pump_task_id == WorkerThreadPool::INVALID_TASK_ID);
-		WorkerThreadPool::get_singleton()->wait_for_task_completion(pump_task_id);
+		MutexLock lock(mutex);
+		while (!pending.load()) {
+			command_cond_var.wait(lock);
+		}
+		lock.temp_unlock();
 		_flush();
 	}
 

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -275,13 +275,11 @@ void RenderingServerDefault::_finish() {
 
 void RenderingServerDefault::init() {
 	if (create_thread) {
-		print_verbose("RenderingServerWrapMT: Starting render thread");
+		print_verbose("RenderingServerDefault: Starting dedicated render thread");
 		DisplayServer::get_singleton()->release_rendering_thread();
-		WorkerThreadPool::TaskID tid = WorkerThreadPool::get_singleton()->add_task(callable_mp(this, &RenderingServerDefault::_thread_loop), true, "Rendering Server pump task", true);
-		command_queue.set_pump_task_id(tid);
-		command_queue.push(this, &RenderingServerDefault::_assign_mt_ids, tid);
+		render_thread.start(_thread_loop_callback, this);
 		command_queue.push_and_sync(this, &RenderingServerDefault::_init);
-		DEV_ASSERT(server_task_id == tid);
+		DEV_ASSERT(server_thread == render_thread.get_id());
 	} else {
 		server_thread = Thread::MAIN_ID;
 		_init();
@@ -292,10 +290,7 @@ void RenderingServerDefault::finish() {
 	if (create_thread) {
 		command_queue.push(this, &RenderingServerDefault::_finish);
 		command_queue.push(this, &RenderingServerDefault::_thread_exit);
-		if (server_task_id != WorkerThreadPool::INVALID_TASK_ID) {
-			WorkerThreadPool::get_singleton()->wait_for_task_completion(server_task_id);
-			server_task_id = WorkerThreadPool::INVALID_TASK_ID;
-		}
+		render_thread.wait_to_finish();
 		server_thread = Thread::MAIN_ID;
 	} else {
 		_finish();
@@ -397,27 +392,27 @@ Size2i RenderingServerDefault::get_maximum_viewport_size() const {
 	}
 }
 
-void RenderingServerDefault::_assign_mt_ids(WorkerThreadPool::TaskID p_pump_task_id) {
+void RenderingServerDefault::_thread_exit() {
+	exit = true;
+}
+
+void RenderingServerDefault::_thread_loop_callback(void *p_userdata) {
+	static_cast<RenderingServerDefault *>(p_userdata)->_thread_loop();
+}
+
+void RenderingServerDefault::_thread_loop() {
 	server_thread = Thread::get_caller_id();
-	server_task_id = p_pump_task_id;
 
 	RenderingDevice *rd = RenderingDevice::get_singleton();
 	if (rd) {
 		// This is needed because the main RD is created on the main thread.
 		rd->make_current();
 	}
-}
 
-void RenderingServerDefault::_thread_exit() {
-	exit = true;
-}
-
-void RenderingServerDefault::_thread_loop() {
 	DisplayServer::get_singleton()->gl_window_make_current(DisplayServerEnums::MAIN_WINDOW_ID); // Move GL to this thread.
 
 	while (!exit) {
-		WorkerThreadPool::get_singleton()->yield();
-		command_queue.flush_all();
+		command_queue.wait_and_flush();
 	}
 
 	DisplayServer::get_singleton()->release_rendering_thread();

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/object/worker_thread_pool.h"
 #include "core/os/thread.h"
 #include "core/templates/command_queue_mt.h"
 #include "core/templates/hash_map.h"
@@ -79,13 +78,13 @@ class RenderingServerDefault : public RenderingServer {
 
 	mutable CommandQueueMT command_queue;
 
+	Thread render_thread;
 	Thread::ID server_thread = Thread::MAIN_ID;
-	WorkerThreadPool::TaskID server_task_id = WorkerThreadPool::INVALID_TASK_ID;
 	bool exit = false;
 	bool create_thread = false;
 
-	void _assign_mt_ids(WorkerThreadPool::TaskID p_pump_task_id);
 	void _thread_exit();
+	static void _thread_loop_callback(void *p_userdata);
 	void _thread_loop();
 
 	void _draw(bool p_swap_buffers, double frame_step);


### PR DESCRIPTION
When using the rendering mode "separate" the code was using a ThreadPool
thread.

Threadpool threads can get busy with other operations, and can
starve the rendering until they are released.   Use a dedicated
thread for the renderer.

This avoids the choppy rendering when Godot is busy.

As an aside, I am using this patch to easily use the Godot Editor with it (so far, I have not found a way to crash it, my hope was to find a way to crash it and start to file actionable bugs on fixing it):

https://gist.github.com/migueldeicaza/16d43dc5445c80b6b2b18ab452f2c850
