### PR TITLE
Change all instances of `TileMap` to `TileMapLayer` in the class reference

### DIFF
--- a/doc/classes/Area2D.xml
+++ b/doc/classes/Area2D.xml
@@ -25,7 +25,7 @@
 		<method name="get_overlapping_bodies" qualifiers="const">
 			<return type="Node2D[]" />
 			<description>
-				Returns a list of intersecting [PhysicsBody2D]s and [TileMap]s. The overlapping body's [member CollisionObject2D.collision_layer] must be part of this area's [member CollisionObject2D.collision_mask] in order to be detected.
+				Returns a list of intersecting [PhysicsBody2D]s and [TileMapLayer]s. The overlapping body's [member CollisionObject2D.collision_layer] must be part of this area's [member CollisionObject2D.collision_mask] in order to be detected.
 				For performance reasons (collisions are all processed at the same time) this list is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.
 			</description>
 		</method>
@@ -39,7 +39,7 @@
 		<method name="has_overlapping_bodies" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if intersecting any [PhysicsBody2D]s or [TileMap]s, otherwise returns [code]false[/code]. The overlapping body's [member CollisionObject2D.collision_layer] must be part of this area's [member CollisionObject2D.collision_mask] in order to be detected.
+				Returns [code]true[/code] if intersecting any [PhysicsBody2D]s or [TileMapLayer]s, otherwise returns [code]false[/code]. The overlapping body's [member CollisionObject2D.collision_layer] must be part of this area's [member CollisionObject2D.collision_mask] in order to be detected.
 				For performance reasons (collisions are all processed at the same time) the list of overlapping bodies is modified once during the physics step, not immediately after objects are moved. Consider using signals instead.
 			</description>
 		</method>
@@ -57,7 +57,7 @@
 			<description>
 				Returns [code]true[/code] if the given physics body intersects or overlaps this [Area2D], [code]false[/code] otherwise.
 				[b]Note:[/b] The result of this test is not immediate after moving objects. For performance, list of overlaps is updated once per frame and before the physics step. Consider using signals instead.
-				The [param body] argument can either be a [PhysicsBody2D] or a [TileMap] instance. While TileMaps are not physics bodies themselves, they register their tiles with collision shapes as a virtual physics body.
+				The [param body] argument can either be a [PhysicsBody2D] or a [TileMapLayer] instance. While TileMaps are not physics bodies themselves, they register their tiles with collision shapes as a virtual physics body.
 			</description>
 		</method>
 	</methods>
@@ -157,13 +157,13 @@
 		<signal name="body_entered">
 			<param index="0" name="body" type="Node2D" />
 			<description>
-				Emitted when the received [param body] enters this area. [param body] can be a [PhysicsBody2D] or a [TileMap]. [TileMap]s are detected if their [TileSet] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
+				Emitted when the received [param body] enters this area. [param body] can be a [PhysicsBody2D] or a [TileMapLayer]. [TileMapLayer]s are detected if their [TileSet] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
 			</description>
 		</signal>
 		<signal name="body_exited">
 			<param index="0" name="body" type="Node2D" />
 			<description>
-				Emitted when the received [param body] exits this area. [param body] can be a [PhysicsBody2D] or a [TileMap]. [TileMap]s are detected if their [TileSet] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
+				Emitted when the received [param body] exits this area. [param body] can be a [PhysicsBody2D] or a [TileMapLayer]. [TileMapLayer]s are detected if their [TileSet] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
 			</description>
 		</signal>
 		<signal name="body_shape_entered">
@@ -172,7 +172,7 @@
 			<param index="2" name="body_shape_index" type="int" />
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when a [Shape2D] of the received [param body] enters a shape of this area. [param body] can be a [PhysicsBody2D] or a [TileMap]. [TileMap]s are detected if their [TileSet] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
+				Emitted when a [Shape2D] of the received [param body] enters a shape of this area. [param body] can be a [PhysicsBody2D] or a [TileMapLayer]. [TileMapLayer]s are detected if their [TileSet] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
 				[param local_shape_index] and [param body_shape_index] contain indices of the interacting shapes from this area and the interacting body, respectively. [param body_rid] contains the [RID] of the body. These values can be used with the [PhysicsServer2D].
 				[b]Example:[/b] Get the [CollisionShape2D] node from the shape index:
 				[codeblocks]
