### PR TITLE
Confirm that input object for `tween_property` has not been deleted and emit an error if it has

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -99,6 +99,7 @@ void Tween::_stop_internal(bool p_reset) {
 
 RequiredResult<PropertyTweener> Tween::tween_property(RequiredParam<const Object> p_target, const NodePath &p_property, Variant p_to, double p_duration) {
 	EXTRACT_PARAM_OR_FAIL_V(target, p_target, nullptr);
+	ERR_FAIL_COND_V_MSG(target->is_queued_for_deletion() || (!target->is_ref_counted() && ObjectDB::get_instance(target->get_instance_id()) == nullptr), nullptr, "The Tween's target object is queued for deletion or has been deleted.");
 	CHECK_VALID();
 
 	Vector<StringName> property_subnames = p_property.get_as_property_path().get_subnames();

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -99,6 +99,7 @@ void Tween::_stop_internal(bool p_reset) {
 
 RequiredResult<PropertyTweener> Tween::tween_property(RequiredParam<const Object> rp_target, const NodePath &p_property, Variant p_to, double p_duration) {
 	EXTRACT_PARAM_OR_FAIL_V(p_target, rp_target, nullptr);
+	ERR_FAIL_COND_V_MSG(p_target->is_queued_for_deletion() || (!p_target->is_ref_counted() && ObjectDB::get_instance(p_target->get_instance_id()) == nullptr), nullptr, "The Tween's target object is queued for deletion or has been deleted.");
 	CHECK_VALID();
 
 	Vector<StringName> property_subnames = p_property.get_as_property_path().get_subnames();


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #122096

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

With this PR, if `tween_property()` is called and the `Object` passed in has been deleted or queued for deletion, the `PropertyTweener` will not be created and an error will be emitted, rather than the game crashing.

The second condition in the error check:
```cpp
!p_target->is_ref_counted() && ObjectDB::get_instance(p_target->get_instance_id()) == nullptr
```
seemed to be necessary to catch a race condition. Without it, the game would still crash very occasionally; in these cases, the string representation of `p_target` was `"<Freed Object>"`. I followed that string to `Variant::stringify()` and found that it was made given as the string representation when the object met those conditions.