### PR TITLE
Auto-switch debugger sessions when remote nodes are selected

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -173,7 +173,7 @@ void EditorDebuggerInspector::_object_selected(ObjectID p_object) {
 	emit_signal(SNAME("object_selected"), p_object);
 }
 
-EditorDebuggerRemoteObjects *EditorDebuggerInspector::set_objects(const Array &p_arr) {
+EditorDebuggerRemoteObjects *EditorDebuggerInspector::set_objects(const Array &p_arr, int p_debugger_id) {
 	ERR_FAIL_COND_V(p_arr.is_empty(), nullptr);
 
 	TypedArray<uint64_t> ids;
@@ -203,6 +203,7 @@ EditorDebuggerRemoteObjects *EditorDebuggerInspector::set_objects(const Array &p
 		remote_objects = memnew(EditorDebuggerRemoteObjects);
 		remote_objects->remote_object_ids = ids;
 		remote_objects->remote_object_ids.make_read_only();
+		remote_objects->debugger_id = p_debugger_id;
 		remote_objects->connect("values_edited", callable_mp(this, &EditorDebuggerInspector::_objects_edited));
 		remote_objects_list.push_back(remote_objects);
 	}

--- a/editor/debugger/editor_debugger_inspector.h
+++ b/editor/debugger/editor_debugger_inspector.h
@@ -55,6 +55,7 @@ public:
 	String node_name; // For human-readable name.
 	List<PropertyInfo> prop_list;
 	HashMap<StringName, TypedDictionary<uint64_t, Variant>> prop_values;
+	int debugger_id = 0;
 
 	bool _hide_script_from_inspector() { return true; }
 	bool _hide_metadata_from_inspector() { return true; }
@@ -88,7 +89,7 @@ public:
 	~EditorDebuggerInspector();
 
 	// Remote Object cache
-	EditorDebuggerRemoteObjects *set_objects(const Array &p_array);
+	EditorDebuggerRemoteObjects *set_objects(const Array &p_array, int p_debugger_id);
 	void clear_remote_inspector();
 	void clear_cache();
 	void invalidate_selection_from_cache(const TypedArray<uint64_t> &p_ids);

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -126,7 +126,7 @@ ScriptEditorDebugger *EditorDebuggerNode::_add_debugger() {
 	node->connect("remote_tree_select_requested", callable_mp(this, &EditorDebuggerNode::_remote_tree_select_requested).bind(id));
 	node->connect("remote_tree_clear_selection_requested", callable_mp(this, &EditorDebuggerNode::_remote_tree_clear_selection_requested).bind(id));
 	node->connect("remote_tree_updated", callable_mp(this, &EditorDebuggerNode::_remote_tree_updated).bind(id));
-	node->connect("remote_objects_updated", callable_mp(this, &EditorDebuggerNode::_remote_objects_updated).bind(id));
+	node->connect("remote_objects_updated", callable_mp(this, &EditorDebuggerNode::_remote_objects_updated));
 	node->connect("remote_object_property_updated", callable_mp(this, &EditorDebuggerNode::_remote_object_property_updated).bind(id));
 	node->connect("remote_objects_requested", callable_mp(this, &EditorDebuggerNode::_remote_objects_requested).bind(id));
 	node->connect("set_breakpoint", callable_mp(this, &EditorDebuggerNode::_breakpoint_set_in_tree).bind(id));
@@ -247,8 +247,23 @@ void EditorDebuggerNode::register_undo_redo(UndoRedo *p_undo_redo) {
 	p_undo_redo->set_property_notify_callback(_properties_changed, this);
 }
 
+void EditorDebuggerNode::set_current_debugger(int p_debugger) {
+	tabs->set_current_tab(p_debugger);
+}
+
 ScriptEditorDebugger *EditorDebuggerNode::get_debugger(int p_id) const {
 	return Object::cast_to<ScriptEditorDebugger>(tabs->get_tab_control(p_id));
+}
+
+int EditorDebuggerNode::get_debugger_id(const ScriptEditorDebugger *p_debugger) {
+	for (int i = 0; i < tabs->get_tab_count(); i++) {
+		const ScriptEditorDebugger *debugger = Object::cast_to<ScriptEditorDebugger>(tabs->get_tab_control(i));
+		if (p_debugger == debugger) {
+			return i;
+		}
+	}
+
+	ERR_FAIL_V(-1);
 }
 
 ScriptEditorDebugger *EditorDebuggerNode::get_previous_debugger() const {
@@ -529,14 +544,6 @@ void EditorDebuggerNode::_debugger_changed(int p_tab) {
 	remote_scene_tree_wait = false;
 	inspect_edited_object_wait = false;
 
-	if (Object *robjs = InspectorDock::get_inspector_singleton()->get_edited_object()) {
-		if (Object::cast_to<EditorDebuggerRemoteObjects>(robjs)) {
-			// Clear inspected object, you can only inspect objects in selected debugger.
-			// Hopefully, in the future, we will have one inspector per debugger.
-			EditorNode::get_singleton()->push_item(nullptr);
-		}
-	}
-
 	if (ScriptEditorDebugger *prev_debug = get_previous_debugger()) {
 		prev_debug->clear_inspector();
 		_text_editor_stack_clear(prev_debug);
@@ -720,14 +727,14 @@ void EditorDebuggerNode::request_remote_tree() {
 	get_current_debugger()->request_remote_tree();
 }
 
-void EditorDebuggerNode::set_remote_selection(const TypedArray<int64_t> &p_ids) {
+void EditorDebuggerNode::set_remote_selection(const TypedArray<int64_t> &p_ids, int p_debugger) {
 	stop_waiting_inspection();
-	get_current_debugger()->request_remote_objects(p_ids);
+	get_debugger(p_debugger)->request_remote_objects(p_ids);
 }
 
 void EditorDebuggerNode::clear_remote_tree_selection() {
 	remote_scene_tree->clear_selection();
-	get_current_debugger()->clear_inspector(remote_scene_tree_clear_msg);
+	get_debugger(remote_scene_tree->get_current_debugger())->clear_inspector();
 }
 
 void EditorDebuggerNode::stop_waiting_inspection() {
@@ -750,9 +757,7 @@ void EditorDebuggerNode::_remote_tree_clear_selection_requested(int p_debugger) 
 		return;
 	}
 	remote_scene_tree->clear_selection();
-	remote_scene_tree_clear_msg = false;
 	get_current_debugger()->clear_inspector(false);
-	remote_scene_tree_clear_msg = true;
 }
 
 void EditorDebuggerNode::_remote_tree_updated(int p_debugger) {
@@ -781,9 +786,9 @@ void EditorDebuggerNode::_remote_tree_button_pressed(Object *p_item, int p_colum
 	}
 }
 
-void EditorDebuggerNode::_remote_objects_updated(EditorDebuggerRemoteObjects *p_objs, int p_debugger) {
-	if (p_debugger == tabs->get_current_tab() && p_objs != InspectorDock::get_inspector_singleton()->get_edited_object()) {
-		EditorNode::get_singleton()->push_item(p_objs);
+void EditorDebuggerNode::_remote_objects_updated(EditorDebuggerRemoteObjects *p_remote_objects) {
+	if (p_remote_objects->debugger_id == tabs->get_current_tab() && p_remote_objects != InspectorDock::get_inspector_singleton()->get_edited_object()) {
+		EditorNode::get_singleton()->push_item(p_remote_objects);
 	}
 }
 

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -106,7 +106,6 @@ private:
 	EditorDebuggerTree *remote_scene_tree = nullptr;
 	bool remote_scene_tree_wait = false;
 	float remote_scene_tree_timeout = 0.0;
-	bool remote_scene_tree_clear_msg = true;
 	bool auto_switch_remote_scene_tree = false;
 	bool debug_with_external_editor = false;
 	bool keep_open = false;
@@ -137,7 +136,7 @@ protected:
 	void _remote_tree_clear_selection_requested(int p_debugger);
 	void _remote_tree_updated(int p_debugger);
 	void _remote_tree_button_pressed(Object *p_item, int p_column, int p_id, MouseButton p_button);
-	void _remote_objects_updated(EditorDebuggerRemoteObjects *p_objs, int p_debugger);
+	void _remote_objects_updated(EditorDebuggerRemoteObjects *p_remote_objects);
 	void _remote_object_property_updated(ObjectID p_id, const String &p_property, int p_debugger);
 	void _remote_objects_requested(const TypedArray<uint64_t> &p_ids, int p_debugger);
 	void _remote_selection_cleared(int p_debugger);
@@ -170,10 +169,12 @@ public:
 	static EditorDebuggerNode *get_singleton() { return singleton; }
 	void register_undo_redo(UndoRedo *p_undo_redo);
 
+	void set_current_debugger(int p_debugger);
 	ScriptEditorDebugger *get_previous_debugger() const;
 	ScriptEditorDebugger *get_current_debugger() const;
 	ScriptEditorDebugger *get_default_debugger() const;
 	ScriptEditorDebugger *get_debugger(int p_debugger) const;
+	int get_debugger_id(const ScriptEditorDebugger *p_debugger);
 
 	void debug_next();
 	void debug_step();
@@ -196,7 +197,7 @@ public:
 
 	// Remote inspector/edit.
 	void request_remote_tree();
-	void set_remote_selection(const TypedArray<int64_t> &p_ids);
+	void set_remote_selection(const TypedArray<int64_t> &p_ids, int p_debugger);
 	void clear_remote_tree_selection();
 	void stop_waiting_inspection();
 	bool match_remote_selection(const TypedArray<uint64_t> &p_ids) const;

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -213,10 +213,10 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 	set_hide_root(false);
 
 	updating_scene_tree = true;
-	const String last_path = get_selected_path();
 	const String filter = SceneTreeDock::get_singleton()->get_filter();
 	LocalVector<TreeItem *> select_items;
 	bool hide_filtered_out_parents = EDITOR_GET("docks/scene_tree/hide_filtered_out_parents");
+	debugger_id = p_debugger; // Needed by hook, could be avoided if every debugger had its own tree.
 
 	bool should_scroll = scrolling_to_item || filter != last_filter;
 	scrolling_to_item = false;
@@ -281,28 +281,19 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 		item->set_meta("node_path", current_path + "/" + item->get_text(0));
 
 		// Select previously selected nodes.
-		if (debugger_id == p_debugger) { // Can use remote id.
-			if (inspected_object_ids.has(uint64_t(node.id))) {
-				ids_present.append(node.id);
-				select_items.push_back(item);
-				if (should_scroll) {
-					// Temporarily set to `false`, to allow caching the unfolds.
-					updating_scene_tree = false;
-					// Expand ancestors to make the item visible.
-					if (TreeItem *parent_item = item->get_parent()) {
-						parent_item->uncollapse_tree();
-					}
-					updating_scene_tree = true;
-					scroll_item = item;
-				}
-			}
-		} else if (last_path == (String)item->get_meta("node_path")) { // Must use path.
-			updating_scene_tree = false; // Force emission of new selections.
+		if (inspected_object_ids.has(uint64_t(node.id))) {
+			ids_present.append(node.id);
 			select_items.push_back(item);
 			if (should_scroll) {
+				// Temporarily set to `false`, to allow caching the unfolds.
+				updating_scene_tree = false;
+				// Expand ancestors to make the item visible.
+				if (TreeItem *parent_item = item->get_parent()) {
+					parent_item->uncollapse_tree();
+				}
+				updating_scene_tree = true;
 				scroll_item = item;
 			}
-			updating_scene_tree = true;
 		}
 
 		// Add buttons.
@@ -388,8 +379,6 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 	}
 
 	inspected_object_ids = ids_present;
-
-	debugger_id = p_debugger; // Needed by hook, could be avoided if every debugger had its own tree.
 
 	for (TreeItem *item : select_items) {
 		item->select(0);

--- a/editor/debugger/editor_debugger_tree.h
+++ b/editor/debugger/editor_debugger_tree.h
@@ -97,7 +97,7 @@ public:
 	void update_icon_max_width();
 	String get_selected_path();
 	ObjectID get_selected_object();
-	int get_current_debugger(); // Would love to have one tree for every debugger.
+	int get_current_debugger() { return debugger_id; }
 	inline TypedArray<uint64_t> get_selection() const { return inspected_object_ids.duplicate(); }
 	void update_scene_tree(const SceneDebuggerTree *p_tree, int p_debugger);
 	void select_nodes(const TypedArray<int64_t> &p_ids);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -452,11 +452,10 @@ void ScriptEditorDebugger::_msg_scene_scene_tree(uint64_t p_thread_id, const Arr
 
 void ScriptEditorDebugger::_msg_scene_inspect_objects(uint64_t p_thread_id, const Array &p_data) {
 	ERR_FAIL_COND(p_data.is_empty());
-	EditorDebuggerRemoteObjects *objs = inspector->set_objects(p_data);
-	if (objs && EditorDebuggerNode::get_singleton()->match_remote_selection(objs->remote_object_ids)) {
+	EditorDebuggerRemoteObjects *robjs = inspector->set_objects(p_data, get_current_debugger_tab());
+	if (robjs && EditorDebuggerNode::get_singleton()->match_remote_selection(robjs->remote_object_ids)) {
 		EditorDebuggerNode::get_singleton()->stop_waiting_inspection();
-
-		emit_signal(SNAME("remote_objects_updated"), objs);
+		emit_signal(SNAME("remote_objects_updated"), robjs);
 	}
 }
 
@@ -911,12 +910,16 @@ void ScriptEditorDebugger::_msg_request_quit(uint64_t p_thread_id, const Array &
 
 void ScriptEditorDebugger::_msg_remote_objects_selected(uint64_t p_thread_id, const Array &p_data) {
 	ERR_FAIL_COND(p_data.is_empty());
-	EditorDebuggerRemoteObjects *objs = inspector->set_objects(p_data);
-	if (objs) {
-		EditorDebuggerNode::get_singleton()->stop_waiting_inspection();
+	EditorDebuggerNode *dbg = EditorDebuggerNode::get_singleton();
+	EditorDebuggerRemoteObjects *robjs = inspector->set_objects(p_data, dbg->get_debugger_id(this));
+	if (robjs) {
+		dbg->stop_waiting_inspection();
+		if (dbg->get_current_debugger() != this) {
+			dbg->set_current_debugger(robjs->debugger_id);
+		}
 
-		emit_signal(SNAME("remote_objects_updated"), objs);
-		emit_signal(SNAME("remote_tree_select_requested"), objs->remote_object_ids.duplicate());
+		emit_signal(SNAME("remote_objects_updated"), robjs);
+		emit_signal(SNAME("remote_tree_select_requested"), robjs->remote_object_ids.duplicate());
 	}
 }
 

--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -372,7 +372,7 @@ void InspectorDock::_select_history(int p_idx) {
 	EditorNode::get_singleton()->push_item(obj);
 
 	if (const EditorDebuggerRemoteObjects *robjs = Object::cast_to<EditorDebuggerRemoteObjects>(obj)) {
-		EditorDebuggerNode::get_singleton()->set_remote_selection(robjs->remote_object_ids.duplicate());
+		EditorDebuggerNode::get_singleton()->set_remote_selection(robjs->remote_object_ids, robjs->debugger_id);
 	}
 }
 
@@ -415,7 +415,7 @@ void InspectorDock::_edit_forward() {
 		EditorNode::get_singleton()->edit_current();
 
 		if (const EditorDebuggerRemoteObjects *robjs = Object::cast_to<EditorDebuggerRemoteObjects>(current)) {
-			EditorDebuggerNode::get_singleton()->set_remote_selection(robjs->remote_object_ids.duplicate());
+			EditorDebuggerNode::get_singleton()->set_remote_selection(robjs->remote_object_ids, robjs->debugger_id);
 		}
 	}
 }
@@ -426,7 +426,7 @@ void InspectorDock::_edit_back() {
 		EditorNode::get_singleton()->edit_current();
 
 		if (const EditorDebuggerRemoteObjects *robjs = Object::cast_to<EditorDebuggerRemoteObjects>(current)) {
-			EditorDebuggerNode::get_singleton()->set_remote_selection(robjs->remote_object_ids.duplicate());
+			EditorDebuggerNode::get_singleton()->set_remote_selection(robjs->remote_object_ids, robjs->debugger_id);
 		}
 	}
 }

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3065,6 +3065,7 @@ void EditorNode::push_item(Object *p_object, const String &p_property, bool p_in
 		GroupsDock::get_singleton()->set_selection(Vector<Node *>());
 		SceneTreeDock::get_singleton()->set_selected(nullptr);
 		InspectorDock::get_singleton()->update(nullptr);
+		EditorDebuggerNode::get_singleton()->clear_remote_tree_selection();
 		hide_unused_editors();
 		return;
 	}


### PR DESCRIPTION
## What problem(s) does this PR solve?

Currently, when selecting a remote node in a session that is not the current one, while the remote side will show the node as selected, the editor side will remain ignorant of it. That's because messages from non-current sessions are ignored.

This PR makes so that selecting a remote node in them will automatically switch the current status to it:

[Screencast_20260804_183544.webm](https://github.com/user-attachments/assets/308a17c4-6868-47c6-b2b1-65906699b8f6)

## Additional information

This PR also fixes selecting remote objects from different sessions in the inspector history resulting in blank objects. Now they also trigger the auto-switch.