### PR TITLE
Implement `flip_h` and `flip_v` in `Button`

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -65,6 +65,12 @@
 		<member name="icon_alignment" type="int" setter="set_icon_alignment" getter="get_icon_alignment" enum="HorizontalAlignment" default="0">
 			Specifies if the icon should be aligned horizontally to the left, right, or center of a button. Uses the same [enum HorizontalAlignment] constants as the text alignment. If centered horizontally and vertically, text will draw on top of the icon.
 		</member>
+		<member name="icon_flip_h" type="bool" setter="set_icon_flip_h" getter="is_icon_flipped_h" default="false">
+			If [code]true[/code], [member icon] is flipped horizontally.
+		</member>
+		<member name="icon_flip_v" type="bool" setter="set_icon_flip_v" getter="is_icon_flipped_v" default="false">
+			If [code]true[/code], [member icon] is flipped vertically.
+		</member>
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms. If left empty, the current locale is used instead.
 		</member>

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -412,6 +412,9 @@ void Button::_notification(int p_what) {
 					}
 					icon_ofs = icon_ofs.floor();
 
+					icon_size.width *= hflip ? -1.0f : 1.0f;
+					icon_size.height *= vflip ? -1.0f : 1.0f;
+
 					Rect2 icon_region = Rect2(icon_ofs, icon_size);
 					draw_texture_rect(_icon, icon_region, false, icon_modulate_color);
 				}
@@ -787,6 +790,32 @@ VerticalAlignment Button::get_vertical_icon_alignment() const {
 	return vertical_icon_alignment;
 }
 
+void Button::set_icon_flip_h(bool p_flip) {
+	if (hflip == p_flip) {
+		return;
+	}
+
+	hflip = p_flip;
+	queue_redraw();
+}
+
+bool Button::is_icon_flipped_h() const {
+	return hflip;
+}
+
+void Button::set_icon_flip_v(bool p_flip) {
+	if (vflip == p_flip) {
+		return;
+	}
+
+	vflip = p_flip;
+	queue_redraw();
+}
+
+bool Button::is_icon_flipped_v() const {
+	return vflip;
+}
+
 void Button::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_text", "text"), &Button::set_text);
 	ClassDB::bind_method(D_METHOD("get_text"), &Button::get_text);
@@ -814,6 +843,10 @@ void Button::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_vertical_icon_alignment"), &Button::get_vertical_icon_alignment);
 	ClassDB::bind_method(D_METHOD("set_expand_icon", "enabled"), &Button::set_expand_icon);
 	ClassDB::bind_method(D_METHOD("is_expand_icon"), &Button::is_expand_icon);
+	ClassDB::bind_method(D_METHOD("set_icon_flip_h", "enable"), &Button::set_icon_flip_h);
+	ClassDB::bind_method(D_METHOD("is_icon_flipped_h"), &Button::is_icon_flipped_h);
+	ClassDB::bind_method(D_METHOD("set_icon_flip_v", "enable"), &Button::set_icon_flip_v);
+	ClassDB::bind_method(D_METHOD("is_icon_flipped_v"), &Button::is_icon_flipped_v);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "text", PROPERTY_HINT_MULTILINE_TEXT), "set_text", "get_text");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), "set_button_icon", "get_button_icon");
@@ -830,6 +863,9 @@ void Button::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "icon_alignment", PROPERTY_HINT_ENUM, "Left,Center,Right"), "set_icon_alignment", "get_icon_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "vertical_icon_alignment", PROPERTY_HINT_ENUM, "Top,Center,Bottom"), "set_vertical_icon_alignment", "get_vertical_icon_alignment");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "expand_icon"), "set_expand_icon", "is_expand_icon");
+	ADD_GROUP("Icon Behavior", "icon_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "icon_flip_h"), "set_icon_flip_h", "is_icon_flipped_h");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "icon_flip_v"), "set_icon_flip_v", "is_icon_flipped_v");
 
 	ADD_GROUP("BiDi", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_direction", PROPERTY_HINT_ENUM, "Auto,Left-to-Right,Right-to-Left,Inherited"), "set_text_direction", "get_text_direction");

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -103,6 +103,9 @@ private:
 		int line_spacing = 0;
 	} theme_cache;
 
+	bool hflip = false;
+	bool vflip = false;
+
 	void _shape(Ref<TextParagraph> p_paragraph = Ref<TextParagraph>(), String p_text = "") const;
 	void _texture_changed();
 	void _update_style_margins(const Ref<StyleBox> &p_stylebox);
@@ -164,6 +167,12 @@ public:
 	void set_vertical_icon_alignment(VerticalAlignment p_alignment);
 	HorizontalAlignment get_icon_alignment() const;
 	VerticalAlignment get_vertical_icon_alignment() const;
+
+	void set_icon_flip_h(bool p_flip);
+	bool is_icon_flipped_h() const;
+
+	void set_icon_flip_v(bool p_flip);
+	bool is_icon_flipped_v() const;
 
 	Button(const String &p_text = String());
 	~Button();


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes godotengine/godot-proposals#15314
- Also see godotengine/godot-proposals#8207

## Additional information

`TextureButton`s already supported this functionality, therefore `Button` should have parity with its icon, too. `Button`s are more common than `TextureButton`s since they support text and `StyleBox`es (which `TextureButton`s don't, unfortunately), and only need one texture to represent all states (normal/hovered/pressed/etc.). Even with no text, these benefits can make them easier to work with in the editor and in code than `TextureButton`s.

This PR prevents the need for manually making a new flipped icon for common cases such as arrows for forward and back buttons, clockwise/counter-clockwise icons (as shown in this GIF) and diagonal pointing arrows that support all four directions with only one base texture. 

<img width="400" height="228" alt="A clockwise icon is flipped as to make it counter-clockwise" src="https://github.com/user-attachments/assets/347d7c98-7561-446a-8f7c-536249a5dbc4" />

Please tell me if there's any changes needed. It must work 100%, but test just so you know I didn't bork anything. :D

N/AI (expands to "No AI")

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
