### PR TITLE
Change dir when dropping a file on the file dialog

### DIFF
--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1315,7 +1315,7 @@ void ProjectManager::shortcut_input(const Ref<InputEvent> &p_ev) {
 	}
 }
 
-void ProjectManager::_files_dropped(PackedStringArray p_files) {
+void ProjectManager::_files_dropped(const PackedStringArray &p_files) {
 	// TODO: Support installing multiple ZIPs at the same time?
 	if (p_files.size() == 1 && p_files[0].ends_with(".zip")) {
 		const String &file = p_files[0];

--- a/editor/project_manager/project_manager.h
+++ b/editor/project_manager/project_manager.h
@@ -270,7 +270,7 @@ class ProjectManager : public Control {
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_ev) override;
 
-	void _files_dropped(PackedStringArray p_files);
+	void _files_dropped(const PackedStringArray &p_files);
 
 protected:
 	void _notification(int p_what);

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -445,6 +445,19 @@ void FileDialog::_post_popup() {
 	_push_history();
 }
 
+void FileDialog::_files_dropped(const PackedStringArray &p_files) {
+	if (p_files.size() != 1) {
+		return;
+	}
+
+	String path = p_files[0].get_base_dir();
+	if (path.is_empty()) {
+		return;
+	}
+
+	set_current_dir(path);
+}
+
 void FileDialog::_push_history() {
 	local_history.resize(local_history_pos + 1);
 	String new_path = dir_access->get_current_dir();
@@ -2679,6 +2692,8 @@ FileDialog::FileDialog() {
 	item_menu = memnew(PopupMenu);
 	item_menu->connect(SceneStringName(id_pressed), callable_mp(this, &FileDialog::_item_menu_id_pressed));
 	add_child(item_menu, false, INTERNAL_MODE_FRONT);
+
+	connect("files_dropped", callable_mp(this, &FileDialog::_files_dropped));
 
 	connect(SceneStringName(confirmed), callable_mp(this, &FileDialog::_action_pressed));
 

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -372,6 +372,8 @@ private:
 
 	virtual void _post_popup() override;
 
+	void _files_dropped(const PackedStringArray &p_files);
+
 protected:
 	Ref<DirAccess> dir_access;
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

When a file dialog is open, trying to drop a file from an external program (e.g. Windows Explorer) will do nothing, even though the mouse cursor changes to indicate that dropping is supported.
Under the assumption that users are trying to open the file or directory that they are about to drop, this change just uses the directory path of the filename and navigates there. It's not perfect in all circumstances, but it's a low risk change and makes interacting with external tools a little bit nicer.

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
