### PR TITLE
Fix out‑of‑bounds read in XMLParser by adding peek() bounds checking..

### DIFF
--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -74,7 +74,7 @@ void XMLParser::_parse_closing_xml_element() {
 	next_char();
 	const char *pBeginClose = P;
 
-	while (*P && *P != '>') {
+	while (peek() && peek() != '>') {
 		next_char();
 	}
 
@@ -83,7 +83,7 @@ void XMLParser::_parse_closing_xml_element() {
 	print_line("XML CLOSE: " + node_name);
 #endif
 
-	if (*P) {
+	if (peek()) {
 		next_char();
 	}
 }
@@ -93,19 +93,19 @@ void XMLParser::_ignore_definition() {
 
 	const char *F = P;
 	// move until end marked with '>' reached
-	while (*P && *P != '>') {
+	while (peek() && peek() != '>') {
 		next_char();
 	}
 	node_name.clear();
 	node_name.append_utf8(F, P - F);
 
-	if (*P) {
+	if (peek()) {
 		next_char();
 	}
 }
 
 bool XMLParser::_parse_cdata() {
-	if (*(P + 1) != '[') {
+	if (peek(1) != '[') {
 		return false;
 	}
 
@@ -113,12 +113,12 @@ bool XMLParser::_parse_cdata() {
 
 	// skip '<![CDATA['
 	int count = 0;
-	while (*P && count < 8) {
+	while (peek() && count < 8) {
 		next_char();
 		++count;
 	}
 
-	if (!*P) {
+	if (!peek()) {
 		node_name = "";
 		return true;
 	}
@@ -127,10 +127,10 @@ bool XMLParser::_parse_cdata() {
 	const char *cDataEnd = nullptr;
 
 	// find end of CDATA
-	while (*P && !cDataEnd) {
-		if (*P == '>' &&
-				(*(P - 1) == ']') &&
-				(*(P - 2) == ']')) {
+	while (peek() && !cDataEnd) {
+		if (peek() == '>' &&
+				(peek(-1) == ']') &&
+				(peek(-2) == ']')) {
 			cDataEnd = P - 2;
 		}
 
@@ -174,10 +174,10 @@ void XMLParser::_parse_comment() {
 		pCommentBegin = P;
 
 		int count = 1;
-		while (*P && count) {
-			if (*P == '>') {
+		while (peek() && count) {
+			if (peek() == '>') {
 				--count;
-			} else if (*P == '<') {
+			} else if (peek() == '<') {
 				++count;
 			}
 			next_char();
@@ -205,28 +205,28 @@ void XMLParser::_parse_opening_xml_element() {
 	const char *startName = P;
 
 	// find end of element
-	while (*P && *P != '>' && !_is_white_space(*P)) {
+	while (peek() && peek() != '>' && !_is_white_space(peek())) {
 		next_char();
 	}
 
 	const char *endName = P;
 
 	// find attributes
-	while (*P && *P != '>') {
-		if (_is_white_space(*P)) {
+	while (peek() && peek() != '>') {
+		if (_is_white_space(peek())) {
 			next_char();
 		} else {
-			if (*P != '/') {
+			if (peek() != '/') {
 				// we've got an attribute
 
 				// read the attribute names
 				const char *attributeNameBegin = P;
 
-				while (*P && !_is_white_space(*P) && *P != '=') {
+				while (peek() && !_is_white_space(peek()) && peek() != '=') {
 					next_char();
 				}
 
-				if (!*P) {
+				if (!peek()) {
 					break;
 				}
 
@@ -235,25 +235,25 @@ void XMLParser::_parse_opening_xml_element() {
 
 				// read the attribute value
 				// check for quotes and single quotes, thx to murphy
-				while ((*P != '\"') && (*P != '\'') && *P) {
+				while (peek() != '\"' && peek() != '\'' && peek()) {
 					next_char();
 				}
 
-				if (!*P) { // malformatted xml file
+				if (!peek()) { // malformatted xml file
 					break;
 				}
 
-				const char attributeQuoteChar = *P;
+				const char attributeQuoteChar = peek();
 
 				next_char();
 				const char *attributeValueBegin = P;
 
-				while (*P != attributeQuoteChar && *P) {
+				while (peek() != attributeQuoteChar && peek()) {
 					next_char();
 				}
 
 				const char *attributeValueEnd = P;
-				if (*P) {
+				if (peek()) {
 					next_char();
 				}
 
@@ -287,7 +287,7 @@ void XMLParser::_parse_opening_xml_element() {
 	print_line("XML OPEN: " + node_name);
 #endif
 
-	if (*P) {
+	if (peek()) {
 		next_char();
 	}
 }
@@ -297,7 +297,7 @@ void XMLParser::_parse_current_node() {
 	node_offset = P - data;
 
 	// more forward until '<' found
-	while (*P != '<' && *P) {
+	while (peek() != '<' && peek()) {
 		next_char();
 	}
 
@@ -308,14 +308,14 @@ void XMLParser::_parse_current_node() {
 		}
 	}
 
-	if (!*P) {
+	if (!peek()) {
 		return;
 	}
 
 	next_char();
 
 	// based on current token, parse and report next element
-	switch (*P) {
+	switch (peek()) {
 		case '/':
 			_parse_closing_xml_element();
 			break;

--- a/core/io/xml_parser.h
+++ b/core/io/xml_parser.h
@@ -90,12 +90,18 @@ private:
 	void _parse_current_node();
 
 	_FORCE_INLINE_ char peek(int p_offset = 0) const {
-		const char *ptr = P + p_offset;
-		return (ptr >= data && ptr < data + length) ? *ptr : '\0';
+		if (!P || !data) {
+			return '\0';
+		}
+		int64_t offset = (P - data) + p_offset;
+		if (offset >= 0 && (uint64_t)offset < length) {
+			return data[offset];
+		}
+		return '\0';
 	}
 
 	_FORCE_INLINE_ void next_char() {
-		if (P < data + length) {
+		if (P && data && P < data + length) {
 			if (*P == '\n') {
 				current_line++;
 			}

--- a/core/io/xml_parser.h
+++ b/core/io/xml_parser.h
@@ -89,11 +89,18 @@ private:
 	void _parse_opening_xml_element();
 	void _parse_current_node();
 
+	_FORCE_INLINE_ char peek(int p_offset = 0) const {
+		const char *ptr = P + p_offset;
+		return (ptr >= data && ptr < data + length) ? *ptr : '\0';
+	}
+
 	_FORCE_INLINE_ void next_char() {
-		if (*P == '\n') {
-			current_line++;
+		if (P < data + length) {
+			if (*P == '\n') {
+				current_line++;
+			}
+			P++;
 		}
-		P++;
 	}
 
 	static void _bind_methods();

--- a/tests/core/io/test_xml_parser.cpp
+++ b/tests/core/io/test_xml_parser.cpp
@@ -232,7 +232,7 @@ TEST_CASE("[XMLParser] CDATA") {
 }
 
 TEST_CASE("[XMLParser] Raw buffer parsing with garbage suffix") {
-	uint8_t buf[] = {'<', 'a', '/', '>', 0xFF, 0xFF, 0xFF}; // 4 valid bytes
+	uint8_t buf[] = { '<', 'a', '/', '>', 0xFF, 0xFF, 0xFF }; // 4 valid bytes
 	XMLParser parser;
 	REQUIRE_EQ(parser._open_buffer(buf, 4), OK);
 	REQUIRE_EQ(parser.read(), OK);
@@ -243,7 +243,7 @@ TEST_CASE("[XMLParser] Raw buffer parsing with garbage suffix") {
 }
 
 TEST_CASE("[XMLParser] Truncated buffer is handled safely") {
-	uint8_t buf[] = {'<', 't', 'a', 'g'}; // "<tag" no closing
+	uint8_t buf[] = { '<', 't', 'a', 'g' }; // "<tag" no closing
 	XMLParser parser;
 	REQUIRE_EQ(parser._open_buffer(buf, 4), OK);
 	REQUIRE_EQ(parser.read(), OK);

--- a/tests/core/io/test_xml_parser.cpp
+++ b/tests/core/io/test_xml_parser.cpp
@@ -231,4 +231,25 @@ TEST_CASE("[XMLParser] CDATA") {
 	CHECK_EQ(parser.get_node_name(), "a");
 }
 
+TEST_CASE("[XMLParser] Raw buffer parsing with garbage suffix") {
+	uint8_t buf[] = {'<', 'a', '/', '>', 0xFF, 0xFF, 0xFF}; // 4 valid bytes
+	XMLParser parser;
+	REQUIRE_EQ(parser._open_buffer(buf, 4), OK);
+	REQUIRE_EQ(parser.read(), OK);
+	CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
+	CHECK_EQ(parser.get_node_name(), "a");
+	CHECK(parser.is_empty());
+	CHECK_EQ(parser.read(), ERR_FILE_EOF);
+}
+
+TEST_CASE("[XMLParser] Truncated buffer is handled safely") {
+	uint8_t buf[] = {'<', 't', 'a', 'g'}; // "<tag" no closing
+	XMLParser parser;
+	REQUIRE_EQ(parser._open_buffer(buf, 4), OK);
+	REQUIRE_EQ(parser.read(), OK);
+	CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
+	CHECK_EQ(parser.get_node_name(), "tag");
+	CHECK_EQ(parser.read(), ERR_FILE_EOF);
+}
+
 } // namespace TestXMLParser


### PR DESCRIPTION
While reading through the XML parser, I noticed that _open_buffer takes a raw pointer but the parser loops assume a null terminator, risking an out‑of‑bounds read. I added a peek() helper that returns '\0' when out of bounds, and replaced all raw dereferences with it – keeping zero‑copy intact. Two new tests confirm it handles truncated/garbage‑suffixed buffers safely.

