### PR TITLE
SCons option to enable S3TC and ETC compression in export templates

### DIFF
--- a/modules/etcpak/SCsub
+++ b/modules/etcpak/SCsub
@@ -31,6 +31,9 @@ env.modules_sources += thirdparty_obj
 
 module_obj = []
 
+if env.editor_build or env["etcpak_export_templates"]:
+    env_etcpak.Append(CPPDEFINES=["ETCPAK_COMPRESS_ENABLED"])
+
 env_etcpak.add_source_files(module_obj, "*.cpp")
 env.modules_sources += module_obj
 

--- a/modules/etcpak/config.py
+++ b/modules/etcpak/config.py
@@ -2,5 +2,17 @@ def can_build(env, platform):
     return True
 
 
+def get_opts(platform):
+    from SCons.Variables import BoolVariable
+
+    return [
+        BoolVariable(
+            "etcpak_export_templates",
+            "Enable S3TC and ETC image compression in export template builds (increases binary size)",
+            False,
+        ),
+    ]
+
+
 def configure(env):
     pass

--- a/modules/etcpak/image_compress_etcpak.cpp
+++ b/modules/etcpak/image_compress_etcpak.cpp
@@ -30,7 +30,7 @@
 
 #include "image_compress_etcpak.h"
 
-#ifdef TOOLS_ENABLED
+#ifdef ETCPAK_COMPRESS_ENABLED
 
 #include "core/os/os.h"
 #include "core/string/print_string.h"
@@ -305,4 +305,4 @@ void _compress_etcpak(EtcpakType p_compress_type, Image *r_img) {
 
 	print_verbose(vformat("etcpak: Encoding took %d ms.", OS::get_singleton()->get_ticks_msec() - start_time));
 }
-#endif // TOOLS_ENABLED
+#endif // ETCPAK_COMPRESS_ENABLED

--- a/modules/etcpak/image_compress_etcpak.h
+++ b/modules/etcpak/image_compress_etcpak.h
@@ -30,7 +30,7 @@
 
 #pragma once
 
-#ifdef TOOLS_ENABLED
+#ifdef ETCPAK_COMPRESS_ENABLED
 
 #include "core/io/image.h"
 
@@ -54,4 +54,4 @@ void _compress_bc(Image *r_img, Image::UsedChannels p_channels);
 
 void _compress_etcpak(EtcpakType p_compress_type, Image *r_img);
 
-#endif // TOOLS_ENABLED
+#endif // ETCPAK_COMPRESS_ENABLED

--- a/modules/etcpak/register_types.cpp
+++ b/modules/etcpak/register_types.cpp
@@ -38,7 +38,7 @@ void initialize_etcpak_module(ModuleInitializationLevel p_level) {
 		return;
 	}
 
-#ifdef TOOLS_ENABLED
+#ifdef ETCPAK_COMPRESS_ENABLED
 	Image::_image_compress_etc1_func = _compress_etc1;
 	Image::_image_compress_etc2_func = _compress_etc2;
 	Image::_image_compress_bc_func = _compress_bc;


### PR DESCRIPTION
I'm contributing to [Museum of All Things](https://github.com/m4ym4y/museum-of-all-things), which dynamically downloads hundreds of images (in an average play session) from the Wikipedia to display in a 3D museum.

Because it's downloading these images as PNGs, JPEGs, etc they are uploaded to the GPU uncompressed. On mobile, this means we're using more of our scarce VRAM, as well as more memory bandwidth (which can have a large impact on performance).

I think compressing the images as ETC could help with this!

Unfortunately, Godot only supports ETC (and S3TC) compression on editor builds, without a SCons option to enable them on export templates.

In https://github.com/godotengine/godot/pull/111015, a SCons option was added to allow including CVTT and Betsy compression in export templates, so this PR adds a similar option for S3TC and ETC!

It's disabled by default, so official Godot builds will still only include this in editor builds; developers will need to compile Godot themselves to turn this on.