### PR TITLE
🤖 Web: Reduce audio buffer allocations

### DIFF
--- a/platform/web/js/libs/audio.worklet.js
+++ b/platform/web/js/libs/audio.worklet.js
@@ -93,6 +93,10 @@ class RingBuffer {
 	}
 }
 
+// A small cap is enough because the no-thread input path can only keep a few
+// transferable chunks in flight between render quanta.
+const MAX_INPUT_TRANSFER_POOL_SIZE = 8;
+
 class GodotProcessor extends AudioWorkletProcessor {
 	constructor() {
 		super();
@@ -104,6 +108,7 @@ class GodotProcessor extends AudioWorkletProcessor {
 		this.output_buffer = new Float32Array();
 		this.input = null;
 		this.input_buffer = new Float32Array();
+		this.input_transfer_pool = [];
 		this.port.onmessage = (event) => {
 			const cmd = event.data['cmd'];
 			const data = event.data['data'];
@@ -115,6 +120,35 @@ class GodotProcessor extends AudioWorkletProcessor {
 		if (this.notifier) {
 			Atomics.add(this.notifier, 0, 1);
 			Atomics.notify(this.notifier, 0);
+		}
+	}
+
+	static get_transfer_buffer(pool, size) {
+		for (let i = pool.length - 1; i >= 0; i--) {
+			const buffer = pool[i];
+			if (buffer.length === size) {
+				pool[i] = pool[pool.length - 1];
+				pool.pop();
+				return buffer;
+			}
+		}
+		return new Float32Array(size);
+	}
+
+	static recycle_transfer_buffer(pool, buffer, max_pool_size) {
+		if (!buffer) {
+			return;
+		}
+		const recycled = new Float32Array(buffer);
+		if (pool.length < max_pool_size) {
+			pool.push(recycled);
+			return;
+		}
+		for (let i = 0; i < pool.length; i++) {
+			if (pool[i].length !== recycled.length) {
+				pool[i] = recycled;
+				return;
+			}
 		}
 	}
 
@@ -135,10 +169,22 @@ class GodotProcessor extends AudioWorkletProcessor {
 			this.input = null;
 			this.lock = null;
 			this.notifier = null;
+			this.input_transfer_pool.length = 0;
 		} else if (p_cmd === 'start_nothreads') {
 			this.output = new RingBuffer(p_data[0], p_data[0].length, false);
+			this.input_transfer_pool.length = 0;
 		} else if (p_cmd === 'chunk') {
-			this.output.write(p_data);
+			const buffer = p_data[0];
+			const size = p_data[1];
+			const chunk = new Float32Array(buffer, 0, size);
+			this.output.write(chunk);
+			this.port.postMessage({ 'cmd': 'chunk_recycle', 'data': buffer }, [buffer]);
+		} else if (p_cmd === 'input_recycle') {
+			GodotProcessor.recycle_transfer_buffer(
+				this.input_transfer_pool,
+				p_data,
+				MAX_INPUT_TRANSFER_POOL_SIZE
+			);
 		}
 	}
 
@@ -157,13 +203,14 @@ class GodotProcessor extends AudioWorkletProcessor {
 		if (process_input) {
 			const input = inputs[0];
 			const chunk = input[0].length * input.length;
-			if (this.input_buffer.length !== chunk) {
-				this.input_buffer = new Float32Array(chunk);
-			}
 			if (!this.threads) {
-				GodotProcessor.write_input(this.input_buffer, input);
-				this.port.postMessage({ 'cmd': 'input', 'data': this.input_buffer });
+				const input_buffer = GodotProcessor.get_transfer_buffer(this.input_transfer_pool, chunk);
+				GodotProcessor.write_input(input_buffer, input);
+				this.port.postMessage({ 'cmd': 'input', 'data': [input_buffer.buffer, chunk] }, [input_buffer.buffer]);
 			} else if (this.input.space_left() >= chunk) {
+				if (this.input_buffer.length !== chunk) {
+					this.input_buffer = new Float32Array(chunk);
+				}
 				GodotProcessor.write_input(this.input_buffer, input);
 				this.input.write(this.input_buffer);
 			} else {

--- a/platform/web/js/libs/library_godot_audio.js
+++ b/platform/web/js/libs/library_godot_audio.js
@@ -103,7 +103,7 @@ class Sample {
 	constructor(params, options = {}) {
 		/** @type {string} */
 		this.id = params.id;
-		/** @type {AudioBuffer} */
+		/** @type {AudioBuffer?} */
 		this._audioBuffer = null;
 		/** @type {number} */
 		this.numberOfChannels = options.numberOfChannels ?? 2;
@@ -122,14 +122,20 @@ class Sample {
 	/**
 	 * Gets the audio buffer of the sample.
 	 * @returns {AudioBuffer}
+	 * @throws {Error} When the sample no longer has an audio buffer.
 	 */
 	getAudioBuffer() {
-		return this._duplicateAudioBuffer();
+		if (this._audioBuffer == null) {
+			throw new Error(`Sample "${this.id}" AudioBuffer is null; it may have already been cleared`);
+		}
+		// AudioBuffer can be shared by multiple AudioBufferSourceNode instances.
+		// Duplicating it on every playback causes large browser-side allocations.
+		return this._audioBuffer;
 	}
 
 	/**
 	 * Sets the audio buffer of the sample.
-	 * @param {AudioBuffer} val The audio buffer to set.
+	 * @param {AudioBuffer?} val The audio buffer to set.
 	 * @returns {void}
 	 */
 	setAudioBuffer(val) {
@@ -143,31 +149,6 @@ class Sample {
 	clear() {
 		this.setAudioBuffer(null);
 		GodotAudio.Sample.delete(this.id);
-	}
-
-	/**
-	 * Returns a duplicate of the stored audio buffer.
-	 * @returns {AudioBuffer}
-	 */
-	_duplicateAudioBuffer() {
-		if (this._audioBuffer == null) {
-			throw new Error('couldn\'t duplicate a null audioBuffer');
-		}
-		/** @type {Array<Float32Array>} */
-		const channels = new Array(this._audioBuffer.numberOfChannels);
-		for (let i = 0; i < this._audioBuffer.numberOfChannels; i++) {
-			const channel = new Float32Array(this._audioBuffer.getChannelData(i));
-			channels[i] = channel;
-		}
-		const buffer = GodotAudio.ctx.createBuffer(
-			this.numberOfChannels,
-			this._audioBuffer.length,
-			this._audioBuffer.sampleRate
-		);
-		for (let i = 0; i < channels.length; i++) {
-			buffer.copyToChannel(channels[i], i, 0);
-		}
-		return buffer;
 	}
 }
 

--- a/platform/web/js/libs/library_godot_audio.js
+++ b/platform/web/js/libs/library_godot_audio.js
@@ -1973,40 +1973,60 @@ const GodotAudioWorklet = {
 			p_in_size,
 			in_callback
 		) {
-			function RingBuffer() {
+			// Bound retained memory while covering a short in-flight backlog and
+			// buffers for alternate render-quantum sizes.
+			const MAX_OUTPUT_POOL_SIZE = 32;
+
+			function NoThreadTransport() {
 				let wpos = 0;
 				let rpos = 0;
 				let pending_samples = 0;
-				const wbuf = new Float32Array(p_out_size);
+				let output_chunk_size = 0;
+				const output_pool = [];
+
+				function acquireOutputBuffer(size) {
+					for (let i = output_pool.length - 1; i >= 0; i--) {
+						const buffer = output_pool[i];
+						if (buffer.length === size) {
+							output_pool[i] = output_pool[output_pool.length - 1];
+							output_pool.pop();
+							return buffer;
+						}
+					}
+					return new Float32Array(size);
+				}
 
 				function send(port) {
 					if (pending_samples === 0) {
 						return;
 					}
+					const chunk_size = output_chunk_size > 0 ? output_chunk_size : pending_samples;
 					const buffer = GodotRuntime.heapSub(HEAPF32, p_out_buf, p_out_size);
 					const size = buffer.length;
-					const tot_sent = pending_samples;
-					out_callback(wpos, pending_samples);
-					if (wpos + pending_samples >= size) {
-						const high = size - wpos;
-						wbuf.set(buffer.subarray(wpos, size));
-						pending_samples -= high;
-						wpos = 0;
-					}
-					if (pending_samples > 0) {
-						wbuf.set(
-							buffer.subarray(wpos, wpos + pending_samples),
-							tot_sent - pending_samples
+					while (pending_samples > 0) {
+						const to_send = Math.min(pending_samples, chunk_size);
+						const chunk = acquireOutputBuffer(to_send);
+						out_callback(wpos, to_send);
+						if (wpos + to_send > size) {
+							const high = size - wpos;
+							chunk.set(buffer.subarray(wpos, size));
+							chunk.set(buffer.subarray(0, to_send - high), high);
+						} else {
+							chunk.set(buffer.subarray(wpos, wpos + to_send));
+						}
+						port.postMessage(
+							{ 'cmd': 'chunk', 'data': [chunk.buffer, to_send] },
+							[chunk.buffer]
 						);
+						wpos = (wpos + to_send) % size;
+						pending_samples -= to_send;
 					}
-					port.postMessage({ 'cmd': 'chunk', 'data': wbuf.subarray(0, tot_sent) });
-					wpos += pending_samples;
-					pending_samples = 0;
 				}
-				this.receive = function (recv_buf) {
+
+				this.receive = function (recv_buf, recv_size, port) {
 					const buffer = GodotRuntime.heapSub(HEAPF32, p_in_buf, p_in_size);
 					const from = rpos;
-					let to_write = recv_buf.length;
+					let to_write = recv_size;
 					let high = 0;
 					if (rpos + to_write >= p_in_size) {
 						high = p_in_size - rpos;
@@ -2015,17 +2035,40 @@ const GodotAudioWorklet = {
 						rpos = 0;
 					}
 					if (to_write) {
-						buffer.set(recv_buf.subarray(high, to_write), rpos);
+						buffer.set(recv_buf.subarray(high, high + to_write), rpos);
 					}
-					in_callback(from, recv_buf.length);
+					in_callback(from, recv_size);
 					rpos += to_write;
+					port.postMessage({ 'cmd': 'input_recycle', 'data': recv_buf.buffer }, [recv_buf.buffer]);
 				};
+
+				this.recycleOutput = function (buffer) {
+					if (!buffer) {
+						return;
+					}
+					const recycled = new Float32Array(buffer);
+					if (output_pool.length < MAX_OUTPUT_POOL_SIZE) {
+						output_pool.push(recycled);
+						return;
+					}
+					// Replace a stale size when a render-quantum change fills the pool
+					// with buffers which can no longer be acquired.
+					for (let i = 0; i < output_pool.length; i++) {
+						if (output_pool[i].length !== recycled.length) {
+							output_pool[i] = recycled;
+							break;
+						}
+					}
+				};
+
 				this.consumed = function (size, port) {
+					output_chunk_size = size;
 					pending_samples += size;
 					send(port);
 				};
 			}
-			GodotAudioWorklet.ring_buffer = new RingBuffer();
+
+			GodotAudioWorklet.ring_buffer = new NoThreadTransport();
 			GodotAudioWorklet.promise.then(function () {
 				const node = GodotAudioWorklet.worklet;
 				const buffer = GodotRuntime.heapSlice(HEAPF32, p_out_buf, p_out_size);
@@ -2033,7 +2076,7 @@ const GodotAudioWorklet = {
 				node.port.postMessage({
 					'cmd': 'start_nothreads',
 					'data': [buffer, p_in_size],
-				});
+				}, [buffer.buffer]);
 				node.port.onmessage = function (event) {
 					if (!GodotAudioWorklet.worklet) {
 						return;
@@ -2044,13 +2087,24 @@ const GodotAudioWorklet = {
 							read,
 							GodotAudioWorklet.worklet.port
 						);
+					} else if (event.data['cmd'] === 'chunk_recycle') {
+						GodotAudioWorklet.ring_buffer.recycleOutput(event.data['data']);
 					} else if (event.data['cmd'] === 'input') {
-						const buf = event.data['data'];
-						if (buf.length > p_in_size) {
-							GodotRuntime.error('Input chunk is too big');
+						const input_buffer = event.data['data'][0];
+						const input_size = event.data['data'][1];
+						if (!Number.isInteger(input_size) || input_size <= 0 || input_size > p_in_size) {
+							GodotAudioWorklet.worklet.port.postMessage(
+								{ 'cmd': 'input_recycle', 'data': input_buffer },
+								[input_buffer]
+							);
+							GodotRuntime.error('Input chunk has an invalid size');
 							return;
 						}
-						GodotAudioWorklet.ring_buffer.receive(buf);
+						GodotAudioWorklet.ring_buffer.receive(
+							new Float32Array(input_buffer, 0, input_size),
+							input_size,
+							GodotAudioWorklet.worklet.port
+						);
 					} else {
 						GodotRuntime.error(event.data);
 					}
@@ -2076,6 +2130,7 @@ const GodotAudioWorklet = {
 					GodotAudioWorklet.worklet.disconnect();
 					GodotAudioWorklet.worklet.port.onmessage = null;
 					GodotAudioWorklet.worklet = null;
+					GodotAudioWorklet.ring_buffer = null;
 					GodotAudioWorklet.promise = null;
 					resolve();
 				}).catch(function (err) {


### PR DESCRIPTION
> [!INFO]
> *AI disclosure*: This contribution was authored by an autonomous AI agent on behalf of @joeykchen to compare downstream Web audio fixes with current `master`, adapt the portable changes, run validation, and draft this description. The resulting patch was reviewed against the original commits and current upstream behavior.

## What problem(s) does this PR solve?

Web audio currently creates avoidable browser-side allocations in two hot paths:

- `Sample.getAudioBuffer()` duplicates all decoded PCM data for every playback, even though Godot does not mutate the registered buffer after assigning it to an `AudioBufferSourceNode`.
- The no-thread AudioWorklet path structured-clones new `Float32Array` backing stores across `MessagePort` for every input and output render chunk.

This increases allocation and garbage-collection pressure, especially on Safari/WebKit and other memory-constrained browsers. It is related to #116750 and the downstream reproduction in https://github.com/goplus/spx/issues/1460. The duplicated `AudioBuffer` is a confirmed allocation amplifier, but this PR does not claim that it is the sole cause of #116750.

This supersedes and extends #118271.

## Additional information

This PR:

- reuses the registered `AudioBuffer` across one-shot `AudioBufferSourceNode` instances;
- transfers no-thread AudioWorklet `ArrayBuffer`s instead of cloning their contents;
- recycles returned input and output buffers in bounded pools;
- lets full pools replace stale buffer sizes after render-quantum or channel-count changes;
- returns invalid oversized input transfers to the worklet pool before reporting the error;
- leaves the threaded AudioWorklet path and the C++/JavaScript ABI unchanged.

The downstream lazy position-reporter optimization is intentionally not included. Current `master` pools position worklets via #107948 and uses the sample-accurate `AudioParam` reset from #109790. Keeping that behavior avoids mixing this allocation fix with playback-position, pause/restart, offset, and pitch semantics.

Validation performed:

- `git diff --check upstream/master`
- ESLint on `platform/web/js/libs/audio.worklet.js` and `platform/web/js/libs/library_godot_audio.js`
- Emscripten 4.0.11 Web template build with `threads=no`: pending
- Emscripten 4.0.11 Web template build with `threads=yes`: pending

Browser runtime and Safari/iOS memory A/B tests have not yet been run locally; this PR is opened as a draft so those results can be added before marking it ready for review.
