### PR TITLE
[POC] GDScript: Add inline cache for function calls

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -957,6 +957,13 @@ Variant Object::call_const(const StringName &p_method, const Variant **p_args, i
 	return method->call(this, p_args, p_argcount, r_error);
 }
 
+Variant::VariantCacheFunctionCall Object::lookup_function_call(const StringName &p_method_name) {
+	if (script_instance != nullptr) {
+		return script_instance->lookup_function_call(p_method_name);
+	}
+	return Variant::VariantCacheFunctionCall();
+}
+
 void Object::_gdvirtual_init_method_ptr(uint32_t p_compat_hash, void *&r_fn_ptr, const StringName &p_fn_name, bool p_compat) const {
 	void *fn_ptr = nullptr;
 	if (_extension->get_virtual_call_data2 && _extension->call_virtual_with_data) {

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -957,11 +957,40 @@ Variant Object::call_const(const StringName &p_method, const Variant **p_args, i
 	return method->call(this, p_args, p_argcount, r_error);
 }
 
-Variant::VariantCacheFunctionCall Object::lookup_function_call(const StringName &p_method_name) {
-	if (script_instance != nullptr) {
-		return script_instance->lookup_function_call(p_method_name);
+VariantCallCache Object::lookup_function_call(const StringName &p_method_name, Callable::CallError::Error &p_error) {
+	VariantCallCache ret;
+	if (p_method_name == CoreStringName(free_)) {
+		// REVIEW: how to not cache free
+		p_error = Callable::CallError::CALL_OK;
+		return ret;
 	}
-	return Variant::VariantCacheFunctionCall();
+	if (script_instance != nullptr) {
+		ret = script_instance->lookup_function_call(p_method_name, p_error);
+
+		switch (p_error) {
+			case Callable::CallError::CALL_OK:
+				return ret;
+			case Callable::CallError::CALL_ERROR_INVALID_METHOD:
+				break;
+			case Callable::CallError::CALL_ERROR_INVALID_ARGUMENT:
+			case Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS:
+			case Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS:
+			case Callable::CallError::CALL_ERROR_METHOD_NOT_CONST:
+				return ret;
+			case Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL: {
+			}
+		}
+	}
+
+	const GDType::Member *member = get_gdtype().members().getptr(p_method_name);
+	if (!member || member->type != GDType::Member::Type::METHOD) {
+		p_error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+		return VariantCallCache();
+	}
+
+	ret = member->payload.method;
+	p_error = Callable::CallError::CALL_OK;
+	return ret;
 }
 
 void Object::_gdvirtual_init_method_ptr(uint32_t p_compat_hash, void *&r_fn_ptr, const StringName &p_fn_name, bool p_compat) const {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -721,6 +721,9 @@ public:
 		return (cerr.error == Callable::CallError::CALL_OK) ? ret : Variant();
 	}
 
+	// Caching
+	virtual Variant::VariantCacheFunctionCall lookup_function_call(const StringName &p_method_name);
+
 	// Depending on the boolean, we call either the virtual function _notification_backward or _notification_forward.
 	// - Forward calls subclasses in descending order (e.g. Object -> Node -> Node3D -> extension -> script).
 	//   Backward calls subclasses in descending order (e.g. script -> extension -> Node3D -> Node -> Object).

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -721,8 +721,7 @@ public:
 		return (cerr.error == Callable::CallError::CALL_OK) ? ret : Variant();
 	}
 
-	// Caching
-	virtual Variant::VariantCacheFunctionCall lookup_function_call(const StringName &p_method_name);
+	virtual VariantCallCache lookup_function_call(const StringName &p_method_name, Callable::CallError::Error &p_error);
 
 	// Depending on the boolean, we call either the virtual function _notification_backward or _notification_forward.
 	// - Forward calls subclasses in descending order (e.g. Object -> Node -> Node3D -> extension -> script).

--- a/core/object/script_instance.cpp
+++ b/core/object/script_instance.cpp
@@ -58,6 +58,10 @@ Variant ScriptInstance::call_const(const StringName &p_method, const Variant **p
 	return callp(p_method, p_args, p_argcount, r_error);
 }
 
+Variant::VariantCacheFunctionCall ScriptInstance::lookup_function_call(const StringName &p_method_name) {
+	return Variant::VariantCacheFunctionCall();
+}
+
 void ScriptInstance::get_property_state(List<Pair<StringName, Variant>> &r_state) {
 	List<PropertyInfo> pinfo;
 	get_property_list(&pinfo);

--- a/core/object/script_instance.cpp
+++ b/core/object/script_instance.cpp
@@ -58,8 +58,9 @@ Variant ScriptInstance::call_const(const StringName &p_method, const Variant **p
 	return callp(p_method, p_args, p_argcount, r_error);
 }
 
-Variant::VariantCacheFunctionCall ScriptInstance::lookup_function_call(const StringName &p_method_name) {
-	return Variant::VariantCacheFunctionCall();
+VariantCallCache ScriptInstance::lookup_function_call(const StringName &p_method_name, Callable::CallError::Error &p_error) {
+	p_error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+	return VariantCallCache();
 }
 
 void ScriptInstance::get_property_state(List<Pair<StringName, Variant>> &r_state) {

--- a/core/object/script_instance.h
+++ b/core/object/script_instance.h
@@ -36,6 +36,9 @@ class Script;
 class ScriptLanguage;
 
 class ScriptInstance {
+protected:
+	Script *script_raw = nullptr;
+
 public:
 	virtual bool set(const StringName &p_name, const Variant &p_value) = 0;
 	virtual bool get(const StringName &p_name, Variant &r_ret) const = 0;
@@ -84,6 +87,7 @@ public:
 	virtual bool refcount_decremented() { return true; } //return true if it can die
 
 	virtual Ref<Script> get_script() const = 0;
+	_ALWAYS_INLINE_ const Script *get_script_raw() const { return script_raw; }
 
 	virtual bool is_placeholder() const { return false; }
 

--- a/core/object/script_instance.h
+++ b/core/object/script_instance.h
@@ -36,9 +36,6 @@ class Script;
 class ScriptLanguage;
 
 class ScriptInstance {
-protected:
-	Script *script_raw = nullptr;
-
 public:
 	virtual bool set(const StringName &p_name, const Variant &p_value) = 0;
 	virtual bool get(const StringName &p_name, Variant &r_ret) const = 0;
@@ -71,6 +68,9 @@ public:
 	}
 
 	virtual Variant call_const(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error); // implement if language supports const functions
+
+	virtual Variant::VariantCacheFunctionCall lookup_function_call(const StringName &p_method_name);
+
 	virtual void notification(int p_notification, bool p_reversed = false) = 0;
 	virtual String to_string(bool *r_valid) {
 		if (r_valid) {
@@ -87,7 +87,7 @@ public:
 	virtual bool refcount_decremented() { return true; } //return true if it can die
 
 	virtual Ref<Script> get_script() const = 0;
-	_ALWAYS_INLINE_ const Script *get_script_raw() const { return script_raw; }
+	virtual bool script_eq(const Ref<Script> &p_script) const = 0;
 
 	virtual bool is_placeholder() const { return false; }
 

--- a/core/object/script_instance.h
+++ b/core/object/script_instance.h
@@ -69,7 +69,7 @@ public:
 
 	virtual Variant call_const(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error); // implement if language supports const functions
 
-	virtual Variant::VariantCacheFunctionCall lookup_function_call(const StringName &p_method_name);
+	virtual VariantCallCache lookup_function_call(const StringName &p_method_name, Callable::CallError::Error &p_error);
 
 	virtual void notification(int p_notification, bool p_reversed = false) = 0;
 	virtual String to_string(bool *r_valid) {

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -210,6 +210,15 @@ void Script::reload_from_file() {
 #endif
 }
 
+void *Script::lookup_method(const StringName &p_method) const {
+	// Do not use inline cache if not supported type.
+	return nullptr;
+}
+
+void Script::call_method(Variant &p_base, void *p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) const {
+	ERR_FAIL_MSG("UNSUPPORTED CALL");
+}
+
 void ScriptServer::set_scripting_enabled(bool p_enabled) {
 	scripting_enabled = p_enabled;
 }

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -210,15 +210,6 @@ void Script::reload_from_file() {
 #endif
 }
 
-void *Script::lookup_method(const StringName &p_method) const {
-	// Do not use inline cache if not supported type.
-	return nullptr;
-}
-
-void Script::call_method(Variant &p_base, void *p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) const {
-	ERR_FAIL_MSG("UNSUPPORTED CALL");
-}
-
 void ScriptServer::set_scripting_enabled(bool p_enabled) {
 	scripting_enabled = p_enabled;
 }

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -176,6 +176,10 @@ public:
 
 	virtual MethodInfo get_method_info(const StringName &p_method) const = 0;
 
+	// For inline caching
+	virtual void *lookup_method(const StringName &p_method) const;
+	virtual void call_method(Variant &p_base, void *p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) const;
+
 	virtual bool is_tool() const = 0;
 	virtual bool is_script_valid() const = 0;
 	virtual bool is_abstract() const = 0;

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -176,10 +176,6 @@ public:
 
 	virtual MethodInfo get_method_info(const StringName &p_method) const = 0;
 
-	// For inline caching
-	virtual void *lookup_method(const StringName &p_method) const;
-	virtual void call_method(Variant &p_base, void *p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) const;
-
 	virtual bool is_tool() const = 0;
 	virtual bool is_script_valid() const = 0;
 	virtual bool is_abstract() const = 0;
@@ -449,6 +445,7 @@ public:
 	virtual void notification(int p_notification, bool p_reversed = false) override {}
 
 	virtual Ref<Script> get_script() const override { return script; }
+	virtual bool script_eq(const Ref<Script> &p_script) const override { return *script == *p_script; }
 
 	virtual ScriptLanguage *get_language() override { return language; }
 

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -989,6 +989,14 @@ public:
 		return Ref<Script>();
 	}
 
+	virtual bool script_eq(const Ref<Script> &p_script) const override {
+		if (native_info->get_script_func) {
+			GDExtensionObjectPtr script = native_info->get_script_func(instance);
+			return *p_script == reinterpret_cast<Script *>(script);
+		}
+		return false;
+	}
+
 	virtual bool is_placeholder() const override {
 		if (native_info->is_placeholder_func) {
 			return native_info->is_placeholder_func(instance);

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -63,6 +63,8 @@
 #include "core/variant/dictionary.h"
 #include "core/variant/variant_deep_duplicate.h"
 
+#include <functional>
+
 class GDType;
 class Object;
 class RefCounted;
@@ -819,6 +821,11 @@ public:
 
 	static void get_utility_function_list(List<StringName> *r_functions);
 	static int get_utility_function_count();
+
+	// For caching function calls
+	// typedef Variant (*VariantCacheFunctionCall)(Variant *, const Variant **, int, Callable::CallError &);
+	typedef std::function<Variant(Variant *, const Variant **, int, Callable::CallError &)> VariantCacheFunctionCall;
+	VariantCacheFunctionCall lookup_function_call(const StringName &p_method_name);
 
 	[[nodiscard]] bool operator==(const Variant &p_variant) const;
 	[[nodiscard]] bool operator<(const Variant &p_variant) const;

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -61,9 +61,8 @@
 #include "core/variant/array.h"
 #include "core/variant/callable.h"
 #include "core/variant/dictionary.h"
+#include "core/variant/variant_cache.h"
 #include "core/variant/variant_deep_duplicate.h"
-
-#include <functional>
 
 class GDType;
 class Object;
@@ -823,9 +822,7 @@ public:
 	static int get_utility_function_count();
 
 	// For caching function calls
-	// typedef Variant (*VariantCacheFunctionCall)(Variant *, const Variant **, int, Callable::CallError &);
-	typedef std::function<Variant(Variant *, const Variant **, int, Callable::CallError &)> VariantCacheFunctionCall;
-	VariantCacheFunctionCall lookup_function_call(const StringName &p_method_name);
+	VariantCallCache lookup_function_call(const StringName &p_method_name, Callable::CallError::Error &p_error);
 
 	[[nodiscard]] bool operator==(const Variant &p_variant) const;
 	[[nodiscard]] bool operator<(const Variant &p_variant) const;

--- a/core/variant/variant_cache.cpp
+++ b/core/variant/variant_cache.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  inline_cache.cpp                                                      */
+/*  variant_cache.cpp                                                     */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,43 +28,13 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "inline_cache.h"
-
-#include "core/debugger/engine_debugger.h"
 #include "core/object/object.h"
-#include "core/os/memory.h"
-#include "core/variant/variant_internal.h"
+#include "core/variant/variant.h"
 
-void FunctionInlineCache::load(Variant &p_base, const StringName &p_method) {
-	Variant::VariantCacheFunctionCall found = p_base.lookup_function_call(p_method);
-	if (found) {
-		// There is a chance another thread already updated while we looked up the function.
-		if (state == CacheState::UNINITIALIZED) {
-			state = CacheState::INITIALIZING;
-			fn = std::move(found);
-			type = get_type(p_base);
-			if (p_base.get_type() == Variant::OBJECT) {
-				Object *obj = *VariantInternal::get_object(&p_base);
-
-				const ScriptInstance *si = obj->get_script_instance();
-				if (si) {
-					script = si->get_script();
-					is_static = false;
-				} else {
-					script = Object::cast_to<Script>(obj);
-					DEV_ASSERT(script.is_valid());
-					is_static = true;
-				}
-			}
-			state = CacheState::MONOMORPHIC;
-		}
-	} else {
-		state = CacheState::DISABLED;
+Variant::VariantCacheFunctionCall Variant::lookup_function_call(const StringName &p_method_name) {
+	// Currently only supports objects
+	if (type == OBJECT) {
+		return _get_obj().obj->lookup_function_call(p_method_name);
 	}
-}
-
-void FunctionInlineCache::reset() {
-	script = nullptr;
-	fn = nullptr;
-	state = CacheState::UNINITIALIZED;
+	return Variant::VariantCacheFunctionCall();
 }

--- a/core/variant/variant_cache.h
+++ b/core/variant/variant_cache.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  variant_cache.cpp                                                     */
+/*  variant_cache.h                                                       */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,13 +28,37 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#include "core/object/object.h"
-#include "core/variant/variant.h"
+#pragma once
 
-Variant::VariantCacheFunctionCall Variant::lookup_function_call(const StringName &p_method_name) {
-	// Currently only supports objects
-	if (type == OBJECT) {
-		return _get_obj().obj->lookup_function_call(p_method_name);
-	}
-	return Variant::VariantCacheFunctionCall();
-}
+class GDScriptFunction;
+class MethodBind;
+
+struct VariantCallCache {
+	enum class Type {
+		INVALID,
+		GDSCRIPT_FUNCTION,
+		METHOD_BIND,
+		VARIANT_BUILTIN_METHOD,
+	};
+
+	Type type;
+
+	struct VariantBuiltInMethod {
+		void (*call)(Variant *, const Variant **, int, Variant &, const Vector<Variant> &, Callable::CallError &);
+		const Vector<Variant> *default_values;
+	};
+
+	union {
+		GDScriptFunction *gdscript_function;
+		const MethodBind *method_bind;
+		VariantBuiltInMethod variant_builtin_method;
+	};
+
+	VariantCallCache() : type(Type::INVALID) {}
+	VariantCallCache(GDScriptFunction *p_gdscript_function) : type(Type::GDSCRIPT_FUNCTION), gdscript_function(p_gdscript_function) {}
+	VariantCallCache(const MethodBind *p_method_bind) : type(Type::METHOD_BIND), method_bind(p_method_bind) {}
+	VariantCallCache(
+			void (*p_call)(Variant *, const Variant **, int, Variant &, const Vector<Variant> &, Callable::CallError &),
+			const Vector<Variant> *p_default_values) :
+			type(Type::VARIANT_BUILTIN_METHOD), variant_builtin_method{ p_call, p_default_values } {}
+};

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1473,6 +1473,32 @@ void Variant::call_static(Variant::Type p_type, const StringName &p_method, cons
 	imf->call(nullptr, p_args, p_argcount, r_ret, imf->default_arguments, r_error);
 }
 
+VariantCallCache Variant::lookup_function_call(const StringName &p_method_name, Callable::CallError::Error &p_error) {
+	if (type == OBJECT) {
+		Object *obj = _get_obj().obj;
+		if (!obj) {
+			p_error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			return VariantCallCache();
+		}
+#ifdef DEBUG_ENABLED
+		if (EngineDebugger::is_active() && !_get_obj().id.is_ref_counted() && ObjectDB::get_instance(_get_obj().id) == nullptr) {
+			p_error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+			return VariantCallCache();
+		}
+#endif // DEBUG ENABLED
+		return _get_obj().obj->lookup_function_call(p_method_name, p_error);
+	}
+	// Else
+	const VariantBuiltInMethodInfo *imf = builtin_method_info[type].getptr(p_method_name);
+
+	if (imf != nullptr) {
+		p_error = Callable::CallError::CALL_OK;
+		return VariantCallCache(imf->call, &imf->default_arguments);
+	}
+	p_error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+	return VariantCallCache();
+}
+
 bool Variant::has_method(const StringName &p_method) const {
 	if (type == OBJECT) {
 		Object *obj = get_validated_object();

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -158,7 +158,6 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 	GDScriptInstance *instance = memnew(GDScriptInstance);
 	instance->members.resize(member_indices.size());
 	instance->script = Ref<GDScript>(this);
-	instance->script_raw = this;
 	instance->owner = p_owner;
 	instance->owner_id = p_owner->get_instance_id();
 	instance->owner->set_script_instance(instance);
@@ -173,7 +172,6 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 	if (r_error.error != Callable::CallError::CALL_OK) {
 		String error_text = Variant::get_call_error_text(instance->owner, "@implicit_new", nullptr, 0, r_error);
 		instance->script = Ref<GDScript>();
-		instance->script_raw = nullptr;
 		instance->owner->set_script_instance(nullptr);
 		{
 			MutexLock lock(GDScriptLanguage::singleton->mutex);
@@ -192,7 +190,6 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 		if (r_error.error != Callable::CallError::CALL_OK) {
 			String error_text = Variant::get_call_error_text(instance->owner, "_init", p_args, p_argcount, r_error);
 			instance->script = Ref<GDScript>();
-			instance->script_raw = nullptr;
 			instance->owner->set_script_instance(nullptr);
 			{
 				MutexLock lock(GDScriptLanguage::singleton->mutex);
@@ -392,35 +389,6 @@ MethodInfo GDScript::get_method_info(const StringName &p_method) const {
 	}
 
 	return E->value->get_method_info();
-}
-
-void *GDScript::lookup_method(const StringName &p_method) const {
-	if (unlikely(p_method == SceneStringName(_ready))) {
-		// Call implicit ready first, including for the super classes recursively.
-		return nullptr;
-	}
-	GDScript *sptr = const_cast<GDScript *>(this);
-	while (sptr) {
-		if (likely(sptr->valid)) {
-			HashMap<StringName, GDScriptFunction *>::Iterator E = sptr->member_functions.find(p_method);
-			if (E) {
-				return E->value;
-			}
-		}
-		sptr = sptr->base.ptr();
-	}
-
-	return nullptr;
-}
-
-void GDScript::call_method(Variant &p_base, void *p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) const {
-	Object *obj = *VariantInternal::get_object(&p_base);
-	GDScriptInstance *instance = static_cast<GDScriptInstance *>(obj->get_script_instance());
-	if (r_ret != nullptr) {
-		*r_ret = static_cast<GDScriptFunction *>(p_method)->call(instance, p_args, p_argcount, r_error);
-	} else {
-		static_cast<GDScriptFunction *>(p_method)->call(instance, p_args, p_argcount, r_error);
-	}
 }
 
 bool GDScript::get_property_default_value(const StringName &p_property, Variant &r_value) const {
@@ -995,6 +963,21 @@ Variant GDScript::callp(const StringName &p_method, const Variant **p_args, int 
 
 	r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
 	return Variant();
+}
+
+Variant::VariantCacheFunctionCall GDScript::lookup_function_call(const StringName &p_method) {
+	GDScript *top = this;
+	while (top) {
+		if (likely(top->valid)) {
+			HashMap<StringName, GDScriptFunction *>::Iterator E = top->member_functions.find(p_method);
+			if (E) {
+				// TODO: add static call check
+				return std::bind(&GDScriptFunction::call_for_variant_cache, E->value, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
+			}
+		}
+		top = top->base.ptr();
+	}
+	return Variant::VariantCacheFunctionCall();
 }
 
 bool GDScript::_get(const StringName &p_name, Variant &r_ret) const {
@@ -1998,6 +1981,25 @@ Variant GDScriptInstance::callp(const StringName &p_method, const Variant **p_ar
 	return Variant();
 }
 
+Variant::VariantCacheFunctionCall GDScriptInstance::lookup_function_call(const StringName &p_method) {
+	GDScript *sptr = script.ptr();
+	if (unlikely(p_method == SceneStringName(_ready))) {
+		// Call implicit ready first, including for the super classes recursively.
+		return Variant::VariantCacheFunctionCall();
+	}
+	while (sptr) {
+		if (likely(sptr->valid)) {
+			HashMap<StringName, GDScriptFunction *>::Iterator E = sptr->member_functions.find(p_method);
+			if (E) {
+				return std::bind(&GDScriptFunction::call_for_variant_cache, E->value, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
+			}
+		}
+		sptr = sptr->base.ptr();
+	}
+
+	return Variant::VariantCacheFunctionCall();
+}
+
 void GDScriptInstance::notification(int p_notification, bool p_reversed) {
 	if (unlikely(!script->valid)) {
 		return;
@@ -2058,6 +2060,10 @@ String GDScriptInstance::to_string(bool *r_valid) {
 
 Ref<Script> GDScriptInstance::get_script() const {
 	return script;
+}
+
+bool GDScriptInstance::script_eq(const Ref<Script> &p_script) const {
+	return *script == *p_script;
 }
 
 ScriptLanguage *GDScriptInstance::get_language() {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -158,6 +158,7 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 	GDScriptInstance *instance = memnew(GDScriptInstance);
 	instance->members.resize(member_indices.size());
 	instance->script = Ref<GDScript>(this);
+	instance->script_raw = this;
 	instance->owner = p_owner;
 	instance->owner_id = p_owner->get_instance_id();
 	instance->owner->set_script_instance(instance);
@@ -172,6 +173,7 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 	if (r_error.error != Callable::CallError::CALL_OK) {
 		String error_text = Variant::get_call_error_text(instance->owner, "@implicit_new", nullptr, 0, r_error);
 		instance->script = Ref<GDScript>();
+		instance->script_raw = nullptr;
 		instance->owner->set_script_instance(nullptr);
 		{
 			MutexLock lock(GDScriptLanguage::singleton->mutex);
@@ -190,6 +192,7 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 		if (r_error.error != Callable::CallError::CALL_OK) {
 			String error_text = Variant::get_call_error_text(instance->owner, "_init", p_args, p_argcount, r_error);
 			instance->script = Ref<GDScript>();
+			instance->script_raw = nullptr;
 			instance->owner->set_script_instance(nullptr);
 			{
 				MutexLock lock(GDScriptLanguage::singleton->mutex);
@@ -389,6 +392,35 @@ MethodInfo GDScript::get_method_info(const StringName &p_method) const {
 	}
 
 	return E->value->get_method_info();
+}
+
+void *GDScript::lookup_method(const StringName &p_method) const {
+	if (unlikely(p_method == SceneStringName(_ready))) {
+		// Call implicit ready first, including for the super classes recursively.
+		return nullptr;
+	}
+	GDScript *sptr = const_cast<GDScript *>(this);
+	while (sptr) {
+		if (likely(sptr->valid)) {
+			HashMap<StringName, GDScriptFunction *>::Iterator E = sptr->member_functions.find(p_method);
+			if (E) {
+				return E->value;
+			}
+		}
+		sptr = sptr->base.ptr();
+	}
+
+	return nullptr;
+}
+
+void GDScript::call_method(Variant &p_base, void *p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) const {
+	Object *obj = *VariantInternal::get_object(&p_base);
+	GDScriptInstance *instance = static_cast<GDScriptInstance *>(obj->get_script_instance());
+	if (r_ret != nullptr) {
+		*r_ret = static_cast<GDScriptFunction *>(p_method)->call(instance, p_args, p_argcount, r_error);
+	} else {
+		static_cast<GDScriptFunction *>(p_method)->call(instance, p_args, p_argcount, r_error);
+	}
 }
 
 bool GDScript::get_property_default_value(const StringName &p_property, Variant &r_value) const {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -123,6 +123,22 @@ Variant GDScriptNativeClass::callp(const StringName &p_method, const Variant **p
 	return Variant();
 }
 
+VariantCallCache GDScriptNativeClass::lookup_function_call(const StringName &p_method_name, Callable::CallError::Error &p_error) {
+	if (p_method_name == SNAME("new")) {
+		return Object::lookup_function_call(p_method_name, p_error);
+	}
+
+	const MethodBind *method = ClassDB::get_method(name, p_method_name);
+	if (method && method->is_static()) {
+		// Native static method.
+		p_error = Callable::CallError::Error::CALL_OK;
+		return VariantCallCache(method);
+	}
+
+	p_error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+	return VariantCallCache();
+}
+
 GDScriptFunction *GDScript::_super_constructor(GDScript *p_script) {
 	if (likely(p_script->valid) && p_script->initializer) {
 		return p_script->initializer;
@@ -965,19 +981,36 @@ Variant GDScript::callp(const StringName &p_method, const Variant **p_args, int 
 	return Variant();
 }
 
-Variant::VariantCacheFunctionCall GDScript::lookup_function_call(const StringName &p_method) {
+VariantCallCache GDScript::lookup_function_call(const StringName &p_method, Callable::CallError::Error &p_error) {
 	GDScript *top = this;
 	while (top) {
 		if (likely(top->valid)) {
 			HashMap<StringName, GDScriptFunction *>::Iterator E = top->member_functions.find(p_method);
 			if (E) {
 				// TODO: add static call check
-				return std::bind(&GDScriptFunction::call_for_variant_cache, E->value, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
+				return VariantCallCache(E->value);
 			}
 		}
 		top = top->base.ptr();
 	}
-	return Variant::VariantCacheFunctionCall();
+
+	// NOTE: I think this should be Object:: but leaving it as is to mirror GDScript::callp
+	VariantCallCache ret = Script::lookup_function_call(p_method, p_error);
+	if (p_error != Callable::CallError::Error::CALL_ERROR_INVALID_METHOD) {
+		return ret;
+	}
+
+	if (_is_abstract && p_method == SNAME("new")) {
+		p_error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+		return ret;
+	}
+
+	if (native.is_valid()) {
+		return native->lookup_function_call(p_method, p_error);
+	}
+
+	p_error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+	return VariantCallCache();
 }
 
 bool GDScript::_get(const StringName &p_name, Variant &r_ret) const {
@@ -1981,23 +2014,25 @@ Variant GDScriptInstance::callp(const StringName &p_method, const Variant **p_ar
 	return Variant();
 }
 
-Variant::VariantCacheFunctionCall GDScriptInstance::lookup_function_call(const StringName &p_method) {
-	GDScript *sptr = script.ptr();
+VariantCallCache GDScriptInstance::lookup_function_call(const StringName &p_method, Callable::CallError::Error &p_error) {
 	if (unlikely(p_method == SceneStringName(_ready))) {
-		// Call implicit ready first, including for the super classes recursively.
-		return Variant::VariantCacheFunctionCall();
+		// Do not cache `ready`
+		p_error = Callable::CallError::Error::CALL_OK;
+		return VariantCallCache();
 	}
+	GDScript *sptr = script.ptr();
 	while (sptr) {
 		if (likely(sptr->valid)) {
 			HashMap<StringName, GDScriptFunction *>::Iterator E = sptr->member_functions.find(p_method);
 			if (E) {
-				return std::bind(&GDScriptFunction::call_for_variant_cache, E->value, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3, std::placeholders::_4);
+				p_error = Callable::CallError::Error::CALL_OK;
+				return VariantCallCache(E->value);
 			}
 		}
 		sptr = sptr->base.ptr();
 	}
-
-	return Variant::VariantCacheFunctionCall();
+	p_error = Callable::CallError::Error::CALL_ERROR_INVALID_METHOD;
+	return VariantCallCache();
 }
 
 void GDScriptInstance::notification(int p_notification, bool p_reversed) {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -159,6 +159,7 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 	GDScriptInstance *instance = memnew(GDScriptInstance);
 	instance->members.resize(member_indices.size());
 	instance->script = Ref<GDScript>(this);
+	instance->script_raw = this;
 	instance->owner = p_owner;
 	instance->owner_id = p_owner->get_instance_id();
 #ifdef DEBUG_ENABLED
@@ -179,6 +180,7 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 	if (r_error.error != Callable::CallError::CALL_OK) {
 		String error_text = Variant::get_call_error_text(instance->owner, "@implicit_new", nullptr, 0, r_error);
 		instance->script = Ref<GDScript>();
+		instance->script_raw = nullptr;
 		instance->owner->set_script_instance(nullptr);
 		{
 			MutexLock lock(GDScriptLanguage::singleton->mutex);
@@ -197,6 +199,7 @@ GDScriptInstance *GDScript::_create_instance(const Variant **p_args, int p_argco
 		if (r_error.error != Callable::CallError::CALL_OK) {
 			String error_text = Variant::get_call_error_text(instance->owner, "_init", p_args, p_argcount, r_error);
 			instance->script = Ref<GDScript>();
+			instance->script_raw = nullptr;
 			instance->owner->set_script_instance(nullptr);
 			{
 				MutexLock lock(GDScriptLanguage::singleton->mutex);
@@ -396,6 +399,35 @@ MethodInfo GDScript::get_method_info(const StringName &p_method) const {
 	}
 
 	return E->value->get_method_info();
+}
+
+void *GDScript::lookup_method(const StringName &p_method) const {
+	if (unlikely(p_method == SceneStringName(_ready))) {
+		// Call implicit ready first, including for the super classes recursively.
+		return nullptr;
+	}
+	GDScript *sptr = const_cast<GDScript *>(this);
+	while (sptr) {
+		if (likely(sptr->valid)) {
+			HashMap<StringName, GDScriptFunction *>::Iterator E = sptr->member_functions.find(p_method);
+			if (E) {
+				return E->value;
+			}
+		}
+		sptr = sptr->base.ptr();
+	}
+
+	return nullptr;
+}
+
+void GDScript::call_method(Variant &p_base, void *p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) const {
+	Object *obj = *VariantInternal::get_object(&p_base);
+	GDScriptInstance *instance = static_cast<GDScriptInstance *>(obj->get_script_instance());
+	if (r_ret != nullptr) {
+		*r_ret = static_cast<GDScriptFunction *>(p_method)->call(instance, p_args, p_argcount, r_error);
+	} else {
+		static_cast<GDScriptFunction *>(p_method)->call(instance, p_args, p_argcount, r_error);
+	}
 }
 
 bool GDScript::get_property_default_value(const StringName &p_property, Variant &r_value) const {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -308,6 +308,9 @@ public:
 
 	virtual MethodInfo get_method_info(const StringName &p_method) const override;
 
+	virtual void *lookup_method(const StringName &p_method) const override;
+	virtual void call_method(Variant &p_base, void *p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) const override;
+
 	virtual void get_script_property_list(List<PropertyInfo> *p_list) const override;
 
 	virtual ScriptLanguage *get_language() const override;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -311,6 +311,9 @@ public:
 
 	virtual MethodInfo get_method_info(const StringName &p_method) const override;
 
+	virtual void *lookup_method(const StringName &p_method) const override;
+	virtual void call_method(Variant &p_base, void *p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) const override;
+
 	virtual void get_script_property_list(List<PropertyInfo> *p_list) const override;
 
 	virtual ScriptLanguage *get_language() const override;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -213,6 +213,8 @@ protected:
 
 	Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;
 
+	virtual Variant::VariantCacheFunctionCall lookup_function_call(const StringName &p_method_name) override;
+
 	static void _bind_methods();
 
 public:
@@ -311,9 +313,6 @@ public:
 
 	virtual MethodInfo get_method_info(const StringName &p_method) const override;
 
-	virtual void *lookup_method(const StringName &p_method) const override;
-	virtual void call_method(Variant &p_base, void *p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) const override;
-
 	virtual void get_script_property_list(List<PropertyInfo> *p_list) const override;
 
 	virtual ScriptLanguage *get_language() const override;
@@ -380,12 +379,15 @@ public:
 
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 
+	virtual Variant::VariantCacheFunctionCall lookup_function_call(const StringName &p_method_name);
+
 	Variant debug_get_member_by_index(int p_idx) const { return members[p_idx]; }
 
 	virtual void notification(int p_notification, bool p_reversed = false);
 	String to_string(bool *r_valid);
 
 	virtual Ref<Script> get_script() const;
+	virtual bool script_eq(const Ref<Script> &p_script) const;
 
 	virtual ScriptLanguage *get_language();
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -51,6 +51,7 @@ public:
 	Variant _new();
 	Object *instantiate();
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;
+	virtual VariantCallCache lookup_function_call(const StringName &p_method_name, Callable::CallError::Error &p_error) override;
 	GDScriptNativeClass(const StringName &p_name);
 };
 
@@ -213,7 +214,7 @@ protected:
 
 	Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;
 
-	virtual Variant::VariantCacheFunctionCall lookup_function_call(const StringName &p_method_name) override;
+	virtual VariantCallCache lookup_function_call(const StringName &p_method_name, Callable::CallError::Error &p_error) override;
 
 	static void _bind_methods();
 
@@ -379,7 +380,7 @@ public:
 
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 
-	virtual Variant::VariantCacheFunctionCall lookup_function_call(const StringName &p_method_name);
+	virtual VariantCallCache lookup_function_call(const StringName &p_method_name, Callable::CallError::Error &p_error);
 
 	Variant debug_get_member_by_index(int p_idx) const { return members[p_idx]; }
 

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -395,11 +395,10 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_lambdas_count = 0;
 	}
 
-	if (inline_cache_count) {
-		function->inline_caches.resize(inline_cache_count);
-		function->_inline_cache_ptr = function->inline_caches.ptr();
-		function->_inline_cache_count = inline_cache_count;
+	for (int i : function_inline_cache_locations) {
+		reinterpret_cast<FunctionInlineCache *>(&function->_code_ptr[i])->reset();
 	}
+	function->function_inline_cache_locations = function_inline_cache_locations;
 
 	if (GDScriptLanguage::get_singleton()->should_track_locals()) {
 		function->stack_debug = stack_debug;
@@ -1090,7 +1089,6 @@ GDScriptByteCodeGenerator::CallTarget GDScriptByteCodeGenerator::get_call_target
 }
 
 void GDScriptByteCodeGenerator::write_call(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) {
-	const uint32_t cache_idx = inline_cache_count++;
 	if (p_target.mode == Address::NIL) {
 		append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL, 2 + p_arguments.size());
 		for (int i = 0; i < p_arguments.size(); i++) {
@@ -1100,7 +1098,10 @@ void GDScriptByteCodeGenerator::write_call(const Address &p_target, const Addres
 		append(Address());
 		append(p_arguments.size());
 		append(p_function_name);
-		append(cache_idx);
+		function_inline_cache_locations.push_back(opcodes.size());
+		for (size_t i = 0; i < FunctionInlineCacheIntSize; i++) {
+			append(0);
+		}
 	} else {
 		append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL_RETURN, 2 + p_arguments.size());
 		for (int i = 0; i < p_arguments.size(); i++) {
@@ -1111,7 +1112,10 @@ void GDScriptByteCodeGenerator::write_call(const Address &p_target, const Addres
 		append(ct.target);
 		append(p_arguments.size());
 		append(p_function_name);
-		append(cache_idx);
+		function_inline_cache_locations.push_back(opcodes.size());
+		for (size_t i = 0; i < FunctionInlineCacheIntSize; i++) {
+			append(0);
+		}
 		ct.cleanup();
 	}
 }
@@ -1129,7 +1133,6 @@ void GDScriptByteCodeGenerator::write_super_call(const Address &p_target, const 
 }
 
 void GDScriptByteCodeGenerator::write_call_async(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) {
-	const uint32_t cache_idx = inline_cache_count++;
 	append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL_ASYNC, 2 + p_arguments.size());
 	for (int i = 0; i < p_arguments.size(); i++) {
 		append(p_arguments[i]);
@@ -1139,7 +1142,10 @@ void GDScriptByteCodeGenerator::write_call_async(const Address &p_target, const 
 	append(ct.target);
 	append(p_arguments.size());
 	append(p_function_name);
-	append(cache_idx);
+	function_inline_cache_locations.push_back(opcodes.size());
+	for (size_t i = 0; i < FunctionInlineCacheIntSize; i++) {
+		append(0);
+	}
 	ct.cleanup();
 }
 
@@ -1365,7 +1371,6 @@ void GDScriptByteCodeGenerator::write_call_method_bind_validated(const Address &
 }
 
 void GDScriptByteCodeGenerator::write_call_self(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) {
-	const uint32_t cache_idx = inline_cache_count++;
 	if (p_target.mode == Address::NIL) {
 		append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL, 2 + p_arguments.size());
 		for (int i = 0; i < p_arguments.size(); i++) {
@@ -1375,7 +1380,10 @@ void GDScriptByteCodeGenerator::write_call_self(const Address &p_target, const S
 		append(Address());
 		append(p_arguments.size());
 		append(p_function_name);
-		append(cache_idx);
+		function_inline_cache_locations.push_back(opcodes.size());
+		for (size_t i = 0; i < FunctionInlineCacheIntSize; i++) {
+			append(0);
+		}
 	} else {
 		append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL_RETURN, 2 + p_arguments.size());
 		for (int i = 0; i < p_arguments.size(); i++) {
@@ -1386,13 +1394,15 @@ void GDScriptByteCodeGenerator::write_call_self(const Address &p_target, const S
 		append(ct.target);
 		append(p_arguments.size());
 		append(p_function_name);
-		append(cache_idx);
+		function_inline_cache_locations.push_back(opcodes.size());
+		for (size_t i = 0; i < FunctionInlineCacheIntSize; i++) {
+			append(0);
+		}
 		ct.cleanup();
 	}
 }
 
 void GDScriptByteCodeGenerator::write_call_self_async(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) {
-	const uint32_t cache_idx = inline_cache_count++;
 	append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL_ASYNC, 2 + p_arguments.size());
 	for (int i = 0; i < p_arguments.size(); i++) {
 		append(p_arguments[i]);
@@ -1402,7 +1412,10 @@ void GDScriptByteCodeGenerator::write_call_self_async(const Address &p_target, c
 	append(ct.target);
 	append(p_arguments.size());
 	append(p_function_name);
-	append(cache_idx);
+	function_inline_cache_locations.push_back(opcodes.size());
+	for (size_t i = 0; i < FunctionInlineCacheIntSize; i++) {
+		append(0);
+	}
 	ct.cleanup();
 }
 

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -395,6 +395,12 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 		function->_lambdas_count = 0;
 	}
 
+	if (inline_cache_count) {
+		function->inline_caches.resize(inline_cache_count);
+		function->_inline_cache_ptr = function->inline_caches.ptr();
+		function->_inline_cache_count = inline_cache_count;
+	}
+
 	if (GDScriptLanguage::get_singleton()->should_track_locals()) {
 		function->stack_debug = stack_debug;
 	}
@@ -1084,6 +1090,7 @@ GDScriptByteCodeGenerator::CallTarget GDScriptByteCodeGenerator::get_call_target
 }
 
 void GDScriptByteCodeGenerator::write_call(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) {
+	const uint32_t cache_idx = inline_cache_count++;
 	if (p_target.mode == Address::NIL) {
 		append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL, 2 + p_arguments.size());
 		for (int i = 0; i < p_arguments.size(); i++) {
@@ -1093,6 +1100,7 @@ void GDScriptByteCodeGenerator::write_call(const Address &p_target, const Addres
 		append(Address());
 		append(p_arguments.size());
 		append(p_function_name);
+		append(cache_idx);
 	} else {
 		append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL_RETURN, 2 + p_arguments.size());
 		for (int i = 0; i < p_arguments.size(); i++) {
@@ -1103,6 +1111,7 @@ void GDScriptByteCodeGenerator::write_call(const Address &p_target, const Addres
 		append(ct.target);
 		append(p_arguments.size());
 		append(p_function_name);
+		append(cache_idx);
 		ct.cleanup();
 	}
 }
@@ -1120,6 +1129,7 @@ void GDScriptByteCodeGenerator::write_super_call(const Address &p_target, const 
 }
 
 void GDScriptByteCodeGenerator::write_call_async(const Address &p_target, const Address &p_base, const StringName &p_function_name, const Vector<Address> &p_arguments) {
+	const uint32_t cache_idx = inline_cache_count++;
 	append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL_ASYNC, 2 + p_arguments.size());
 	for (int i = 0; i < p_arguments.size(); i++) {
 		append(p_arguments[i]);
@@ -1129,6 +1139,7 @@ void GDScriptByteCodeGenerator::write_call_async(const Address &p_target, const 
 	append(ct.target);
 	append(p_arguments.size());
 	append(p_function_name);
+	append(cache_idx);
 	ct.cleanup();
 }
 
@@ -1354,6 +1365,7 @@ void GDScriptByteCodeGenerator::write_call_method_bind_validated(const Address &
 }
 
 void GDScriptByteCodeGenerator::write_call_self(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) {
+	const uint32_t cache_idx = inline_cache_count++;
 	if (p_target.mode == Address::NIL) {
 		append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL, 2 + p_arguments.size());
 		for (int i = 0; i < p_arguments.size(); i++) {
@@ -1363,6 +1375,7 @@ void GDScriptByteCodeGenerator::write_call_self(const Address &p_target, const S
 		append(Address());
 		append(p_arguments.size());
 		append(p_function_name);
+		append(cache_idx);
 	} else {
 		append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL_RETURN, 2 + p_arguments.size());
 		for (int i = 0; i < p_arguments.size(); i++) {
@@ -1373,11 +1386,13 @@ void GDScriptByteCodeGenerator::write_call_self(const Address &p_target, const S
 		append(ct.target);
 		append(p_arguments.size());
 		append(p_function_name);
+		append(cache_idx);
 		ct.cleanup();
 	}
 }
 
 void GDScriptByteCodeGenerator::write_call_self_async(const Address &p_target, const StringName &p_function_name, const Vector<Address> &p_arguments) {
+	const uint32_t cache_idx = inline_cache_count++;
 	append_opcode_and_argcount(GDScriptFunction::OPCODE_CALL_ASYNC, 2 + p_arguments.size());
 	for (int i = 0; i < p_arguments.size(); i++) {
 		append(p_arguments[i]);
@@ -1387,6 +1402,7 @@ void GDScriptByteCodeGenerator::write_call_self_async(const Address &p_target, c
 	append(ct.target);
 	append(p_arguments.size());
 	append(p_function_name);
+	append(cache_idx);
 	ct.cleanup();
 }
 

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -30,6 +30,8 @@
 
 #include "gdscript_byte_codegen.h"
 
+#include "inline_cache.h"
+
 #include "core/object/class_db.h"
 
 uint32_t GDScriptByteCodeGenerator::add_parameter(const StringName &p_name, bool p_is_optional, const GDScriptDataType &p_type) {

--- a/modules/gdscript/gdscript_byte_codegen.cpp
+++ b/modules/gdscript/gdscript_byte_codegen.cpp
@@ -398,7 +398,7 @@ GDScriptFunction *GDScriptByteCodeGenerator::write_end() {
 	}
 
 	for (int i : function_inline_cache_locations) {
-		reinterpret_cast<FunctionInlineCache *>(&function->_code_ptr[i])->reset();
+		FunctionInlineCache::get_ptr(reinterpret_cast<uintptr_t>(&function->_code_ptr[i]))->reset();
 	}
 	function->function_inline_cache_locations = function_inline_cache_locations;
 

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -83,7 +83,6 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	RBMap<StringName, int> stack_identifiers;
 	List<int> stack_identifiers_counts;
 	RBMap<StringName, int> local_constants;
-	int inline_cache_count = 0;
 
 	Vector<StackSlot> locals;
 	HashSet<int> dirty_locals;
@@ -155,6 +154,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	List<int> ternary_jump_skip_pos;
 
 	List<List<int>> current_breaks_to_patch;
+	Vector<int> function_inline_cache_locations;
 
 	void add_stack_identifier(const StringName &p_id, int p_stackpos) {
 		if (locals.size() > max_locals) {

--- a/modules/gdscript/gdscript_byte_codegen.h
+++ b/modules/gdscript/gdscript_byte_codegen.h
@@ -83,6 +83,7 @@ class GDScriptByteCodeGenerator : public GDScriptCodeGenerator {
 	RBMap<StringName, int> stack_identifiers;
 	List<int> stack_identifiers_counts;
 	RBMap<StringName, int> local_constants;
+	int inline_cache_count = 0;
 
 	Vector<StackSlot> locals;
 	HashSet<int> dirty_locals;

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -709,7 +709,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				}
 				text += ")";
 
-				incr = 5 + argc;
+				incr = 6 + argc;
 			} break;
 			case OPCODE_CALL_METHOD_BIND:
 			case OPCODE_CALL_METHOD_BIND_RET: {

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -709,7 +709,7 @@ void GDScriptFunction::disassemble(const Vector<String> &p_code_lines) const {
 				}
 				text += ")";
 
-				incr = 6 + argc;
+				incr = 5 + FunctionInlineCacheIntSize + argc;
 			} break;
 			case OPCODE_CALL_METHOD_BIND:
 			case OPCODE_CALL_METHOD_BIND_RET: {

--- a/modules/gdscript/gdscript_disassembler.cpp
+++ b/modules/gdscript/gdscript_disassembler.cpp
@@ -32,6 +32,7 @@
 
 #include "gdscript.h"
 #include "gdscript_function.h"
+#include "inline_cache.h"
 
 #include "core/object/method_bind.h"
 #include "core/string/string_builder.h"

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -161,6 +161,14 @@ StringName GDScriptFunction::get_global_name(int p_idx) const {
 	return global_names[p_idx];
 }
 
+Variant GDScriptFunction::call_for_variant_cache(Variant *p_instance, const Variant **p_args, int p_argcount, Callable::CallError &r_err) {
+	if (p_instance->get_type() == Variant::OBJECT) {
+		Object *obj = *VariantInternal::get_object(p_instance);
+		return call(reinterpret_cast<GDScriptInstance *>(obj->get_script_instance()), p_args, p_argcount, r_err);
+	}
+	ERR_FAIL_V_MSG(Variant(), "GDScript cache fail: calling on non object type");
+}
+
 struct _GDFKC {
 	int order = 0;
 	List<int> pos;
@@ -244,6 +252,10 @@ GDScriptFunction::~GDScriptFunction() {
 		argument_types.write[i].script_type_ref = Ref<Script>();
 	}
 	return_type.script_type_ref = Ref<Script>();
+
+	for (int i : function_inline_cache_locations) {
+		reinterpret_cast<FunctionInlineCache *>(&_code_ptr[i])->reset();
+	}
 
 #ifdef DEBUG_ENABLED
 	MutexLock lock(GDScriptLanguage::get_singleton()->mutex);

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -247,7 +247,7 @@ GDScriptFunction::~GDScriptFunction() {
 	return_type.script_type_ref = Ref<Script>();
 
 	for (int i : function_inline_cache_locations) {
-		reinterpret_cast<FunctionInlineCache *>(&_code_ptr[i])->reset();
+		FunctionInlineCache::get_ptr(reinterpret_cast<uintptr_t>(&_code_ptr[i]))->reset();
 	}
 
 #ifdef DEBUG_ENABLED

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -31,6 +31,7 @@
 #include "gdscript_function.h"
 
 #include "gdscript.h"
+#include "inline_cache.h"
 
 #include "core/object/class_db.h"
 
@@ -159,14 +160,6 @@ Variant GDScriptFunction::get_constant(int p_idx) const {
 StringName GDScriptFunction::get_global_name(int p_idx) const {
 	ERR_FAIL_INDEX_V(p_idx, global_names.size(), "<errgname>");
 	return global_names[p_idx];
-}
-
-Variant GDScriptFunction::call_for_variant_cache(Variant *p_instance, const Variant **p_args, int p_argcount, Callable::CallError &r_err) {
-	if (p_instance->get_type() == Variant::OBJECT) {
-		Object *obj = *VariantInternal::get_object(p_instance);
-		return call(reinterpret_cast<GDScriptInstance *>(obj->get_script_instance()), p_args, p_argcount, r_err);
-	}
-	ERR_FAIL_V_MSG(Variant(), "GDScript cache fail: calling on non object type");
 }
 
 struct _GDFKC {

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "gdscript_utility_functions.h"
+#include "inline_cache.h"
 
 #include "core/object/ref_counted.h"
 #include "core/object/script_language.h"
@@ -380,6 +381,7 @@ private:
 	Vector<GDScriptUtilityFunctions::FunctionPtr> gds_utilities;
 	Vector<const MethodBind *> methods;
 	Vector<GDScriptFunction *> lambdas;
+	TightLocalVector<InlineCache> inline_caches;
 
 	int _code_size = 0;
 	int _default_arg_count = 0;
@@ -398,6 +400,7 @@ private:
 	int _gds_utilities_count = 0;
 	int _methods_count = 0;
 	int _lambdas_count = 0;
+	int _inline_cache_count = 0;
 
 	int *_code_ptr = nullptr;
 	const int *_default_arg_ptr = nullptr;
@@ -416,6 +419,7 @@ private:
 	const GDScriptUtilityFunctions::FunctionPtr *_gds_utilities_ptr = nullptr;
 	const MethodBind *const *_methods_ptr = nullptr;
 	GDScriptFunction **_lambdas_ptr = nullptr;
+	InlineCache *_inline_cache_ptr = nullptr;
 
 #ifdef DEBUG_ENABLED
 	CharString func_cname;

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -381,7 +381,7 @@ private:
 	Vector<GDScriptUtilityFunctions::FunctionPtr> gds_utilities;
 	Vector<const MethodBind *> methods;
 	Vector<GDScriptFunction *> lambdas;
-	TightLocalVector<InlineCache> inline_caches;
+	LocalVector<int> function_inline_cache_locations;
 
 	int _code_size = 0;
 	int _default_arg_count = 0;
@@ -400,7 +400,6 @@ private:
 	int _gds_utilities_count = 0;
 	int _methods_count = 0;
 	int _lambdas_count = 0;
-	int _inline_cache_count = 0;
 
 	int *_code_ptr = nullptr;
 	const int *_default_arg_ptr = nullptr;
@@ -419,7 +418,6 @@ private:
 	const GDScriptUtilityFunctions::FunctionPtr *_gds_utilities_ptr = nullptr;
 	const MethodBind *const *_methods_ptr = nullptr;
 	GDScriptFunction **_lambdas_ptr = nullptr;
-	InlineCache *_inline_cache_ptr = nullptr;
 
 #ifdef DEBUG_ENABLED
 	CharString func_cname;
@@ -492,6 +490,8 @@ public:
 	StringName get_global_name(int p_idx) const;
 
 	Variant call(GDScriptInstance *p_instance, const Variant **p_args, int p_argcount, Callable::CallError &r_err, CallState *p_state = nullptr);
+	Variant call_for_variant_cache(Variant *p_instance, const Variant **p_args, int p_argcount, Callable::CallError &r_err);
+
 	void debug_get_stack_member_state(int p_line, List<Pair<StringName, int>> *r_stackvars) const;
 
 #ifdef DEBUG_ENABLED

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -31,7 +31,6 @@
 #pragma once
 
 #include "gdscript_utility_functions.h"
-#include "inline_cache.h"
 
 #include "core/object/ref_counted.h"
 #include "core/object/script_language.h"
@@ -490,7 +489,6 @@ public:
 	StringName get_global_name(int p_idx) const;
 
 	Variant call(GDScriptInstance *p_instance, const Variant **p_args, int p_argcount, Callable::CallError &r_err, CallState *p_state = nullptr);
-	Variant call_for_variant_cache(Variant *p_instance, const Variant **p_args, int p_argcount, Callable::CallError &r_err);
 
 	void debug_get_stack_member_state(int p_line, List<Pair<StringName, int>> *r_stackvars) const;
 

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "gdscript_utility_functions.h"
+#include "inline_cache.h"
 
 #include "core/object/ref_counted.h"
 #include "core/object/script_language.h"
@@ -381,6 +382,7 @@ private:
 	Vector<GDScriptUtilityFunctions::FunctionPtr> gds_utilities;
 	Vector<MethodBind *> methods;
 	Vector<GDScriptFunction *> lambdas;
+	TightLocalVector<InlineCache> inline_caches;
 
 	int _code_size = 0;
 	int _default_arg_count = 0;
@@ -399,6 +401,7 @@ private:
 	int _gds_utilities_count = 0;
 	int _methods_count = 0;
 	int _lambdas_count = 0;
+	int _inline_cache_count = 0;
 
 	int *_code_ptr = nullptr;
 	const int *_default_arg_ptr = nullptr;
@@ -417,6 +420,7 @@ private:
 	const GDScriptUtilityFunctions::FunctionPtr *_gds_utilities_ptr = nullptr;
 	MethodBind **_methods_ptr = nullptr;
 	GDScriptFunction **_lambdas_ptr = nullptr;
+	InlineCache *_inline_cache_ptr = nullptr;
 
 #ifdef DEBUG_ENABLED
 	CharString func_cname;

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1907,7 +1907,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				bool call_async = (_code_ptr[ip]) == OPCODE_CALL_ASYNC;
 #endif
 				LOAD_INSTRUCTION_ARGS
-				CHECK_SPACE(3 + instr_arg_count);
+				CHECK_SPACE(4 + instr_arg_count);
 
 				ip += instr_arg_count;
 
@@ -1923,6 +1923,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GET_INSTRUCTION_ARG(base, argc);
 				Variant **argptrs = instruction_args;
 
+				InlineCache *ic = _inline_cache_ptr + _code_ptr[ip + 3];
+
 #ifdef DEBUG_ENABLED
 				uint64_t call_time = 0;
 
@@ -1937,7 +1939,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Callable::CallError err;
 				if (call_ret) {
 					GET_INSTRUCTION_ARG(ret, argc + 1);
-					base->callp(*methodname, (const Variant **)argptrs, argc, temp_ret, err);
+					ic->call(*base, *methodname, (const Variant **)argptrs, argc, &temp_ret, err);
 					*ret = temp_ret;
 #ifdef DEBUG_ENABLED
 					if (ret->get_type() == Variant::NIL) {
@@ -1972,7 +1974,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					}
 #endif
 				} else {
-					base->callp(*methodname, (const Variant **)argptrs, argc, temp_ret, err);
+					ic->call(*base, *methodname, (const Variant **)argptrs, argc, nullptr, err);
 				}
 #ifdef DEBUG_ENABLED
 
@@ -2028,7 +2030,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				}
 #endif // DEBUG_ENABLED
 
-				ip += 3;
+				ip += 4;
 			}
 			DISPATCH_OPCODE;
 

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1923,7 +1923,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GET_INSTRUCTION_ARG(base, argc);
 				Variant **argptrs = instruction_args;
 
-				InlineCache *ic = _inline_cache_ptr + _code_ptr[ip + 3];
+				FunctionInlineCache *fn = reinterpret_cast<FunctionInlineCache *>(&_code_ptr[ip + 3]);
 
 #ifdef DEBUG_ENABLED
 				uint64_t call_time = 0;
@@ -1939,7 +1939,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Callable::CallError err;
 				if (call_ret) {
 					GET_INSTRUCTION_ARG(ret, argc + 1);
-					ic->call(*base, *methodname, (const Variant **)argptrs, argc, &temp_ret, err);
+					fn->callp(*base, *methodname, const_cast<const Variant **>(argptrs), argc, &temp_ret, err);
 					*ret = temp_ret;
 #ifdef DEBUG_ENABLED
 					if (ret->get_type() == Variant::NIL) {
@@ -1974,7 +1974,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					}
 #endif
 				} else {
-					ic->call(*base, *methodname, (const Variant **)argptrs, argc, nullptr, err);
+					fn->callp(*base, *methodname, const_cast<const Variant **>(argptrs), argc, nullptr, err);
 				}
 #ifdef DEBUG_ENABLED
 
@@ -2030,7 +2030,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				}
 #endif // DEBUG_ENABLED
 
-				ip += 4;
+				ip += 3 + FunctionInlineCacheIntSize;
 			}
 			DISPATCH_OPCODE;
 

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -31,6 +31,7 @@
 #include "gdscript.h"
 #include "gdscript_function.h"
 #include "gdscript_lambda_callable.h"
+#include "inline_cache.h"
 
 #include "core/object/class_db.h"
 #include "core/os/os.h"
@@ -1939,7 +1940,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				Callable::CallError err;
 				if (call_ret) {
 					GET_INSTRUCTION_ARG(ret, argc + 1);
-					fn->callp(*base, *methodname, const_cast<const Variant **>(argptrs), argc, &temp_ret, err);
+					temp_ret = fn->callp(*base, *methodname, const_cast<const Variant **>(argptrs), argc, err);
 					*ret = temp_ret;
 #ifdef DEBUG_ENABLED
 					if (ret->get_type() == Variant::NIL) {
@@ -1974,7 +1975,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					}
 #endif
 				} else {
-					fn->callp(*base, *methodname, const_cast<const Variant **>(argptrs), argc, nullptr, err);
+					fn->callp(*base, *methodname, const_cast<const Variant **>(argptrs), argc, err);
 				}
 #ifdef DEBUG_ENABLED
 

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -1924,7 +1924,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GET_INSTRUCTION_ARG(base, argc);
 				Variant **argptrs = instruction_args;
 
-				FunctionInlineCache *fn = reinterpret_cast<FunctionInlineCache *>(&_code_ptr[ip + 3]);
+				FunctionInlineCache *fn = FunctionInlineCache::get_ptr(reinterpret_cast<uintptr_t>(&_code_ptr[ip + 3]));
 
 #ifdef DEBUG_ENABLED
 				uint64_t call_time = 0;

--- a/modules/gdscript/inline_cache.cpp
+++ b/modules/gdscript/inline_cache.cpp
@@ -1,0 +1,145 @@
+/**************************************************************************/
+/*  inline_cache.cpp                                                      */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "inline_cache.h"
+
+#include "core/debugger/engine_debugger.h"
+#include "core/object/object.h"
+#include "core/os/memory.h"
+#include "core/variant/variant_internal.h"
+
+void InlineCache::add_entry(const Script *p_script, void *p_method) {
+	DEV_ASSERT(size < MAX_SIZE);
+
+	if (size == 0) {
+		script = p_script;
+		method = p_method;
+	} else {
+		if (size == 1) {
+			// convert to polymorphic
+			const Script **new_scripts = reinterpret_cast<const Script **>(memalloc(sizeof(const Script *) * MAX_SIZE));
+			void **new_methods = reinterpret_cast<void **>(memalloc(sizeof(void *) * MAX_SIZE));
+
+			new_scripts[0] = script;
+			new_methods[0] = method;
+
+			scripts = new_scripts;
+			methods = new_methods;
+		}
+		scripts[size] = p_script;
+		methods[size] = p_method;
+	}
+	size++;
+}
+
+void InlineCache::set_mega() {
+	if (size > 1 && size <= MAX_SIZE) {
+		memfree(scripts);
+		memfree(methods);
+	}
+	size = SIZE_MEGA;
+}
+
+void InlineCache::call(Variant &p_base, const StringName &p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error) {
+	if (size == SIZE_MEGA || p_base.get_type() != Variant::OBJECT) {
+		goto fallback;
+	}
+	{
+		const Object *obj = *VariantInternal::get_object(&p_base);
+
+		if (!obj) {
+			r_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
+			return;
+		}
+
+#ifdef DEBUG_ENABLED
+		if (EngineDebugger::is_active() && !VariantInternal::get_object_id(&p_base).is_ref_counted() && ObjectDB::get_instance(VariantInternal::get_object_id(&p_base)) == nullptr) {
+			r_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
+			return;
+		}
+
+#endif // DEBUG_ENABLED
+
+		const ScriptInstance *si = obj->get_script_instance();
+		// For static method calls, there is no ScriptInstance instead the object is the Script.
+		const Script *lookup_script = si != nullptr ? si->get_script_raw() : Object::cast_to<Script>(obj);
+
+		if (unlikely(lookup_script == nullptr)) {
+			set_mega();
+			goto fallback;
+		}
+
+		void *found_method = nullptr;
+		// Lookup section
+		if (size == 1) {
+			if (likely(lookup_script == script)) {
+				found_method = method;
+			}
+		} else if (size > 1) {
+			// Search entries
+			for (uint8_t i = 0; i < size; i++) {
+				if (lookup_script == scripts[i]) {
+					found_method = methods[i];
+					break;
+				}
+			}
+		}
+		if (likely(found_method != nullptr)) {
+			lookup_script->call_method(p_base, found_method, p_args, p_argcount, r_ret, r_error);
+			return;
+		}
+		// Lookup failed, add new cache entry
+		if (size != MAX_SIZE) {
+			found_method = lookup_script->lookup_method(p_method);
+			if (likely(found_method != nullptr)) {
+				add_entry(lookup_script, found_method);
+				lookup_script->call_method(p_base, found_method, p_args, p_argcount, r_ret, r_error);
+				return;
+			}
+		}
+		set_mega();
+	}
+
+	// Bad case
+fallback:
+	if (r_ret != nullptr) {
+		p_base.callp(p_method, p_args, p_argcount, *r_ret, r_error);
+	} else {
+		Variant v;
+		p_base.callp(p_method, p_args, p_argcount, v, r_error);
+	}
+}
+
+InlineCache::~InlineCache() {
+	if (size > 1 && size <= MAX_SIZE) {
+		memfree(scripts);
+		memfree(methods);
+	}
+}

--- a/modules/gdscript/inline_cache.cpp
+++ b/modules/gdscript/inline_cache.cpp
@@ -36,13 +36,15 @@
 #include "core/variant/variant_internal.h"
 
 void FunctionInlineCache::load(Variant &p_base, const StringName &p_method) {
-	Variant::VariantCacheFunctionCall found = p_base.lookup_function_call(p_method);
-	if (found) {
+	Callable::CallError::Error err;
+	VariantCallCache found = p_base.lookup_function_call(p_method, err);
+	if (found.type != VariantCallCache::Type::INVALID) {
 		// There is a chance another thread already updated while we looked up the function.
 		if (state == CacheState::UNINITIALIZED) {
 			state = CacheState::INITIALIZING;
 			fn = std::move(found);
-			type = get_type(p_base);
+			type = p_base.get_type();
+			gdtype = get_gdtype(p_base);
 			if (p_base.get_type() == Variant::OBJECT) {
 				Object *obj = *VariantInternal::get_object(&p_base);
 
@@ -65,6 +67,7 @@ void FunctionInlineCache::load(Variant &p_base, const StringName &p_method) {
 
 void FunctionInlineCache::reset() {
 	script = nullptr;
-	fn = nullptr;
+	fn = {};
+	type = Variant::NIL;
 	state = CacheState::UNINITIALIZED;
 }

--- a/modules/gdscript/inline_cache.h
+++ b/modules/gdscript/inline_cache.h
@@ -1,0 +1,67 @@
+/**************************************************************************/
+/*  inline_cache.h                                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/script_language.h"
+#include "core/variant/variant.h"
+
+class InlineCache {
+	// Used as the size of polymorphic allocations.
+	static const uint8_t MAX_SIZE = 4u;
+	// Indicates that the cache is megamorphic
+	static const uint8_t SIZE_MEGA = 255u;
+
+	union {
+		const Script *script;
+		const Script **scripts;
+	};
+	union {
+		void *method;
+		void **methods;
+	};
+	// Size determines type of cache used:
+	// 0 - uninitialized
+	// 1 - monomorphic, check script/method
+	// 2-4 - polymorphic, search scripts/methods
+	// 255 - megamorphic - fallback to normal lookup
+	uint8_t size = 0;
+
+	void add_entry(const Script *p_script, void *p_method);
+	void set_mega();
+
+public:
+	void call(Variant &p_base, const StringName &p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error);
+
+	InlineCache() = default;
+	InlineCache(const InlineCache &) = delete;
+	InlineCache operator=(const InlineCache &) = delete;
+	~InlineCache();
+};

--- a/modules/gdscript/inline_cache.h
+++ b/modules/gdscript/inline_cache.h
@@ -33,35 +33,73 @@
 #include "core/object/script_language.h"
 #include "core/variant/variant.h"
 
-class InlineCache {
-	// Used as the size of polymorphic allocations.
-	static const uint8_t MAX_SIZE = 4u;
-	// Indicates that the cache is megamorphic
-	static const uint8_t SIZE_MEGA = 255u;
-
-	union {
-		const Script *script;
-		const Script **scripts;
+struct FunctionInlineCache {
+	enum class CacheState : uint8_t {
+		UNINITIALIZED,
+		INITIALIZING,
+		MONOMORPHIC,
+		DISABLED,
 	};
-	union {
-		void *method;
-		void **methods;
-	};
-	// Size determines type of cache used:
-	// 0 - uninitialized
-	// 1 - monomorphic, check script/method
-	// 2-4 - polymorphic, search scripts/methods
-	// 255 - megamorphic - fallback to normal lookup
-	uint8_t size = 0;
 
-	void add_entry(const Script *p_script, void *p_method);
-	void set_mega();
+	CacheState state;
+	bool is_static;
+
+	GDType *type;
+	Ref<Script> script;
+	Variant::VariantCacheFunctionCall fn;
+
+private:
+	void load(Variant &p_base, const StringName &p_method);
+
+	_FORCE_INLINE_ static GDType *get_type(const Variant &v) {
+		Variant::Type vtype = v.get_type();
+		if (vtype == Variant::OBJECT) {
+			return const_cast<GDType *>(&(*VariantInternal::get_object(&v))->get_gdtype());
+		}
+		// Others not supported currently.
+		return nullptr;
+	}
+
+	_FORCE_INLINE_ bool hit(Variant &p_base) const {
+		return get_type(p_base) == type && (p_base.get_type() != Variant::OBJECT || script_matches(*VariantInternal::get_object(&p_base)));
+	}
+
+	_FORCE_INLINE_ bool script_matches(Object *obj) const {
+		if (is_static) {
+			return *script == Object::cast_to<Script>(obj);
+		}
+		const ScriptInstance *si = obj->get_script_instance();
+		return si->script_eq(script);
+	}
 
 public:
-	void call(Variant &p_base, const StringName &p_method, const Variant **p_args, int p_argcount, Variant *r_ret, Callable::CallError &r_error);
+	_FORCE_INLINE_ void callp(Variant &p_base, const StringName &p_method, const Variant **p_args, int p_argcount, Variant *p_ret, Callable::CallError &p_error) {
+		if (unlikely(state == CacheState::UNINITIALIZED)) {
+			load(p_base, p_method);
+		}
+		if (state == CacheState::MONOMORPHIC) {
+			if (likely(hit(p_base))) {
+				if (p_ret != nullptr) {
+					*p_ret = fn(&p_base, p_args, p_argcount, p_error);
+				} else {
+					fn(&p_base, p_args, p_argcount, p_error);
+				}
+				return;
+			} else {
+				state = CacheState::DISABLED;
+				// TODO: cleanup?
+			}
+		}
+		// Fallback to variant call
+		if (p_ret != nullptr) {
+			p_base.callp(p_method, p_args, p_argcount, *p_ret, p_error);
+		} else {
+			Variant v;
+			p_base.callp(p_method, p_args, p_argcount, v, p_error);
+		}
+	}
 
-	InlineCache() = default;
-	InlineCache(const InlineCache &) = delete;
-	InlineCache operator=(const InlineCache &) = delete;
-	~InlineCache();
+	void reset();
 };
+
+constexpr size_t FunctionInlineCacheIntSize = (sizeof(FunctionInlineCache) + sizeof(int) - 1) / sizeof(int);

--- a/modules/gdscript/inline_cache.h
+++ b/modules/gdscript/inline_cache.h
@@ -113,6 +113,12 @@ public:
 	}
 
 	void reset();
+
+	static _FORCE_INLINE_ FunctionInlineCache *get_ptr(uintptr_t start_idx) {
+		// Use next aligned location
+		return reinterpret_cast<FunctionInlineCache *>((start_idx + alignof(FunctionInlineCache) - 1) & -static_cast<intptr_t>(alignof(FunctionInlineCache)));
+	}
 };
 
-constexpr size_t FunctionInlineCacheIntSize = (sizeof(FunctionInlineCache) + sizeof(int) - 1) / sizeof(int);
+// Rounds up and add space for alignment
+constexpr size_t FunctionInlineCacheIntSize = (sizeof(FunctionInlineCache) + alignof(FunctionInlineCache) - 1) / sizeof(int);

--- a/modules/gdscript/inline_cache.h
+++ b/modules/gdscript/inline_cache.h
@@ -30,6 +30,9 @@
 
 #pragma once
 
+#include "gdscript_function.h"
+
+#include "core/object/method_bind.h"
 #include "core/object/script_language.h"
 #include "core/variant/variant.h"
 
@@ -44,14 +47,15 @@ struct FunctionInlineCache {
 	CacheState state;
 	bool is_static;
 
-	GDType *type;
+	Variant::Type type;
+	GDType *gdtype;
 	Ref<Script> script;
-	Variant::VariantCacheFunctionCall fn;
+	VariantCallCache fn;
 
 private:
 	void load(Variant &p_base, const StringName &p_method);
 
-	_FORCE_INLINE_ static GDType *get_type(const Variant &v) {
+	_FORCE_INLINE_ static GDType *get_gdtype(const Variant &v) {
 		Variant::Type vtype = v.get_type();
 		if (vtype == Variant::OBJECT) {
 			return const_cast<GDType *>(&(*VariantInternal::get_object(&v))->get_gdtype());
@@ -61,7 +65,7 @@ private:
 	}
 
 	_FORCE_INLINE_ bool hit(Variant &p_base) const {
-		return get_type(p_base) == type && (p_base.get_type() != Variant::OBJECT || script_matches(*VariantInternal::get_object(&p_base)));
+		return p_base.get_type() == type && (p_base.get_type() != Variant::OBJECT || (get_gdtype(p_base) == gdtype && script_matches(*VariantInternal::get_object(&p_base))));
 	}
 
 	_FORCE_INLINE_ bool script_matches(Object *obj) const {
@@ -73,30 +77,39 @@ private:
 	}
 
 public:
-	_FORCE_INLINE_ void callp(Variant &p_base, const StringName &p_method, const Variant **p_args, int p_argcount, Variant *p_ret, Callable::CallError &p_error) {
+	_FORCE_INLINE_ Variant callp(Variant &p_base, const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &p_error) {
 		if (unlikely(state == CacheState::UNINITIALIZED)) {
 			load(p_base, p_method);
 		}
 		if (state == CacheState::MONOMORPHIC) {
 			if (likely(hit(p_base))) {
-				if (p_ret != nullptr) {
-					*p_ret = fn(&p_base, p_args, p_argcount, p_error);
-				} else {
-					fn(&p_base, p_args, p_argcount, p_error);
+				switch (fn.type) {
+					case VariantCallCache::Type::GDSCRIPT_FUNCTION: {
+						DEV_ASSERT(p_base.get_type() == Variant::OBJECT);
+						Object *obj = *VariantInternal::get_object(&p_base);
+						return fn.gdscript_function->call(reinterpret_cast<GDScriptInstance *>(obj->get_script_instance()), p_args, p_argcount, p_error);
+					} break;
+					case VariantCallCache::Type::METHOD_BIND: {
+						return fn.method_bind->call(*VariantInternal::get_object(&p_base), p_args, p_argcount, p_error);
+					} break;
+					case VariantCallCache::Type::VARIANT_BUILTIN_METHOD: {
+						Variant ret;
+						fn.variant_builtin_method.call(&p_base, p_args, p_argcount, ret, *fn.variant_builtin_method.default_values, p_error);
+						return ret;
+					}
+					default:
+						WARN_PRINT("Unhandled call cache type");
+						state = CacheState::DISABLED;
 				}
-				return;
 			} else {
 				state = CacheState::DISABLED;
 				// TODO: cleanup?
 			}
 		}
 		// Fallback to variant call
-		if (p_ret != nullptr) {
-			p_base.callp(p_method, p_args, p_argcount, *p_ret, p_error);
-		} else {
-			Variant v;
-			p_base.callp(p_method, p_args, p_argcount, v, p_error);
-		}
+		Variant v;
+		p_base.callp(p_method, p_args, p_argcount, v, p_error);
+		return v;
 	}
 
 	void reset();

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1977,6 +1977,10 @@ Ref<Script> CSharpInstance::get_script() const {
 	return script;
 }
 
+bool CSharpInstance::script_eq(const Ref<Script> &p_script) const {
+	return *script == *p_script;
+}
+
 ScriptLanguage *CSharpInstance::get_language() {
 	return CSharpLanguage::get_singleton();
 }

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -376,6 +376,7 @@ public:
 	String to_string(bool *r_valid) override;
 
 	Ref<Script> get_script() const override;
+	bool script_eq(const Ref<Script> &p_script) const override;
 
 	ScriptLanguage *get_language() override;
 

--- a/tests/core/object/test_object.cpp
+++ b/tests/core/object/test_object.cpp
@@ -106,6 +106,9 @@ public:
 	Ref<Script> get_script() const override {
 		return Ref<Script>();
 	}
+	bool script_eq(const Ref<Script> &p_script) const override {
+		return false;
+	}
 	const Variant get_rpc_config() const override {
 		return Variant();
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Reduces GDScript function call overhead.

## Additional information

This PR is a proof of concept implementing [inline caching](https://en.wikipedia.org/wiki/Inline_caching) for GDScript function calls. The high level idea is that when we look up a function to call, the same class/script will result in the same function found. Usually, there is only one concrete type that is being used.

The cache only supports the monomorphic case (one type). If the cache ever misses after loading, it transitions to an invalid state where all calls will fall back to the current `Variant::callp` way. The implementation can pretty easily be extended to support polymorphic cases. 

No AI used.

## Motivation

A large portion of function call time is spent dispatching. See the profiling of calling a simple empty function (monomorphic) in a loop.

<img width="362" height="135" alt="image" src="https://github.com/user-attachments/assets/5c28b4da-c24b-4c6a-91f1-d1ab78038934" />

Functions are called through `Variant::callp` so we spend only 37.66/87.31 = 43% of the time in the function body. That leaves 57% of function overhead in the lookup/dispatching!

## Benchmarking

[function-benchmark.zip](https://github.com/user-attachments/files/31498774/function-benchmark.zip)

<details>
<summary>Scenarios</summary>

All classes used have the body:

```gdscript
func f():
    pass

static func g():
    pass
```

Note: the test never uses multiple instances of the same class but this should not noticeably affect the performance delta of the change. 

### Cache hit (Monomorphic/instance)

```gdscript
var a := A.new()

for i in N:
	a.f()
```

### Cache hit (Monomorphic/static)

```gdscript
for i in N:
	A.g()
```

### Cache hit (Monomorphic/Variant built-in)

```gdscript
var a: Variant
if true:
	a = Array()

for i in N:
	a.size()
```

### Cache miss (Megamorphic/instance)

```gdscript
var obj = A.new()

for i in N:
	obj.f()
	if i == 0:
		obj.free()
		obj = B.new()
```

### Cache miss (Megamorphic/static)

```gdscript
var c = A

for i in N:
	c.g()
	if i == 0:
		c = B
```

### Cache miss (Megamorphic/Variant built-in)

```gdscript
var a = Array()

for i in N:
	a.size()
	if i == 0:
		a = Dictionary()
```

</details>

<details>
<summary>Hardware specs</summary>
CPU: AMD 9800x3d
RAM: 32GB DDR5 6400 CL28
</details>

These results are run on release templates built on GCC/MinGW Win11. The program was opened 5 times and run 5 times for each category. The 25 runs were then aggregated and the 15th percentile is shown in the table. Tested with `N=100_000_000` iterations, however numbers are normalized to nanoseconds per iteration.

| Cache hit/miss | Function type | Variant type | Master (ns/iter) | PR (ns/iter) | Delta | % Change |
| --- | --- | --- | --- | --- | --- | --- |
| Hit | Instance | GDScript | 22.36 | 14.31 | -8.05 | -36% |
| Hit | Static | GDScript | 17.75 | 12.53 | -5.22 | -29% |
| Hit | Instance | Array | 10.24 | 9.04 | -1.20 | -11% |
| Miss | Instance | GDScript | 25.20 | 25.67 | +0.47 | +2% |
| Miss | Static | GDScript | 21.34 | 21.61 | +0.27 | +1% |
| Miss | Instance | Array/Dict | 13.40 | 14.48 | +1.08 | +8% |

Monomorphic is likely the most common case in practice and sees a sizeable improvement in this benchmark. I suspect real-world improvements will be greater as class hierarchies and larger method maps will increase the unoptimized lookup time.

Meanwhile, the change will add a slight overhead to the megamorphic case as there is an additional check and level of indirection now. 

## Implementation details

I've labelled this PR a POC because I regard some parts as not done _properly_. I am open to improvements on the implementation.

### Cache Key

The logic to compare if the cache is a hit is as follows:

1. Variant type matches.
2. If the type is not Object, cache hit, otherwise continue checks 3+4
3. The `GDType *` of the base Variant is the same.
4. If the Variant is an Object, the Script is the same.
    - If static, the Object is the same Script ref.
    - Otherwise, the script instance references the same Script.

Additionally the logic to compare if the Script matches is implemented as virtual function on `Object`. Ideally it wouldn't be virtual but `ScriptInstanceExtension` has a dynamic way to fetch the `Script`. 

### Lookup

I added `lookup_function_call` that mirrors `callp` but instead returns a callable function. See section below on how it's stored.

### Function Representation

A few types of "callable functions" are supported. As only one will be used at a time, these are in a union. 

* `GDScriptFunction *` - store the pointer
* `MethodBind *` - store the pointer
* `VariantBuiltInMethodInfo *` - store the `call` function pointer and pointer to default arguments `Vector<Variant>`

## TODO

These are the known issues/improvements that I will likely not resolve for the POC:

- [ ] Thread safety (probably implemented via a `RWLock` and will add some overhead or every thread has its own cache)
- [ ] Support other types
  - [ ] Scripts (C#, GDExtension) - I think these need will need changes to the API
  - [x] GDScriptNativeClass
  - [x] Variant types (Array, Dictionary, etc)
- [ ] Hot reloading (requires invalidating cache)
- [ ] Target other opcodes (currently only supports `OPCODE_CALL/CALL_ASYNC/CALL_RETURN`)

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
