### PR TITLE
Fix debugger server error disappeared in editor’s output.

### DIFF
--- a/editor/debugger/editor_debugger_server.cpp
+++ b/editor/debugger/editor_debugger_server.cpp
@@ -99,7 +99,7 @@ Error EditorDebuggerServerTCP::start(const String &p_uri) {
 			break;
 		}
 		if (attempt >= max_attempts) {
-			EditorNode::get_log()->add_message(vformat("Cannot listen on port %d, remote debugging unavailable.", bind_port), EditorLog::MSG_TYPE_ERROR);
+			EditorNode::get_log()->add_message(vformat("Cannot listen on %s:%d, remote debugging unavailable.", bind_host, bind_port), EditorLog::MSG_TYPE_ERROR);
 			return err;
 		}
 		int last_port = bind_port++;

--- a/editor/run/editor_run_bar.cpp
+++ b/editor/run/editor_run_bar.cpp
@@ -360,6 +360,10 @@ void EditorRunBar::_run_scene(const String &p_scene_path, const Vector<String> &
 	if (uri.is_empty()) {
 		uri = "tcp://";
 	}
+
+	// Prevent clearing useful information.
+	emit_signal(SNAME("play_pressed"));
+
 	EditorDebuggerNode::get_singleton()->start(uri);
 	Error error = editor_run.run(run_filename, write_movie_file, args);
 	if (error != OK) {
@@ -370,8 +374,6 @@ void EditorRunBar::_run_scene(const String &p_scene_path, const Vector<String> &
 
 	_update_play_buttons();
 	stop_button->set_disabled(false);
-
-	emit_signal(SNAME("play_pressed"));
 }
 
 void EditorRunBar::_run_native(const Ref<EditorExportPreset> &p_preset) {

--- a/editor/run/game_view_plugin.cpp
+++ b/editor/run/game_view_plugin.cpp
@@ -1224,7 +1224,7 @@ void GameView::_notification(int p_what) {
 				_update_embed_buttons();
 				_update_embed_menu_options();
 
-				EditorRunBar::get_singleton()->connect("play_pressed", callable_mp(this, &GameView::_play_pressed));
+				EditorRunBar::get_singleton()->connect("play_pressed", callable_mp(this, &GameView::_play_pressed), CONNECT_DEFERRED);
 				EditorRunBar::get_singleton()->connect("stop_pressed", callable_mp(this, &GameView::_stop_pressed));
 				EditorRun::instance_starting_callback = _instance_starting_static;
 				EditorRun::instance_rq_screenshot_callback = _instance_rq_screenshot_static;


### PR DESCRIPTION

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #122026
- Maybe also relate to #81102

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

Due to the delayed emission of the play_pressed signal, the information originally written to the output panel is cleared, and the user cannot see the information of the debugger server.

`play_pressed` connected to `EditorNode::_project_run_started`.
https://github.com/godotengine/godot/blob/eda2a482e9ce82e4056cfffae0ea98c1954605a1/editor/editor_node.cpp#L5548-L5551

After you will see:
<img width="852" height="258" alt="godot windows editor x86_64_TrSDUgEQ06" src="https://github.com/user-attachments/assets/4cdb1e57-4157-4231-a3ad-a170493cded1" />

Over the past few years, I have seen many people encounter the situation where the output panel displays nothing when run a scene. 
A reliable way to reproduce this:
Let the debugger listen for an IP address that has become invalid. 
For example, start the editor after enabling PC's hotspot, and set the debugger host to the hotspot’s IP; then disable the hotspot so that the address becomes invalid.