### PR TITLE
Metal: use specialization constants that set the compute workgroup size

### DIFF
--- a/drivers/metal/metal_objects_shared.h
+++ b/drivers/metal/metal_objects_shared.h
@@ -917,7 +917,12 @@ public:
 
 class API_AVAILABLE(macos(11.0), ios(14.0), tvos(14.0), visionos(2.0)) MDComputeShader final : public MDShader {
 public:
+	/// The workgroup size when all specialization constants have their default values.
 	MTL::Size local = {};
+
+	/// The ID of the specialization constant that controls each dimension of `local`.
+	/// If no constant controls a dimension, the value is UINT32_MAX.
+	uint32_t local_size_spec_id[3] = { UINT32_MAX, UINT32_MAX, UINT32_MAX };
 
 	std::shared_ptr<MDLibrary> kernel;
 

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -1255,6 +1255,7 @@ RDD::ShaderID RenderingDeviceDriverMetal::shader_create_from_container(const Ref
 				libraries[RDD::ShaderStage::SHADER_STAGE_COMPUTE]);
 
 		cs->local = MTL::Size(refl.compute_local_size[0], refl.compute_local_size[1], refl.compute_local_size[2]);
+		memcpy(cs->local_size_spec_id, refl.compute_local_spec_id, sizeof(cs->local_size_spec_id));
 		shader = cs;
 	} else {
 		MDRenderShader *rs = new MDRenderShader(
@@ -2229,6 +2230,28 @@ void RenderingDeviceDriverMetal::command_compute_dispatch_indirect(CommandBuffer
 
 // ----- PIPELINE -----
 
+/*! @brief Returns the workgroup size of `p_shader` after the specialization constants apply.
+ *
+ * Metal gets the threadgroup size at dispatch time, not from the shader. Thus a pipeline must
+ * hold the specialized size. A dimension that no constant controls keeps its default value.
+ */
+static MTL::Size _resolve_local_size(const MDComputeShader *p_shader, VectorView<RDD::PipelineSpecializationConstant> p_specialization_constants) {
+	NS::UInteger dimensions[3] = { p_shader->local.width, p_shader->local.height, p_shader->local.depth };
+	for (uint32_t dim = 0; dim < std_size(p_shader->local_size_spec_id); dim++) {
+		if (p_shader->local_size_spec_id[dim] == UINT32_MAX) {
+			continue;
+		}
+		for (uint32_t i = 0; i < p_specialization_constants.size(); i++) {
+			const RDD::PipelineSpecializationConstant &sc = p_specialization_constants[i];
+			if (sc.constant_id == p_shader->local_size_spec_id[dim] && sc.int_value != 0) {
+				dimensions[dim] = sc.int_value;
+				break;
+			}
+		}
+	}
+	return MTL::Size(dimensions[0], dimensions[1], dimensions[2]);
+}
+
 RDD::PipelineID RenderingDeviceDriverMetal::compute_pipeline_create(ShaderID p_shader, VectorView<PipelineSpecializationConstant> p_specialization_constants) {
 	MDComputeShader *shader = (MDComputeShader *)(p_shader.id);
 
@@ -2273,7 +2296,7 @@ RDD::PipelineID RenderingDeviceDriverMetal::compute_pipeline_create(ShaderID p_s
 	ERR_FAIL_COND_V_MSG(!state, PipelineID(), "Failed to create compute pipeline state");
 
 	MDComputePipeline *pipeline = new MDComputePipeline(state);
-	pipeline->compute_state.local = shader->local;
+	pipeline->compute_state.local = _resolve_local_size(shader, p_specialization_constants);
 	pipeline->shader = shader;
 
 	if (arc) {

--- a/servers/rendering/rendering_device_commons.h
+++ b/servers/rendering/rendering_device_commons.h
@@ -1165,6 +1165,10 @@ public:
 		bool has_multiview = false;
 		bool has_dynamic_buffers = false;
 		uint32_t compute_local_size[3] = {};
+		/// The ID of the specialization constant that controls each dimension of
+		/// `compute_local_size`. A dimension that no constant controls has the value
+		/// UINT32_MAX.
+		uint32_t compute_local_spec_id[3] = { UINT32_MAX, UINT32_MAX, UINT32_MAX };
 		uint32_t push_constant_size = 0;
 
 		Vector<Vector<ShaderUniform>> uniform_sets;

--- a/servers/rendering/rendering_shader_container.cpp
+++ b/servers/rendering/rendering_shader_container.cpp
@@ -334,6 +334,10 @@ Error RenderingShaderContainer::reflect_spirv(const String &p_shader_name, Span<
 				reflection.compute_local_size[0] = module.entry_points->local_size.x;
 				reflection.compute_local_size[1] = module.entry_points->local_size.y;
 				reflection.compute_local_size[2] = module.entry_points->local_size.z;
+				// A specialization constant can control a dimension. Then `local_size` holds the
+				// default value of that constant, and the ID identifies the constant.
+				static_assert(sizeof(reflection.compute_local_spec_id) == sizeof(module.entry_points->local_size_spec_id));
+				memcpy(reflection.compute_local_spec_id, module.entry_points->local_size_spec_id, sizeof(reflection.compute_local_spec_id));
 			}
 			uint32_t binding_count = 0;
 			result = spvReflectEnumerateDescriptorBindings(&module, &binding_count, nullptr);
@@ -689,6 +693,9 @@ void RenderingShaderContainer::set_from_shader_reflection(const ReflectShader &p
 	reflection_data.compute_local_size[0] = p_reflection.compute_local_size[0];
 	reflection_data.compute_local_size[1] = p_reflection.compute_local_size[1];
 	reflection_data.compute_local_size[2] = p_reflection.compute_local_size[2];
+	reflection_data.compute_local_spec_id[0] = p_reflection.compute_local_spec_id[0];
+	reflection_data.compute_local_spec_id[1] = p_reflection.compute_local_spec_id[1];
+	reflection_data.compute_local_spec_id[2] = p_reflection.compute_local_spec_id[2];
 	reflection_data.set_count = p_reflection.uniform_sets.size();
 	reflection_data.push_constant_size = p_reflection.push_constant_size;
 	reflection_data.push_constant_stages_mask = uint32_t(p_reflection.push_constant_stages);
@@ -748,6 +755,9 @@ RenderingDeviceCommons::ShaderReflection RenderingShaderContainer::get_shader_re
 	shader_refl.compute_local_size[0] = reflection_data.compute_local_size[0];
 	shader_refl.compute_local_size[1] = reflection_data.compute_local_size[1];
 	shader_refl.compute_local_size[2] = reflection_data.compute_local_size[2];
+	shader_refl.compute_local_spec_id[0] = reflection_data.compute_local_spec_id[0];
+	shader_refl.compute_local_spec_id[1] = reflection_data.compute_local_spec_id[1];
+	shader_refl.compute_local_spec_id[2] = reflection_data.compute_local_spec_id[2];
 	shader_refl.uniform_sets.resize(reflection_data.set_count);
 	shader_refl.specialization_constants.resize(reflection_data.specialization_constants_count);
 	shader_refl.stages_vector.resize(reflection_data.stage_count);
@@ -802,9 +812,11 @@ bool RenderingShaderContainer::from_bytes(const PackedByteArray &p_bytes) {
 	bytes_offset += _from_bytes_header_extra_data(&bytes_ptr[bytes_offset]);
 
 	ERR_FAIL_COND_V_MSG(container_header.magic_number != CONTAINER_MAGIC_NUMBER, false, "Incorrect magic number in shader container.");
-	ERR_FAIL_COND_V_MSG(container_header.version > CONTAINER_VERSION, false, "Unsupported version in shader container.");
+	// The version identifies the memory layout of the shared reflection data. A different
+	// version can have a different layout. Thus the engine must reject it and compile again.
+	ERR_FAIL_COND_V_MSG(container_header.version != CONTAINER_VERSION, false, "Unsupported version in shader container.");
 	ERR_FAIL_COND_V_MSG(container_header.format != _format(), false, "Incorrect format in shader container.");
-	ERR_FAIL_COND_V_MSG(container_header.format_version > _format_version(), false, "Unsupported format version in shader container.");
+	ERR_FAIL_COND_V_MSG(container_header.format_version != _format_version(), false, "Unsupported format version in shader container.");
 
 	// Adjust shaders to the size indicated by the container header.
 	shaders.resize(container_header.shader_count);

--- a/servers/rendering/rendering_shader_container.h
+++ b/servers/rendering/rendering_shader_container.h
@@ -42,7 +42,7 @@ class RenderingShaderContainer : public RefCounted {
 
 public:
 	static const uint32_t CONTAINER_MAGIC_NUMBER = 0x43535247;
-	static const uint32_t CONTAINER_VERSION = 2;
+	static const uint32_t CONTAINER_VERSION = 3;
 
 protected:
 	using RDC = RenderingDeviceCommons;
@@ -63,6 +63,7 @@ protected:
 		uint32_t has_multiview = 0;
 		uint32_t has_dynamic_buffers = 0;
 		uint32_t compute_local_size[3] = {};
+		uint32_t compute_local_spec_id[3] = { UINT32_MAX, UINT32_MAX, UINT32_MAX };
 		uint32_t set_count = 0;
 		uint32_t push_constant_size = 0;
 		uint32_t push_constant_stages_mask = 0;
@@ -226,6 +227,7 @@ protected:
 		uint64_t vertex_input_mask = 0;
 		uint32_t fragment_output_mask = 0;
 		uint32_t compute_local_size[3] = {};
+		uint32_t compute_local_spec_id[3] = { UINT32_MAX, UINT32_MAX, UINT32_MAX };
 		uint32_t push_constant_size = 0;
 		bool has_multiview = false;
 		bool has_dynamic_buffers = false;

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -1056,6 +1056,8 @@ Patches:
 
 - `0001-zero-size-for-sc-sized-arrays.patch` ([GH-94985](https://github.com/godotengine/godot/pull/94985))
 - `0002-spirv-headers.patch` ([GH-111452](https://github.com/godotengine/godot/pull/111452))
+- `0003-findnode-id-lookup-table.patch` ([GH-121835](https://github.com/godotengine/godot/pull/121835))
+- `0004-local-size-spec-constant-default.patch` ([GH-122071](https://github.com/godotengine/godot/pull/122071))
 
 
 ## swappy-frame-pacing

--- a/thirdparty/spirv-reflect/patches/0004-local-size-spec-constant-default.patch
+++ b/thirdparty/spirv-reflect/patches/0004-local-size-spec-constant-default.patch
@@ -1,0 +1,89 @@
+diff --git a/thirdparty/spirv-reflect/spirv_reflect.c b/thirdparty/spirv-reflect/spirv_reflect.c
+index a415afcc67..9e275cd39f 100644
+--- a/thirdparty/spirv-reflect/spirv_reflect.c
++++ b/thirdparty/spirv-reflect/spirv_reflect.c
+@@ -52,7 +52,7 @@ enum {
+ };
+ 
+ enum {
+-  INVALID_VALUE  = 0xFFFFFFFF,
++  INVALID_VALUE  = SPV_REFLECT_INVALID_VALUE,
+ };
+ 
+ enum {
+@@ -3726,6 +3726,9 @@ static SpvReflectResult ParseEntryPoints(SpvReflectPrvParser* p_parser, SpvRefle
+     }
+ 
+     SpvReflectEntryPoint* p_entry_point = &(p_module->entry_points[entry_point_index]);
++    p_entry_point->local_size_spec_id[0] = (uint32_t)INVALID_VALUE;
++    p_entry_point->local_size_spec_id[1] = (uint32_t)INVALID_VALUE;
++    p_entry_point->local_size_spec_id[2] = (uint32_t)INVALID_VALUE;
+     CHECKED_READU32_CAST(p_parser, p_node->word_offset + 1, SpvExecutionModel, p_entry_point->spirv_execution_model);
+     CHECKED_READU32(p_parser, p_node->word_offset + 2, p_entry_point->id);
+ 
+@@ -3886,23 +3889,13 @@ static SpvReflectResult ParseExecutionModes(SpvReflectPrvParser* p_parser, SpvRe
+           SpvReflectPrvNode* y_node = FindNode(p_parser, local_size_y_id);
+           SpvReflectPrvNode* z_node = FindNode(p_parser, local_size_z_id);
+           if (IsNotNull(x_node) && IsNotNull(y_node) && IsNotNull(z_node)) {
+-            if (IsSpecConstant(x_node)) {
+-              p_entry_point->local_size.x = (uint32_t)SPV_REFLECT_EXECUTION_MODE_SPEC_CONSTANT;
+-            } else {
+-              CHECKED_READU32(p_parser, x_node->word_offset + 3, p_entry_point->local_size.x);
+-            }
++            CHECKED_READU32(p_parser, x_node->word_offset + 3, p_entry_point->local_size.x);
++            CHECKED_READU32(p_parser, y_node->word_offset + 3, p_entry_point->local_size.y);
++            CHECKED_READU32(p_parser, z_node->word_offset + 3, p_entry_point->local_size.z);
+ 
+-            if (IsSpecConstant(y_node)) {
+-              p_entry_point->local_size.y = (uint32_t)SPV_REFLECT_EXECUTION_MODE_SPEC_CONSTANT;
+-            } else {
+-              CHECKED_READU32(p_parser, y_node->word_offset + 3, p_entry_point->local_size.y);
+-            }
+-
+-            if (IsSpecConstant(z_node)) {
+-              p_entry_point->local_size.z = (uint32_t)SPV_REFLECT_EXECUTION_MODE_SPEC_CONSTANT;
+-            } else {
+-              CHECKED_READU32(p_parser, z_node->word_offset + 3, p_entry_point->local_size.z);
+-            }
++            p_entry_point->local_size_spec_id[0] = IsSpecConstant(x_node) ? x_node->decorations.spec_id : (uint32_t)INVALID_VALUE;
++            p_entry_point->local_size_spec_id[1] = IsSpecConstant(y_node) ? y_node->decorations.spec_id : (uint32_t)INVALID_VALUE;
++            p_entry_point->local_size_spec_id[2] = IsSpecConstant(z_node) ? z_node->decorations.spec_id : (uint32_t)INVALID_VALUE;
+           }
+         } break;
+ 
+diff --git a/thirdparty/spirv-reflect/spirv_reflect.h b/thirdparty/spirv-reflect/spirv_reflect.h
+index 431bce997c..d2773cc07d 100644
+--- a/thirdparty/spirv-reflect/spirv_reflect.h
++++ b/thirdparty/spirv-reflect/spirv_reflect.h
+@@ -338,6 +338,11 @@ enum {
+   SPV_REFLECT_SET_NUMBER_DONT_CHANGE            = ~0
+ };
+ 
++// A field that holds this value has no data.
++enum {
++  SPV_REFLECT_INVALID_VALUE                     = 0xFFFFFFFF,
++};
++
+ typedef struct SpvReflectNumericTraits {
+   struct Scalar {
+     uint32_t                        width;
+@@ -555,11 +560,19 @@ typedef struct SpvReflectEntryPoint {
+   uint32_t                          execution_mode_count;
+   SpvExecutionMode*                 execution_modes;
+ 
++  // The workgroup size. If a specialization constant controls a dimension, that
++  // dimension has the default value of the constant. Thus this field is always a
++  // usable size. Read `local_size_spec_id` to find the dimensions that a
++  // specialization constant controls.
+   struct LocalSize {
+     uint32_t                        x;
+     uint32_t                        y;
+     uint32_t                        z;
+   } local_size;
++  // The ID of the specialization constant that controls each dimension of
++  // `local_size`. A dimension that no constant controls has the value
++  // SPV_REFLECT_INVALID_VALUE.
++  uint32_t                          local_size_spec_id[3];
+   uint32_t                          invocations; // valid for geometry
+   uint32_t                          output_vertices; // valid for geometry, tesselation
+ } SpvReflectEntryPoint;

--- a/thirdparty/spirv-reflect/spirv_reflect.c
+++ b/thirdparty/spirv-reflect/spirv_reflect.c
@@ -52,7 +52,7 @@ enum {
 };
 
 enum {
-  INVALID_VALUE  = 0xFFFFFFFF,
+  INVALID_VALUE  = SPV_REFLECT_INVALID_VALUE,
 };
 
 enum {
@@ -3726,6 +3726,9 @@ static SpvReflectResult ParseEntryPoints(SpvReflectPrvParser* p_parser, SpvRefle
     }
 
     SpvReflectEntryPoint* p_entry_point = &(p_module->entry_points[entry_point_index]);
+    p_entry_point->local_size_spec_id[0] = (uint32_t)INVALID_VALUE;
+    p_entry_point->local_size_spec_id[1] = (uint32_t)INVALID_VALUE;
+    p_entry_point->local_size_spec_id[2] = (uint32_t)INVALID_VALUE;
     CHECKED_READU32_CAST(p_parser, p_node->word_offset + 1, SpvExecutionModel, p_entry_point->spirv_execution_model);
     CHECKED_READU32(p_parser, p_node->word_offset + 2, p_entry_point->id);
 
@@ -3886,23 +3889,13 @@ static SpvReflectResult ParseExecutionModes(SpvReflectPrvParser* p_parser, SpvRe
           SpvReflectPrvNode* y_node = FindNode(p_parser, local_size_y_id);
           SpvReflectPrvNode* z_node = FindNode(p_parser, local_size_z_id);
           if (IsNotNull(x_node) && IsNotNull(y_node) && IsNotNull(z_node)) {
-            if (IsSpecConstant(x_node)) {
-              p_entry_point->local_size.x = (uint32_t)SPV_REFLECT_EXECUTION_MODE_SPEC_CONSTANT;
-            } else {
-              CHECKED_READU32(p_parser, x_node->word_offset + 3, p_entry_point->local_size.x);
-            }
+            CHECKED_READU32(p_parser, x_node->word_offset + 3, p_entry_point->local_size.x);
+            CHECKED_READU32(p_parser, y_node->word_offset + 3, p_entry_point->local_size.y);
+            CHECKED_READU32(p_parser, z_node->word_offset + 3, p_entry_point->local_size.z);
 
-            if (IsSpecConstant(y_node)) {
-              p_entry_point->local_size.y = (uint32_t)SPV_REFLECT_EXECUTION_MODE_SPEC_CONSTANT;
-            } else {
-              CHECKED_READU32(p_parser, y_node->word_offset + 3, p_entry_point->local_size.y);
-            }
-
-            if (IsSpecConstant(z_node)) {
-              p_entry_point->local_size.z = (uint32_t)SPV_REFLECT_EXECUTION_MODE_SPEC_CONSTANT;
-            } else {
-              CHECKED_READU32(p_parser, z_node->word_offset + 3, p_entry_point->local_size.z);
-            }
+            p_entry_point->local_size_spec_id[0] = IsSpecConstant(x_node) ? x_node->decorations.spec_id : (uint32_t)INVALID_VALUE;
+            p_entry_point->local_size_spec_id[1] = IsSpecConstant(y_node) ? y_node->decorations.spec_id : (uint32_t)INVALID_VALUE;
+            p_entry_point->local_size_spec_id[2] = IsSpecConstant(z_node) ? z_node->decorations.spec_id : (uint32_t)INVALID_VALUE;
           }
         } break;
 

--- a/thirdparty/spirv-reflect/spirv_reflect.h
+++ b/thirdparty/spirv-reflect/spirv_reflect.h
@@ -338,6 +338,11 @@ enum {
   SPV_REFLECT_SET_NUMBER_DONT_CHANGE            = ~0
 };
 
+// A field that holds this value has no data.
+enum {
+  SPV_REFLECT_INVALID_VALUE                     = 0xFFFFFFFF,
+};
+
 typedef struct SpvReflectNumericTraits {
   struct Scalar {
     uint32_t                        width;
@@ -555,11 +560,19 @@ typedef struct SpvReflectEntryPoint {
   uint32_t                          execution_mode_count;
   SpvExecutionMode*                 execution_modes;
 
+  // The workgroup size. If a specialization constant controls a dimension, that
+  // dimension has the default value of the constant. Thus this field is always a
+  // usable size. Read `local_size_spec_id` to find the dimensions that a
+  // specialization constant controls.
   struct LocalSize {
     uint32_t                        x;
     uint32_t                        y;
     uint32_t                        z;
   } local_size;
+  // The ID of the specialization constant that controls each dimension of
+  // `local_size`. A dimension that no constant controls has the value
+  // SPV_REFLECT_INVALID_VALUE.
+  uint32_t                          local_size_spec_id[3];
   uint32_t                          invocations; // valid for geometry
   uint32_t                          output_vertices; // valid for geometry, tesselation
 } SpvReflectEntryPoint;


### PR DESCRIPTION
## Summary

A compute shader can set its workgroup size with a specialization constant, for example `layout(local_size_x_id = 0) in;`. On the Metal backend, such a shader does nothing. The driver does not do the dispatch operation, and Godot does not report an error. The same shader operates correctly on Vulkan.

> [!IMPORTANT]
>
> Vulkan already works on 4.7, so this improves back-end support. D3D12 will require additional changes to rewrite the DXIL.

### SPIRV-Reflect

I made some minor improvements to `spirv_reflect.{h,c}` to separate spec id and the default value assigned to the local size, so that it can be used by Godot reflection. The default value and spec IDs for local workgroup sizes are now persisted so it can be used by downstream drivers like D3D12 and Metal.

## MRP

[mrp_compute_local_size_spec_constant.zip](https://github.com/user-attachments/files/30678293/mrp_compute_local_size_spec_constant.zip)

### 4.7

#### Metal

```nushell
godot --rendering-driver metal --quit
```

<details>
<summary> OUTPUT </summary>

```
Godot Engine v4.7.stable.official.5b4e0cb0f - https://godotengine.org
Metal 4.0 - Forward+ - Using Device #0: Apple - Apple M4 Max (Apple9)

Rendering driver: metal
Device: Apple M4 Max (Apple9)

--- literal local_size_x = 64 ---
  dispatched 2 groups
  invocations that ran: 128  -> launch size 64
  gl_WorkGroupSize.x seen by shader: 64
  PASS - launch size and gl_WorkGroupSize both 64

--- local_size_x_id = 0, default 64 ---
  dispatched 2 groups
  invocations that ran: 0  -> launch size 0
  gl_WorkGroupSize.x seen by shader: <nothing ran>
  FAIL - dispatch produced no writes at all, and no error was reported

--- local_size_x_id = 0, specialized to 32 ---
  dispatched 2 groups
  invocations that ran: 0  -> launch size 0
  gl_WorkGroupSize.x seen by shader: <nothing ran>
  FAIL - dispatch produced no writes at all, and no error was reported

--- local_size_x_id = 0, specialized to 16 ---
  dispatched 2 groups
  invocations that ran: 0  -> launch size 0
  gl_WorkGroupSize.x seen by shader: <nothing ran>
  FAIL - dispatch produced no writes at all, and no error was reported
```

</details>

#### Vulkan

```nushell
godot --rendering-driver vulkan --quit
```

<details>
<summary> OUTPUT </summary>

```
Godot Engine v4.7.stable.official.5b4e0cb0f - https://godotengine.org
Vulkan 1.2.334 - Forward+ - Using Device #0: Apple - Apple M4 Max

Rendering driver: vulkan
Device: Apple M4 Max

--- literal local_size_x = 64 ---
  dispatched 2 groups
  invocations that ran: 128  -> launch size 64
  gl_WorkGroupSize.x seen by shader: 64
  PASS - launch size and gl_WorkGroupSize both 64

--- local_size_x_id = 0, default 64 ---
OpSpecConstantComposite is not supported yet.
  dispatched 2 groups
  invocations that ran: 128  -> launch size 64
  gl_WorkGroupSize.x seen by shader: 64
  PASS - launch size and gl_WorkGroupSize both 64

--- local_size_x_id = 0, specialized to 32 ---
OpSpecConstantComposite is not supported yet.
  dispatched 2 groups
  invocations that ran: 64  -> launch size 32
  gl_WorkGroupSize.x seen by shader: 32
  PASS - launch size and gl_WorkGroupSize both 32

--- local_size_x_id = 0, specialized to 16 ---
OpSpecConstantComposite is not supported yet.
  dispatched 2 groups
  invocations that ran: 32  -> launch size 16
  gl_WorkGroupSize.x seen by shader: 16
  PASS - launch size and gl_WorkGroupSize both 16
```

</details>

### 4.8.dev

#### Metal

```nushell
godot --rendering-driver metal --quit
```

<details>
<summary> OUTPUT </summary>

```
Godot Engine v4.8.dev.custom_build.eda2a482e (2026-07-31 17:44:29 UTC) - https://godotengine.org
Metal 4.0 - Forward+ - Using Device #0: Apple - Apple M4 Max (Apple9)

Rendering driver: metal
Device: Apple M4 Max (Apple9)

--- literal local_size_x = 64 ---
  dispatched 2 groups
  invocations that ran: 128  -> launch size 64
  gl_WorkGroupSize.x seen by shader: 64
  PASS - launch size and gl_WorkGroupSize both 64

--- local_size_x_id = 0, default 64 ---
  dispatched 2 groups
  invocations that ran: 128  -> launch size 64
  gl_WorkGroupSize.x seen by shader: 64
  PASS - launch size and gl_WorkGroupSize both 64

--- local_size_x_id = 0, specialized to 32 ---
  dispatched 2 groups
  invocations that ran: 64  -> launch size 32
  gl_WorkGroupSize.x seen by shader: 32
  PASS - launch size and gl_WorkGroupSize both 32

--- local_size_x_id = 0, specialized to 16 ---
  dispatched 2 groups
  invocations that ran: 32  -> launch size 16
  gl_WorkGroupSize.x seen by shader: 16
  PASS - launch size and gl_WorkGroupSize both 16
```

</details>

## 🤖 AI Disclosure

The MRP was generated by AI; and I used it to validate the fix. The fix was developed and tested by me.
