### PR TITLE
FIX: RichTextLabel - Maintain proportional scroll position on resize

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1133,6 +1133,11 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 
 		double l_height = text_buf->get_line_ascent(line) + text_buf->get_line_descent(line);
 		if (p_ofs.y + off.y + l_height <= 0) {
+			if (p_frame == main && visible_line_count == 0 && text_buf->get_line_count() > line + 1) {
+				Vector2i range = main->lines[first_line].text_buf->get_line_range(line + 1);
+				character_inside_first_drawn_subline = range.x;
+			}
+
 			off.y += l_height;
 			continue;
 		}
@@ -2790,7 +2795,8 @@ void RichTextLabel::_notification(int p_what) {
 
 			// Search for the first line.
 			int to_line = main->first_invalid_line.load();
-			int from_line = _find_first_line(0, to_line, vofs);
+			first_line = _find_first_line(0, to_line, vofs);
+			int from_line = first_line;
 
 			// Bottom margin for text clipping.
 			float v_limit = theme_cache.normal_style->get_margin(SIDE_BOTTOM);
@@ -2835,6 +2841,7 @@ void RichTextLabel::_notification(int p_what) {
 			visible_paragraph_count = 0;
 			visible_line_count = 0;
 			visible_rect = Rect2i();
+			character_inside_first_drawn_subline = 0;
 
 			// New cache draw.
 			Point2 ofs = text_rect.get_position() + Vector2(0, vbegin + main->lines[from_line].offset.y - vofs);
@@ -4140,7 +4147,16 @@ bool RichTextLabel::_validate_line_caches() {
 			total_height = _update_scroll_exceeds(total_height, ctrl_height, wrap_width, i, old_scroll, text_rect.size.height);
 			main->first_resized_line.store(i);
 		}
-
+		if (!(scroll_follow && scroll_following)) {
+			int offset_y = 0;
+			for (int i = 0; i < main->lines[first_line].text_buf->get_line_count(); i++) {
+				if (character_inside_first_drawn_subline >= main->lines[first_line].text_buf->get_line_range(i).x && character_inside_first_drawn_subline < main->lines[first_line].text_buf->get_line_range(i).y) {
+					break;
+				}
+				offset_y += main->lines[first_line].text_buf->get_line_ascent(i) + main->lines[first_line].text_buf->get_line_descent(i) + theme_cache.line_separation;
+			}
+			vscroll->set_value(main->lines[first_line].offset.y + offset_y + theme_cache.line_separation);
+		}
 		main->first_resized_line.store(main->lines.size());
 
 		if (fit_content) {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -4113,6 +4113,7 @@ bool RichTextLabel::_validate_line_caches() {
 
 		// Update fonts.
 		float old_scroll = vscroll->get_value();
+		float old_max = vscroll->get_max();
 		if (main->first_invalid_font_line.load() != (int)main->lines.size()) {
 			for (int i = main->first_invalid_font_line.load(); i < (int)main->lines.size(); i++) {
 				_update_line_font(main, i, theme_cache.normal_font, theme_cache.normal_font_size);
@@ -4140,7 +4141,13 @@ bool RichTextLabel::_validate_line_caches() {
 			total_height = _update_scroll_exceeds(total_height, ctrl_height, wrap_width, i, old_scroll, text_rect.size.height);
 			main->first_resized_line.store(i);
 		}
-
+		if (!(scroll_follow && scroll_following)) {
+			float scaled_old_scroll = old_scroll;
+			if (old_max > 0.0f) {
+				scaled_old_scroll = total_height * old_scroll / old_max;
+			}
+			vscroll->set_value(scaled_old_scroll);
+		}
 		main->first_resized_line.store(main->lines.size());
 
 		if (fit_content) {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -546,6 +546,8 @@ private:
 	int scroll_w = 0;
 	bool scroll_updated = false;
 	bool updating_scroll = false;
+	int first_line = 0;
+	int character_inside_first_drawn_subline = 0;
 	int current_idx = 1;
 	int current_char_ofs = 0;
 	int visible_paragraph_count = 0;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #109472

## Additional information

`old_scroll` is just an absolute numerical value, using it directly was making the scroll bar slide upwards, `scaled_old_scroll` takes into account panel resize to maintain the scroll relative position.

