### PR TITLE
[Buildsystem] Ping `master` cache after saving cache

### DIFF
--- a/.github/actions/godot-cache-save/action.yml
+++ b/.github/actions/godot-cache-save/action.yml
@@ -20,3 +20,14 @@ runs:
       with:
         path: ${{ inputs.scons-cache }}
         key: ${{ inputs.cache-name }}|${{ github.ref_name }}|${{ github.sha }}
+
+    # This is done after saving the new cache so that the base cache remains more relevant, to reduce
+    # the risk of the cache being purged when multiple large PRs are pushed/merged at the same time.
+    - name: Ping default cache
+      uses: actions/cache/restore@v6
+      if: github.ref_name != github.event.repository.default_branch
+      with:
+        path: ${{ inputs.scons-cache }}
+        key: ${{ inputs.cache-name }}|${{ github.event.repository.default_branch }}|${{ github.sha }}
+        restore-keys: ${{ inputs.cache-name }}|${{ github.event.repository.default_branch }}
+        lookup-only: true


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

This should improve cache retention on large builds.

## Additional information

I noticed that the `master` branch cache got purged a few times recently, and I suspect this was due to several PRs being opened against maintenance branches. If, for example, four large PRs are opened or updated or merged at the same time on separate branches, this would trigger a situation where the `master` cache is fetched, and then each of those PRs would save caches making up a significant portion of the size of the `master` cache, which would fill up the cache limit. When GitHub then decides to purge caches the `master` cache would be older than a lot of large caches, regardless of other PR activity, causing the `master` cache to be purged

This *should* reduce the risk of this (it is still possible for this to cause purges of caches on steps that are relatively quick, for example if the iOS builds for each branch are built quickly, in this case that cache would still be older than caches on the branch, but this should still help)

An alternative solution would be to simply not save caches on merge for non-master branches as they wouldn't really be useful for the most part, but that would affect forks so I think this is a good solution for now

This hasn't really been an issue until recently as far as I can tell generally, but there has been batches of PRs for multiple older branches recently which probably pushes things to their limits

Confirmed on my own branch that this makes the `master` cache sort more recently than the cache of each build

No AI was used in making this PR.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
