### PR TITLE
Fix behavior of `find_keycode_from_string()` being platform-specific

### DIFF
--- a/core/os/keyboard.cpp
+++ b/core/os/keyboard.cpp
@@ -62,18 +62,29 @@ static const _KeyCodeText _keycodes[] = {
 	{Key::PAGEDOWN              ,"PageDown"},
 	{Key::SHIFT                 ,"Shift"},
 	{Key::CTRL                  ,"Ctrl"},
+	// Include all strings for all platforms. The first string
+	// should be the one expected from get_keycode_string().
 #if defined(MACOS_ENABLED)
 	{Key::META                  ,"Command"},
+	{Key::META                  ,"Windows"},
+	{Key::META                  ,"Meta"},
 	{Key::CMD_OR_CTRL           ,"Command"},
 	{Key::ALT                   ,"Option"},
+	{Key::ALT                   ,"Alt"},
 #elif defined(WINDOWS_ENABLED)
 	{Key::META                  ,"Windows"},
-	{Key::CMD_OR_CTRL           ,"Ctrl"},
-	{Key::ALT                   ,"Alt"},
-#else
+	{Key::META                  ,"Command"},
 	{Key::META                  ,"Meta"},
 	{Key::CMD_OR_CTRL           ,"Ctrl"},
 	{Key::ALT                   ,"Alt"},
+	{Key::ALT                   ,"Option"},
+#else
+	{Key::META                  ,"Meta"},
+	{Key::META                  ,"Windows"},
+	{Key::META                  ,"Command"},
+	{Key::CMD_OR_CTRL           ,"Ctrl"},
+	{Key::ALT                   ,"Alt"},
+	{Key::ALT                   ,"Option"},
 #endif
 	{Key::CAPSLOCK              ,"CapsLock"},
 	{Key::NUMLOCK               ,"NumLock"},


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Doing `find_keycode_from_string("Windows")` on a non-Windows platform returns `KEY_NONE`. That's rather unexpected...

I recently discovered my addon does not work properly on Linux, because I was using Windows keycode. And what's worse, making `get_keycode_string()` work properly on all platforms is not trivial and requires knowledge about platform-specific keycode strings, which weren't documented.

This PR fixes that by making all platforms recognize all strings. Calling `get_keycode_string("Windows")` will now return `KEY_META` on all platforms.

## Additional information

Unfortunately I wasn't able to get rid of  `defined()` checks, leading to quite a bit duplicate code. This is to ensure that `get_keycode_string()` works correctly.