### PR TITLE
Use automatic display scale on the web editor

### DIFF
--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -2039,35 +2039,7 @@ float EditorSettings::get_auto_display_scale() {
 	}
 #endif
 
-#if defined(MACOS_ENABLED) || defined(LINUXBSD_ENABLED) || defined(WINDOWS_ENABLED) || defined(ANDROID_ENABLED)
 	return DisplayServer::get_singleton()->screen_get_max_scale();
-#else
-
-	// Fallback logic based on resolution and reported DPI (only used for Linux/X11 and Web).
-	const int screen = DisplayServer::get_singleton()->window_get_current_screen();
-
-	if (DisplayServer::get_singleton()->screen_get_size(screen) == Vector2i()) {
-		// Invalid screen size, skip.
-		return 1.0;
-	}
-
-	// Use the smallest dimension to use a correct display scale on portrait displays.
-	const int smallest_dimension = MIN(DisplayServer::get_singleton()->screen_get_size(screen).x, DisplayServer::get_singleton()->screen_get_size(screen).y);
-	if (DisplayServer::get_singleton()->screen_get_dpi(screen) >= 192 && smallest_dimension >= 1400) {
-		// hiDPI display.
-		return 2.0;
-	} else if (smallest_dimension >= 1700) {
-		// Likely a hiDPI display, but we aren't certain due to the returned DPI.
-		// Use an intermediate scale to handle this situation.
-		return 1.5;
-	} else if (smallest_dimension <= 800) {
-		// Small loDPI display. Use a smaller display scale so that editor elements fit more easily.
-		// Icons won't look great, but this is better than having editor elements overflow from its window.
-		return 0.75;
-	}
-	return 1.0;
-
-#endif // defined(MACOS_ENABLED) || defined(LINUXBSD_ENABLED) || defined(WINDOWS_ENABLED) || defined(ANDROID_ENABLED)
 }
 
 String EditorSettings::get_language() const {


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/122109 (best merged after that PR).

This matches the behavior seen on native platforms.

When merged after https://github.com/godotengine/godot-proposals/issues/2661, this in turn removes the need for fallback code for any platform, since all platforms now support automatic display scaling according to OS settings.

## Preview

### Desktop

*Firefox 153 on Fedora 44 (X11).*

<img width="532" height="382" alt="Image" src="https://github.com/user-attachments/assets/984b3b10-e17e-49b8-85a6-15dfdb63890f" />

### Mobile

*Firefox 153 on Android 16 on a Samsung Galaxy S26 Ultra (1080p resolution, minimum width set to 449 dp in the developer options).*

<img width="521" height="448" alt="Screenshot_20260805_014752_Firefox" src="https://github.com/user-attachments/assets/98912490-8234-4c7d-b30c-e6938ddee40b" />

By the way, I didn't find an easy way to host an HTTPS-enabled web server for local testing of the web editor on a mobile device (HTTPS is required for the secure context). I ended up using this: https://github.com/TheWaWaR/simple-http-server/issues/86#issuecomment-5185848324

Maybe we should make `platform/web/serve.py` able to host with HTTPS and a self-signed certificate?