### PR TITLE
Clarify global coordinates for PhysicsDirectSpaceState2D queries

### DIFF
--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		Provides direct access to a physics space in the [PhysicsServer2D]. It's used mainly to do queries against objects and areas residing in a given space.
+		All coordinates and transforms used for queries are in global coordinate space. They should not be relative to the [CanvasItem] making the query. For example, use [method Node2D.to_global] to convert a local position to global coordinates.
 		[b]Note:[/b] This class is not meant to be instantiated directly. Use [member World2D.direct_space_state] to get the world's physics 2D space state.
 	</description>
 	<tutorials>

--- a/doc/classes/PhysicsShapeQueryParameters2D.xml
+++ b/doc/classes/PhysicsShapeQueryParameters2D.xml
@@ -63,7 +63,7 @@
 			[/codeblocks]
 		</member>
 		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform" default="Transform2D(1, 0, 0, 1, 0, 0)">
-			The queried shape's transform matrix.
+			The queried shape's transform matrix, in global coordinates.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Clarifies that `PhysicsDirectSpaceState2D` queries use global coordinates rather than coordinates local to the `CanvasItem` making the query.
- Specifies that `PhysicsShapeQueryParameters2D.transform` is expressed in global coordinates.

## Additional information

The point and ray query parameter classes already identify their positions as global. This adds the shared rule to the direct space state class and fills the remaining ambiguity for shape query transforms without repeating it on every method.

Validated with:

- `python3 doc/tools/make_rst.py doc/classes modules platform --dry-run --color`
- `python3 doc/tools/doc_status.py doc/classes modules/*/doc_classes platform/*/doc_classes -c`
- `python3 misc/scripts/file_format.py doc/classes/PhysicsDirectSpaceState2D.xml doc/classes/PhysicsShapeQueryParameters2D.xml`
- `python3 misc/scripts/validate_xml.py doc/classes/PhysicsDirectSpaceState2D.xml doc/classes/PhysicsShapeQueryParameters2D.xml`
- `codespell doc/classes/PhysicsDirectSpaceState2D.xml doc/classes/PhysicsShapeQueryParameters2D.xml`
- `git diff --check`
