### PR TITLE
Fix lights not getting unpaired when setting geometry layer mask.

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -928,10 +928,9 @@ void RendererSceneCull::instance_set_layer_mask(RID p_instance, uint32_t p_mask)
 		return;
 	}
 
-	// Particles always need to be unpaired. Geometry may need to be unpaired, but only if lights or decals use pairing.
+	// Particles and geometries need to be unpaired.
 	// Needs to happen before layer mask changes so we can avoid attempting to unpair something that was never paired.
-	if (instance->base_type == RSE::INSTANCE_PARTICLES ||
-			(((geometry_instance_pair_mask & (1 << RSE::INSTANCE_LIGHT)) || (geometry_instance_pair_mask & (1 << RSE::INSTANCE_DECAL))) && ((1 << instance->base_type) & RSE::INSTANCE_GEOMETRY_MASK))) {
+	if (instance->base_type == RSE::INSTANCE_PARTICLES || ((1 << instance->base_type) & RSE::INSTANCE_GEOMETRY_MASK)) {
 		_unpair_instance(instance);
 		singleton->_instance_queue_update(instance, false, false);
 	}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121989

`geometry_instance_pair_mask` was used to determine whether lights get paired with geometries to skip unnecessary `_instance_unpair` calls. However, this assumption is incorrect, since lights are always paired with geometries, regardless of the value of this member. Since Forward+ did not have the light bit set in the mask, the unpairing would incorrectly get skipped. To fix this, we always perform unpairing for geometries.

## Additional information

N/A