### PR TITLE
Add unit tests for Vector2::orthogonal() and Vector2::is_same()

### DIFF
--- a/tests/core/math/test_vector2.cpp
+++ b/tests/core/math/test_vector2.cpp
@@ -497,4 +497,26 @@ TEST_CASE("[Vector2] Finite number checks") {
 	}
 }
 
+TEST_CASE("[Vector2] Orthogonal and identity methods") {
+	CHECK_MESSAGE(
+			Vector2(1, 2).orthogonal() == Vector2(2, -1),
+			"Vector2(1, 2).orthogonal() should return the vector rotated 90 degrees clockwise.");
+	CHECK_MESSAGE(
+			Vector2(0, 0).orthogonal() == Vector2(0, 0),
+			"Vector2(0, 0).orthogonal() should return the zero vector.");
+	CHECK_MESSAGE(
+			Vector2(-3, 4).orthogonal() == Vector2(4, 3),
+			"Vector2(-3, 4).orthogonal() should return the vector rotated 90 degrees clockwise.");
+
+	CHECK_MESSAGE(
+			Vector2(1, 2).is_same(Vector2(1, 2)),
+			"Vector2::is_same() should return true for identical vectors.");
+	CHECK_FALSE_MESSAGE(
+			Vector2(1, 2).is_same(Vector2(1, 3)),
+			"Vector2::is_same() should return false for different vectors.");
+	CHECK_MESSAGE(
+			Vector2(Math::NaN, 1).is_same(Vector2(Math::NaN, 1)),
+			"Vector2::is_same() should treat two NaN components as equal, unlike the == operator.");
+}
+
 } // namespace TestVector2


### PR DESCRIPTION
## What problem(s) does this PR solve?

Adds missing unit test coverage for `Vector2::orthogonal()` and `Vector2::is_same()`, which had no tests despite other Vector2 methods being covered.

## Additional information

Contributes to #43440.

Test coverage added:
- `orthogonal()`: verified against representative vectors including the zero vector, matching the `Vector2(y, -x)` formula.
- `is_same()`: verified equality/inequality, and specifically that it treats two NaN components as equal (unlike the `==` operator), matching its underlying `Math::is_same()` implementation.

## AI disclosure

I used Claude (Anthropic) as a guide while writing this PR, as this is my first contribution to Godot. Specifically, it helped me:
- Identify which Vector2 methods lacked test coverage by comparing the class header against the existing test file.
- Understand the exact behavior of `orthogonal()` and `is_same()` by walking through their source code (including the underlying `Math::is_same()` helper) with me.
- Match the existing code style/conventions used in `test_vector2.cpp` (CHECK_MESSAGE/CHECK_FALSE_MESSAGE formatting).

I reviewed, compiled, and ran the resulting tests myself (all 22 test cases pass, 148 assertions) before opening this PR, and understand what the code does.
