### PR TITLE
Fix wrong common class logic for inspected remote nodes

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -148,7 +148,7 @@ EditorDebuggerInspector::~EditorDebuggerInspector() {
 
 void EditorDebuggerInspector::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("object_selected", PropertyInfo(Variant::INT, "id")));
-	ADD_SIGNAL(MethodInfo("objects_edited", PropertyInfo(Variant::ARRAY, "ids"), PropertyInfo(Variant::STRING, "property"), PropertyInfo("value"), PropertyInfo(Variant::STRING, "field")));
+	ADD_SIGNAL(MethodInfo("objects_edited", PropertyInfo(Variant::STRING, "property"), PropertyInfo(Variant::DICTIONARY, "values", PROPERTY_HINT_DICTIONARY_TYPE, "int;Variant"), PropertyInfo(Variant::STRING, "field")));
 	ADD_SIGNAL(MethodInfo("object_property_updated", PropertyInfo(Variant::INT, "id"), PropertyInfo(Variant::STRING, "property")));
 }
 
@@ -344,6 +344,8 @@ EditorDebuggerRemoteObjects *EditorDebuggerInspector::set_objects(const Array &p
 				}
 			}
 		}
+	} else {
+		has_custom_class = false;
 	}
 
 	if (!has_custom_class && class_name != SNAME("Object")) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

When selecting multiple remote nodes, the editor checks for a common class shared by all of them. However, the code logic wasn't executed if one of the nodes had a script but no custom class. This PR fixes that.

## Additional information

I also fixed an incorrect signal binding in the same file. It's a single line change, and signal itself works fine even with the wrong bindings, so I don't think it's worth a PR of its own.