### PR TITLE
Fix: Editable Children material override decaying into an anonymous s…

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -781,6 +781,14 @@ Variant SceneState::make_local_resource(Variant &p_value, const SceneState::Node
 
 	Node *base = (p_i == 0 || p_node->is_instance()) ? p_node : (p_node->get_owner() ? p_node->get_owner() : p_ret_nodes[0]);
 
+	// If the resource override is an external file, do not duplicate it into an anonymous subresource.
+	// Configure it for the local scene and keep it pointing to its external file.
+	if (p_edit_state == GEN_EDIT_STATE_MAIN || res->get_path().is_resource_file()) {
+		res->configure_for_local_scene(base, p_resources_local_to_scenes[base]);
+		p_resources_local_to_scenes[base][res] = res;
+		return res;
+	}
+
 	if (p_node_data.type == TYPE_INSTANTIATED) { // For the (root) nodes of sub-scenes, treat them as parts of the sub-scenes.
 		return get_remap_resource(res, p_resources_local_to_scenes, p_node->get(p_sname), base);
 	}
@@ -789,12 +797,6 @@ Variant SceneState::make_local_resource(Variant &p_value, const SceneState::Node
 	HashMap<Ref<Resource>, Ref<Resource>>::Iterator R = p_resources_local_to_scenes[base].find(res);
 	if (R) {
 		return R->value;
-	}
-
-	if (p_edit_state == GEN_EDIT_STATE_MAIN) { // For the main scene, use the resource as is
-		res->configure_for_local_scene(base, p_resources_local_to_scenes[base]);
-		p_resources_local_to_scenes[base][res] = res;
-		return res;
 	}
 
 	// For instances, a copy must be made.


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121428
- Closes #94919
- Closes #97127
- Closes #69424

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
Fixes a regression caused by commit 1b4f116db14123b4cfab655de40d2e4f81aea517 (introduced in PR #64487). This commit made the Editable Children sub node material override as well as any external resource fail into `SceneState::get_remap_resource(const Ref<Resource> &p_resource, HashMap<Node *, HashMap<Ref<Resource>, Ref<Resource>>> &remap_cache, const Ref<Resource> &p_fallback, Node *p_for_scene)`, resulting in them being duplicated without their path once instantiated, decaying into a sub resource.