### PR TITLE
Do not enter "create mode" in NavigationObstacle3D when it's empty

### DIFF
--- a/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
+++ b/modules/navigation_3d/editor/navigation_obstacle_3d_editor_plugin.cpp
@@ -268,11 +268,7 @@ void NavigationObstacle3DEditorPlugin::edit(Object *p_object) {
 	RenderingServer *rs = RenderingServer::get_singleton();
 
 	if (obstacle_node) {
-		if (obstacle_node->get_vertices().is_empty()) {
-			set_mode(MODE_CREATE);
-		} else {
-			set_mode(MODE_EDIT);
-		}
+		set_mode(MODE_EDIT);
 		wip_vertices.clear();
 		wip_active = false;
 		edited_point = -1;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #121646

## Additional information

Simplified object editing code in `NavigationObstacle3DEditorPlugin` so it won't enable "create mode" by default (when the vertex array is empty) allowing to move the node and enter editing mode manually if needed.