### PR TITLE
Implement `DisplayServer.screen_get_scale()` on Windows

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1854,7 +1854,7 @@
 				[b]Note:[/b] One of the following constants can be used as [param screen]: [constant SCREEN_OF_MAIN_WINDOW], [constant SCREEN_PRIMARY], [constant SCREEN_WITH_MOUSE_FOCUS], or [constant SCREEN_WITH_KEYBOARD_FOCUS].
 				[b]Note:[/b] On macOS, the returned value is [code]2.0[/code] for hiDPI (Retina) screens, and [code]1.0[/code] for all other cases.
 				[b]Note:[/b] On Linux (Wayland), the returned value is accurate only when [param screen] is [constant SCREEN_OF_MAIN_WINDOW]. Due to API limitations, passing a direct index will return a rounded-up integer, if the screen has a fractional scale (e.g. [code]1.25[/code] would get rounded up to [code]2.0[/code]).
-				[b]Note:[/b] This method is implemented on Android, iOS, Web, macOS, and Linux (Wayland). On other platforms, this method always returns [code]1.0[/code].
+				[b]Note:[/b] This method is implemented on Android, iOS, Web, macOS, Linux (Wayland), and Windows. On other platforms, this method always returns [code]1.0[/code].
 			</description>
 		</method>
 		<method name="screen_get_size" qualifiers="const">

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -2039,9 +2039,11 @@ float EditorSettings::get_auto_display_scale() {
 	}
 #endif
 
-#if defined(MACOS_ENABLED) || defined(ANDROID_ENABLED)
+#if defined(MACOS_ENABLED) || defined(WINDOWS_ENABLED) || defined(ANDROID_ENABLED)
 	return DisplayServer::get_singleton()->screen_get_max_scale();
 #else
+
+	// Fallback logic based on resolution and reported DPI (only used for Linux/X11 and Web).
 	const int screen = DisplayServer::get_singleton()->window_get_current_screen();
 
 	if (DisplayServer::get_singleton()->screen_get_size(screen) == Vector2i()) {
@@ -2049,9 +2051,6 @@ float EditorSettings::get_auto_display_scale() {
 		return 1.0;
 	}
 
-#if defined(WINDOWS_ENABLED)
-	return DisplayServer::get_singleton()->screen_get_dpi(screen) / 96.0;
-#else
 	// Use the smallest dimension to use a correct display scale on portrait displays.
 	const int smallest_dimension = MIN(DisplayServer::get_singleton()->screen_get_size(screen).x, DisplayServer::get_singleton()->screen_get_size(screen).y);
 	if (DisplayServer::get_singleton()->screen_get_dpi(screen) >= 192 && smallest_dimension >= 1400) {
@@ -2067,9 +2066,8 @@ float EditorSettings::get_auto_display_scale() {
 		return 0.75;
 	}
 	return 1.0;
-#endif // defined(WINDOWS_ENABLED)
 
-#endif // defined(MACOS_ENABLED) || defined(ANDROID_ENABLED)
+#endif // defined(MACOS_ENABLED) || defined(WINDOWS_ENABLED) || defined(ANDROID_ENABLED)
 }
 
 String EditorSettings::get_language() const {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1521,6 +1521,12 @@ int DisplayServerWindows::screen_get_dpi(int p_screen) const {
 	return data.dpi;
 }
 
+float DisplayServerWindows::screen_get_scale(int p_screen) const {
+	// Windows always reports the monitor DPI as 96 when the scale option in Windows' settings is set to 100%,
+	// regardless of the monitor's resolution and physical size. This value is then multiplied by the scale factor.
+	return screen_get_dpi(p_screen) / 96.0;
+}
+
 Color DisplayServerWindows::screen_get_pixel(const Point2i &p_position) const {
 	Point2i pos = p_position + _get_screens_origin();
 

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -624,6 +624,7 @@ public:
 	virtual Size2i screen_get_size(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Rect2i screen_get_usable_rect(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
 	virtual int screen_get_dpi(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
+	virtual float screen_get_scale(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_refresh_rate(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Color screen_get_pixel(const Point2i &p_position) const override;
 	virtual Ref<Image> screen_get_image(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;


### PR DESCRIPTION
- Replace [dedicated automatic editor scale logic for Windows](https://github.com/godotengine/godot/pull/111326) with the standard DisplayServer method call.

Tested on Windows 11 24H2 on an ASUS ROG PG32UCDP (physically 138 DPI but reports 96 DPI at 100%), at 100% and 125% Windows scale options.

___

- This partially addresses https://github.com/godotengine/godot-proposals/issues/2661 (only Linux/X11 is left now).

## Preview

`master` | This PR
-|-
<img width="154" height="94" alt="image" src="https://github.com/user-attachments/assets/5ac810e3-5a1d-4112-b5e8-ba0c2549af1a" /> | <img width="151" height="95" alt="image" src="https://github.com/user-attachments/assets/dd9d18f7-b4e7-415f-97ee-d1249c666989" />
