### PR TITLE
Add halfway-point test for Math::snapped with negative step

### DIFF
--- a/tests/core/math/test_math_funcs.cpp
+++ b/tests/core/math/test_math_funcs.cpp
@@ -530,6 +530,9 @@ TEST_CASE("[Math] snapped") {
 	CHECK(Math::snapped(-0.5, -1.0) == doctest::Approx(-1.0));
 	CHECK(Math::snapped(0.0, -1.0) == doctest::Approx(0));
 	CHECK(Math::snapped(128'000.025, -1.0) == doctest::Approx(128'000.0));
+
+	CHECK(Math::snapped(5.0, 2.0) == doctest::Approx(6.0));
+	CHECK(Math::snapped(5.0, -2.0) == doctest::Approx(4.0));
 }
 
 TEST_CASE("[Math] larger_prime") {


### PR DESCRIPTION
## What problem(s) does this PR solve?

Adds a test-only check for `Math::snapped()` at an exact halfway point,
showing that the sign of `p_step` flips which multiple ties resolve to:
- `snapped(5.0, 2.0)  == 6.0` (positive step → resolves to the larger multiple)
- `snapped(5.0, -2.0) == 4.0` (negative step → resolves to the smaller multiple)

No production code changed.

## Additional information

The existing tests check negative `p_step` in isolation, but never pair it
with the same `p_value` against a positive `p_step` of equal magnitude.
This PR adds that direct comparison, which is what makes the tie-breaking
asymmetry visible — something the current suite doesn't cover.

AI Disclosure: I'm using AI for grammar correctness and formatting for the description.