### PR TITLE
Fix move node(s) here editor action for controls within container

### DIFF
--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -1039,6 +1039,9 @@ void CanvasItemEditor::_add_node_pressed(int p_result) {
 			for (Node *node : nodes_to_move) {
 				CanvasItem *ci = Object::cast_to<CanvasItem>(node);
 				if (ci) {
+					if (!_is_node_movable(ci, true)) {
+						continue;
+					}
 					Transform2D xform = ci->get_global_transform_with_canvas().affine_inverse() * ci->get_transform();
 					undo_redo->add_do_method(ci, "_edit_set_position", xform.xform(node_create_position));
 					undo_redo->add_undo_method(ci, "_edit_set_position", ci->_edit_get_position());
@@ -2545,7 +2548,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 				}
 			}
 			for (Node *node : EditorNode::get_singleton()->get_editor_selection()->get_top_selected_node_list()) {
-				if (Object::cast_to<CanvasItem>(node)) {
+				if (Object::cast_to<CanvasItem>(node) && _is_node_movable(node, false)) {
 					add_node_menu->add_icon_item(get_editor_theme_icon(SNAME("ToolMove")), TTRC("Move Node(s) Here"), ADD_MOVE);
 					break;
 				}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/121900

## Additional information

If you only select controls that are within a container context menu option for "move node(s) here" is not shown.

For a mixed selection a toast message is shown that children of container get their position from their parent. Same as when you try to drag them with the mouse.
 
[Screencast_20260731_132419.webm](https://github.com/user-attachments/assets/d3ade375-4f5c-4a26-9f94-6b411f3d3bd9)


This change currently also stops it from moving locked nodes