### PR TITLE
Cache arraymesh_faces generation and limit editor gizmo instance creation

### DIFF
--- a/editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.cpp
@@ -326,7 +326,7 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	const Color collision_color = cs->is_disabled() ? Color(1.0, 1.0, 1.0, 0.75) : cs->get_debug_color();
 
 	if (cs->get_debug_fill_enabled()) {
-		bool wasCacheValid = s->isDebugMeshFacesCacheValid();
+		bool wasCacheValid = s->is_debug_mesh_faces_cache_valid();
 		Ref<ArrayMesh> array_mesh = s->get_debug_arraymesh_faces(collision_color);
 		if (array_mesh.is_valid()
 			&& array_mesh->get_surface_count() > 0

--- a/editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.cpp
@@ -326,8 +326,11 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	const Color collision_color = cs->is_disabled() ? Color(1.0, 1.0, 1.0, 0.75) : cs->get_debug_color();
 
 	if (cs->get_debug_fill_enabled()) {
+		bool wasCacheValid = s->isDebugMeshFacesCacheValid();
 		Ref<ArrayMesh> array_mesh = s->get_debug_arraymesh_faces(collision_color);
-		if (array_mesh.is_valid() && array_mesh->get_surface_count() > 0) {
+		if (array_mesh.is_valid()
+			&& array_mesh->get_surface_count() > 0
+			&& !wasCacheValid) {
 			p_gizmo->add_mesh(array_mesh, material_arraymesh);
 		}
 	}

--- a/editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.cpp
@@ -328,9 +328,7 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	if (cs->get_debug_fill_enabled()) {
 		bool wasCacheValid = s->is_debug_mesh_faces_cache_valid();
 		Ref<ArrayMesh> array_mesh = s->get_debug_arraymesh_faces(collision_color);
-		if (array_mesh.is_valid()
-			&& array_mesh->get_surface_count() > 0
-			&& !wasCacheValid) {
+		if (array_mesh.is_valid() && array_mesh->get_surface_count() > 0 && !wasCacheValid) {
 			p_gizmo->add_mesh(array_mesh, material_arraymesh);
 		}
 	}

--- a/scene/resources/3d/box_shape_3d.cpp
+++ b/scene/resources/3d/box_shape_3d.cpp
@@ -50,7 +50,13 @@ Vector<Vector3> BoxShape3D::get_debug_mesh_lines() const {
 	return lines;
 }
 
-Ref<ArrayMesh> BoxShape3D::get_debug_arraymesh_faces(const Color &p_modulate) const {
+Ref<ArrayMesh> BoxShape3D::get_debug_arraymesh_faces(const Color &p_modulate) {
+	if (debug_mesh_faces_cache.is_valid()) {
+		return debug_mesh_faces_cache;
+	}
+	print_line("BoxShape3D Cache Miss");
+	debug_mesh_faces_cache.instantiate();
+
 	Array box_array;
 	box_array.resize(RSE::ARRAY_MAX);
 	BoxMesh::create_mesh_array(box_array, size);
@@ -65,6 +71,8 @@ Ref<ArrayMesh> BoxShape3D::get_debug_arraymesh_faces(const Color &p_modulate) co
 	Ref<ArrayMesh> box_mesh = memnew(ArrayMesh);
 	box_array[RSE::ARRAY_COLOR] = colors;
 	box_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, box_array);
+
+	debug_mesh_faces_cache = box_mesh;
 	return box_mesh;
 }
 

--- a/scene/resources/3d/box_shape_3d.h
+++ b/scene/resources/3d/box_shape_3d.h
@@ -50,7 +50,7 @@ public:
 	Vector3 get_size() const;
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
-	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
+	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) override;
 	virtual real_t get_enclosing_radius() const override;
 
 	BoxShape3D();

--- a/scene/resources/3d/capsule_shape_3d.cpp
+++ b/scene/resources/3d/capsule_shape_3d.cpp
@@ -69,7 +69,11 @@ Vector<Vector3> CapsuleShape3D::get_debug_mesh_lines() const {
 	return points;
 }
 
-Ref<ArrayMesh> CapsuleShape3D::get_debug_arraymesh_faces(const Color &p_modulate) const {
+Ref<ArrayMesh> CapsuleShape3D::get_debug_arraymesh_faces(const Color &p_modulate) {
+	if (debug_mesh_faces_cache.is_valid()) {
+		return debug_mesh_faces_cache;
+	}
+	print_line("CapsuleShape3D Cache Miss");
 	Array capsule_array;
 	capsule_array.resize(RSE::ARRAY_MAX);
 	CapsuleMesh::create_mesh_array(capsule_array, radius, height, 32, 8);
@@ -84,6 +88,8 @@ Ref<ArrayMesh> CapsuleShape3D::get_debug_arraymesh_faces(const Color &p_modulate
 	Ref<ArrayMesh> capsule_mesh = memnew(ArrayMesh);
 	capsule_array[RSE::ARRAY_COLOR] = colors;
 	capsule_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, capsule_array);
+
+	debug_mesh_faces_cache = capsule_mesh;
 	return capsule_mesh;
 }
 

--- a/scene/resources/3d/capsule_shape_3d.h
+++ b/scene/resources/3d/capsule_shape_3d.h
@@ -53,7 +53,7 @@ public:
 	real_t get_mid_height() const;
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
-	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
+	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) override;
 	virtual real_t get_enclosing_radius() const override;
 
 	CapsuleShape3D();

--- a/scene/resources/3d/concave_polygon_shape_3d.cpp
+++ b/scene/resources/3d/concave_polygon_shape_3d.cpp
@@ -61,7 +61,12 @@ Vector<Vector3> ConcavePolygonShape3D::get_debug_mesh_lines() const {
 	return points;
 }
 
-Ref<ArrayMesh> ConcavePolygonShape3D::get_debug_arraymesh_faces(const Color &p_modulate) const {
+Ref<ArrayMesh> ConcavePolygonShape3D::get_debug_arraymesh_faces(const Color &p_modulate) {
+	if (debug_mesh_faces_cache.is_valid()) {
+		return debug_mesh_faces_cache;
+	}
+	print_line("ConcavePolygonShape3D Cache Miss");
+
 	Vector<Color> colors;
 
 	for (int i = 0; i < faces.size(); i++) {
@@ -74,6 +79,7 @@ Ref<ArrayMesh> ConcavePolygonShape3D::get_debug_arraymesh_faces(const Color &p_m
 	a[RSE::ARRAY_VERTEX] = faces;
 	a[RSE::ARRAY_COLOR] = colors;
 	mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, a);
+	debug_mesh_faces_cache = mesh;
 
 	return mesh;
 }

--- a/scene/resources/3d/concave_polygon_shape_3d.h
+++ b/scene/resources/3d/concave_polygon_shape_3d.h
@@ -73,7 +73,7 @@ public:
 	bool is_backface_collision_enabled() const;
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
-	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
+	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) override;
 	virtual real_t get_enclosing_radius() const override;
 
 	ConcavePolygonShape3D();

--- a/scene/resources/3d/convex_polygon_shape_3d.cpp
+++ b/scene/resources/3d/convex_polygon_shape_3d.cpp
@@ -56,7 +56,11 @@ Vector<Vector3> ConvexPolygonShape3D::get_debug_mesh_lines() const {
 	return Vector<Vector3>();
 }
 
-Ref<ArrayMesh> ConvexPolygonShape3D::get_debug_arraymesh_faces(const Color &p_modulate) const {
+Ref<ArrayMesh> ConvexPolygonShape3D::get_debug_arraymesh_faces(const Color &p_modulate) {
+	if (debug_mesh_faces_cache.is_valid()) {
+		return debug_mesh_faces_cache;
+	}
+	print_line("ConvexPolygonShape3D Cache Miss");
 	const Vector<Vector3> hull_points = get_points();
 
 	Vector<Vector3> verts;
@@ -90,6 +94,8 @@ Ref<ArrayMesh> ConvexPolygonShape3D::get_debug_arraymesh_faces(const Color &p_mo
 	a[RSE::ARRAY_COLOR] = colors;
 	a[RSE::ARRAY_INDEX] = indices;
 	mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, a);
+
+	debug_mesh_faces_cache = mesh;
 
 	return mesh;
 }

--- a/scene/resources/3d/convex_polygon_shape_3d.h
+++ b/scene/resources/3d/convex_polygon_shape_3d.h
@@ -48,7 +48,7 @@ public:
 	Vector<Vector3> get_points() const;
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
-	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
+	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) override;
 	virtual real_t get_enclosing_radius() const override;
 
 	ConvexPolygonShape3D();

--- a/scene/resources/3d/cylinder_shape_3d.cpp
+++ b/scene/resources/3d/cylinder_shape_3d.cpp
@@ -62,7 +62,11 @@ Vector<Vector3> CylinderShape3D::get_debug_mesh_lines() const {
 	return points;
 }
 
-Ref<ArrayMesh> CylinderShape3D::get_debug_arraymesh_faces(const Color &p_modulate) const {
+Ref<ArrayMesh> CylinderShape3D::get_debug_arraymesh_faces(const Color &p_modulate) {
+	if (debug_mesh_faces_cache.is_valid()) {
+		return debug_mesh_faces_cache;
+	}
+	print_line("CylinderShape3D Cache Miss");
 	Array cylinder_array;
 	cylinder_array.resize(RSE::ARRAY_MAX);
 	CylinderMesh::create_mesh_array(cylinder_array, radius, radius, height, 32);
@@ -77,6 +81,8 @@ Ref<ArrayMesh> CylinderShape3D::get_debug_arraymesh_faces(const Color &p_modulat
 	Ref<ArrayMesh> cylinder_mesh = memnew(ArrayMesh);
 	cylinder_array[RSE::ARRAY_COLOR] = colors;
 	cylinder_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, cylinder_array);
+
+	debug_mesh_faces_cache = cylinder_mesh;
 	return cylinder_mesh;
 }
 

--- a/scene/resources/3d/cylinder_shape_3d.h
+++ b/scene/resources/3d/cylinder_shape_3d.h
@@ -50,7 +50,7 @@ public:
 	float get_height() const;
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
-	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
+	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) override;
 	virtual real_t get_enclosing_radius() const override;
 
 	CylinderShape3D();

--- a/scene/resources/3d/height_map_shape_3d.cpp
+++ b/scene/resources/3d/height_map_shape_3d.cpp
@@ -86,7 +86,11 @@ Vector<Vector3> HeightMapShape3D::get_debug_mesh_lines() const {
 	return points;
 }
 
-Ref<ArrayMesh> HeightMapShape3D::get_debug_arraymesh_faces(const Color &p_modulate) const {
+Ref<ArrayMesh> HeightMapShape3D::get_debug_arraymesh_faces(const Color &p_modulate) {
+	if (debug_mesh_faces_cache.is_valid()) {
+		return debug_mesh_faces_cache;
+	}
+	print_line("HeightMapShape3D Cache Miss");
 	Vector<Vector3> verts;
 	Vector<Color> colors;
 	Vector<int> indices;
@@ -137,6 +141,7 @@ Ref<ArrayMesh> HeightMapShape3D::get_debug_arraymesh_faces(const Color &p_modula
 	a[RSE::ARRAY_INDEX] = indices;
 	mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, a);
 
+	debug_mesh_faces_cache = mesh;
 	return mesh;
 }
 

--- a/scene/resources/3d/height_map_shape_3d.h
+++ b/scene/resources/3d/height_map_shape_3d.h
@@ -62,7 +62,7 @@ public:
 	void update_map_data_from_image(const Ref<Image> &p_image, real_t p_height_min, real_t p_height_max);
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
-	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
+	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) override;
 	virtual real_t get_enclosing_radius() const override;
 
 	HeightMapShape3D();

--- a/scene/resources/3d/separation_ray_shape_3d.cpp
+++ b/scene/resources/3d/separation_ray_shape_3d.cpp
@@ -43,8 +43,13 @@ Vector<Vector3> SeparationRayShape3D::get_debug_mesh_lines() const {
 	return points;
 }
 
-Ref<ArrayMesh> SeparationRayShape3D::get_debug_arraymesh_faces(const Color &p_modulate) const {
-	return memnew(ArrayMesh);
+Ref<ArrayMesh> SeparationRayShape3D::get_debug_arraymesh_faces(const Color &p_modulate) {
+	if (debug_mesh_faces_cache.is_valid()) {
+		return debug_mesh_faces_cache;
+	}
+	print_line("SeparationRayShape3D Cache Miss");
+	debug_mesh_faces_cache = memnew(ArrayMesh);
+	return debug_mesh_faces_cache;
 }
 
 real_t SeparationRayShape3D::get_enclosing_radius() const {

--- a/scene/resources/3d/separation_ray_shape_3d.h
+++ b/scene/resources/3d/separation_ray_shape_3d.h
@@ -51,7 +51,7 @@ public:
 	bool get_slide_on_slope() const;
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
-	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
+	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) override;
 	virtual real_t get_enclosing_radius() const override;
 
 	SeparationRayShape3D();

--- a/scene/resources/3d/shape_3d.cpp
+++ b/scene/resources/3d/shape_3d.cpp
@@ -125,7 +125,12 @@ Ref<ArrayMesh> Shape3D::get_debug_mesh() {
 		}
 
 		if (debug_fill) {
-			Ref<ArrayMesh> array_mesh = get_debug_arraymesh_faces(debug_color * Color(1.0, 1.0, 1.0, 0.0625));
+			Ref<ArrayMesh> array_mesh;
+			if (debug_mesh_faces_cache.is_valid()) { array_mesh = debug_mesh_faces_cache; }
+			else {
+				debug_mesh_faces_cache = get_debug_arraymesh_faces(debug_color * Color(1.0, 1.0, 1.0, 0.0625));
+				array_mesh = debug_mesh_faces_cache;
+			}
 			if (array_mesh.is_valid() && array_mesh->get_surface_count() > 0) {
 				Array solid_array = array_mesh->surface_get_arrays(0);
 				debug_mesh_cache->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, solid_array);

--- a/scene/resources/3d/shape_3d.cpp
+++ b/scene/resources/3d/shape_3d.cpp
@@ -142,6 +142,7 @@ Ref<ArrayMesh> Shape3D::get_debug_mesh() {
 void Shape3D::_update_shape() {
 	emit_changed();
 	debug_mesh_cache.unref();
+	debug_mesh_faces_cache.unref();
 }
 
 void Shape3D::_bind_methods() {

--- a/scene/resources/3d/shape_3d.cpp
+++ b/scene/resources/3d/shape_3d.cpp
@@ -125,12 +125,7 @@ Ref<ArrayMesh> Shape3D::get_debug_mesh() {
 		}
 
 		if (debug_fill) {
-			Ref<ArrayMesh> array_mesh;
-			if (debug_mesh_faces_cache.is_valid()) { array_mesh = debug_mesh_faces_cache; }
-			else {
-				debug_mesh_faces_cache = get_debug_arraymesh_faces(debug_color * Color(1.0, 1.0, 1.0, 0.0625));
-				array_mesh = debug_mesh_faces_cache;
-			}
+			Ref<ArrayMesh> array_mesh = get_debug_arraymesh_faces(debug_color * Color(1.0, 1.0, 1.0, 0.0625));
 			if (array_mesh.is_valid() && array_mesh->get_surface_count() > 0) {
 				Array solid_array = array_mesh->surface_get_arrays(0);
 				debug_mesh_cache->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, solid_array);

--- a/scene/resources/3d/shape_3d.h
+++ b/scene/resources/3d/shape_3d.h
@@ -53,6 +53,8 @@ class Shape3D : public Resource {
 #endif // DEBUG_ENABLED
 
 protected:
+	Ref<ArrayMesh> debug_mesh_faces_cache;
+
 	static void _bind_methods();
 
 	_FORCE_INLINE_ RID get_shape() const { return shape; }
@@ -60,12 +62,15 @@ protected:
 
 	virtual void _update_shape();
 
+
 public:
 	virtual RID get_rid() const override { return shape; }
 
+	bool isDebugMeshFacesCacheValid() { return debug_mesh_faces_cache.is_valid(); }
+
 	Ref<ArrayMesh> get_debug_mesh();
 	virtual Vector<Vector3> get_debug_mesh_lines() const = 0; // { return Vector<Vector3>(); }
-	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const = 0;
+	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) = 0;
 	/// Returns the radius of a sphere that fully enclose this shape
 	virtual real_t get_enclosing_radius() const = 0;
 

--- a/scene/resources/3d/shape_3d.h
+++ b/scene/resources/3d/shape_3d.h
@@ -44,6 +44,7 @@ class Shape3D : public Resource {
 	real_t margin = 0.04;
 
 	Ref<ArrayMesh> debug_mesh_cache;
+	Ref<ArrayMesh> debug_mesh_faces_cache;
 
 	// Not wrapped in `#ifdef DEBUG_ENABLED` as it is used for rendering.
 	Color debug_color = Color(0.0, 0.0, 0.0, 0.0);

--- a/scene/resources/3d/shape_3d.h
+++ b/scene/resources/3d/shape_3d.h
@@ -44,7 +44,6 @@ class Shape3D : public Resource {
 	real_t margin = 0.04;
 
 	Ref<ArrayMesh> debug_mesh_cache;
-	Ref<ArrayMesh> debug_mesh_faces_cache;
 
 	// Not wrapped in `#ifdef DEBUG_ENABLED` as it is used for rendering.
 	Color debug_color = Color(0.0, 0.0, 0.0, 0.0);

--- a/scene/resources/3d/shape_3d.h
+++ b/scene/resources/3d/shape_3d.h
@@ -66,7 +66,7 @@ protected:
 public:
 	virtual RID get_rid() const override { return shape; }
 
-	bool isDebugMeshFacesCacheValid() { return debug_mesh_faces_cache.is_valid(); }
+	bool is_debug_mesh_faces_cache_valid() const { return debug_mesh_faces_cache.is_valid(); }
 
 	Ref<ArrayMesh> get_debug_mesh();
 	virtual Vector<Vector3> get_debug_mesh_lines() const = 0; // { return Vector<Vector3>(); }

--- a/scene/resources/3d/sphere_shape_3d.cpp
+++ b/scene/resources/3d/sphere_shape_3d.cpp
@@ -56,7 +56,13 @@ Vector<Vector3> SphereShape3D::get_debug_mesh_lines() const {
 	return points;
 }
 
-Ref<ArrayMesh> SphereShape3D::get_debug_arraymesh_faces(const Color &p_modulate) const {
+Ref<ArrayMesh> SphereShape3D::get_debug_arraymesh_faces(const Color &p_modulate) {
+	if (debug_mesh_faces_cache.is_valid()) {
+		return debug_mesh_faces_cache;
+	}
+	print_line("SphereShape3D Cache Miss");
+	debug_mesh_faces_cache.instantiate();
+
 	Array sphere_array;
 	sphere_array.resize(RSE::ARRAY_MAX);
 	SphereMesh::create_mesh_array(sphere_array, radius, radius * 2, 32);
@@ -71,6 +77,8 @@ Ref<ArrayMesh> SphereShape3D::get_debug_arraymesh_faces(const Color &p_modulate)
 	Ref<ArrayMesh> sphere_mesh = memnew(ArrayMesh);
 	sphere_array[RSE::ARRAY_COLOR] = colors;
 	sphere_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, sphere_array);
+
+	debug_mesh_faces_cache = sphere_mesh;
 	return sphere_mesh;
 }
 

--- a/scene/resources/3d/sphere_shape_3d.h
+++ b/scene/resources/3d/sphere_shape_3d.h
@@ -48,7 +48,7 @@ public:
 	float get_radius() const;
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
-	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
+	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) override;
 	virtual real_t get_enclosing_radius() const override;
 
 	SphereShape3D();

--- a/scene/resources/3d/world_boundary_shape_3d.cpp
+++ b/scene/resources/3d/world_boundary_shape_3d.cpp
@@ -63,7 +63,11 @@ Vector<Vector3> WorldBoundaryShape3D::get_debug_mesh_lines() const {
 	return points;
 }
 
-Ref<ArrayMesh> WorldBoundaryShape3D::get_debug_arraymesh_faces(const Color &p_modulate) const {
+Ref<ArrayMesh> WorldBoundaryShape3D::get_debug_arraymesh_faces(const Color &p_modulate) {
+	if (debug_mesh_faces_cache.is_valid()) {
+		return debug_mesh_faces_cache;
+	}
+	print_line("WorldBoundaryShape3D Cache Miss");
 	Plane p = get_plane();
 
 	Vector3 n1 = p.get_any_perpendicular_normal();
@@ -107,6 +111,7 @@ Ref<ArrayMesh> WorldBoundaryShape3D::get_debug_arraymesh_faces(const Color &p_mo
 	a[RSE::ARRAY_INDEX] = indices;
 	mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, a);
 
+	debug_mesh_faces_cache = mesh;
 	return mesh;
 }
 

--- a/scene/resources/3d/world_boundary_shape_3d.h
+++ b/scene/resources/3d/world_boundary_shape_3d.h
@@ -47,7 +47,7 @@ public:
 	const Plane &get_plane() const;
 
 	virtual Vector<Vector3> get_debug_mesh_lines() const override;
-	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) const override;
+	virtual Ref<ArrayMesh> get_debug_arraymesh_faces(const Color &p_modulate) override;
 	virtual real_t get_enclosing_radius() const override {
 		// Should be infinite?
 		return 0;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #103676

## Additional information
This is a draft.

This PR provides a fairly significant framerate improvement to the editor when "View Gizmos" are turned on. In my local tests, against the https://github.com/Jamsers/Crater-Province-Level project used to demonstrate the issue originally, I see a change from approximately 128 to 156 FPS with the camera in its default starting position.
The altered code also hits code produced at the time of regression, shown in the bisection.

Submitting this early to get some eyes on it, as I'm currently at a bit of a loss as to how I should better structure this to prevent the excessive creation of `Instance` objects, a result of the `p_gizmo->add_mesh(..` call. I'm still pretty fresh with the repo, as well as C++.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
