### PR TITLE
[TextEdit] Fix `lines_edited_from` signal in `clear()`

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4399,7 +4399,7 @@ void TextEdit::_clear() {
 	carets.write[0].last_fit_x = 0;
 	deselect();
 
-	emit_signal(SNAME("lines_edited_from"), old_text_size, 0);
+	emit_signal(SNAME("lines_edited_from"), old_text_size - 1, 0);
 }
 
 void TextEdit::_set_text(const String &p_text, bool p_emit_signal) {

--- a/tests/scene/test_text_edit.cpp
+++ b/tests/scene/test_text_edit.cpp
@@ -132,7 +132,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			// Can clear even if not editable.
 			text_edit->set_editable(false);
 
-			Array lines_edited_clear_args = { { 1, 0 } };
+			Array lines_edited_clear_args = { { 0, 0 } };
 
 			text_edit->clear();
 			MessageQueue::get_singleton()->flush();


### PR DESCRIPTION
The `TextEdit::clear()` method was emitting `lines_edited_from` with an invalid line index (`old_text_size` instead of `old_text_size - 1`). Since lines are 0-indexed, the last line index is `old_text_size - 1`.

This caused out-of-bounds access in `CodeEdit::_update_delimiter_cache()`.

Also updates the test to expect the correct signal parameters.

Validated by building the Windows editor with SCons and testing it.


### Minimal reproduction project (MRP)

[new-game.zip](https://github.com/user-attachments/files/30614430/new-game.zip)
