### PR TITLE
Jolt Physics: MinGW32 defines __STDCPP_DEFAULT_NEW_ALIGNMENT__  as 16 but its allocations are 8 byte aligned

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -519,6 +519,10 @@ Files extracted from upstream source:
 - All files in `Jolt/`, except `Jolt/Jolt.cmake`, any files dependent on `ENABLE_OBJECT_STREAM` as seen in `Jolt/Jolt.cmake` and the `Jolt/Physics/Hair/`, `Jolt/Compute/` and `Jolt/Shaders/` folders.
 - `LICENSE`
 
+Patches:
+
+- `0001-backport-upstream-commit-63f2f57.patch` (GH-121974)
+
 
 ## libbacktrace
 

--- a/thirdparty/jolt_physics/Jolt/Core/Core.h
+++ b/thirdparty/jolt_physics/Jolt/Core/Core.h
@@ -585,7 +585,14 @@ static_assert(sizeof(uint64) == 8, "Invalid size of uint64");
 // Default memory allocation alignment.
 // This define can be overridden in case the user provides an Allocate function that has a different alignment than the platform default.
 #ifndef JPH_DEFAULT_ALLOCATE_ALIGNMENT
-	#define JPH_DEFAULT_ALLOCATE_ALIGNMENT __STDCPP_DEFAULT_NEW_ALIGNMENT__
+	#if defined(JPH_COMPILER_MINGW) && JPH_CPU_ARCH_BITS == 32
+		// 32-bit MinGW g++ lies that __STDCPP_DEFAULT_NEW_ALIGNMENT__ is 16, but it is actually 8.
+		// See: https://github.com/godotengine/godot/issues/121608#issuecomment-5142806330
+		// Note: See similar fix for the definition of JPH_INTERNAL_DEFAULT_ALLOCATE.
+		#define JPH_DEFAULT_ALLOCATE_ALIGNMENT 8
+	#else
+		#define JPH_DEFAULT_ALLOCATE_ALIGNMENT __STDCPP_DEFAULT_NEW_ALIGNMENT__
+	#endif
 #endif
 
 // Cache line size (used for aligning to cache line)

--- a/thirdparty/jolt_physics/Jolt/Core/Memory.h
+++ b/thirdparty/jolt_physics/Jolt/Core/Memory.h
@@ -38,6 +38,7 @@ JPH_EXPORT void RegisterDefaultAllocator();
 // It uses the non-aligned version, which on 32 bit platforms usually returns an 8 byte aligned block.
 // We therefore default to 16 byte aligned allocations when the regular new operator is used.
 // See: https://github.com/godotengine/godot/issues/105455#issuecomment-2824311547
+// Note: See similar fix for the definition of JPH_DEFAULT_ALLOCATE_ALIGNMENT
 #if defined(JPH_COMPILER_MINGW) && JPH_CPU_ARCH_BITS == 32
 	#define JPH_INTERNAL_DEFAULT_ALLOCATE(size) JPH::AlignedAllocate(size, 16)
 	#define JPH_INTERNAL_DEFAULT_FREE(pointer) JPH::AlignedFree(pointer)

--- a/thirdparty/jolt_physics/patches/0001-backport-upstream-commit-63f2f57.patch
+++ b/thirdparty/jolt_physics/patches/0001-backport-upstream-commit-63f2f57.patch
@@ -1,0 +1,32 @@
+diff --git a/thirdparty/jolt_physics/Jolt/Core/Core.h b/thirdparty/jolt_physics/Jolt/Core/Core.h
+index 30377deeff..10362b3225 100644
+--- a/thirdparty/jolt_physics/Jolt/Core/Core.h
++++ b/thirdparty/jolt_physics/Jolt/Core/Core.h
+@@ -585,7 +585,14 @@ static_assert(sizeof(uint64) == 8, "Invalid size of uint64");
+ // Default memory allocation alignment.
+ // This define can be overridden in case the user provides an Allocate function that has a different alignment than the platform default.
+ #ifndef JPH_DEFAULT_ALLOCATE_ALIGNMENT
+-	#define JPH_DEFAULT_ALLOCATE_ALIGNMENT __STDCPP_DEFAULT_NEW_ALIGNMENT__
++	#if defined(JPH_COMPILER_MINGW) && JPH_CPU_ARCH_BITS == 32
++		// 32-bit MinGW g++ lies that __STDCPP_DEFAULT_NEW_ALIGNMENT__ is 16, but it is actually 8.
++		// See: https://github.com/godotengine/godot/issues/121608#issuecomment-5142806330
++		// Note: See similar fix for the definition of JPH_INTERNAL_DEFAULT_ALLOCATE.
++		#define JPH_DEFAULT_ALLOCATE_ALIGNMENT 8
++	#else
++		#define JPH_DEFAULT_ALLOCATE_ALIGNMENT __STDCPP_DEFAULT_NEW_ALIGNMENT__
++	#endif
+ #endif
+ 
+ // Cache line size (used for aligning to cache line)
+diff --git a/thirdparty/jolt_physics/Jolt/Core/Memory.h b/thirdparty/jolt_physics/Jolt/Core/Memory.h
+index 5df9781dd5..bf98d4fe79 100644
+--- a/thirdparty/jolt_physics/Jolt/Core/Memory.h
++++ b/thirdparty/jolt_physics/Jolt/Core/Memory.h
+@@ -38,6 +38,7 @@ JPH_EXPORT void RegisterDefaultAllocator();
+ // It uses the non-aligned version, which on 32 bit platforms usually returns an 8 byte aligned block.
+ // We therefore default to 16 byte aligned allocations when the regular new operator is used.
+ // See: https://github.com/godotengine/godot/issues/105455#issuecomment-2824311547
++// Note: See similar fix for the definition of JPH_DEFAULT_ALLOCATE_ALIGNMENT
+ #if defined(JPH_COMPILER_MINGW) && JPH_CPU_ARCH_BITS == 32
+ 	#define JPH_INTERNAL_DEFAULT_ALLOCATE(size) JPH::AlignedAllocate(size, 16)
+ 	#define JPH_INTERNAL_DEFAULT_FREE(pointer) JPH::AlignedFree(pointer)


### PR DESCRIPTION
Since 5.5.0 Jolt uses JPH_DEFAULT_ALLOCATE_ALIGNMENT (which defaults to __STDCPP_DEFAULT_NEW_ALIGNMENT__) to decide wether or not to use aligned allocations for arrays. On MinGW32 this leads to TriangleSplitterBinning::mBins not being 16 byte aligned. This causes an unaligned __m128 read which triggers this crash.

Fixes #121608