### PR TITLE
[Android] Fix error spam on right-clicking file system dock.

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2789,12 +2789,14 @@ int FileSystemDock::_get_menu_option_from_key(const Ref<InputEventKey> &p_key) {
 		return FILE_MENU_NEW_TEXTFILE;
 	} else if (ED_IS_SHORTCUT("filesystem_dock/rename", p_key)) {
 		return FILE_MENU_RENAME;
+#if !defined(ANDROID_ENABLED) && !defined(WEB_ENABLED)
 	} else if (ED_IS_SHORTCUT("filesystem_dock/show_in_explorer", p_key)) {
 		return FILE_MENU_SHOW_IN_EXPLORER;
 	} else if (ED_IS_SHORTCUT("filesystem_dock/open_in_external_program", p_key)) {
 		return FILE_MENU_OPEN_EXTERNAL;
 	} else if (ED_IS_SHORTCUT("filesystem_dock/open_in_terminal", p_key)) {
 		return FILE_MENU_OPEN_IN_TERMINAL;
+#endif
 	} else if (ED_IS_SHORTCUT("filesystem_dock/focus_path", p_key)) {
 		return EXTRA_FOCUS_PATH;
 	} else if (ED_IS_SHORTCUT("editor/open_search", p_key)) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes error prints show when right-clicking on file system menu (e.g, when testing with scrpy, not sure what event it is producing).

<img width="636" height="66" alt="Screenshot 2026-08-02 at 17 53 31" src="https://github.com/user-attachments/assets/2bb8f74a-8f84-4520-909b-6c63c7cdbb23" />
