### PR TITLE
Variant from PtrToArg

### DIFF
--- a/core/variant/method_ptrarg.h
+++ b/core/variant/method_ptrarg.h
@@ -1,0 +1,39 @@
+/**************************************************************************/
+/*  method_ptrcall.h                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include <type_traits>
+
+template <typename T, typename = void>
+struct PtrToArg;
+
+template <typename T>
+struct PtrToArg<T, std::enable_if_t<!std::is_same_v<T, std::decay_t<T>>>> : PtrToArg<std::decay_t<T>> {};

--- a/core/variant/method_ptrarg.h
+++ b/core/variant/method_ptrarg.h
@@ -37,3 +37,9 @@ struct PtrToArg;
 
 template <typename T>
 struct PtrToArg<T, std::enable_if_t<!std::is_same_v<T, std::decay_t<T>>>> : PtrToArg<std::decay_t<T>> {};
+
+template <typename T, typename = void>
+struct ConvertiblePtrToArg : std::false_type {};
+
+template <typename T>
+struct ConvertiblePtrToArg<T, std::void_t<decltype(PtrToArg<T>::encode(std::declval<T>(), std::declval<void *>()))>> : std::true_type {};

--- a/core/variant/method_ptrcall.h
+++ b/core/variant/method_ptrcall.h
@@ -33,6 +33,7 @@
 #include "core/object/object.h"
 #include "core/object/object_id.h"
 #include "core/typedefs.h"
+#include "core/variant/method_ptrarg.h"
 #include "core/variant/variant.h"
 
 namespace Internal {
@@ -136,12 +137,6 @@ struct PtrToArgStringConvertByReference {
 };
 
 } //namespace Internal
-
-template <typename T, typename = void>
-struct PtrToArg;
-
-template <typename T>
-struct PtrToArg<T, std::enable_if_t<!std::is_same_v<T, std::decay_t<T>>>> : PtrToArg<std::decay_t<T>> {};
 
 template <>
 struct PtrToArg<bool> : Internal::PtrToArgConvert<bool, uint8_t> {};

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -61,6 +61,7 @@
 #include "core/variant/array.h"
 #include "core/variant/callable.h"
 #include "core/variant/dictionary.h"
+#include "core/variant/method_ptrarg.h"
 #include "core/variant/variant_deep_duplicate.h"
 
 class GDType;
@@ -564,6 +565,13 @@ public:
 	template <typename K, typename V>
 	_FORCE_INLINE_ Variant(const TypedDictionary<K, V> &p_typed_dictionary) :
 			Variant(static_cast<const Dictionary &>(p_typed_dictionary)) {}
+
+	template <typename T, typename = std::enable_if_t<ConvertiblePtrToArg<T>::value>
+	_FORCE_INLINE_ explicit Variant(const T &v) {
+		typename PtrToArg<T>::EncodeT t;
+		PtrToArg<T>::encode(v, t);
+		*this = t;
+	}
 
 	// If this changes the table in variant_op must be updated
 	enum Operator {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Required for the godotengine/godot-proposals#14507 proposal.

## Additional information

With this PR API users can register custom conversions via `PtrToArg` for types external to Godot. When embedding the engine with LibGodot, this aids the case of language bindings and toolkit integration. For example, Python `PyObject` objects can easily be converted back and forth to `Variant` when binding classes. Another example could be Qt types such as `QString` which makes possible to share methods across both frameworks.
