### PR TITLE
Fix `Node::duplicate` fails to duplicate properties referencing children unless they are explicitly named

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2893,7 +2893,7 @@ Node *Node::_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap) c
 	}
 
 	if (get_name() != String()) {
-		node->set_name(get_name());
+		node->_set_name_nocheck(get_name());
 	}
 
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Resolves this issue, see my comment: https://github.com/godotengine/godot/issues/121878

## Additional information

Everything is detailed in the issue thread here: https://github.com/godotengine/godot/issues/121878

No AI used.