@@ -192,7 +192,7 @@
 			<param index="2" name="body_shape_index" type="int" />
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when a [Shape2D] of the received [param body] exits a shape of this area. [param body] can be a [PhysicsBody2D] or a [TileMap]. [TileMap]s are detected if their [TileSet] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
+				Emitted when a [Shape2D] of the received [param body] exits a shape of this area. [param body] can be a [PhysicsBody2D] or a [TileMapLayer]. [TileMapLayer]s are detected if their [TileSet] has collision shapes configured. Requires [member monitoring] to be set to [code]true[/code].
 				See also [signal body_shape_entered].
 			</description>
 		</signal>

--- a/doc/classes/EditorDock.xml
+++ b/doc/classes/EditorDock.xml
@@ -130,7 +130,7 @@
 			The color of the dock tab's title. If its alpha is [code]0.0[/code], the default font color will be used.
 		</member>
 		<member name="transient" type="bool" setter="set_transient" getter="is_transient" default="false">
-			If [code]true[/code], the dock is not automatically opened or closed when loading an editor layout, only moved. It also can't be opened using a shortcut. This is meant for docks that are opened and closed in specific cases, such as when selecting a [TileMap] or [AnimationTree] node.
+			If [code]true[/code], the dock is not automatically opened or closed when loading an editor layout, only moved. It also can't be opened using a shortcut. This is meant for docks that are opened and closed in specific cases, such as when selecting a [TileMapLayer] or [AnimationTree] node.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/NavigationPolygon.xml
+++ b/doc/classes/NavigationPolygon.xml
@@ -216,11 +216,11 @@
 			Represents the size of the [enum SamplePartitionType] enum.
 		</constant>
 		<constant name="PARSED_GEOMETRY_MESH_INSTANCES" value="0" enum="ParsedGeometryType">
-			Parses mesh instances as obstruction geometry. This includes [Polygon2D], [MeshInstance2D], [MultiMeshInstance2D], and [TileMap] nodes.
+			Parses mesh instances as obstruction geometry. This includes [Polygon2D], [MeshInstance2D], [MultiMeshInstance2D], and [TileMapLayer] nodes.
 			Meshes are only parsed when they use a 2D vertices surface format.
 		</constant>
 		<constant name="PARSED_GEOMETRY_STATIC_COLLIDERS" value="1" enum="ParsedGeometryType">
-			Parses [StaticBody2D] and [TileMap] colliders as obstruction geometry. The collider should be in any of the layers specified by [member parsed_collision_mask].
+			Parses [StaticBody2D] and [TileMapLayer] colliders as obstruction geometry. The collider should be in any of the layers specified by [member parsed_collision_mask].
 		</constant>
 		<constant name="PARSED_GEOMETRY_BOTH" value="2" enum="ParsedGeometryType">
 			Both [constant PARSED_GEOMETRY_MESH_INSTANCES] and [constant PARSED_GEOMETRY_STATIC_COLLIDERS].

--- a/doc/classes/RigidBody2D.xml
+++ b/doc/classes/RigidBody2D.xml
@@ -253,15 +253,15 @@
 		<signal name="body_entered">
 			<param index="0" name="body" type="Node" />
 			<description>
-				Emitted when a collision with another [PhysicsBody2D] or [TileMap] occurs. Requires [member contact_monitor] to be set to [code]true[/code] and [member max_contacts_reported] to be set high enough to detect all the collisions. [TileMap]s are detected if the [TileSet] has Collision [Shape2D]s.
-				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
+				Emitted when a collision with another [PhysicsBody2D] or [TileMapLayer] occurs. Requires [member contact_monitor] to be set to [code]true[/code] and [member max_contacts_reported] to be set high enough to detect all the collisions. [TileMapLayer]s are detected if the [TileSet] has Collision [Shape2D]s.
+				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMapLayer].
 			</description>
 		</signal>
 		<signal name="body_exited">
 			<param index="0" name="body" type="Node" />
 			<description>
-				Emitted when the collision with another [PhysicsBody2D] or [TileMap] ends. Requires [member contact_monitor] to be set to [code]true[/code] and [member max_contacts_reported] to be set high enough to detect all the collisions. [TileMap]s are detected if the [TileSet] has Collision [Shape2D]s.
-				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
+				Emitted when the collision with another [PhysicsBody2D] or [TileMapLayer] ends. Requires [member contact_monitor] to be set to [code]true[/code] and [member max_contacts_reported] to be set high enough to detect all the collisions. [TileMapLayer]s are detected if the [TileSet] has Collision [Shape2D]s.
+				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMapLayer].
 			</description>
 		</signal>
 		<signal name="body_shape_entered">
