### PR TITLE
Fix unconditional logging of haptic engine vibration errors on iOS

### DIFF
--- a/drivers/apple_embedded/apple_embedded.mm
+++ b/drivers/apple_embedded/apple_embedded.mm
@@ -106,12 +106,22 @@ void AppleEmbedded::vibrate_haptic_engine(float p_duration_seconds, float p_ampl
 					};
 				}
 
-				NSError *error;
+				NSError *error = nil;
 				CHHapticPattern *pattern = [[CHHapticPattern alloc] initWithDictionary:hapticDict error:&error];
-
-				[[cur_haptic_engine createPlayerWithPattern:pattern error:&error] startAtTime:0 error:&error];
-
-				NSLog(@"Could not vibrate using haptic engine: %@", error);
+				if (error) {
+					NSLog(@"Could not vibrate using haptic engine: %@", error);
+					return;
+				}
+				id player = [cur_haptic_engine createPlayerWithPattern:pattern error:&error];
+				if (error) {
+					NSLog(@"Could not vibrate using haptic engine: %@", error);
+					return;
+				}
+				[player startAtTime:0 error:&error];
+				if (error) {
+					NSLog(@"Could not vibrate using haptic engine: %@", error);
+					return;
+				}
 			}
 
 			return;


### PR DESCRIPTION

Solves #121614 

Brief summary : Error log for haptic vibration error on iPhone triggers even when haptic vibration does work, this PR resolves it.

I have tested the issue with MRP on demo project using `Input.vibrate_handheld()` in `func _ready():` 

The original thought of code is not mine, It is taken from #121590 
However, I have tested it and the log appears because of non-existent conditional statement which will trigger log in every case and after adding the condition, haptic logs work as expected


The issue appears a little harmless, but can make confusion to why the logs are saying haptic error when the actual haptics does work.

- *Bugsquad edit:* fixes #121614 