### PR TITLE
[4.5] mbedTLS: Always use Godot's OS as entropy source

### DIFF
--- a/core/crypto/crypto_core.cpp
+++ b/core/crypto/crypto_core.cpp
@@ -43,11 +43,20 @@
 #include <mbedtls/compat-2.x.h>
 #endif
 
+extern "C" {
+int mbedtls_hardware_poll(void *p_data, unsigned char *r_buffer, size_t p_len, size_t *r_len) {
+	*r_len = 0;
+	Error err = OS::get_singleton()->get_entropy(r_buffer, p_len);
+	ERR_FAIL_COND_V(err, MBEDTLS_ERR_ENTROPY_SOURCE_FAILED);
+	*r_len = p_len;
+	return 0;
+}
+}
+
 // RandomGenerator
 CryptoCore::RandomGenerator::RandomGenerator() {
 	entropy = memalloc(sizeof(mbedtls_entropy_context));
 	mbedtls_entropy_init((mbedtls_entropy_context *)entropy);
-	mbedtls_entropy_add_source((mbedtls_entropy_context *)entropy, &CryptoCore::RandomGenerator::_entropy_poll, nullptr, 256, MBEDTLS_ENTROPY_SOURCE_STRONG);
 	ctx = memalloc(sizeof(mbedtls_ctr_drbg_context));
 	mbedtls_ctr_drbg_init((mbedtls_ctr_drbg_context *)ctx);
 }
@@ -57,14 +66,6 @@ CryptoCore::RandomGenerator::~RandomGenerator() {
 	memfree(ctx);
 	mbedtls_entropy_free((mbedtls_entropy_context *)entropy);
 	memfree(entropy);
-}
-
-int CryptoCore::RandomGenerator::_entropy_poll(void *p_data, unsigned char *r_buffer, size_t p_len, size_t *r_len) {
-	*r_len = 0;
-	Error err = OS::get_singleton()->get_entropy(r_buffer, p_len);
-	ERR_FAIL_COND_V(err, MBEDTLS_ERR_ENTROPY_SOURCE_FAILED);
-	*r_len = p_len;
-	return 0;
 }
 
 Error CryptoCore::RandomGenerator::init() {

--- a/core/crypto/crypto_core.h
+++ b/core/crypto/crypto_core.h
@@ -39,8 +39,6 @@ public:
 		void *entropy = nullptr;
 		void *ctx = nullptr;
 
-		static int _entropy_poll(void *p_data, unsigned char *r_buffer, size_t p_len, size_t *r_len);
-
 	public:
 		RandomGenerator();
 		~RandomGenerator();

--- a/thirdparty/mbedtls/include/godot_core_mbedtls_config.h
+++ b/thirdparty/mbedtls/include/godot_core_mbedtls_config.h
@@ -48,7 +48,10 @@
 #define MBEDTLS_SHA1_C
 #define MBEDTLS_SHA256_C
 #define MBEDTLS_PLATFORM_ZEROIZE_ALT
-#define MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES
+
+// Custom entropy source.
+#define MBEDTLS_NO_PLATFORM_ENTROPY
+#define MBEDTLS_ENTROPY_HARDWARE_ALT
 
 // This is only to pass a check in the mbedtls check_config.h header, none of
 // the files we include as part of the core build uses it anyway, we already

--- a/thirdparty/mbedtls/include/godot_module_mbedtls_config.h
+++ b/thirdparty/mbedtls/include/godot_module_mbedtls_config.h
@@ -56,6 +56,10 @@
 #define GODOT_MBEDTLS_THREADING_ALT
 #endif
 
+// Custom entropy source.
+#define MBEDTLS_NO_PLATFORM_ENTROPY
+#define MBEDTLS_ENTROPY_HARDWARE_ALT
+
 #if !(defined(__linux__) && defined(__aarch64__))
 // ARMv8 hardware AES operations. Detection only possible on linux.
 // May technically be supported on some ARM32 arches but doesn't seem


### PR DESCRIPTION
## What problem(s) does this PR solve?

Regression fix for mbedtls.

## Additional information

4.5 implementation of #121759.