### PR TITLE
Don't do code completion in shader comments

### DIFF
--- a/editor/shader/shader_text_editor.cpp
+++ b/editor/shader/shader_text_editor.cpp
@@ -937,6 +937,11 @@ static void _complete_include_paths(List<ScriptLanguage::CodeCompletionOption> *
 }
 
 void ShaderTextEditor::_code_complete_script(const String &p_code, List<ScriptLanguage::CodeCompletionOption> *r_options, bool &r_force) {
+	CodeEdit *editor = code_editor->get_text_editor();
+	if (editor->is_in_comment(editor->get_caret_line(), editor->get_caret_column()) != -1) {
+		return;
+	}
+
 	List<ScriptLanguage::CodeCompletionOption> pp_options;
 	List<ScriptLanguage::CodeCompletionOption> pp_defines;
 	ShaderPreprocessor preprocessor;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/120151

## Additional information

I looked for a fix in `ShaderLanguage` but that seems significantly more difficult. For reference the suggestions are added here:

https://github.com/godotengine/godot/blob/eda2a482e9ce82e4056cfffae0ea98c1954605a1/servers/rendering/shader_language.cpp#L11609-L11627

This means we need to set `keyword_completion_context` to `CF_UNSPECIFIED` to avoid code completion this way. In my testing `keyword_completion_context` is last set here (cutout from `_parse_shader` called in the code section above):

https://github.com/godotengine/godot/blob/eda2a482e9ce82e4056cfffae0ea98c1954605a1/servers/rendering/shader_language.cpp#L11203-L11222
`_parse_shader` ignores comments entirely and the context is set to the first unsuccessfully parsed part of the shader.