### PR TITLE
Fix hash function for `const char *` producing a pointer-based hash instead of a string-based hash

### DIFF
--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -208,6 +208,9 @@ struct HashMapHasherDefaultImpl<char *> {
 };
 
 template <>
+struct HashMapHasherDefaultImpl<const char *> : HashMapHasherDefaultImpl<char *> {};
+
+template <>
 struct HashMapHasherDefaultImpl<wchar_t> {
 	static _FORCE_INLINE_ uint32_t hash(const wchar_t p_wchar) { return hash_fmix32(uint32_t(p_wchar)); }
 };


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes source-level regression from https://github.com/godotengine/godot/pull/111361

Currently, `const char *` is hashed by pointer (as `uint64_t`) instead of by string (like `char *` / `String`).

## Additional information

It seems like nothing in Godot currently hits this bug because nothing hashes on `const char *` via `HashMapHasherDefault` (`HashMap`, `HashSet`, `AHashMap`...)

> Author Disclosure: Bug identified by AI. I wrote the fix.