### PR TITLE
Fix issues with callable parameters ending with a match branch

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2462,7 +2462,7 @@ GDScriptParser::MatchNode *GDScriptParser::parse_match() {
 
 	List<AnnotationNode *> match_branch_annotation_stack;
 
-	while (!check(GDScriptTokenizer::Token::DEDENT) && !is_at_end()) {
+	while (!check(GDScriptTokenizer::Token::DEDENT) && !check(GDScriptTokenizer::Token::COMMA) && !is_at_end()) {
 		if (match(GDScriptTokenizer::Token::PASS)) {
 			consume(GDScriptTokenizer::Token::NEWLINE, R"(Expected newline after "pass".)");
 			continue;
@@ -2503,6 +2503,10 @@ GDScriptParser::MatchNode *GDScriptParser::parse_match() {
 		match_node->branches.push_back(branch);
 	}
 	complete_extents(match_node);
+
+	if (check(GDScriptTokenizer::Token::COMMA)) {
+		return match_node;
+	}
 
 	consume(GDScriptTokenizer::Token::DEDENT, R"(Expected an indented block after "match" statement.)");
 

--- a/modules/gdscript/tests/scripts/parser/errors/callable_parameter_ending_with_match_branch.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/callable_parameter_ending_with_match_branch.gd
@@ -1,0 +1,18 @@
+func test() -> void:
+	Inner \
+			.new("test") \
+			._accepting_lambdas(
+				func() -> void:
+					match 123:
+						123:
+							var _hello: = "world",
+			)
+
+
+class Inner extends Node:
+	func _init(_p_test: String) -> void:
+		pass
+
+
+	func _accepting_lambdas(_p_lambda: Callable) -> void:
+		pass

--- a/modules/gdscript/tests/scripts/parser/errors/callable_parameter_ending_with_match_branch.out
+++ b/modules/gdscript/tests/scripts/parser/errors/callable_parameter_ending_with_match_branch.out
@@ -1,0 +1,1 @@
+GDTEST_OK


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #122042

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

This PR just handles the case where a comma could be parsed while parsing a match branch.