### PR TITLE
AudioStreamInteractive: Fix FADE_DISABLED/_OUT with filler clip

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -821,30 +821,19 @@ void AudioStreamPlaybackInteractive::_queue(int p_to_clip_index, bool p_is_auto_
 			src_no_loop = true;
 		}
 
-		if (transition.fade_mode == AudioStreamInteractive::FADE_DISABLED || transition.fade_mode == AudioStreamInteractive::FADE_OUT) {
-			// No fading, immediately start at full volume.
-			to_state.fade_volume = 0.0;
-			to_state.fade_speed = 1.0; //start at full volume, as filler is meant as a transition.
-		} else {
-			// Fade enable, prepare fade.
-			to_state.fade_volume = 0.0;
-			to_state.fade_speed = fade_speed;
-		}
-
 		to_state.fade_wait = src_fade_wait + filler_end;
 
 	} else {
 		to_state.fade_wait = src_fade_wait;
-
-		if (transition.fade_mode == AudioStreamInteractive::FADE_DISABLED || transition.fade_mode == AudioStreamInteractive::FADE_OUT) {
-			to_state.fade_volume = 1.0;
-			to_state.fade_speed = 0.0;
-		} else {
-			to_state.fade_volume = 0.0;
-			to_state.fade_speed = fade_speed;
-		}
-
 		to_state.auto_advance = auto_advance_to;
+	}
+
+	if (transition.fade_mode == AudioStreamInteractive::FADE_DISABLED || transition.fade_mode == AudioStreamInteractive::FADE_OUT) {
+		to_state.fade_volume = 1.0;
+		to_state.fade_speed = 0.0;
+	} else {
+		to_state.fade_volume = 0.0;
+		to_state.fade_speed = fade_speed;
 	}
 }
 


### PR DESCRIPTION
Previously, if a transition was configured with `FADE_DISABLED` or `FADE_OUT` but had a filler clip, the target clip would erroneously be faded in for 1 beat. This was caused by typos in the `if (use_filler_clip ...)` version of the logic that sets `to_state.fade_volume` and `to_state.fade_speed` in the FADE_DISABLED/FADE_OUT case: `fade_volume` is the volume to fade *from*, and it was set to `0.0` in all cases when a filler clip is in use. It should be `1.0` (i.e. start at full volume) in the `FADE_DISABLED`/`FADE_OUT` case.

The `!use_filler_clip` case below has correct logic. Since the code should be identical in both cases, move the correct code outside the `if (use_filler_clip)` conditional.

## What problem(s) does this PR solve?

As described above. I have not filed a bug because I found a 1-character fix while doing research before filing a bug!

## Additional information

https://github.com/endlessm/threadbare/pull/2618 exhibits the problem in a real game. I realise this is far from a minimal reproducer! So:

Here is a project that reproduces the problem. [asi-121952.zip](https://github.com/user-attachments/files/30563280/asi-121952.zip) It has an AudioStreamInteractive with 3 clips:

- C (a loop of two C notes an octave apart)
- G (two G notes an octave apart, not looping)
- A (a loop of two A notes an octave apart)

C -> A and A -> C have transitions configured with:

- Transition from: Clip End in one case and Next Bar in the other case - it makes no difference because the clips are 1 bar long
- Transition to: Clip Start
- Fade mode: Disabled
- Fade Beats: 0.0 (should be ignored anyway since fade is disabled)
- Filler Clip: G

There is a pair of buttons to trigger a switch to C and to A. You can hear that the filler clip plays at the correct time, at full volume, but then the volume at the start of the target clip is 0 and it fades in before looping at full volume.

With the patch in this PR, the target clip correctly does not fade in.