### PR TITLE
Fix incorrect gizmo positions in the canvas editor

### DIFF
--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -1642,6 +1642,7 @@ bool CanvasItemEditor::_gui_input_rotate(const Ref<InputEvent> &p_event) {
 				if (drag_selection.size() > 0) {
 					drag_type = DRAG_ROTATE;
 					drag_from = transform.affine_inverse().xform(b->get_position());
+					drag_to = drag_from;
 					CanvasItem *ci = drag_selection.front()->get();
 					if (!Math::is_inf(temp_pivot.x) || !Math::is_inf(temp_pivot.y)) {
 						drag_rotation_center = temp_pivot;
@@ -1651,6 +1652,7 @@ bool CanvasItemEditor::_gui_input_rotate(const Ref<InputEvent> &p_event) {
 						drag_rotation_center = ci->get_screen_transform().get_origin();
 					}
 					_save_canvas_item_state(drag_selection);
+					viewport->queue_redraw();
 					return true;
 				} else {
 					if (has_locked_items) {
@@ -2101,6 +2103,7 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 				}
 
 				drag_from = transform.affine_inverse().xform(b->get_position());
+				drag_to = drag_from;
 				drag_selection = selection;
 				_save_canvas_item_state(drag_selection);
 				return true;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fix the line rotation indicator drawn in the canvas editor pointing to the wrong direction on the first click, and not being drawn at all on subsequent clicks:

<img width="417" height="279" alt="Screenshot_20260730_142201" src="https://github.com/user-attachments/assets/96aadd60-da75-4d87-afe5-2b9093c2e1eb" />

- Fix scale handle stretching on first click:

<img width="397" height="282" alt="image" src="https://github.com/user-attachments/assets/788b85f4-63f6-435a-b3ab-bddc600af909" />