### PR TITLE
[Docs] Add a note how to use EditorPaths class

### DIFF
--- a/doc/classes/EditorPaths.xml
+++ b/doc/classes/EditorPaths.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		This editor-only singleton returns OS-specific paths to various data folders and files. It can be used in editor plugins to ensure files are saved in the correct location on each operating system.
+		[b]Note:[/b] This class shouldn't be instantiated directly. Instead, access the singleton using [method EditorInterface.get_editor_paths].
 		[b]Note:[/b] This singleton is not accessible in exported projects. Attempting to access it in an exported project will result in a script error as the singleton won't be declared. To prevent script errors in exported projects, use [method Engine.has_singleton] to check whether the singleton is available before using it.
 		[b]Note:[/b] On the Linux/BSD platform, Godot complies with the [url=https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html]XDG Base Directory Specification[/url]. You can override environment variables following the specification to change the editor and project data paths.
 	</description>


### PR DESCRIPTION
## What problem(s) does this PR solve?

Explains the intended way to use EditorPaths class.

## Additional information

My use case:
- I wanted to use EditorPaths singleton for my plugin to get settings directory.
- Docs say it is a singleton. Ok, I tried to use it as `EditorPaths.get_config_dir()`.
- Didn't work, godot said I need to instantiate it first. Ok, I tried to instantiate it first  with `EditotorPaths.new()` and then call the method. I got error "Condition "singleton != nullptr" is true" which is not really descriptive and at this point I'm stuck and thinking it is some kind of engine bug.
- I tried to ask AI, and with second attempt (first one was about using `EditorPaths.get_config_dir()` directly too) it tells me that there is actually a `EditorInterface.get_config_dir()` method. I usually use F1 in editor, so I didn't know there was a function which returns this singleton.

So in this PR I added a note, similar to the one used in e.g. EditorToaster or EditorSettings classes, which tells how you are supposed to access this singleton.
