### PR TITLE
Fix code completion suggesting function names for variables

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -10533,7 +10533,11 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 
 				_set_tkpos(prev_pos);
 
-				_get_completable_identifier(nullptr, COMPLETION_MAIN_FUNCTION, name);
+				if (type == TYPE_VOID && !is_constant) {
+					_get_completable_identifier(nullptr, COMPLETION_MAIN_FUNCTION, name);
+				} else {
+					_get_completable_identifier(nullptr, COMPLETION_NONE, name);
+				}
 
 				if (name == StringName()) {
 					if (is_constant) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #122035

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
This line sets the completion mode to `COMPLETION_MAIN_FUNCTION`.
https://github.com/godotengine/godot/blob/eda2a482e9ce82e4056cfffae0ea98c1954605a1/servers/rendering/shader_language.cpp#L10536

This causes constants and variables in the most outer scope to suggest main functions like `vertex`, `fragment`, `light` etc.

I changed it so that main functions would only be suggested when typing actual void functions like `void a...`
For any other type or when there is a `const`, completion is turned off.
