### PR TITLE
Add support for one way collision shapes, with rays

### DIFF
--- a/modules/godot_physics_2d/godot_shape_2d.h
+++ b/modules/godot_physics_2d/godot_shape_2d.h
@@ -194,7 +194,7 @@ public:
 
 	virtual PS2DE::ShapeType get_type() const override { return PS2DE::SHAPE_SEPARATION_RAY; }
 
-	virtual bool allows_one_way_collision() const override { return false; }
+	virtual bool allows_one_way_collision() const override { return true; }
 
 	virtual void project_rangev(const Vector2 &p_normal, const Transform2D &p_transform, real_t &r_min, real_t &r_max) const override { project_range(p_normal, p_transform, r_min, r_max); }
 	virtual void get_supports(const Vector2 &p_normal, Vector2 *r_supports, int &r_amount) const override;

--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -192,7 +192,6 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray(const PS2DT::RayParameters &p
 		}
 
 		if (shape->intersect_segment(local_from, local_to, shape_point, shape_normal)) {
-
 			Vector2 world_normal = inv_xform.basis_xform_inv(shape_normal).normalized();
 
 			if (is_shape_one_way) {

--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -161,7 +161,7 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray(const PS2DT::RayParameters &p
 		bool is_shape_one_way = col_obj->is_shape_set_as_one_way_collision(shape_idx);
 
 		Vector2 one_way_dir;
-		
+
 		if (is_shape_one_way) {
 			// If it is, get its one way direction, to use later
 			one_way_dir = xform.basis_xform(col_obj->get_shape_one_way_collision_direction(shape_idx)).normalized();

--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -155,9 +155,29 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray(const PS2DT::RayParameters &p
 
 		Vector2 shape_point, shape_normal;
 
+		Transform2D xform = col_obj->get_transform() * col_obj->get_shape_transform(shape_idx);
+
+		// Is the colliding shape, one way?
+		bool is_shape_one_way = col_obj->is_shape_set_as_one_way_collision(shape_idx);
+
+		Vector2 one_way_dir;
+		
+		if (is_shape_one_way) {
+			// If it is, get its one way direction, to use later
+			one_way_dir = xform.basis_xform(col_obj->get_shape_one_way_collision_direction(shape_idx)).normalized();
+		}
+
 		if (shape->contains_point(local_from)) {
 			if (p_parameters.hit_from_inside) {
 				// Hit shape at starting point.
+
+				// Check if shape is one-way
+				if (is_shape_one_way) {
+					if (one_way_dir != Vector2() && one_way_dir.dot(normal) < CMP_EPSILON) {
+						continue;
+					}
+				}
+
 				min_d = 0;
 				res_point = begin;
 				res_normal = Vector2();
@@ -172,7 +192,16 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray(const PS2DT::RayParameters &p
 		}
 
 		if (shape->intersect_segment(local_from, local_to, shape_point, shape_normal)) {
-			Transform2D xform = col_obj->get_transform() * col_obj->get_shape_transform(shape_idx);
+
+			Vector2 world_normal = inv_xform.basis_xform_inv(shape_normal).normalized();
+
+			if (is_shape_one_way) {
+				// If ray normal is parallel to one way direction, ignore, since the ray can pass through.
+				if (one_way_dir != Vector2() && one_way_dir.dot(world_normal) > -CMP_EPSILON) {
+					continue;
+				}
+			}
+
 			shape_point = xform.xform(shape_point);
 
 			real_t ld = normal.dot(shape_point);
@@ -180,7 +209,7 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray(const PS2DT::RayParameters &p
 			if (ld < min_d) {
 				min_d = ld;
 				res_point = shape_point;
-				res_normal = inv_xform.basis_xform_inv(shape_normal).normalized();
+				res_normal = world_normal;
 				res_shape = shape_idx;
 				res_obj = col_obj;
 				collided = true;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?
This PR solves the issue that one way collision shapes, were not supported at all by raycasts or seperation rays, which has been an incredibly frustrating for myself, and many other godot users

- Closes #106603 and closes #66547

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

The pr works by simply comparing the dot product of the one way direction to the rays collision normal, and if they match then reports it as a collision, otherwise moves on. it also supports "hit_from_inside" by simply comparing the direction of the ray, to the one way direction of the shape. Had to move line 175's xform variable up a bit, to allow it to be reused for the "hit_from_inside" check too, as i figured that'd be the most optimized way of doing it.

I also called the one way direction variable "`one_way_dir`", however i noticed other similar places use "valid_dir", which i can easily change to match, if needed.

This is my first PR for godot, and a pretty big one too! so apologies if theres anything thats not up to snuff, lemme know if theres any changes / concerns.
