### PR TITLE
Update color of the debugger tab on theme change

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -131,7 +131,7 @@ ScriptEditorDebugger *EditorDebuggerNode::_add_debugger() {
 	node->connect("remote_objects_requested", callable_mp(this, &EditorDebuggerNode::_remote_objects_requested).bind(id));
 	node->connect("set_breakpoint", callable_mp(this, &EditorDebuggerNode::_breakpoint_set_in_tree).bind(id));
 	node->connect("clear_breakpoints", callable_mp(this, &EditorDebuggerNode::_breakpoints_cleared_in_tree).bind(id));
-	node->connect("errors_cleared", callable_mp(this, &EditorDebuggerNode::_update_errors));
+	node->connect("errors_cleared", callable_mp(this, &EditorDebuggerNode::_update_errors).bind(false));
 
 	if (tabs->get_tab_count() > 0) {
 		get_debugger(0)->clear_style();
@@ -356,6 +356,8 @@ void EditorDebuggerNode::_notification(int p_what) {
 			if (tabs->get_tab_count() > 1) {
 				tabs->add_theme_style_override(SceneStringName(panel), EditorNode::get_singleton()->get_editor_theme()->get_stylebox(SNAME("DebuggerPanel"), EditorStringName(EditorStyles)));
 			}
+
+			_update_errors(true);
 			_update_margins();
 
 			remote_scene_tree->update_icon_max_width();
@@ -447,7 +449,7 @@ void EditorDebuggerNode::_notification(int p_what) {
 	}
 }
 
-void EditorDebuggerNode::_update_errors() {
+void EditorDebuggerNode::_update_errors(bool p_force) {
 	int error_count = 0;
 	int warning_count = 0;
 	_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
@@ -455,7 +457,7 @@ void EditorDebuggerNode::_update_errors() {
 		warning_count += dbg->get_warning_count();
 	});
 
-	if (error_count != last_error_count || warning_count != last_warning_count) {
+	if (p_force || error_count != last_error_count || warning_count != last_warning_count) {
 		_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
 			dbg->update_tabs();
 		});

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -120,7 +120,7 @@ private:
 	HashSet<Ref<EditorDebuggerPlugin>> debugger_plugins;
 
 	ScriptEditorDebugger *_add_debugger();
-	void _update_errors();
+	void _update_errors(bool p_force = false);
 	void _update_margins();
 
 	friend class DebuggerEditorPlugin;


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes the color of the debugger tab not being updated on theme change:

|Default Color|Outdated Color|
|-|-|
|<img width="132" height="34" alt="image" src="https://github.com/user-attachments/assets/a7aa994b-cb9a-45de-bef0-5c43f2ca7d96" />|<img width="132" height="34" alt="image" src="https://github.com/user-attachments/assets/4da108e8-dcb0-4074-99f0-24ffa6bdd23a" />|
