### PR TITLE
Core: Fix `append_utf16` default argument conflict

### DIFF
--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -562,8 +562,8 @@ public:
 
 	Char16String utf16() const;
 	Error append_utf16(const char16_t *p_utf16, int p_len = -1, bool p_default_little_endian = true);
-	Error append_utf16(const Span<char16_t> p_range, bool p_skip_cr = false) {
-		return append_utf16(p_range.ptr(), p_range.size(), p_skip_cr);
+	Error append_utf16(const Span<char16_t> p_range, bool p_default_little_endian = true) {
+		return append_utf16(p_range.ptr(), p_range.size(), p_default_little_endian);
 	}
 	static String utf16(const char16_t *p_utf16, int p_len = -1) {
 		String ret;

--- a/tests/core/string/test_string.cpp
+++ b/tests/core/string/test_string.cpp
@@ -94,7 +94,17 @@ TEST_CASE("[String] UTF8") {
 	CHECK(parsed == u32str);
 
 	parsed.clear();
+	err = parsed.append_utf8(expected.utf8().span());
+	CHECK(err == OK);
+	CHECK(parsed == u32str);
+
+	parsed.clear();
 	err = parsed.append_utf8((const char *)u8str);
+	CHECK(err == OK);
+	CHECK(parsed == u32str);
+
+	parsed.clear();
+	err = parsed.append_utf8(Span(u8str).reinterpret<char>());
 	CHECK(err == OK);
 	CHECK(parsed == u32str);
 
@@ -113,7 +123,17 @@ TEST_CASE("[String] UTF16") {
 	CHECK(parsed == u32str);
 
 	parsed.clear();
+	err = parsed.append_utf16(expected.utf16().span());
+	CHECK(err == OK);
+	CHECK(parsed == u32str);
+
+	parsed.clear();
 	err = parsed.append_utf16(u16str);
+	CHECK(err == OK);
+	CHECK(parsed == u32str);
+
+	parsed.clear();
+	err = parsed.append_utf16(Span(u16str));
 	CHECK(err == OK);
 	CHECK(parsed == u32str);
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

Since its introduction in #101293, the default arguments for `append_utf16` differ depending on if the passed value is a pointer + length, or a `Span` (formerly `StrRange`). This seems to be a copy/paste error, as the argument is meant to be `bool p_default_little_endian = true`, but for `Span` it used `bool p_skip_cr = false` which was removed from `append_utf8` in #110867. This assigns the correct name & default value for the argument.

## Additional information

Additional `String` tests were added to ensure pointer/length & `Span` functions have identical outputs. Without this change, the utf-16 `Span` checks would fail, as they'd be passed as big-endian erroneously.