### PR TITLE
Fix description of toolbox icon location

### DIFF
--- a/modules/tilemap/doc_classes/TileMap.xml
+++ b/modules/tilemap/doc_classes/TileMap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="TileMap" inherits="Node2D" api_type="core" deprecated="Use multiple [TileMapLayer] nodes instead. To convert a TileMap to a set of TileMapLayer nodes, open the TileMap bottom panel with the node selected, click the toolbox icon in the top-right corner and choose &apos;Extract TileMap layers as individual TileMapLayer nodes&apos;." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="TileMap" inherits="Node2D" api_type="core" deprecated="Use multiple [TileMapLayer] nodes instead. To convert a TileMap to a set of TileMapLayer nodes, open the TileMap bottom panel with the node selected, click the toolbox icon in the toolbar and choose &apos;Extract TileMap layers as individual TileMapLayer nodes&apos;." xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
 		Node for 2D tile-based maps.
 	</brief_description>


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Does not close any open issues I could find.

## Additional information

Simple change of language in deprecation warning from "top-right" to "top-left". I assume the button that is being referred to was moved recently, as it is not located where the warning currently says it is:
<img width="2880" height="1800" alt="tilemap_warning" src="https://github.com/user-attachments/assets/663dcf65-e673-49c7-9ed1-16c2d0550c21" />

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
