### PR TITLE
C# (.NET): Initial WebAssembly export support integration

### DIFF
--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -122,6 +122,7 @@ def configure(env: "SConsEnvironment"):
 
     env["EXPORTED_FUNCTIONS"] = ["_main"]
     env["EXPORTED_RUNTIME_METHODS"] = []
+    env["supported"] = ["mono"]
 
     # Validate arch.
     supported_arches = ["wasm32", "wasm64"]

--- a/platform/web/js/libs/library_godot_mono.js
+++ b/platform/web/js/libs/library_godot_mono.js
@@ -1,0 +1,50 @@
+/**
+ * Godot Emscripten library for .NET 8 WASM Runtime Integration.
+ * 
+ * This file binds Godot's C++ Web platform to the .NET WASM runtime (dotnet.js).
+ */
+const GodotMono = {
+	$GodotMono__deps: ['$GodotRuntime', '$GodotConfig'],
+	$GodotMono: {
+		runtime_initialized: false,
+		dotnet_exports: null,
+
+		init_dotnet: function(wasm_file) {
+			if (GodotMono.runtime_initialized) return Promise.resolve();
+
+			return new Promise((resolve, reject) => {
+				GodotRuntime.print("Initializing .NET WASM runtime...");
+				// Load dotnet.js from the same path as the Godot executable
+				const dotnet_js_url = GodotConfig.locateFile("dotnet.js");
+				
+				const script = document.createElement("script");
+				script.src = dotnet_js_url;
+				script.onload = () => {
+					window.dotnet.create().then((dotnet) => {
+						GodotMono.dotnet_exports = dotnet.getAssemblyExports("GodotSharp.dll");
+						GodotMono.runtime_initialized = true;
+						GodotRuntime.print(".NET WASM runtime initialized successfully.");
+						resolve();
+					}).catch(reject);
+				};
+				script.onerror = reject;
+				document.body.appendChild(script);
+			});
+		},
+	},
+
+	godot_mono_init__proxy: 'sync',
+	godot_mono_init__sig: 'ii',
+	godot_mono_init: function() {
+		// Called from C++ during Engine initialization
+		if (GodotMono.runtime_initialized) {
+			return 1;
+		}
+		// Synchronous fallback (or we use Asyncify)
+		GodotRuntime.error("GodotMono requires async initialization. Ensure Asyncify is enabled.");
+		return 0;
+	},
+};
+
+autoAddDeps(GodotMono, '$GodotMono');
+mergeInto(LibraryManager.library, GodotMono);


### PR DESCRIPTION
Partially addresses #70796.

This draft PR begins the process of re-adding support for web platform exports for the C# (.NET 8) version of the engine.

### Changes so far:
- **Build System:** Updated `platform/web/detect.py` to correctly flag `mono` as a supported module in the SCons environment, unblocking web compilations for `.NET`.
- **Emscripten Bindings:** Stubbed out the initial Emscripten JavaScript library (`platform/web/js/libs/library_godot_mono.js`) required to bootstrap and load the `.NET 8` WASM runtime (`dotnet.js`) alongside the Godot Engine web shell.

### Next Steps:
- Modify `modules/mono/glue` to bridge native OS threading calls with the Emscripten thread pool.
- Implement the editor export plugin (`modules/mono/editor/export_plugin.cpp`) to compile the user's C# project to `browser-wasm` during the export pipeline.
- Synchronous initialization fallback handling for environments lacking Asyncify.

I am putting this up as a Draft to track progress and ensure the architectural approach aligns with the core team's expectations before I dive deeper into the `mono/glue` C++ bindings.

