### PR TITLE
Make RID_Owners threadsafe in the Dummy Renderer

### DIFF
--- a/servers/rendering/dummy/storage/material_storage.h
+++ b/servers/rendering/dummy/storage/material_storage.h
@@ -50,7 +50,7 @@ private:
 		HashMap<StringName, ShaderLanguage::ShaderNode::Uniform> uniforms;
 	};
 
-	mutable RID_Owner<DummyShader> shader_owner;
+	mutable RID_Owner<DummyShader, true> shader_owner;
 
 	ShaderCompiler dummy_compiler;
 	HashSet<RID> dummy_embedded_set;
@@ -60,7 +60,7 @@ private:
 		RID next_pass;
 	};
 
-	mutable RID_Owner<DummyMaterial> material_owner;
+	mutable RID_Owner<DummyMaterial, true> material_owner;
 
 public:
 	static MaterialStorage *get_singleton() { return singleton; }

--- a/servers/rendering/dummy/storage/mesh_storage.h
+++ b/servers/rendering/dummy/storage/mesh_storage.h
@@ -47,13 +47,13 @@ class MeshStorage : public RendererMeshStorage {
 private:
 	static MeshStorage *singleton;
 
-	mutable RID_Owner<DummyMesh> mesh_owner;
+	mutable RID_Owner<DummyMesh, true> mesh_owner;
 
 	struct DummyMultiMesh {
 		PackedFloat32Array buffer;
 	};
 
-	mutable RID_Owner<DummyMultiMesh> multimesh_owner;
+	mutable RID_Owner<DummyMultiMesh, true> multimesh_owner;
 
 public:
 	static MeshStorage *get_singleton() { return singleton; }

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -42,7 +42,7 @@ private:
 	struct DummyTexture {
 		Ref<Image> image;
 	};
-	mutable RID_PtrOwner<DummyTexture> texture_owner;
+	mutable RID_PtrOwner<DummyTexture, true> texture_owner;
 
 public:
 	static TextureStorage *get_singleton() { return singleton; }


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/121949

This is needed since these RIDs can be allocated from any thread.

This matches the behavior on the other renderers


