### PR TITLE
Fix plain black/white background in the Profiler and Visual Profiler when using modern theme

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -38,6 +38,7 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/check_box.h"
+#include "scene/gui/color_rect.h"
 #include "scene/gui/flow_container.h"
 #include "scene/gui/label.h"
 #include "scene/resources/image_texture.h"
@@ -221,7 +222,7 @@ void EditorProfiler::_update_plot() {
 		wr[i + 0] = Math::fast_ftoi(background_color.r * 255);
 		wr[i + 1] = Math::fast_ftoi(background_color.g * 255);
 		wr[i + 2] = Math::fast_ftoi(background_color.b * 255);
-		wr[i + 3] = 255;
+		wr[i + 3] = Math::fast_ftoi(background_color.a * 255);
 	}
 
 	//find highest value
@@ -338,7 +339,7 @@ void EditorProfiler::_update_plot() {
 				wr[widx + 0] = is_filled ? red : Math::fast_ftoi(background_color.r * 255);
 				wr[widx + 1] = is_filled ? green : Math::fast_ftoi(background_color.g * 255);
 				wr[widx + 2] = is_filled ? blue : Math::fast_ftoi(background_color.b * 255);
-				wr[widx + 3] = 255;
+				wr[widx + 3] = is_filled ? 255 : Math::fast_ftoi(background_color.a * 255);
 			}
 		}
 	}
@@ -470,6 +471,7 @@ void EditorProfiler::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			activate->set_button_icon(get_editor_theme_icon(SNAME("Play")));
 			clear_button->set_button_icon(get_editor_theme_icon(SNAME("Clear")));
+			graph_background->set_color(get_theme_color(SNAME("dark_color_1"), EditorStringName(Editor)));
 
 			theme_cache.seek_line_color = get_theme_color(SceneStringName(font_color), EditorStringName(Editor));
 			theme_cache.seek_line_color.a = 0.8;
@@ -795,15 +797,19 @@ EditorProfiler::EditorProfiler() {
 	variables->connect("item_edited", callable_mp(this, &EditorProfiler::_item_edited));
 	variables->connect("item_collapsed", callable_mp(this, &EditorProfiler::_item_collapsed));
 
+	graph_background = memnew(ColorRect);
+	h_split->add_child(graph_background);
+
 	graph = memnew(TextureRect);
 	graph->set_custom_minimum_size(Size2(250 * EDSCALE, 0));
 	graph->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
+	graph->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	graph->set_mouse_filter(MOUSE_FILTER_STOP);
 	graph->connect(SceneStringName(draw), callable_mp(this, &EditorProfiler::_graph_tex_draw));
 	graph->connect(SceneStringName(gui_input), callable_mp(this, &EditorProfiler::_graph_tex_input));
 	graph->connect(SceneStringName(mouse_exited), callable_mp(this, &EditorProfiler::_graph_tex_mouse_exit));
 
-	h_split->add_child(graph);
+	graph_background->add_child(graph);
 	graph->set_h_size_flags(SIZE_EXPAND_FILL);
 
 	int metric_size = CLAMP(int(EDITOR_GET("debugger/profiler_frame_history_size")), 60, 10000);

--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -40,6 +40,7 @@
 #include "scene/gui/tree.h"
 
 class ImageTexture;
+class ColorRect;
 
 class EditorProfiler : public VBoxContainer {
 	GDCLASS(EditorProfiler, VBoxContainer);
@@ -100,6 +101,7 @@ private:
 	Button *activate = nullptr;
 	Button *clear_button = nullptr;
 	TextureRect *graph = nullptr;
+	ColorRect *graph_background = nullptr;
 	Ref<ImageTexture> graph_texture;
 	Vector<uint8_t> graph_image;
 

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -37,6 +37,7 @@
 #include "editor/run/editor_run_bar.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
+#include "scene/gui/color_rect.h"
 #include "scene/gui/flow_container.h"
 #include "scene/gui/label.h"
 #include "scene/resources/image_texture.h"
@@ -187,7 +188,7 @@ void EditorVisualProfiler::_update_plot() {
 		wr[i + 0] = Math::fast_ftoi(background_color.r * 255);
 		wr[i + 1] = Math::fast_ftoi(background_color.g * 255);
 		wr[i + 2] = Math::fast_ftoi(background_color.b * 255);
-		wr[i + 3] = 255;
+		wr[i + 3] = Math::fast_ftoi(background_color.a * 255);
 	}
 
 	//find highest value
@@ -281,43 +282,47 @@ void EditorVisualProfiler::_update_plot() {
 
 			//plot CPU
 			for (int j = 0; j < h; j++) {
-				uint8_t r, g, b;
+				uint8_t r, g, b, a;
 
 				if (column_cpu[j].a == 0) {
 					r = Math::fast_ftoi(background_color.r * 255);
 					g = Math::fast_ftoi(background_color.g * 255);
 					b = Math::fast_ftoi(background_color.b * 255);
+					a = Math::fast_ftoi(background_color.a * 255);
 				} else {
 					r = CLAMP((column_cpu[j].r / column_cpu[j].a) * 255.0, 0, 255);
 					g = CLAMP((column_cpu[j].g / column_cpu[j].a) * 255.0, 0, 255);
 					b = CLAMP((column_cpu[j].b / column_cpu[j].a) * 255.0, 0, 255);
+					a = 255;
 				}
 
 				int widx = (j * w + i) * 4;
 				wr[widx + 0] = r;
 				wr[widx + 1] = g;
 				wr[widx + 2] = b;
-				wr[widx + 3] = 255;
+				wr[widx + 3] = a;
 			}
 			//plot GPU
 			for (int j = 0; j < h; j++) {
-				uint8_t r, g, b;
+				uint8_t r, g, b, a;
 
 				if (column_gpu[j].a == 0) {
 					r = Math::fast_ftoi(background_color.r * 255);
 					g = Math::fast_ftoi(background_color.g * 255);
 					b = Math::fast_ftoi(background_color.b * 255);
+					a = Math::fast_ftoi(background_color.a * 255);
 				} else {
 					r = CLAMP((column_gpu[j].r / column_gpu[j].a) * 255.0, 0, 255);
 					g = CLAMP((column_gpu[j].g / column_gpu[j].a) * 255.0, 0, 255);
 					b = CLAMP((column_gpu[j].b / column_gpu[j].a) * 255.0, 0, 255);
+					a = 255;
 				}
 
 				int widx = (j * w + w / 2 + i) * 4;
 				wr[widx + 0] = r;
 				wr[widx + 1] = g;
 				wr[widx + 2] = b;
-				wr[widx + 3] = 255;
+				wr[widx + 3] = a;
 			}
 		}
 	}
@@ -475,6 +480,11 @@ void EditorVisualProfiler::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			activate->set_button_icon(get_editor_theme_icon(SNAME("Play")));
 			clear_button->set_button_icon(get_editor_theme_icon(SNAME("Clear")));
+			graph_background->set_color(get_theme_color(SNAME("dark_color_1"), EditorStringName(Editor)));
+
+			if (last_metric > -1) {
+				_update_plot();
+			}
 		} break;
 	}
 }
