### PR TITLE
GDScript: Don't use soft type for default container type

### DIFF
--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -153,7 +153,7 @@ public:
 		_FORCE_INLINE_ static DataType get_variant_type() { // Default DataType for container elements.
 			DataType datatype;
 			datatype.kind = VARIANT;
-			datatype.type_source = INFERRED;
+			datatype.type_source = ANNOTATED_INFERRED;
 			return datatype;
 		}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Simplifies reasoning by getting rid of a soft type occurrence.

## Additional information

A soft type, that is type with a `type_source == INFERRED` will be treated like `Variant` in most cases (see e.g. `_gdtype_from_datatype`). Thus there is no reason to have `kind == VARIANT` type with `type_source == INFERRED`. If a place uses the type and does not check for `type_source` this change makes no difference. If a place uses the type and does check for `type_source` it will still treat the type as `Variant`
