### PR TITLE
Update comments in `AudioStreamPlaybackPlaylist::mix` to make the `fade_buffer` fix clearer

### DIFF
--- a/modules/interactive_music/audio_stream_playlist.cpp
+++ b/modules/interactive_music/audio_stream_playlist.cpp
@@ -322,11 +322,12 @@ int AudioStreamPlaybackPlaylist::mix(AudioFrame *p_buffer, float p_rate_scale, i
 					}
 					fade_index = -1;
 				} else {
+					// Index i was already mixed but will be accessed later already, so set it to 0.
+					fade_buffer[i] = AudioFrame(0.0, 0.0);
 					// Move remaining mixed data to fade buffer.
 					for (int j = i + 1; j < to_mix; j++) {
 						fade_buffer[j] = mix_buffer[j];
 					}
-					fade_buffer[i] = AudioFrame(0.0, 0.0);
 
 					fade_index = prev;
 					fade_volume = 1.0;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Follow-up of https://github.com/godotengine/godot/pull/100986

Makes the code a tiny bit faster by writing in series, and updates the comment to make it clearer what's happening.
Nitpick that was ignored to make the above merge easier.
