### PR TITLE
[Wayland] Fix submenus refusing to open on Wayland

### DIFF
--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -4499,16 +4499,16 @@ void WaylandThread::window_create_popup(DisplayServerEnums::WindowID p_window_id
 	ERR_FAIL_NULL(parent_xdg_surface);
 
 	// Popups without an explicit xdg_popup grab are dismissed (at least by Gnome-Mutter)
-	// as soon as the cursor isnt over any surface belonging to the popups tree.
+	// as soon as the cursor isn't over any surface belonging to the popups tree.
 	//
-	// Submenus are sometimes positioned so it just about touches its parents edge with 
-	// a 1 pixel gap between the two surfaces (look at panel margin/content scale rounding 
-	// upstream) and the cursor crossing that gap while moving from the parent item 
-	// towards the submenu is enough to trigger this -> making the submenu flash and 
-	// close immediately. 
+	// Submenus are sometimes positioned so it just about touches its parents edge with
+	// a 1 pixel gap between the two surfaces (look at panel margin/content scale rounding
+	// upstream) and the cursor crossing that gap while moving from the parent item
+	// towards the submenu is enough to trigger this -> making the submenu flash and
+	// close immediately.
 	//
 	// We know the popup is meant to be adjacent to its parent along a given axis.
-	// Whenever the offset places it right at or just past the parents edge, we can clamp 
+	// Whenever the offset places it right at or just past the parents edge, we can clamp
 	// away small gaps like this so the two surfaces always touch or slightly overlap.
 	constexpr int32_t POPUP_ADJACENCY_GAP_FIX_PX = 4;
 	if (offset.x > 0 && offset.x - positioner_rect.size.width >= 0 && offset.x - positioner_rect.size.width <= POPUP_ADJACENCY_GAP_FIX_PX) {

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -4498,6 +4498,30 @@ void WaylandThread::window_create_popup(DisplayServerEnums::WindowID p_window_id
 
 	ERR_FAIL_NULL(parent_xdg_surface);
 
+	// Popups without an explicit xdg_popup grab are dismissed (at least by Gnome-Mutter)
+	// as soon as the cursor isnt over any surface belonging to the popups tree.
+	//
+	// Submenus are sometimes positioned so it just about touches its parents edge with 
+	// a 1 pixel gap between the two surfaces (look at panel margin/content scale rounding 
+	// upstream) and the cursor crossing that gap while moving from the parent item 
+	// towards the submenu is enough to trigger this -> making the submenu flash and 
+	// close immediately. 
+	//
+	// We know the popup is meant to be adjacent to its parent along a given axis.
+	// Whenever the offset places it right at or just past the parents edge, we can clamp 
+	// away small gaps like this so the two surfaces always touch or slightly overlap.
+	constexpr int32_t POPUP_ADJACENCY_GAP_FIX_PX = 4;
+	if (offset.x > 0 && offset.x - positioner_rect.size.width >= 0 && offset.x - positioner_rect.size.width <= POPUP_ADJACENCY_GAP_FIX_PX) {
+		offset.x = positioner_rect.size.width;
+	} else if (offset.x < 0 && offset.x + ws.rect.size.width <= 0 && offset.x + ws.rect.size.width >= -POPUP_ADJACENCY_GAP_FIX_PX) {
+		offset.x = -ws.rect.size.width;
+	}
+	if (offset.y > 0 && offset.y - positioner_rect.size.height >= 0 && offset.y - positioner_rect.size.height <= POPUP_ADJACENCY_GAP_FIX_PX) {
+		offset.y = positioner_rect.size.height;
+	} else if (offset.y < 0 && offset.y + ws.rect.size.height <= 0 && offset.y + ws.rect.size.height >= -POPUP_ADJACENCY_GAP_FIX_PX) {
+		offset.y = -ws.rect.size.height;
+	}
+
 	struct xdg_positioner *xdg_positioner = xdg_wm_base_create_positioner(registry.xdg_wm_base);
 	xdg_positioner_set_size(xdg_positioner, ws.rect.size.width, ws.rect.size.height);
 	xdg_positioner_set_anchor(xdg_positioner, XDG_POSITIONER_ANCHOR_TOP_LEFT);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #121897

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

### Summary

Under the Wayland display driver, context menus with submenus (e.g. editor filesystem context menu item "Create New" submenu and cascading menu bar dropdowns) would sometimes refuse/fail to display when hovered. This did not reproduce under X11 or XWayland.

### Cause

Wayland popups are implemented as plain `xdg_popup` without an explicit `xdg_popup_grab`. The xdg-shell protocol describes that compositor is free to close such an "ungrabbed" popup when pointer is not over surface belonging to that popups own surface tree.

Submenus were sometimes positioned with a 1px gap between themselves and their parent menu (coming from panel margin/content-scale rounding upstream in GUI positioning logic).  When the pointer moved from the parent menu item toward the submenu, it would cross that 1px gap and compositors like Mutter would interpret this as the pointer leaving the popup and immediately send `xdg_popup.done`, closing the submenu immidiately again.

This was confirmed with `WAYLAND_DEBUG=1` protocol traces: every submenu positioned with a 1px gap relative to its parent was dismissed by the compositor within about ~25ms. All submenus that touched or overlapped its parent with no gap werent affected.

### Fix

In `WaylandThread::window_create_popup`: Clamp small gaps (currently <=4px) between a popup and its parent along the axis where they"re meant to be adjacent so the two surfaces always touch or slightly overlap. Pointer therfor never exits the sufrace tree.

### Test

Verified live against a real GNOME/Mutter Wayland session (Fedora Worktation 44, nvidia GPU) using `WAYLAND_DEBUG=1` protocol logging:

- **Before fix:** 11/11 submenus positioned with a 1px gap were closed by Mutter shortly after opening
- **After fix:** 0/18 popups were closed with equivalent test scenario

Manually reproduced and confirmed fixed:
- File System context menu "Create New" item submenu
- Cascading menu bar dropdown submenus like the viewports "View/Gizmos".

### Notes for reviewers

This addresses the symptom by guaranteeing pixellevel adjacency, which should be okay since the popups dont use `xdg_popup_grab`. It does not change the underlying panel-margin/scale logik that produces the occasional 1px gap in the first place, nor does it refactor menu popups to use the protocol grab-based model. Both should be considered as followups but I would consider them out of scope for this fix.

### AI Disclosure

An LLM was used during development of this PR in following areas/stages:

- Discovering relevant logic in the codebase
- Setting up some tests within local environment 
  - i.e. setting up protocol debug logging 
- A few sanity-checks along the way to check if what I was doing might conflict in other areas
- Checking for obvious bugs in the fix
- Rephrasing some parts of this PRs description
  - Also checked if PR contained any major problems / if the description is actually descriptive and relevant. Helped cut out irrelevant info. 