### PR TITLE
Remove `emscripten_cancel_main_loop` from web `exit_callback`

### DIFF
--- a/platform/web/web_main.cpp
+++ b/platform/web/web_main.cpp
@@ -70,7 +70,6 @@ void exit_callback() {
 	delete os; // We used a normal new, so it needs a normal delete.
 	os = nullptr;
 	godot_cleanup_profiler();
-	emscripten_cancel_main_loop(); // We are exiting in this iteration.
 	emscripten_force_exit(exit_code); // Exit runtime.
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #122054.

## Additional information

It turns out calling `emscripten_cancel_main_loop` right before `emscripten_force_exit` is broken in Emscripten, causing this `Uncaught RuntimeError` assertion to fire.

This was added in #118771, mostly as a precaution and (as I understand it) largely unrelated to the actual fix of replacing a `free` with `delete`, so this shouldn't cause any regressions as far as the issue being addressed in #118771 is concerned.

See the discussion and upstream Emscripten issue linked [here](https://github.com/godotengine/godot/pull/118771#issuecomment-5135419242) for more information.