### PR TITLE
[Project Manager] Fix Wrap Long Project Title and Compact Mode

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1378,6 +1378,12 @@
 			If [code]true[/code], enable TLSv1.3 negotiation.
 			[b]Note:[/b] Only supported when using Mbed TLS 3.0 or later (Linux distribution packages may be compiled against older system Mbed TLS packages), otherwise the maximum supported TLS version is always TLSv1.2.
 		</member>
+		<member name="project_manager/compact_mode" type="bool" setter="" getter="">
+			If [code]true[/code], enables hiding the Project List Sidebar when the Project Manager is shrunk, horizontally, below a threshold, which is set in [member project_manager/compact_mode_threshold].
+		</member>
+		<member name="project_manager/compact_mode_threshold" type="int" setter="" getter="">
+			Sets the threshold, in pixels, beyond which the Project List Sidebar collapses when the Project Manager is resized. If [code]0[/code], the sidebar disappears when there is not enough space for it. This only has an effect if [member project_manager/compact_mode] is [code]true[/code].
+		</member>
 		<member name="project_manager/default_renderer" type="String" setter="" getter="">
 			The renderer type that will be checked off by default when creating a new project. Accepted strings are "forward_plus", "mobile" or "gl_compatibility".
 		</member>

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -424,72 +424,60 @@ void ProjectListItemControl::set_is_grayed(bool p_grayed) {
 	}
 }
 
