### PR TITLE
Fix code folding logic to stop folding over foldable regions

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1794,7 +1794,7 @@ bool CodeEdit::_fold_line(int p_line) {
 					end_line = i;
 					continue;
 				}
-				if (is_in_string(i) == -1 && is_in_comment(i) == -1) {
+				if ((is_in_string(i) == -1 && is_in_comment(i) == -1) || (can_fold_line(i) && get_indent_level(i) == start_indent)) {
 					break;
 				}
 			}

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1794,7 +1794,8 @@ bool CodeEdit::_fold_line(int p_line) {
 					end_line = i;
 					continue;
 				}
-				if ((is_in_string(i) == -1 && is_in_comment(i) == -1) || (can_fold_line(i) && get_indent_level(i) == start_indent)) {
+				int delimiter_end_line = get_delimiter_end_position(i, get_line(i).size() - 1).y;
+				if ((is_in_string(i) == -1 && is_in_comment(i) == -1) || (can_fold_line(i) && get_indent_level(i) == start_indent && delimiter_end_line == i)) {
 					break;
 				}
 			}

--- a/tests/scene/test_code_edit.cpp
+++ b/tests/scene/test_code_edit.cpp
@@ -3274,7 +3274,7 @@ TEST_CASE("[SceneTree][CodeEdit] folding") {
 		code_edit->fold_line(0);
 		CHECK(code_edit->is_line_folded(0));
 		CHECK_FALSE(code_edit->is_line_folded(1));
-		CHECK(code_edit->get_next_visible_line_offset_from(1, 1) == 2);
+		CHECK(code_edit->get_next_visible_line_offset_from(1, 1) == 4);
 
 		code_edit->set_text("test\n\tline1\n$line1\nline2$\n\ttest");
 		CHECK(code_edit->can_fold_line(0));
@@ -3284,7 +3284,7 @@ TEST_CASE("[SceneTree][CodeEdit] folding") {
 		code_edit->fold_line(0);
 		CHECK(code_edit->is_line_folded(0));
 		CHECK_FALSE(code_edit->is_line_folded(1));
-		CHECK(code_edit->get_next_visible_line_offset_from(1, 1) == 2);
+		CHECK(code_edit->get_next_visible_line_offset_from(1, 1) == 4);
 	}
 
 	SUBCASE("[CodeEdit] folding comments including and/or adjacent to code regions") {

--- a/tests/scene/test_code_edit.cpp
+++ b/tests/scene/test_code_edit.cpp
@@ -3201,7 +3201,7 @@ TEST_CASE("[SceneTree][CodeEdit] folding") {
 		code_edit->fold_line(0);
 		CHECK(code_edit->is_line_folded(0));
 		CHECK_FALSE(code_edit->is_line_folded(1));
-		CHECK(code_edit->get_next_visible_line_offset_from(1, 1) == 4);
+		CHECK(code_edit->get_next_visible_line_offset_from(1, 1) == 2);
 
 		code_edit->set_text("test\n\tline1\n^line1\n^line2\n\ttest");
 		CHECK(code_edit->can_fold_line(0));
@@ -3211,7 +3211,15 @@ TEST_CASE("[SceneTree][CodeEdit] folding") {
 		code_edit->fold_line(0);
 		CHECK(code_edit->is_line_folded(0));
 		CHECK_FALSE(code_edit->is_line_folded(1));
-		CHECK(code_edit->get_next_visible_line_offset_from(1, 1) == 4);
+		CHECK(code_edit->get_next_visible_line_offset_from(1, 1) == 2);
+
+		// Folding should stop at the next foldable line at the same indentation level even if comment.
+		code_edit->set_text("test\nline1\n\tline2\n#line3\n\t#line4\ntest");
+		CHECK(code_edit->can_fold_line(1));
+		CHECK_FALSE(code_edit->can_fold_line(2));
+		code_edit->fold_line(1);
+		CHECK(code_edit->is_line_folded(1));
+		CHECK(code_edit->get_next_visible_line_offset_from(1, 2) == 3);
 
 		// Indent level 0->1, comment after lines
 		code_edit->set_text("line1\n\tline2\n#test");
@@ -3266,7 +3274,7 @@ TEST_CASE("[SceneTree][CodeEdit] folding") {
 		code_edit->fold_line(0);
 		CHECK(code_edit->is_line_folded(0));
 		CHECK_FALSE(code_edit->is_line_folded(1));
-		CHECK(code_edit->get_next_visible_line_offset_from(1, 1) == 4);
+		CHECK(code_edit->get_next_visible_line_offset_from(1, 1) == 2);
 
 		code_edit->set_text("test\n\tline1\n$line1\nline2$\n\ttest");
 		CHECK(code_edit->can_fold_line(0));
@@ -3276,7 +3284,7 @@ TEST_CASE("[SceneTree][CodeEdit] folding") {
 		code_edit->fold_line(0);
 		CHECK(code_edit->is_line_folded(0));
 		CHECK_FALSE(code_edit->is_line_folded(1));
-		CHECK(code_edit->get_next_visible_line_offset_from(1, 1) == 4);
+		CHECK(code_edit->get_next_visible_line_offset_from(1, 1) == 2);
 	}
 
 	SUBCASE("[CodeEdit] folding comments including and/or adjacent to code regions") {


### PR DESCRIPTION
Fix code folding logic to stop folding over foldable regions at the same level of indentation, this is particularly annoying when trying to fold code once you've commented out functions below it, the current behaviour will fold your commented out functions with it as demonstrated in the videos shared in the original issue.


## What problem(s) does this PR solve?

- Closes [#121954](https://github.com/godotengine/godot/issues/121954)

## Additional information


I carefully worked through the test cases I had to modify to ensure it still makes sense and added a new test case for the specific behaviour change.



https://github.com/user-attachments/assets/5c898248-8c96-43bb-9538-028a8f52b87c

