### PR TITLE
Fix bug in `OpenXRUtil::string_from_xruuid`

### DIFF
--- a/modules/openxr/openxr_util.cpp
+++ b/modules/openxr/openxr_util.cpp
@@ -111,7 +111,7 @@ String OpenXRUtil::string_from_xruuid(const XrUuid &xr_uuid) {
 	for (int i = 0; i < XR_UUID_SIZE; i++) {
 		non_zero |= xr_uuid.data[i] != 0;
 
-		char a = xr_uuid.data[i] & 0xF0 >> 4;
+		char a = (xr_uuid.data[i] & 0xF0) >> 4;
 		char b = xr_uuid.data[i] & 0x0F;
 
 		if (a < 10) {


### PR DESCRIPTION
## What problem(s) does this PR solve?
`OpenXRUtil::string_from_xruuid` was generating the wrong hexadecimal string from `XrUuid`, due to `>>` having higher precedence than `&`.

In particular, this:
```c++
char a = xr_uuid.data[i] & 0xF0 >> 4;
char b = xr_uuid.data[i] & 0x0F;
```

Is equivalent to
```c++
char a = xr_uuid.data[i] & 0x0F;
char b = xr_uuid.data[i] & 0x0F;
```

This would result in the hexadecimal string appearing to duplicate the last 4 bits of each 8 bit number.
For example, the base 10 value of `33` would incorrectly become `0x11` (`33` is `0x21`)

This PR adds parenthesis so that `&` is evaluated before `>>`