@@ -270,10 +270,10 @@
 			<param index="2" name="body_shape_index" type="int" />
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when one of this RigidBody2D's [Shape2D]s collides with another [PhysicsBody2D] or [TileMap]'s [Shape2D]s. Requires [member contact_monitor] to be set to [code]true[/code] and [member max_contacts_reported] to be set high enough to detect all the collisions. [TileMap]s are detected if the [TileSet] has Collision [Shape2D]s.
+				Emitted when one of this RigidBody2D's [Shape2D]s collides with another [PhysicsBody2D] or [TileMapLayer]'s [Shape2D]s. Requires [member contact_monitor] to be set to [code]true[/code] and [member max_contacts_reported] to be set high enough to detect all the collisions. [TileMapLayer]s are detected if the [TileSet] has Collision [Shape2D]s.
 				[param body_rid] the [RID] of the other [PhysicsBody2D] or [TileSet]'s [CollisionObject2D] used by the [PhysicsServer2D].
-				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
-				[param body_shape_index] the index of the [Shape2D] of the other [PhysicsBody2D] or [TileMap] used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
+				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMapLayer].
+				[param body_shape_index] the index of the [Shape2D] of the other [PhysicsBody2D] or [TileMapLayer] used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
 				[param local_shape_index] the index of the [Shape2D] of this RigidBody2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
 			</description>
 		</signal>
@@ -283,10 +283,10 @@
 			<param index="2" name="body_shape_index" type="int" />
 			<param index="3" name="local_shape_index" type="int" />
 			<description>
-				Emitted when the collision between one of this RigidBody2D's [Shape2D]s and another [PhysicsBody2D] or [TileMap]'s [Shape2D]s ends. Requires [member contact_monitor] to be set to [code]true[/code] and [member max_contacts_reported] to be set high enough to detect all the collisions. [TileMap]s are detected if the [TileSet] has Collision [Shape2D]s.
+				Emitted when the collision between one of this RigidBody2D's [Shape2D]s and another [PhysicsBody2D] or [TileMapLayer]'s [Shape2D]s ends. Requires [member contact_monitor] to be set to [code]true[/code] and [member max_contacts_reported] to be set high enough to detect all the collisions. [TileMapLayer]s are detected if the [TileSet] has Collision [Shape2D]s.
 				[param body_rid] the [RID] of the other [PhysicsBody2D] or [TileSet]'s [CollisionObject2D] used by the [PhysicsServer2D].
-				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMap].
-				[param body_shape_index] the index of the [Shape2D] of the other [PhysicsBody2D] or [TileMap] used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
+				[param body] the [Node], if it exists in the tree, of the other [PhysicsBody2D] or [TileMapLayer].
+				[param body_shape_index] the index of the [Shape2D] of the other [PhysicsBody2D] or [TileMapLayer] used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]body.shape_owner_get_owner(body.shape_find_owner(body_shape_index))[/code].
 				[param local_shape_index] the index of the [Shape2D] of this RigidBody2D used by the [PhysicsServer2D]. Get the [CollisionShape2D] node with [code]self.shape_owner_get_owner(self.shape_find_owner(local_shape_index))[/code].
 			</description>
 		</signal>

--- a/modules/tilemap/doc_classes/TileMapPattern.xml
+++ b/modules/tilemap/doc_classes/TileMapPattern.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="TileMapPattern" inherits="Resource" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
-		Holds a pattern to be copied from or pasted into [TileMap]s.
+		Holds a pattern to be copied from or pasted into [TileMapLayer]s.
 	</brief_description>
 	<description>
-		This resource holds a set of cells to help bulk manipulations of [TileMap].
+		This resource holds a set of cells to help bulk manipulations of [TileMapLayer].
 		A pattern always starts at the [code](0, 0)[/code] coordinates and cannot have cells with negative coordinates.
 	</description>
 	<tutorials>


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes godotengine/godot-docs#10599

## Additional information

I was surprised that `TileMap`s are still being mentioned as a functional class, so I decided to get this over with. :D (The mentions of TileMap editor, I kept because that _is_ in the code.)

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
