### PR TITLE
Improve VehicleBody3d and VehicleWheels3d defaults

### DIFF
--- a/doc/classes/VehicleBody3D.xml
+++ b/doc/classes/VehicleBody3D.xml
@@ -23,7 +23,7 @@
 			[b]Note:[/b] The simulation does not take the effect of gears into account, you will need to add logic for this if you wish to simulate gears.
 			A negative value will result in the vehicle reversing.
 		</member>
-		<member name="mass" type="float" setter="set_mass" getter="get_mass" overrides="RigidBody3D" default="40.0" />
+		<member name="mass" type="float" setter="set_mass" getter="get_mass" overrides="RigidBody3D" default="1000.0" />
 		<member name="steering" type="float" setter="set_steering" getter="get_steering" default="0.0">
 			The steering angle for the vehicle. Setting this to a non-zero value will result in the vehicle turning when it's moving. Wheels that have [member VehicleWheel3D.use_as_steering] set to [code]true[/code] will automatically be rotated.
 			[b]Note:[/b] This property is edited in the inspector in degrees. In code the property is set in radians.

--- a/doc/classes/VehicleWheel3D.xml
+++ b/doc/classes/VehicleWheel3D.xml
@@ -53,10 +53,10 @@
 		<member name="brake" type="float" setter="set_brake" getter="get_brake" default="0.0">
 			Slows down the wheel by applying a braking force. The wheel is only slowed down if it is in contact with a surface. The force you need to apply to adequately slow down your vehicle depends on the [member RigidBody3D.mass] of the vehicle. For a vehicle with a mass set to 1000, try a value in the 25 - 30 range for hard braking.
 		</member>
-		<member name="damping_compression" type="float" setter="set_damping_compression" getter="get_damping_compression" default="0.83">
+		<member name="damping_compression" type="float" setter="set_damping_compression" getter="get_damping_compression" default="0.3">
 			The damping applied to the suspension spring when being compressed, meaning when the wheel is moving up relative to the vehicle. It is measured in Newton-seconds per millimeter (N⋅s/mm), or megagrams per second (Mg/s). This value should be between 0.0 (no damping) and 1.0, but may be more. A value of 0.0 means the car will keep bouncing as the spring keeps its energy. A good value for this is around 0.3 for a normal car, 0.5 for a race car.
 		</member>
-		<member name="damping_relaxation" type="float" setter="set_damping_relaxation" getter="get_damping_relaxation" default="0.88">
+		<member name="damping_relaxation" type="float" setter="set_damping_relaxation" getter="get_damping_relaxation" default="0.5">
 			The damping applied to the suspension spring when rebounding or extending, meaning when the wheel is moving down relative to the vehicle. It is measured in Newton-seconds per millimeter (N⋅s/mm), or megagrams per second (Mg/s). This value should be between 0.0 (no damping) and 1.0, but may be more. This value should always be slightly higher than the [member damping_compression] property. For a [member damping_compression] value of 0.3, try a relaxation value of 0.5.
 		</member>
 		<member name="engine_force" type="float" setter="set_engine_force" getter="get_engine_force" default="0.0">
@@ -71,7 +71,7 @@
 		<member name="suspension_max_force" type="float" setter="set_suspension_max_force" getter="get_suspension_max_force" default="6000.0">
 			The maximum force the spring can resist. This value should be higher than a quarter of the [member RigidBody3D.mass] of the [VehicleBody3D] or the spring will not carry the weight of the vehicle. Good results are often obtained by a value that is about 3× to 4× this number.
 		</member>
-		<member name="suspension_stiffness" type="float" setter="set_suspension_stiffness" getter="get_suspension_stiffness" default="5.88">
+		<member name="suspension_stiffness" type="float" setter="set_suspension_stiffness" getter="get_suspension_stiffness" default="50.0">
 			The stiffness of the suspension, measured in Newtons per millimeter (N/mm), or megagrams per second squared (Mg/s²). Use a value lower than 50 for an off-road car, a value between 50 and 100 for a race car and try something around 200 for something like a Formula 1 car.
 		</member>
 		<member name="suspension_travel" type="float" setter="set_suspension_travel" getter="get_suspension_travel" default="0.2">
@@ -83,11 +83,11 @@
 		<member name="use_as_traction" type="bool" setter="set_use_as_traction" getter="is_used_as_traction" default="false">
 			If [code]true[/code], this wheel transfers engine force to the ground to propel the vehicle forward. This value is used in conjunction with [member VehicleBody3D.engine_force] and ignored if you are using the per-wheel [member engine_force] value instead.
 		</member>
-		<member name="wheel_friction_slip" type="float" setter="set_friction_slip" getter="get_friction_slip" default="10.5">
+		<member name="wheel_friction_slip" type="float" setter="set_friction_slip" getter="get_friction_slip" default="1.0">
 			This determines how much grip this wheel has. It is combined with the friction setting of the surface the wheel is in contact with. 0.0 means no grip, 1.0 is normal grip. For a drift car setup, try setting the grip of the rear wheels slightly lower than the front wheels, or use a lower value to simulate tire wear.
 			It's best to set this to 1.0 when starting out.
 		</member>
-		<member name="wheel_radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
+		<member name="wheel_radius" type="float" setter="set_radius" getter="get_radius" default="0.3">
 			The radius of the wheel in meters.
 		</member>
 		<member name="wheel_rest_length" type="float" setter="set_suspension_rest_length" getter="get_suspension_rest_length" default="0.15">

--- a/scene/3d/physics/vehicle_body_3d.cpp
+++ b/scene/3d/physics/vehicle_body_3d.cpp
@@ -1062,5 +1062,5 @@ void VehicleBody3D::_bind_methods() {
 
 VehicleBody3D::VehicleBody3D() {
 	exclude.insert(get_rid());
-	set_mass(40);
+	set_mass(1000);
 }

--- a/scene/3d/physics/vehicle_body_3d.h
+++ b/scene/3d/physics/vehicle_body_3d.h
@@ -89,12 +89,12 @@ class VehicleWheel3D : public Node3D {
 
 	real_t m_suspensionRestLength = 0.15;
 	real_t m_maxSuspensionTravel = 0.2;
-	real_t m_wheelRadius = 0.5;
+	real_t m_wheelRadius = 0.3;
 
-	real_t m_suspensionStiffness = 5.88;
-	real_t m_wheelsDampingCompression = 0.83;
-	real_t m_wheelsDampingRelaxation = 0.88;
-	real_t m_frictionSlip = 10.5;
+	real_t m_suspensionStiffness = 50;
+	real_t m_wheelsDampingCompression = 0.3;
+	real_t m_wheelsDampingRelaxation = 0.5;
+	real_t m_frictionSlip = 1;
 	real_t m_maxSuspensionForce = 6000.0;
 	bool m_bIsFrontWheel = false;
 


### PR DESCRIPTION
- Closes godotengine/godot-proposals#2217

Follows [VehicleWheel3D](https://docs.godotengine.org/en/stable/classes/class_vehiclewheel3d.html#class-vehiclewheel3d) reference values for car mass, damping, suspension stiffness, friction slip.
Also slightly reduce default wheel radius.

Tried using the TruckTown demo as reference for testing, but there are some hardcoded speed values that made it quite bad. In my own case, these values worked with slightly higher slip and very high damping values for a formula 1 like arcade car.

#### Additional work: 
- It seems overriding RigidBody3D's mass property hint would require refactoring parts of the engine's core? The idea would be to change the range to ~500-5000
- Maybe also change default suspension max force?