### PR TITLE
Docs: Replace "Note:" and "Warning:" blocks with admonitions in RST files

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -2512,6 +2512,12 @@ def format_text_block(
             state,
         )
 
+    # Backwards compatibility for admonition blocks.
+    text = re.sub(r"\\ \*\*Note:\*\* (.*)", ".. classref_note::\n\n    \\1\n", text)
+    text = re.sub(r"\\ \*\*Warning:\*\* (.*)", ".. classref_warning::\n\n    \\1\n", text)
+    text = re.sub(r"\\ \*\*Tip:\*\* (.*)", ".. classref_tip::\n\n    \\1\n", text)
+    text = re.sub(r"\\ \*\*Important:\*\* (.*)", ".. classref_important::\n\n    \\1\n", text)
+
     return text
 
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

I thought I'd remembered writing a proposal for this some time ago, but couldn't find it tonight (or another proposal that matches it). If need be I can write a proposal for it soon, to go alongside this PR.

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

This PR adds an extra processing step to the conversion from the XML class reference files to RST documents, so that `[b]Note:[/b]` and `[b]Warning:[/b]` blocks are now placed in admonition blocks (`[note]`, `[warning]`, etc). These help them stand out more to readers (especially important for warnings).

| Before | After |
| ------- | ------ |
| <img width="834" height="602" alt="CleanShot 2026-08-03 at 22 05 04@2x" src="https://github.com/user-attachments/assets/04c1c009-6aae-47bd-8f13-bac1de2ba982" /> | <img width="842" height="577" alt="CleanShot 2026-08-05 at 09 21 48@2x" src="https://github.com/user-attachments/assets/f592d277-158d-4157-b163-61967ba7e45d" /> |


Note that localization is not currently supported; as you can see in the PR changes, the strings "Note:" and "Warning:" are hardcoded. I don't think that this should _break_ anything in localized versions - they should just appear the same as before. But for this to support localized versions of the class reference, we'll need to find the corresponding strings in each language and replace them in the regex pattern here.
