### PR TITLE
Implement `DisplayServer.screen_get_scale()` on Linux/X11

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1854,7 +1854,7 @@
 				[b]Note:[/b] One of the following constants can be used as [param screen]: [constant SCREEN_OF_MAIN_WINDOW], [constant SCREEN_PRIMARY], [constant SCREEN_WITH_MOUSE_FOCUS], or [constant SCREEN_WITH_KEYBOARD_FOCUS].
 				[b]Note:[/b] On macOS, the returned value is [code]2.0[/code] for hiDPI (Retina) screens, and [code]1.0[/code] for all other cases.
 				[b]Note:[/b] On Linux (Wayland), the returned value is accurate only when [param screen] is [constant SCREEN_OF_MAIN_WINDOW]. Due to API limitations, passing a direct index will return a rounded-up integer, if the screen has a fractional scale (e.g. [code]1.25[/code] would get rounded up to [code]2.0[/code]).
-				[b]Note:[/b] This method is implemented on Android, iOS, Web, macOS, Linux (Wayland), and Windows. On other platforms, this method always returns [code]1.0[/code].
+				[b]Note:[/b] This method is implemented on Android, iOS, Web, macOS, Linux, and Windows. On other platforms, this method always returns [code]1.0[/code].
 			</description>
 		</method>
 		<method name="screen_get_size" qualifiers="const">

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -2039,7 +2039,7 @@ float EditorSettings::get_auto_display_scale() {
 	}
 #endif
 
-#if defined(MACOS_ENABLED) || defined(WINDOWS_ENABLED) || defined(ANDROID_ENABLED)
+#if defined(MACOS_ENABLED) || defined(LINUXBSD_ENABLED) || defined(WINDOWS_ENABLED) || defined(ANDROID_ENABLED)
 	return DisplayServer::get_singleton()->screen_get_max_scale();
 #else
 
@@ -2067,7 +2067,7 @@ float EditorSettings::get_auto_display_scale() {
 	}
 	return 1.0;
 
-#endif // defined(MACOS_ENABLED) || defined(WINDOWS_ENABLED) || defined(ANDROID_ENABLED)
+#endif // defined(MACOS_ENABLED) || defined(LINUXBSD_ENABLED) || defined(WINDOWS_ENABLED) || defined(ANDROID_ENABLED)
 }
 
 String EditorSettings::get_language() const {

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -51,6 +51,7 @@
 #include "servers/rendering/dummy/rasterizer_dummy.h"
 
 #include <X11/Xatom.h>
+#include <X11/Xresource.h>
 
 #ifdef SOWRAP_ENABLED
 #include "x11/dynwrappers/xext-so_wrap.h"
@@ -1662,7 +1663,7 @@ int DisplayServerX11::screen_get_dpi(int p_screen) const {
 	int screen_count = get_screen_count();
 	ERR_FAIL_INDEX_V(p_screen, screen_count, 96);
 
-	//Get physical monitor Dimensions through XRandR and calculate dpi
+	// Get physical monitor Dimensions through XRandR and calculate DPI.
 	Size2i sc = screen_get_size(p_screen);
 	if (xrandr_ext_ok) {
 		int count = 0;
@@ -1693,8 +1694,56 @@ int DisplayServerX11::screen_get_dpi(int p_screen) const {
 		return (xdpi + ydpi) / (xdpi && ydpi ? 2 : 1);
 	}
 
-	//could not get dpi
+	// Could not get DPI.
 	return 96;
+}
+
+float DisplayServerX11::screen_get_scale(int p_screen) const {
+	_THREAD_SAFE_METHOD_
+
+	p_screen = _get_screen_index(p_screen);
+	ERR_FAIL_INDEX_V(p_screen, get_screen_count(), 1.0);
+
+	// KDE on X11 stores fractional scaling in the Xsettings configuration file.
+	// Other desktop environments such as GNOME usually only support fractional scaling on Wayland.
+	// <https://wiki.archlinux.org/title/Xsettingsd>
+	const String xsettings_path = OS::get_singleton()->get_environment("HOME").path_join(".config/xsettingsd/xsettingsd.conf");
+	if (FileAccess::exists(xsettings_path)) {
+		Ref<FileAccess> file = FileAccess::open(xsettings_path, FileAccess::READ);
+		if (file.is_valid()) {
+			// The display scaling value is split into an integer portion, and a fractional part reported as `dpi * 1024`.
+			// The fractional part rolls over to `96 * 1024 = 98304` when reaching a new integer scale factor.
+			//
+			// We do not use the value reported by `screen_get_dpi()` as it reports the actual physical DPI of the monitor,
+			// rather than a pseudo-DPI value meant for scaling (which is always 96 DPI at 100% scaling, like on Windows).
+			int window_scaling_factor = 1;
+			float dpi = 0.0;
+			while (!file->eof_reached()) {
+				const String line = file->get_line().strip_edges();
+
+				if (line.begins_with("Gdk/WindowScalingFactor")) {
+					const Vector<String> parts = line.split(" ");
+					if (parts.size() == 2) {
+						window_scaling_factor = parts[1].to_int();
+					}
+				}
+
+				if (line.begins_with("Gdk/UnscaledDPI")) {
+					const Vector<String> parts = line.split(" ");
+					if (parts.size() == 2) {
+						dpi = parts[1].to_float() / 1024.0;
+					}
+				}
+			}
+
+			if (dpi > 0.0) {
+				return (dpi * MAX(window_scaling_factor, 1)) / 96.0;
+			}
+		}
+	}
+
+	// Could not get scale factor.
+	return 1.0;
 }
 
 int get_image_errorhandler(Display *dpy, XErrorEvent *ev) {

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -451,6 +451,7 @@ public:
 	virtual Size2i screen_get_size(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Rect2i screen_get_usable_rect(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
 	virtual int screen_get_dpi(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
+	virtual float screen_get_scale(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
 	virtual float screen_get_refresh_rate(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Color screen_get_pixel(const Point2i &p_position) const override;
 	virtual Ref<Image> screen_get_image(int p_screen = DisplayServerEnums::SCREEN_OF_MAIN_WINDOW) const override;


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/122069.

___

- Make automatic editor scaling use this reported value on Linux/X11.

> [!NOTE]
>
> Support for fractional scaling on X11 is only available in some desktop environments.
> For example, KDE supports it, while GNOME does not support it.

- This closes https://github.com/godotengine/godot-proposals/issues/2661 (now implemented for all platforms :slightly_smiling_face:).

**Testing project:** [test_display_scale.zip](https://github.com/user-attachments/files/30723481/test_display_scale.zip)

## Preview

*Tested on KDE Plasma 6.7.3 on Fedora 44.*

https://github.com/user-attachments/assets/f733d3af-9b5e-416d-8e52-f50629f2d54f

