### PR TITLE
Metal: fix crash using `texture_create_from_extension`

### DIFF
--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -420,8 +420,11 @@ RDD::TextureID RenderingDeviceDriverMetal::texture_create_from_extension(uint64_
 	MTL::PixelFormat format = (MTL::PixelFormat)pixel_formats->getMTLPixelFormat(p_format);
 	if (res->pixelFormat() != format) {
 		MTL::TextureSwizzleChannels swizzle = MTL::TextureSwizzleChannels::Default();
+		// newTextureView returns retain count of 1.
 		res = res->newTextureView(format, res->textureType(), NS::Range::Make(0, res->mipmapLevelCount()), NS::Range::Make(0, p_array_layers), swizzle);
 		ERR_FAIL_NULL_V_MSG(res, TextureID(), "Unable to create texture view.");
+	} else {
+		res->retain();
 	}
 
 	_track_resource(res);


### PR DESCRIPTION
When the input texture did not need a view, the Metal driver didn't take ownership, resulting in an unbalanced release in `texture_free`.

Closes #121229
