### PR TITLE
TouchActionsPanel: Add a TAB button and move it to bottom in portrait mode

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8370,21 +8370,21 @@ void EditorNode::_bottom_panel_resized() {
 void EditorNode::_touch_actions_panel_mode_changed() {
 	int panel_mode = EDITOR_GET("interface/touchscreen/touch_actions_panel");
 	switch (panel_mode) {
-		case 1:
+		case 1: // Embedded
 			if (touch_actions_panel != nullptr) {
 				touch_actions_panel->queue_free();
 			}
-			touch_actions_panel = memnew(TouchActionsPanel);
-			main_hbox->call_deferred("add_child", touch_actions_panel);
+			touch_actions_panel = memnew(TouchActionsPanel(false));
+			main_box->call_deferred("add_child", touch_actions_panel);
 			break;
-		case 2:
+		case 2: // Floating
 			if (touch_actions_panel != nullptr) {
 				touch_actions_panel->queue_free();
 			}
-			touch_actions_panel = memnew(TouchActionsPanel);
+			touch_actions_panel = memnew(TouchActionsPanel(true));
 			call_deferred("add_child", touch_actions_panel);
 			break;
-		case 0:
+		case 0: // Disabled
 			if (touch_actions_panel != nullptr) {
 				touch_actions_panel->queue_free();
 				touch_actions_panel = nullptr;
@@ -8759,11 +8759,13 @@ EditorNode::EditorNode() {
 	title_bar = memnew(EditorTitleBar);
 	base_vbox->add_child(title_bar);
 
-	main_hbox = memnew(HBoxContainer);
-	main_hbox->add_child(main_vbox);
+	main_box = memnew(BoxContainer);
+	main_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	main_box->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	main_vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	main_hbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	base_vbox->add_child(main_hbox);
+	main_vbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	main_box->add_child(main_vbox);
+	base_vbox->add_child(main_box);
 
 	_touch_actions_panel_mode_changed();
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -43,6 +43,7 @@ typedef void (*EditorPluginInitializeCallback)();
 typedef bool (*EditorBuildCallback)();
 
 class AcceptDialog;
+class BoxContainer;
 class ColorPicker;
 class ConfirmationDialog;
 class Control;
@@ -294,8 +295,8 @@ private:
 	OptionButton *renderer = nullptr;
 
 #ifdef ANDROID_ENABLED
-	VBoxContainer *base_vbox = nullptr; // It only contains the title_bar and main_hbox.
-	HBoxContainer *main_hbox = nullptr; // It only contains the touch_actions_panel and main_vbox.
+	VBoxContainer *base_vbox = nullptr; // It only contains the title_bar and main_box.
+	BoxContainer *main_box = nullptr; // It only contains the touch_actions_panel and main_vbox.
 	TouchActionsPanel *touch_actions_panel = nullptr;
 	void _touch_actions_panel_mode_changed();
 #endif

--- a/editor/gui/touch_actions_panel.cpp
+++ b/editor/gui/touch_actions_panel.cpp
@@ -45,7 +45,8 @@ void TouchActionsPanel::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			DisplayServer::get_singleton()->set_hardware_keyboard_connection_change_callback(callable_mp(this, &TouchActionsPanel::_hardware_keyboard_connected));
 			_hardware_keyboard_connected(DisplayServer::get_singleton()->has_hardware_keyboard());
-			if (!is_floating) {
+			DisplayServer::get_singleton()->connect("orientation_changed", callable_mp(this, &TouchActionsPanel::_screen_orientation_changed));
+			if (!is_floating && !portrait_mode) {
 				get_parent()->move_child(this, embedded_panel_index);
 			}
 		} break;
@@ -71,6 +72,7 @@ void TouchActionsPanel::_notification(int p_what) {
 			cut_button->set_button_icon(get_editor_theme_icon(SNAME("ActionCut")));
 			copy_button->set_button_icon(get_editor_theme_icon(SNAME("ActionCopy")));
 			paste_button->set_button_icon(get_editor_theme_icon(SNAME("ActionPaste")));
+			tab_button->set_button_icon(get_editor_theme_icon(SNAME("KeyboardTab")));
 		} break;
 	}
 }
@@ -91,6 +93,21 @@ void TouchActionsPanel::input(const Ref<InputEvent> &event) {
 
 void TouchActionsPanel::_hardware_keyboard_connected(bool p_connected) {
 	set_visible(!p_connected);
+}
+
+void TouchActionsPanel::_screen_orientation_changed(int p_new_orientation) {
+	portrait_mode = p_new_orientation == 1;
+
+	if (is_floating) {
+		return;
+	}
+
+	box->set_vertical(!portrait_mode);
+	box->set_alignment(portrait_mode ? BoxContainer::ALIGNMENT_CENTER : BoxContainer::ALIGNMENT_BEGIN);
+	panel_pos_button->set_visible(!portrait_mode);
+	separator->set_color(portrait_mode ? Color(0, 0, 0, 0) : Color(0.5, 0.5, 0.5));
+	get_parent()->move_child(this, portrait_mode ? 1 : embedded_panel_index);
+	get_parent()->call("set_vertical", portrait_mode);
 }
 
 void TouchActionsPanel::_simulate_editor_shortcut(const String &p_shortcut_name) {
@@ -129,7 +146,7 @@ void TouchActionsPanel::_on_modifier_button_toggled(bool p_pressed, int p_modifi
 
 Button *TouchActionsPanel::_add_new_action_button(const String &p_shortcut, const String &p_name, Key p_keycode) {
 	Button *action_button = memnew(Button);
-	action_button->set_theme_type_variation("FlatMenuButton");
+	action_button->set_theme_type_variation("TouchActionsPanelButton");
 	action_button->set_accessibility_name(p_name);
 	action_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	action_button->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
@@ -158,7 +175,7 @@ void TouchActionsPanel::_add_new_modifier_button(Modifier p_modifier) {
 	Button *toggle_button = memnew(Button);
 	toggle_button->set_text(text);
 	toggle_button->set_toggle_mode(true);
-	toggle_button->set_theme_type_variation("FlatMenuButton");
+	toggle_button->set_theme_type_variation("TouchActionsPanelButton");
 	toggle_button->set_accessibility_name(text);
 	toggle_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 	toggle_button->connect(SceneStringName(toggled), callable_mp(this, &TouchActionsPanel::_on_modifier_button_toggled).bind((int)p_modifier));
@@ -223,9 +240,11 @@ void TouchActionsPanel::_switch_embedded_panel_side() {
 	EditorSettings::get_singleton()->save();
 }
 
-TouchActionsPanel::TouchActionsPanel() {
-	int panel_mode = EDITOR_GET("interface/touchscreen/touch_actions_panel");
-	is_floating = panel_mode == 2;
+TouchActionsPanel::TouchActionsPanel(bool p_floating) {
+	is_floating = p_floating;
+
+	Vector2 parent_area = get_parent_area_size();
+	portrait_mode = parent_area.height > parent_area.width;
 
 	if (is_floating) {
 		Ref<StyleBoxFlat> panel_style;
@@ -237,10 +256,11 @@ TouchActionsPanel::TouchActionsPanel() {
 		panel_style->set_content_margin_all(12);
 		add_theme_style_override(SceneStringName(panel), panel_style);
 
-		set_position(EDITOR_DEF("_touch_actions_panel_position", Point2(480, 480))); // Dropped it here for no good reason — users can move it anyway.
+		set_position(EDITOR_DEF("_touch_actions_panel_position", Point2(100, 480)));
 	}
 
 	box = memnew(BoxContainer);
+	box->set_alignment(portrait_mode ? BoxContainer::ALIGNMENT_CENTER : BoxContainer::ALIGNMENT_BEGIN);
 	box->add_theme_constant_override("separation", 20);
 	if (is_floating) {
 		box->set_vertical(EDITOR_DEF("_touch_actions_panel_vertical_layout", false));
@@ -257,7 +277,7 @@ TouchActionsPanel::TouchActionsPanel() {
 		box->add_child(drag_handle);
 
 		layout_toggle_button = memnew(Button);
-		layout_toggle_button->set_theme_type_variation("FlatMenuButton");
+		layout_toggle_button->set_theme_type_variation("TouchActionsPanelButton");
 		layout_toggle_button->set_accessibility_name(TTRC("Switch Layout"));
 		layout_toggle_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 		layout_toggle_button->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
@@ -266,7 +286,7 @@ TouchActionsPanel::TouchActionsPanel() {
 
 		lock_panel_button = memnew(Button);
 		lock_panel_button->set_toggle_mode(true);
-		lock_panel_button->set_theme_type_variation("FlatMenuButton");
+		lock_panel_button->set_theme_type_variation("TouchActionsPanelButton");
 		lock_panel_button->set_accessibility_name(TTRC("Lock Panel"));
 		lock_panel_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 		lock_panel_button->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
@@ -274,18 +294,24 @@ TouchActionsPanel::TouchActionsPanel() {
 		box->add_child(lock_panel_button);
 	} else {
 		panel_pos_button = memnew(Button);
-		panel_pos_button->set_theme_type_variation("FlatMenuButton");
+		panel_pos_button->set_theme_type_variation("TouchActionsPanelButton");
 		panel_pos_button->set_accessibility_name(TTRC("Switch Embedded Panel Position"));
 		panel_pos_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 		panel_pos_button->set_icon_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+		panel_pos_button->set_visible(!portrait_mode);
 		panel_pos_button->connect(SceneStringName(pressed), callable_mp(this, &TouchActionsPanel::_switch_embedded_panel_side));
 		box->add_child(panel_pos_button);
 
 		embedded_panel_index = EDITOR_DEF("_touch_actions_panel_embed_index", 0);
 	}
 
-	ColorRect *separator = memnew(ColorRect);
-	separator->set_color(Color(0.5, 0.5, 0.5));
+	separator = memnew(ColorRect);
+	if (is_floating || !portrait_mode) {
+		separator->set_color(Color(0.5, 0.5, 0.5));
+	} else {
+		// Using it as a margin for corner radius.
+		separator->set_color(Color(0, 0, 0, 0));
+	}
 	separator->set_custom_minimum_size(Size2(2, 2));
 	box->add_child(separator);
 
@@ -297,6 +323,7 @@ TouchActionsPanel::TouchActionsPanel() {
 	cut_button = _add_new_action_button("ui_cut", TTRC("Cut"));
 	copy_button = _add_new_action_button("ui_copy", TTRC("Copy"));
 	paste_button = _add_new_action_button("ui_paste", TTRC("Paste"));
+	tab_button = _add_new_action_button("", TTRC("Tab"), Key::TAB);
 
 	_add_new_modifier_button(MODIFIER_CTRL);
 	_add_new_modifier_button(MODIFIER_SHIFT);

--- a/editor/gui/touch_actions_panel.h
+++ b/editor/gui/touch_actions_panel.h
@@ -34,6 +34,7 @@
 
 class BoxContainer;
 class Button;
+class ColorRect;
 class TextureRect;
 
 class TouchActionsPanel : public PanelContainer {
@@ -48,11 +49,13 @@ private:
 	Button *cut_button = nullptr;
 	Button *copy_button = nullptr;
 	Button *paste_button = nullptr;
+	Button *tab_button = nullptr;
 
 	TextureRect *drag_handle = nullptr;
 	Button *layout_toggle_button = nullptr;
 	Button *lock_panel_button = nullptr;
 	Button *panel_pos_button = nullptr;
+	ColorRect *separator = nullptr;
 
 	bool locked_panel = false;
 	bool dragging = false;
@@ -70,6 +73,7 @@ private:
 
 	bool is_floating = false; // Embedded panel mode is default.
 	int embedded_panel_index = 0;
+	bool portrait_mode = false;
 
 	void _notification(int p_what);
 	virtual void input(const Ref<InputEvent> &event) override;
@@ -86,7 +90,8 @@ private:
 	void _on_modifier_button_toggled(bool p_pressed, int p_modifier);
 
 	void _hardware_keyboard_connected(bool p_connected);
+	void _screen_orientation_changed(int p_new_orientation);
 
 public:
-	TouchActionsPanel();
+	TouchActionsPanel(bool p_floating);
 };

--- a/editor/icons/KeyboardTab.svg
+++ b/editor/icons/KeyboardTab.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" fill="#e0e0e0" viewBox="0 -960 960 960"><path d="M768-240v-480h72v480h-72Zm-264-48-51-51 105-105H120v-72h438L453-621l51-51 192 192-192 192Z"/></svg>

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1999,6 +1999,13 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_stylebox(SceneStringName(hover), "EditorLogFilterButton", p_config.flat_button_hover);
 			p_theme->set_stylebox(SceneStringName(pressed), "EditorLogFilterButton", p_config.flat_button_pressed);
 			p_theme->set_stylebox("hover_pressed", "EditorLogFilterButton", p_config.flat_button_hover_pressed);
+
+			p_theme->set_type_variation("TouchActionsPanelButton", "FlatButtonNoIconTint");
+			Ref<StyleBoxFlat> tap_button_hover = p_config.flat_button_hover->duplicate();
+			Color hover_color = p_config.flat_button_hover_color;
+			hover_color.a = 0.25f;
+			tap_button_hover->set_bg_color(hover_color);
+			p_theme->set_stylebox(SceneStringName(hover), "TouchActionsPanelButton", tap_button_hover);
 		}
 
 		// Checkbox.


### PR DESCRIPTION
- Move TouchActionsPanel to bottom in portrait mode.
- Adds a new action button for TAB key
- Add a subtle hover style to panel buttons.
    - This fixes an issue where the hover style remains visible after clicking a button because the mouse pointer is still positioned over it. Can't remove the hover style completely because it would affect mouse and stylus usability, so making it more subtle.