@@ -867,15 +877,19 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	variables->connect("cell_selected", callable_mp(this, &EditorVisualProfiler::_item_selected));
 	variables->connect("item_collapsed", callable_mp(this, &EditorVisualProfiler::_item_collapsed));
 
+	graph_background = memnew(ColorRect);
+	h_split->add_child(graph_background);
+
 	graph = memnew(TextureRect);
 	graph->set_custom_minimum_size(Size2(250 * EDSCALE, 0));
 	graph->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
+	graph->set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	graph->set_mouse_filter(MOUSE_FILTER_STOP);
 	graph->connect(SceneStringName(draw), callable_mp(this, &EditorVisualProfiler::_graph_tex_draw));
 	graph->connect(SceneStringName(gui_input), callable_mp(this, &EditorVisualProfiler::_graph_tex_input));
 	graph->connect(SceneStringName(mouse_exited), callable_mp(this, &EditorVisualProfiler::_graph_tex_mouse_exit));
 
-	h_split->add_child(graph);
+	graph_background->add_child(graph);
 	graph->set_h_size_flags(SIZE_EXPAND_FILL);
 
 	int metric_size = CLAMP(int(EDITOR_GET("debugger/profiler_frame_history_size")), 60, 10000);

--- a/editor/debugger/editor_visual_profiler.h
+++ b/editor/debugger/editor_visual_profiler.h
@@ -40,6 +40,7 @@
 #include "scene/gui/tree.h"
 
 class ImageTexture;
+class ColorRect;
 
 class EditorVisualProfiler : public VBoxContainer {
 	GDCLASS(EditorVisualProfiler, VBoxContainer);
@@ -73,6 +74,7 @@ private:
 	TextureRect *graph = nullptr;
 	Ref<ImageTexture> graph_texture;
 	Vector<uint8_t> graph_image;
+	ColorRect *graph_background = nullptr;
 	Tree *variables = nullptr;
 	HSplitContainer *h_split = nullptr;
 	CheckBox *frame_relative = nullptr;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #120576

## Additional information

It turned out that the modern theme uses opacity for its colors but the plots in the profilers were setting the alpha to 1 when drawing background colors because the classic theme doesn't have colors with opacity.

I followed the style of `AudioStreamEditor` for this fix. The color rects are added as the necessary layers for the transparent color blending.

Below is the Solarized Light theme comparison.

Classic theme.

| Profiler | Visual Profiler |
|--------|--------|
| <img width="1065" height="468" alt="godot windows editor dev x86_64_7u2BmQ4GOc" src="https://github.com/user-attachments/assets/b0145bb6-9d3d-458d-b863-f74130e58e1b" /> | <img width="1069" height="468" alt="image" src="https://github.com/user-attachments/assets/b25bd613-c26a-4e19-a622-a2b70dbdd6aa" /> |

Modern theme.

| Profiler | Visual Profiler |
|--------|--------|
| <img width="1067" height="464" alt="image" src="https://github.com/user-attachments/assets/8766f674-9c66-4193-b094-2556e843a5be" /> | <img width="1068" height="462" alt="image" src="https://github.com/user-attachments/assets/66090b51-0efb-4818-b7e4-3adac796e2eb" /> |
