### PR TITLE
Don't use `get_item_idx_from_text()` to disable items

### DIFF
--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -824,7 +824,7 @@ void AnimationNodeStateMachineEditor::_open_menu(const Vector2 &p_position) {
 	LocalVector<StringName> animation_names = tree->get_sorted_animation_list();
 	menu->add_submenu_node_item(TTR("Add Animation"), animations_menu);
 	if (animation_names.is_empty()) {
-		menu->set_item_disabled(menu->get_item_idx_from_text(TTR("Add Animation")), true);
+		menu->set_item_disabled(-1, true);
 	} else {
 		for (const StringName &name : animation_names) {
 			animations_menu->add_icon_item(theme_cache.animation_icon, name);

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4080,11 +4080,10 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 
 					menu->add_check_item(TTRC("Editable Children"), TOOL_SCENE_EDITABLE_CHILDREN);
 					menu->set_item_shortcut(-1, ED_GET_SHORTCUT("scene_tree/toggle_editable_children"));
+					menu->set_item_checked(-1, editable);
 
 					menu->add_check_item(TTRC("Load as Placeholder"), TOOL_SCENE_USE_PLACEHOLDER);
-
-					menu->set_item_checked(menu->get_item_idx_from_text(TTR("Editable Children")), editable);
-					menu->set_item_checked(menu->get_item_idx_from_text(TTR("Load as Placeholder")), placeholder);
+					menu->set_item_checked(-1, placeholder);
 				}
 				is_tool_scene_open_available = true;
 			}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

There are better ways to get item ID than searching it by text. In most cases, you can just access the last item with `-1`.

Notably, the `from_text()` method caused Editable Children to not get checked properly when using non-English language, because the searched text was different (technically a regression from #113987 🤷‍♂️).
