### PR TITLE
Tweak reference to GodotPhysics3D being the default physics engine

### DIFF
--- a/doc/classes/HeightMapShape3D.xml
+++ b/doc/classes/HeightMapShape3D.xml
@@ -6,7 +6,7 @@
 	<description>
 		A 3D heightmap shape, intended for use in physics to provide a shape for a [CollisionShape3D]. This type is most commonly used for terrain with vertices placed in a fixed-width grid.
 		The heightmap is represented as a 2D grid of height values, which represent the position of grid points on the Y axis. Grid points are spaced 1 unit apart on the X and Z axes, and the grid is centered on the origin of the [CollisionShape3D] node. Internally, each grid square is divided into two triangles.
-		Due to the nature of the heightmap, it cannot be used to model overhangs or caves, which would require multiple vertices at the same vertical location. Holes can be punched through the collision by assigning [constant @GDScript.NAN] to the height of the desired vertices (this is supported in both GodotPhysics3D and Jolt Physics). You could then insert meshes with their own separate collision to provide overhangs, caves, and so on.
+		Due to the nature of the heightmap, it cannot be used to model overhangs or caves, which would require multiple vertices at the same vertical location. Holes can be punched through the collision by assigning [constant @GDScript.NAN] to the height of the desired vertices. You could then insert meshes with their own separate collision to provide overhangs, caves, and so on.
 		[b]Performance:[/b] [HeightMapShape3D] is faster to check collisions against than [ConcavePolygonShape3D], but it is significantly slower than primitive shapes like [BoxShape3D].
 		A heightmap collision shape can also be built by using an [Image] reference:
 		[codeblocks]

--- a/doc/classes/SoftBody3D.xml
+++ b/doc/classes/SoftBody3D.xml
@@ -6,7 +6,7 @@
 	<description>
 		A deformable 3D physics mesh. Used to create elastic or deformable objects such as cloth, rubber, or other flexible materials.
 		Additionally, [SoftBody3D] is subject to wind forces defined in [Area3D] (see [member Area3D.wind_source_path], [member Area3D.wind_force_magnitude], and [member Area3D.wind_attenuation_factor]).
-		[b]Note:[/b] It's recommended to use Jolt Physics when using [SoftBody3D] instead of the default GodotPhysics3D, as Jolt Physics' soft body implementation is faster and more reliable. You can switch the physics engine using the [member ProjectSettings.physics/3d/physics_engine] project setting.
+		[b]Note:[/b] It's recommended to use Jolt Physics when using [SoftBody3D] instead of GodotPhysics3D, as Jolt Physics' soft body implementation is faster and more reliable. Jolt Physics is the default for projects created with Godot 4.6 or later. For projects created with older Godot versions, you can switch the physics engine using the [member ProjectSettings.physics/3d/physics_engine] project setting.
 	</description>
 	<tutorials>
 		<link title="SoftBody">$DOCS_URL/tutorials/physics/soft_body.html</link>


### PR DESCRIPTION
This is technically still the case, but projects created with Godot 4.6 or later automatically switch to Jolt Physics.

This also removes a redundant note in the HeightMapShape documentation since all physics engines bundled in Godot support holes in heightmaps.

- This closes https://github.com/godotengine/godot-docs/issues/12120.
