### PR TITLE
Fix out of bounds errors when reloading edited scene

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4897,7 +4897,7 @@ int EditorNode::new_scene() {
 	return idx;
 }
 
-Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, bool p_set_inherited, bool p_force_open_imported, bool p_update_tabs) {
+Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, bool p_set_inherited, bool p_force_open_imported, bool p_update_tabs, bool p_force_new_scene) {
 	const String lpath = ProjectSettings::get_singleton()->localize_path(ResourceUID::ensure_path(p_scene));
 	_update_prev_closed_scenes(lpath, false);
 
@@ -4984,7 +4984,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 	}
 
 	int idx = editor_data.get_edited_scene();
-	if (idx == -1 || editor_data.get_edited_scene_root() || !editor_data.get_scene_path(idx).is_empty()) {
+	if (idx == -1 || editor_data.get_edited_scene_root() || !editor_data.get_scene_path(idx).is_empty() || p_force_new_scene) {
 		idx = editor_data.add_edited_scene(-1);
 	}
 	editor_data.set_scene_root(idx, new_scene);
@@ -7180,7 +7180,7 @@ void EditorNode::reload_scene(const String &p_path) {
 
 	// Reload scene.
 	_remove_scene(scene_idx, false);
-	Error err = load_scene(p_path, true, false, false, false);
+	Error err = load_scene(p_path, true, false, false, false, true);
 	if (err != OK) {
 		return;
 	}
@@ -7194,8 +7194,8 @@ void EditorNode::reload_scene(const String &p_path) {
 		_set_current_scene_nocheck(current_tab, true);
 	} else {
 		editor_data.set_edited_scene(current_tab);
-		scene_tabs->update_scene_tabs();
 	}
+	scene_tabs->update_scene_tabs();
 }
 
 void EditorNode::find_all_instances_inheriting_path_in_node(Node *p_root, Node *p_node, const String &p_instance_path, HashSet<Node *> &p_instance_list) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4939,7 +4939,7 @@ int EditorNode::new_scene() {
 	return idx;
 }
 
-Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, bool p_set_inherited, bool p_force_open_imported, bool p_update_tabs) {
+Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, bool p_set_inherited, bool p_force_open_imported, bool p_update_tabs, bool p_force_new_scene) {
 	const String lpath = ProjectSettings::get_singleton()->localize_path(ResourceUID::ensure_path(p_scene));
 	_update_prev_closed_scenes(lpath, false);
 
@@ -5026,7 +5026,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 	}
 
 	int idx = editor_data.get_edited_scene();
-	if (idx == -1 || editor_data.get_edited_scene_root() || !editor_data.get_scene_path(idx).is_empty()) {
+	if (idx == -1 || editor_data.get_edited_scene_root() || !editor_data.get_scene_path(idx).is_empty() || p_force_new_scene) {
 		idx = editor_data.add_edited_scene(-1);
 	}
 	editor_data.set_scene_root(idx, new_scene);
@@ -7227,7 +7227,7 @@ void EditorNode::reload_scene(const String &p_path) {
 
 	// Reload scene.
 	_remove_scene(scene_idx, false);
-	Error err = load_scene(p_path, true, false, true, false);
+	Error err = load_scene(p_path, true, false, true, false, true);
 	if (err != OK) {
 		return;
 	}
@@ -7241,8 +7241,8 @@ void EditorNode::reload_scene(const String &p_path) {
 		_set_current_scene_nocheck(current_tab, true);
 	} else {
 		editor_data.set_edited_scene(current_tab);
-		scene_tabs->update_scene_tabs();
 	}
+	scene_tabs->update_scene_tabs();
 }
 
 void EditorNode::find_all_instances_inheriting_path_in_node(Node *p_root, Node *p_node, const String &p_instance_path, HashSet<Node *> &p_instance_list) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -869,7 +869,7 @@ public:
 	void set_preview_locale(const String &p_locale, bool p_pseudolocalization);
 
 	int new_scene();
-	Error load_scene(const String &p_scene, bool p_ignore_broken_deps = false, bool p_set_inherited = false, bool p_force_open_imported = false, bool p_update_tabs = true);
+	Error load_scene(const String &p_scene, bool p_ignore_broken_deps = false, bool p_set_inherited = false, bool p_force_open_imported = false, bool p_update_tabs = true, bool p_force_new_scene = false);
 	Error open_scene(const String &p_scene, bool p_ignore_broken_deps = false, bool p_set_inherited = false, bool p_force_open_imported = false);
 	Error load_resource(const String &p_resource, bool p_ignore_broken_deps = false);
 	Error load_scene_or_resource(const String &p_file, bool p_ignore_broken_deps = false, bool p_change_scene_tab_if_already_open = true);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -884,7 +884,7 @@ public:
 	void set_preview_locale(const String &p_locale, bool p_pseudolocalization);
 
 	int new_scene();
-	Error load_scene(const String &p_scene, bool p_ignore_broken_deps = false, bool p_set_inherited = false, bool p_force_open_imported = false, bool p_update_tabs = true);
+	Error load_scene(const String &p_scene, bool p_ignore_broken_deps = false, bool p_set_inherited = false, bool p_force_open_imported = false, bool p_update_tabs = true, bool p_force_new_scene = false);
 	Error open_scene(const String &p_scene, bool p_ignore_broken_deps = false, bool p_set_inherited = false, bool p_force_open_imported = false);
 	Error load_resource(const String &p_resource, bool p_ignore_broken_deps = false);
 	Error load_scene_or_resource(const String &p_file, bool p_ignore_broken_deps = false, bool p_change_scene_tab_if_already_open = true);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #121929

Fixes two things that can cause out of bounds errors in `EditorData` and the scene editors `TabBar`, whenever an edited scene is reloaded, such as when a file this scene depends on is moved in the file system (see linked issue).

Fixes:
1. The tabs of the scene editors `TabBar` were not being updated when the scene that is being reloaded is the currently edited scene.
2. If the current edited scene is empty whenever a scene is reloaded, the reloaded scene would overwrite the empty scene, without accounting for the decrease in the total number of edited scenes. This can also cause the editor to crash if the empty scene is not the last tab.

## Additional information
Note that my fix for point 2 is to never overwrite an empty scene when reloading a scene. This makes more sense to me than the current behavior. e.g. moving a file shouldn't have the side effect of closing a tab in the scene editor.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
