### PR TITLE
Fix scenario null error when disabling "Own World 3D" on viewports

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4959,6 +4959,7 @@ void Viewport::set_use_own_world_3d(bool p_use_own_world_3d) {
 			own_world_3d.instantiate();
 		}
 	} else {
+		RenderingServer::get_singleton()->viewport_set_scenario(viewport, RID());
 		own_world_3d = Ref<World3D>();
 		if (world_3d.is_valid()) {
 			world_3d->disconnect_changed(callable_mp(this, &Viewport::_own_world_3d_changed));


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121818 

## Additional information

Assignment at `own_world_3d = Ref<World3D>()` causes the old World3D to free the rid of its scenario, but  `viewport->scenario`  still points to the now invalid rid. This causes an error later when `viewport_set_scenario` tries to use it in `scenario_remove_viewport_visibility_mask`.