-void ProjectListItemControl::set_project_title_index(int p_title_index) {
-	project_title_index = p_title_index;
-}
-
 void ProjectListItemControl::set_project_title_autowrap() {
+	ProjectList *pl = get_list();
 	title_fullsize_cache = project_title->get_size().x;
-	window_size_cache = get_window()->get_size().x;
 
 	int tag_size = 0;
 	int tag_maxsize = 0;
 	for (Node *child : tag_container->iterate_children()) {
 		ProjectTag *tag = Object::cast_to<ProjectTag>(child);
-		tag_size += tag->get_size().x;
-
-		if (tag_maxsize == 0) {
-			tag_maxsize = tag->get_custom_maximum_size().x;
+		int temp_tag_size = tag->get_size().x;
+		tag_size += temp_tag_size;
+		if (temp_tag_size > tag_maxsize) {
+			tag_maxsize = temp_tag_size;
 		}
 	}
+	tag_fullsize_cache = tag_size;
 	tag_size_cache = MIN(tag_size, tag_maxsize);
-	int &title_size_cache = get_list()->title_size_cache[project_title_index];
 
-	int size_check = 800 * EDSCALE;
-	if (title_size_cache == 0) {
-		title_size_cache = size_check;
+	const int project_title_and_tags_fullsize = title_fullsize_cache + tag_size;
+	int &largest_project_title_and_tags_fullsize = pl->largest_project_title_and_tags_fullsize;
+	if (project_title_and_tags_fullsize > largest_project_title_and_tags_fullsize) {
+		largest_project_title_and_tags_fullsize = project_title_and_tags_fullsize;
 	}
 
-	if (title_fullsize_cache > size_check - tag_size_cache) {
-		resize_project_title();
+	int &abs_title_and_tags_minsize = pl->abs_title_and_tags_minsize_cache;
+	if (abs_title_and_tags_minsize == 0) {
+		ProjectTag *tag = memnew(ProjectTag("dummy"));
+		const int abs_tag_maxsize = tag->get_custom_maximum_size().x;
+		memdelete(tag);
+		abs_title_and_tags_minsize = (200 * EDSCALE) + abs_tag_maxsize;
+	}
+
+	int &title_and_tags_size = pl->title_and_tags_size_cache;
+
+	if (title_fullsize_cache > title_and_tags_size - tag_size && !pl->before_ready) {
+		resize_project_title(title_and_tags_size, abs_title_and_tags_minsize);
 	}
 }
 
-void ProjectListItemControl::resize_project_title() {
-	if (get_window() == nullptr) {
+void ProjectListItemControl::resize_project_title(int p_title_and_tags_size, int p_abs_title_and_tags_minsize) {
+	if (p_title_and_tags_size >= title_fullsize_cache + tag_fullsize_cache) {
+		if (project_title->get_autowrap_mode() != TextServer::AUTOWRAP_OFF) {
+			project_title->set_custom_maximum_size(Vector2(-1, -1));
+			project_title->set_custom_minimum_size(Vector2(0, 0));
+			project_title->set_autowrap_mode(TextServer::AUTOWRAP_OFF);
+		}
 		return;
 	}
 
-	int window_size = get_window()->get_size().x;
-	int difference = window_size - window_size_cache;
-	window_size_cache = window_size;
-
-	int &title_size_cache = get_list()->title_size_cache[project_title_index];
-	title_size_cache += difference;
-
-	if (title_size_cache > title_fullsize_cache + tag_size_cache) {
-		project_title->set_custom_maximum_size(Vector2(-1, -1));
-		project_title->set_custom_minimum_size(Vector2(0, 0));
-		project_title->set_autowrap_mode(TextServer::AUTOWRAP_OFF);
-
-		return;
-	}
-	ProjectTag tag = ProjectTag("dummy");
-	int tag_maxsize = tag.get_custom_maximum_size().x;
-	int title_maxsize = title_size_cache - tag_size_cache;
-	int title_minsize = title_size_cache - tag_maxsize;
-
-	int abs_minsize = (200 * EDSCALE);
-	if (title_fullsize_cache > abs_minsize) {
-		if (title_minsize < abs_minsize) {
-			title_minsize = abs_minsize + tag_maxsize - tag_size_cache;
-		}
-		if (title_maxsize < title_minsize) {
-			project_title->set_custom_maximum_size(Vector2(title_minsize, -1));
-		} else {
-			project_title->set_custom_maximum_size(Vector2(title_maxsize, -1));
-		}
-		project_title->set_custom_minimum_size(Vector2(title_minsize, 0));
+	const int abs_title_minsize = p_abs_title_and_tags_minsize - tag_size_cache;
+	if (title_fullsize_cache >= abs_title_minsize) {
+		const int title_maxsize = p_title_and_tags_size - tag_size_cache;
+		const int title_size = MAX(title_maxsize, abs_title_minsize);
+		project_title->set_custom_maximum_size(Vector2(title_size, -1));
+		project_title->set_custom_minimum_size(Vector2(title_size, 0));
 		project_title->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	}
 }
@@ -703,7 +691,12 @@ void ProjectList::_notification(int p_what) {
 			AccessibilityServer::get_singleton()->update_set_role(ae, AccessibilityServerEnums::AccessibilityRole::ROLE_LIST_BOX);
 			AccessibilityServer::get_singleton()->update_set_list_item_count(ae, _projects.size());
 			AccessibilityServer::get_singleton()->update_set_flag(ae, AccessibilityServerEnums::AccessibilityFlags::FLAG_MULTISELECTABLE, false);
-		}
+		} break;
+
+		case NOTIFICATION_READY: {
+			window_size_cache = get_window()->get_size().x;
+			before_ready = false;
+		} break;
 	}
 }
 
@@ -936,14 +929,12 @@ void ProjectList::update_project_list() {
 	// If you have 150 projects, it may read through 150 files on your disk at once + load 150 icons.
 	// FIXME: Does it really have to be a full, hard reload? Runtime updates should be made much cheaper.
 
-	int temp_title_index = -1;
 	if (ProjectManager::get_singleton()->is_initialized()) {
 		// Clear whole list
 		for (int i = 0; i < _projects.size(); ++i) {
 			Item &project = _projects.write[i];
 			CRASH_COND(project.control == nullptr);
 
-			temp_title_index = project.project_title_index;
 			memdelete(project.control); // Why not queue_free()?
 		}
 
@@ -956,9 +947,6 @@ void ProjectList::update_project_list() {
 
 	// Create controls
 	for (int i = 0; i < _projects.size(); ++i) {
-		Item &item = _projects.write[i];
-		item.project_title_index = temp_title_index;
-
 		_create_project_item_control(i);
 	}
 
@@ -1146,14 +1134,10 @@ int ProjectList::refresh_project(const String &dir_path) {
 
 	bool was_selected = _selected_project_paths.has(dir_path);
 
-	int temp_title_index = -1;
-
 	// Remove item in any case
 	for (int i = 0; i < _projects.size(); ++i) {
 		const Item &existing_item = _projects[i];
 		if (existing_item.path == dir_path) {
-			temp_title_index = existing_item.project_title_index;
-
 			_remove_project(i, false);
 			break;
 		}
@@ -1165,7 +1149,6 @@ int ProjectList::refresh_project(const String &dir_path) {
 
 		Item item = load_project_data(dir_path, is_favorite);
 
-		item.project_title_index = temp_title_index;
 		_projects.push_back(item);
 		_create_project_item_control(_projects.size() - 1);
 
@@ -1232,15 +1215,6 @@ void ProjectList::_create_project_item_control(int p_index) {
 	hb->connect("explore_pressed", callable_mp(this, &ProjectList::_on_explore_pressed).bind(item.path));
 #endif
 	hb->connect("request_menu", callable_mp(this, &ProjectList::_open_menu).bind(hb));
-
-	if (item.project_title_index == -1) {
-		project_title_index_count++;
-		title_size_cache[project_title_index_count] = 0;
-		item.project_title_index = project_title_index_count;
-		hb->set_project_title_index(project_title_index_count);
-	} else {
-		hb->set_project_title_index(item.project_title_index);
-	}
 
 	project_list_vbox->add_child(hb);
 }
@@ -1597,8 +1571,18 @@ void ProjectList::erase_selected_projects(bool p_delete_project_contents) {
 // Resize project titles.
 
 void ProjectList::resize_project_titles() {
+	Window *win = get_window();
+	if (win == nullptr) {
+		return;
+	}
+
+	const int window_size = win->get_size().x;
+	const int difference = window_size - window_size_cache;
+	window_size_cache = window_size;
+	title_and_tags_size_cache += difference;
+
 	for (Item &item : _projects) {
-		item.control->resize_project_title();
+		item.control->resize_project_title(title_and_tags_size_cache, abs_title_and_tags_minsize_cache);
 	}
 }
 

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -1581,6 +1581,20 @@ void ProjectList::resize_project_titles() {
 	window_size_cache = window_size;
 	title_and_tags_size_cache += difference;
 
+	if (compact_mode) {
+		const bool sb_visible = ProjectManager::get_singleton()->is_project_list_sidebar_visible();
+		if (sb_visible && !sb_visible_cache) {
+			title_and_tags_size_cache -= sidebar_size_cache;
+		} else if (!sb_visible && sb_visible_cache) {
+			title_and_tags_size_cache += sidebar_size_cache;
+		}
+		sb_visible_cache = sb_visible;
+	} else if (compact_mode_cache && !sb_visible_cache) {
+		title_and_tags_size_cache -= sidebar_size_cache;
+		sb_visible_cache = true;
+	}
+	compact_mode_cache = compact_mode;
+
 	for (Item &item : _projects) {
 		item.control->resize_project_title(title_and_tags_size_cache, abs_title_and_tags_minsize_cache);
 	}

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -309,6 +309,9 @@ public:
 	// Compact mode.
 
 	bool compact_mode = false;
+	bool compact_mode_cache = false;
+	bool sb_visible_cache = false;
+	int sidebar_size_cache = 0;
 
 	// Initialization & loading.
 

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -62,8 +62,6 @@ class ProjectListItemControl : public HBoxContainer {
 
 	Color favorite_focus_color;
 
-	int project_title_index = -1;
-
 	bool project_is_missing = false;
 	bool icon_needs_reload = true;
 	bool is_selected = false;
@@ -97,8 +95,8 @@ private:
 	// Caches for resizing project titles.
 
 	int title_fullsize_cache = 0;
+	int tag_fullsize_cache = 0;
 	int tag_size_cache = 0;
-	int window_size_cache = 0;
 
 protected:
 	void _notification(int p_what);
@@ -120,10 +118,9 @@ public:
 	void set_is_favorite(bool p_favorite);
 	void set_is_missing(bool p_missing);
 	void set_is_grayed(bool p_grayed);
-	void set_project_title_index(int p_title_index);
 	void set_project_title_autowrap();
 
-	void resize_project_title();
+	void resize_project_title(int p_title_size, int p_abs_title_and_tags_minsize);
 
 	ProjectListItemControl();
 };
@@ -172,7 +169,6 @@ public:
 		bool missing = false;
 		bool recovery_mode = false;
 		int version = 0;
-		int project_title_index = -1;
 
 		ProjectListItemControl *control = nullptr;
 
@@ -221,8 +217,11 @@ public:
 		String get_last_edited_string() const;
 	};
 
-	HashMap<int, int> title_size_cache;
-	int project_title_index_count = -1;
+	bool before_ready = true;
+	int window_size_cache = 0;
+	int title_and_tags_size_cache = 0;
+	int largest_project_title_and_tags_fullsize = 0;
+	int abs_title_and_tags_minsize_cache = 0;
 
 private:
 	String _config_path;
@@ -306,6 +305,10 @@ public:
 	static inline const char *SIGNAL_MENU_OPTION_SELECTED = "menu_option_selected";
 
 	static bool project_feature_looks_like_version(const String &p_feature);
+
+	// Compact mode.
+
+	bool compact_mode = false;
 
 	// Initialization & loading.
 

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -113,6 +113,16 @@ void ProjectManager::_notification(int p_what) {
 			_update_list_placeholder();
 			_titlebar_resized();
 			_update_compact_mode(true);
+
+			const int sidebar_size = project_list_sidebar->get_size().x;
+			const int root_padding = root_container->get_margin_size(SIDE_LEFT) + root_container->get_margin_size(SIDE_RIGHT);
+			const int pl_width = project_list->get_size().x;
+			const int pl_edge_width = pl_width - project_list->largest_project_title_and_tags_fullsize;
+			Ref<StyleBox> project_list_stylebox = get_theme_stylebox("project_list", "ProjectManager");
+			const int project_list_h_margin = project_list_stylebox.is_valid() ? project_list_stylebox->get_content_margin(SIDE_LEFT) + project_list_stylebox->get_content_margin(SIDE_RIGHT) : 0;
+			project_list->title_and_tags_size_cache = root_container->get_size().x - pl_edge_width - sidebar_size - root_padding - project_list_h_margin;
+
+			project_list->resize_project_titles();
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -112,9 +112,14 @@ void ProjectManager::_notification(int p_what) {
 			_select_main_view(MAIN_VIEW_PROJECTS);
 			_update_list_placeholder();
 			_titlebar_resized();
-			_update_compact_mode(true);
 
+			compact_mode_default_threshold = root_container->get_combined_minimum_size().width - project_list->largest_project_title_and_tags_fullsize + project_list->abs_title_and_tags_minsize_cache;
+			_reset_compact_mode_threshold();
+
+			project_list->sb_visible_cache = is_project_list_sidebar_visible();
 			const int sidebar_size = project_list_sidebar->get_size().x;
+			project_list->sidebar_size_cache = sidebar_size;
+
 			const int root_padding = root_container->get_margin_size(SIDE_LEFT) + root_container->get_margin_size(SIDE_RIGHT);
 			const int pl_width = project_list->get_size().x;
 			const int pl_edge_width = pl_width - project_list->largest_project_title_and_tags_fullsize;
@@ -154,11 +159,15 @@ void ProjectManager::_notification(int p_what) {
 			if (EditorThemeManager::is_generated_theme_outdated()) {
 				_update_theme();
 			}
+			_update_project_manager_settings();
 			_update_list_placeholder();
 		} break;
+
 		case NOTIFICATION_RESIZED: {
+			if (compact_mode) {
+				_update_compact_mode();
+			}
 			project_list->resize_project_titles();
-			_update_compact_mode();
 		} break;
 	}
 }
@@ -194,21 +203,26 @@ void ProjectManager::_build_icon_type_cache(Ref<Theme> p_theme) {
 
 // Main layout.
 
-// Hides certain parts of the Project Manager when window width gets smaller than combined_minimum_size.
-void ProjectManager::_update_compact_mode(bool p_reset_threshold) {
-	if (p_reset_threshold) {
-		project_list_sidebar->show();
-		compact_mode_threshold = root_container->get_combined_minimum_size().width;
-	}
+void ProjectManager::_reset_compact_mode_threshold() {
+	const int threshold = EDITOR_GET("project_manager/compact_mode_threshold");
+	compact_mode_threshold = threshold > 0 ? threshold : compact_mode_default_threshold;
+	_update_compact_mode();
+}
 
-	bool compact_mode = get_size().width < compact_mode_threshold;
-	project_list_sidebar->set_visible(!compact_mode);
+// Hides certain parts of the Project Manager when window width gets smaller than combined_minimum_size.
+void ProjectManager::_update_compact_mode() {
+	if (!compact_mode) {
+		project_list_sidebar->show();
+	} else {
+		const bool compact = get_size().width < compact_mode_threshold;
+		project_list_sidebar->set_visible(!compact);
+	}
 }
 
 void ProjectManager::_update_size_limits() {
 	const Size2 default_minimum_size = Size2(720, 450) * EDSCALE;
 	const Size2 display_size = DisplayServer::get_singleton()->screen_get_usable_rect(DisplayServerEnums::SCREEN_OF_MAIN_WINDOW).size;
-	const real_t smallest_display_dimension = display_size.width < display_size.height ? display_size.width : display_size.height;
+	const real_t smallest_display_dimension = MIN(display_size.width, display_size.height);
 	const Size2 minimum_size = default_minimum_size.minf(smallest_display_dimension);
 
 	// Define a minimum window size to prevent UI elements from overlapping or being cut off.
@@ -1368,6 +1382,25 @@ void ProjectManager::_titlebar_resized() {
 	}
 }
 
+bool ProjectManager::is_project_list_sidebar_visible() {
+	return project_list_sidebar->is_visible();
+}
+
+Vector2 ProjectManager::get_project_list_sidebar_size() {
+	return project_list_sidebar->get_size();
+}
+
+void ProjectManager::_update_project_manager_settings() {
+	// Compact Mode setting
+	{
+		compact_mode = EDITOR_GET("project_manager/compact_mode");
+
+		_reset_compact_mode_threshold();
+		project_list->compact_mode = compact_mode;
+		project_list->resize_project_titles();
+	}
+}
+
 void ProjectManager::_open_donate_page() {
 	OS::get_singleton()->shell_open("https://fund.godotengine.org/?ref=project_manager");
 }
@@ -1651,7 +1684,6 @@ ProjectManager::ProjectManager() {
 			project_list->connect(ProjectList::SIGNAL_SELECTION_CHANGED, callable_mp(this, &ProjectManager::_update_project_buttons));
 			project_list->connect(ProjectList::SIGNAL_PROJECT_ASK_OPEN, callable_mp(this, &ProjectManager::_open_selected_projects_check_recovery_mode));
 			project_list->connect(ProjectList::SIGNAL_MENU_OPTION_SELECTED, callable_mp(this, &ProjectManager::_project_list_menu_option));
-			project_list->connect(SceneStringName(minimum_size_changed), callable_mp(this, &ProjectManager::_update_compact_mode).bind(true));
 
 			// Empty project list placeholder.
 			{
@@ -2035,6 +2067,9 @@ ProjectManager::ProjectManager() {
 		title_bar->set_can_move_window(true);
 		title_bar->connect(SceneStringName(item_rect_changed), callable_mp(this, &ProjectManager::_titlebar_resized));
 	}
+
+	compact_mode = EDITOR_GET("project_manager/compact_mode");
+	project_list->compact_mode = compact_mode;
 
 	_update_size_limits();
 }

--- a/editor/project_manager/project_manager.h
+++ b/editor/project_manager/project_manager.h
@@ -75,6 +75,12 @@ class ProjectManager : public Control {
 
 	// Main layout.
 
+	bool compact_mode = false;
+	int compact_mode_default_threshold = 0;
+	int compact_mode_threshold = 0;
+	void _reset_compact_mode_threshold();
+	void _update_compact_mode();
+
 	Ref<Theme> theme;
 
 	void _update_size_limits();
@@ -94,9 +100,6 @@ class ProjectManager : public Control {
 	HBoxContainer *main_view_toggles = nullptr;
 	Button *quick_settings_button = nullptr;
 	VBoxContainer *project_list_sidebar = nullptr;
-
-	int compact_mode_threshold = 0;
-	void _update_compact_mode(bool p_reset_threshold = false);
 
 	enum MainViewTab {
 		MAIN_VIEW_PROJECTS,
@@ -272,6 +275,9 @@ class ProjectManager : public Control {
 
 	void _files_dropped(PackedStringArray p_files);
 
+	// Editor Settings.
+	void _update_project_manager_settings();
+
 protected:
 	void _notification(int p_what);
 
@@ -289,6 +295,11 @@ public:
 	// Project tag management.
 
 	void add_new_tag(const String &p_tag);
+
+	// Compact mode.
+
+	bool is_project_list_sidebar_visible();
+	Vector2 get_project_list_sidebar_size();
 
 	// Theme.
 	Ref<Theme> get_theme() const { return theme; }

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1200,6 +1200,13 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "project_manager/sorting_order", 0, "Last Edited,Name,Path")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "project_manager/directory_naming_convention", 1, "No Convention,kebab-case,snake_case,camelCase,PascalCase,Title Case")
 
+#if defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED) || defined(MACOS_ENABLED)
+	_initial_set("project_manager/compact_mode", false, true);
+	_initial_set("project_manager/compact_mode_threshold", 0, true);
+#elif defined(ANDROID_ENABLED)
+	_initial_set("project_manager/compact_mode", true, true);
+#endif
+
 #if defined(WEB_ENABLED)
 	// Web platform only supports `gl_compatibility`.
 	const String default_renderer = "gl_compatibility";


### PR DESCRIPTION
- Closes https://github.com/godotengine/godot/issues/122075
- Actually closes https://github.com/godotengine/godot/issues/122092
- Fixes https://github.com/godotengine/godot/issues/122257
- Fixes index reuse error noted in PR https://github.com/godotengine/godot/pull/122037
- Supersedes https://github.com/godotengine/godot/pull/122095
- Supersedes https://github.com/godotengine/godot/pull/122152
- Introduced in https://github.com/godotengine/godot/pull/119580 and https://github.com/godotengine/godot/pull/121387

**This is meant for 4.8. You can find the fix for 4.7.2 here:** https://github.com/godotengine/godot/pull/122350.


# What problem(s) does this PR solve?

- **This PR fixes all issues with wrapping project titles and compact mode.** For more info, see the two suspended PRs.
- Simplifies logic significantly while maintaining the same functionality, fixing issues with long project titles not wrapping correctly.
- **Replaces the magic number** former used for `title_size_cache`  through logic, so **the value is calculated and save for future layout changes**, while the magic number had to be adjusted for layout changes.
- **Should work on any scale now.**
- Implements compact mode setting like explained in  https://github.com/godotengine/godot/pull/122152.


## https://github.com/godotengine/godot/issues/122075

https://github.com/user-attachments/assets/923d71b1-a738-4f19-af06-a21b2393a258


## https://github.com/godotengine/godot/issues/122092
The bug in that issue was caused by https://github.com/godotengine/godot/pull/121387 as it introduced a compact mode which hid the sidebar when the project manager was shrunk beyond a threshold. This PR does two things:

- Adds Compact Mode setting: project_manager/compact_mode.
- Adds Compact Mode Threshold setting: project_manager/compact_mode_threshold, which sets the point to hide the project manager sidebar.

#### Reasoning

Since the mentioned PR was andriod focused, a compact mode setting builds upon the PR, it is set to on by default on the intended mobile devices and off on desktop devices.
Because desktop devices have more real-estate, the compact_mode_threshold gives users more fine grained control.

(This text is from https://github.com/godotengine/godot/pull/122152)


# Difference to https://github.com/godotengine/godot/pull/122152 / https://github.com/godotengine/godot/pull/122095


- Fixes multiple bugs contained in https://github.com/godotengine/godot/pull/122152 / https://github.com/godotengine/godot/pull/122095 (when I write this).
- https://github.com/godotengine/godot/pull/122152 / https://github.com/godotengine/godot/pull/122095 do NOT fix https://github.com/godotengine/godot/issues/122257.
- This PR replaces the magic number former used for `title_size_cache`  through logic, so the value is calculated and save for future layout changes, while the magic number had to be adjusted for layout changes.
- Some Optimizations, which also makes the code cleaner to read.
- The behaviour itself. Here a demo:


### This is https://github.com/godotengine/godot/pull/122152:


https://github.com/user-attachments/assets/d0164631-e7ca-4d43-b2bf-095b1917c9d4


As you may notice, the **tags do not resize at first**, title and tags share the space somewhere in the middle.
Also, you see the errors from https://github.com/godotengine/godot/issues/122257 in the terminal window.


### This PR:


https://github.com/user-attachments/assets/0802d76f-a8ea-4ba6-a746-7c65818f1cd9


It ensures that **the tags do resize at first**, so the title can take mor space, which can be used more efficiently.
You don't see any errors in the terminal window.


Also, https://github.com/godotengine/godot/pull/122152 currently broke the compact mode setting. For demo:


https://github.com/godotengine/godot/pull/122152:


https://github.com/user-attachments/assets/cd94772c-5d69-421a-ab3d-dcc6ccd5ed45


This PR:


https://github.com/user-attachments/assets/18ae8213-4000-4dce-be12-d2fb7476e8f8




## Additional information

Validated by building the Windows editor with SCons and testing it, as well as testing the test artifact for Windows.
