### PR TITLE
docs: SoftBody3D note - Jolt is default since 4.6

### DIFF
--- a/doc/classes/SoftBody3D.xml
+++ b/doc/classes/SoftBody3D.xml
@@ -6,7 +6,7 @@
 	<description>
 		A deformable 3D physics mesh. Used to create elastic or deformable objects such as cloth, rubber, or other flexible materials.
 		Additionally, [SoftBody3D] is subject to wind forces defined in [Area3D] (see [member Area3D.wind_source_path], [member Area3D.wind_force_magnitude], and [member Area3D.wind_attenuation_factor]).
-		[b]Note:[/b] It's recommended to use Jolt Physics when using [SoftBody3D] instead of the default GodotPhysics3D, as Jolt Physics' soft body implementation is faster and more reliable. You can switch the physics engine using the [member ProjectSettings.physics/3d/physics_engine] project setting.
+		[b]Note:[/b] It's recommended to use Jolt Physics when using [SoftBody3D], as Jolt Physics' soft body implementation is faster and more reliable than GodotPhysics3D. Projects created in Godot 4.6 and later use Jolt Physics by default; existing projects may still use GodotPhysics3D until switched. You can switch the physics engine using the [member ProjectSettings.physics/3d/physics_engine] project setting.
 	</description>
 	<tutorials>
 		<link title="SoftBody">$DOCS_URL/tutorials/physics/soft_body.html</link>


### PR DESCRIPTION
﻿## Summary
- Updates the SoftBody3D class reference note so it no longer calls GodotPhysics3D "the default".
- Clarifies that Jolt Physics is default for projects created in Godot 4.6+, while older projects may still be on GodotPhysics3D until switched.

## Why
The generated class docs (and therefore docs.godotengine.org) still said SoftBody3D should be used "instead of the default GodotPhysics3D". That is outdated as of 4.6 and contradicts the soft body tutorial.

Related to godotengine/godot-docs#12120 (class reference is generated from this XML; do not edit the generated RST in godot-docs).

## Test plan
- [x] Wording aligned with tutorials/physics/soft_body.rst in godot-docs
- [ ] Docs regenerate / CI class reference checks pass
