### PR TITLE
[TextEdit] Separate clear() and menu "Clear" undo behavior

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4454,19 +4454,6 @@ void TextEdit::clear() {
 }
 
 void TextEdit::_clear() {
-	if (editable && undo_enabled) {
-		remove_secondary_carets();
-		_move_caret_document_start(false);
-		begin_complex_operation();
-
-		_remove_text(0, 0, MAX(0, get_line_count() - 1), MAX(get_line(MAX(get_line_count() - 1, 0)).size() - 1, 0));
-		insert_text_at_caret("");
-		text.clear();
-
-		end_complex_operation();
-		return;
-	}
-	// Cannot merge with above, as we are not part of the tree on creation.
 	int old_text_size = text.size();
 
 	clear_undo_history();
@@ -4481,6 +4468,27 @@ void TextEdit::_clear() {
 	deselect();
 
 	emit_signal(SNAME("lines_edited_from"), old_text_size - 1, 0);
+}
+
+void TextEdit::_clear_preserving_undo_history() {
+	if (!undo_enabled) {
+		clear();
+		return;
+	}
+
+	setting_text = true;
+
+	_move_caret_document_start(false);
+	begin_complex_operation();
+
+	_remove_text(0, 0, MAX(0, get_line_count() - 1), MAX(get_line(MAX(get_line_count() - 1, 0)).size() - 1, 0));
+	insert_text_at_caret("");
+	text.clear();
+
+	end_complex_operation();
+
+	setting_text = false;
+	emit_signal(SNAME("text_set"));
 }
 
 void TextEdit::_set_text(const String &p_text, bool p_emit_signal) {
@@ -5229,7 +5237,7 @@ void TextEdit::menu_option(int p_option) {
 		} break;
 		case MENU_CLEAR: {
 			if (editable) {
-				clear();
+				_clear_preserving_undo_history();
 			}
 		} break;
 		case MENU_SELECT_ALL: {

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -347,6 +347,7 @@ private:
 	Array st_args;
 
 	void _clear();
+	void _clear_preserving_undo_history();
 	void _update_caches(bool p_invalidate_all = false);
 
 	void _close_ime_window();

--- a/tests/scene/test_text_edit.cpp
+++ b/tests/scene/test_text_edit.cpp
@@ -70,6 +70,8 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 		Array lines_edited_args = { { 0, 0 }, { 0, 0 } };
 
 		SUBCASE("[TextEdit] clear and set text") {
+			Array lines_edited_clear_args = { { 0, 0 } };
+
 			// "text_changed" should not be emitted on clear / set.
 			text_edit->clear();
 			MessageQueue::get_singleton()->flush();
@@ -77,7 +79,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			CHECK(text_edit->get_caret_column() == 0);
 			CHECK(text_edit->get_line_count() == 1);
 			SIGNAL_CHECK("text_set", empty_signal_args);
-			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_clear_args);
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 
@@ -91,19 +93,10 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			SIGNAL_CHECK_FALSE("text_changed");
 
-			text_edit->clear();
-			MessageQueue::get_singleton()->flush();
-			CHECK(text_edit->get_text() == "");
-			CHECK(text_edit->get_caret_column() == 0);
-			SIGNAL_CHECK("text_set", empty_signal_args);
-			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
-			SIGNAL_CHECK_FALSE("caret_changed");
-			SIGNAL_CHECK_FALSE("text_changed");
-
 			// Can undo / redo words when editable.
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
-			CHECK(text_edit->get_text() == "test text");
+			CHECK(text_edit->get_text() == "");
 			CHECK(text_edit->get_caret_column() == 0);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
@@ -112,27 +105,54 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			text_edit->redo();
 			MessageQueue::get_singleton()->flush();
-			CHECK(text_edit->get_text() == "");
-			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_text() == "test text");
+			CHECK(text_edit->get_caret_column() == 9);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
 			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_set");
+
+			// clear() should clear undo history.
+			text_edit->clear();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "");
+			CHECK(text_edit->get_caret_column() == 0);
+			SIGNAL_CHECK("text_set", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_clear_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_changed");
+
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "");
+			CHECK(text_edit->get_caret_column() == 0);
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_set");
+
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "");
+			CHECK(text_edit->get_caret_column() == 0);
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+			SIGNAL_CHECK_FALSE("text_changed");
 			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_set");
 
 			// Cannot undo when not-editable but should still clear.
-			text_edit->undo();
+			text_edit->set_text("test text");
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "test text");
 			CHECK(text_edit->get_caret_column() == 0);
+			CHECK(text_edit->get_line_count() == 1);
+			SIGNAL_CHECK("text_set", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
-			SIGNAL_CHECK("text_changed", empty_signal_args);
-			SIGNAL_CHECK_FALSE("caret_changed");
-			SIGNAL_CHECK_FALSE("text_set");
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_changed");
 
 			// Can clear even if not editable.
 			text_edit->set_editable(false);
-
-			Array lines_edited_clear_args = { { 0, 0 } };
 
 			text_edit->clear();
 			MessageQueue::get_singleton()->flush();
@@ -206,14 +226,44 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			SIGNAL_CHECK("caret_changed", empty_signal_args);
 			CHECK(text_edit->has_selection());
 
-			text_edit->clear();
+			// Context menu "Clear" should preserve undo history, unlike clear() which clears it.
+			text_edit->set_text("text");
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "text");
+			CHECK(text_edit->get_caret_column() == 0);
+			CHECK_FALSE(text_edit->has_selection());
+			SIGNAL_CHECK("text_set", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_changed");
+
+			text_edit->menu_option(TextEdit::MENU_CLEAR);
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "");
 			CHECK(text_edit->get_caret_column() == 0);
 			CHECK_FALSE(text_edit->has_selection());
 			SIGNAL_CHECK("text_set", empty_signal_args);
 			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
-			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_changed");
+
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "text");
+			CHECK(text_edit->get_caret_column() == 0);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_set");
+
+			text_edit->clear();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "");
+			CHECK(text_edit->get_caret_column() == 0);
+			CHECK_FALSE(text_edit->has_selection());
+			SIGNAL_CHECK("text_set", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_clear_args);
+			SIGNAL_CHECK_FALSE("caret_changed");
 			SIGNAL_CHECK_FALSE("text_changed");
 		}
 


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot/issues/122002
- Closes https://github.com/godotengine/godot-proposals/issues/15363

- **`clear()` now always clears undo history** (as stated in the documentation)
- **Context menu "Clear" retains its current behaviour** and preserves undo history (allows undo)

This fixes the inconsistency where both programmatic `clear()` and user-facing
menu "Clear" had the same behavior. Now users can undo an accidental
"Clear" from the context menu, while clear() provides a true reset.

Modified:
- scene/gui/text_edit.cpp: Relocate undo history preserving logic from `_clear()` to `_clear_preserving_undo_history()`
- scene/gui/text_edit.h: Add declaration for `_clear_preserving_undo_history()`
- tests/scene/test_text_edit.cpp: Update tests to verify new behavior
- doc/classes/TextEdit.xml: Improve documentation for `clear()` to clarify its behavior.

Validated by building the Windows editor with SCons and testing it.