### PR TITLE
[Windows] Apply `y` offset to OpenGL blit to screen when using transparent border in full-screen.

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -96,6 +96,7 @@
 
 #ifdef WINDOWS_ENABLED
 bool RasterizerGLES3::screen_flipped_y = false;
+int RasterizerGLES3::screen_y_offset = 0;
 #endif
 
 void RasterizerGLES3::begin_frame(double frame_step) {
@@ -436,10 +437,16 @@ void RasterizerGLES3::_blit_render_target_to_screen(DisplayServerEnums::WindowID
 		}
 	}
 
-	Vector2 screen_rect_end = p_blit.dst_rect.get_end();
+	Rect2i dst_rect = p_blit.dst_rect;
+#ifdef WINDOWS_ENABLED
+	if (!screen_flipped_y) {
+		dst_rect.position.y += screen_y_offset;
+	}
+#endif
+	Vector2 screen_rect_end = dst_rect.get_end();
 
-	Vector2 p1 = Vector2(p_blit.dst_rect.position.x, flip_y ? screen_rect_end.y : p_blit.dst_rect.position.y);
-	Vector2 p2 = Vector2(screen_rect_end.x, flip_y ? p_blit.dst_rect.position.y : screen_rect_end.y);
+	Vector2 p1 = Vector2(dst_rect.position.x, flip_y ? screen_rect_end.y : dst_rect.position.y);
+	Vector2 p2 = Vector2(screen_rect_end.x, flip_y ? dst_rect.position.y : screen_rect_end.y);
 	Vector2 size = p2 - p1;
 
 	Rect2 screenrect = Rect2(Vector2(0.0, flip_y ? 1.0 : 0.0), Vector2(1.0, flip_y ? -1.0 : 1.0));

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -59,6 +59,7 @@ private:
 
 #ifdef WINDOWS_ENABLED
 	static bool screen_flipped_y;
+	static int screen_y_offset;
 #endif
 
 protected:
@@ -116,6 +117,9 @@ public:
 #ifdef WINDOWS_ENABLED
 	static void set_screen_flipped_y(bool p_flipped) {
 		screen_flipped_y = p_flipped;
+	}
+	static void set_screen_y_offset(int p_offset) {
+		screen_y_offset = p_offset;
 	}
 #endif
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -218,6 +218,8 @@ Vector2i _logical_to_physical(const Vector2i &p_point) {
 }
 
 Vector2i DisplayServerWindows::_get_screen_expand_offset(int p_screen) const {
+	constexpr int FS_TRANSP_BORDER = 2;
+
 	Vector2i p1 = _logical_to_physical(screen_get_position(p_screen));
 	Vector2i p2 = _logical_to_physical(screen_get_position(p_screen) + screen_get_size(p_screen));
 
@@ -238,16 +240,16 @@ Vector2i DisplayServerWindows::_get_screen_expand_offset(int p_screen) const {
 	}
 
 	if (screen_down == -1) {
-		return Vector2i(0, 2);
+		return Vector2i(0, FS_TRANSP_BORDER);
 	} else if (screen_right == -1) {
-		return Vector2i(2, 0);
+		return Vector2i(FS_TRANSP_BORDER, 0);
 	} else {
 		int diff_d = screen_get_refresh_rate(p_screen) - screen_get_refresh_rate(screen_down);
 		int diff_r = screen_get_refresh_rate(p_screen) - screen_get_refresh_rate(screen_right);
 		if (diff_d < diff_r) {
-			return Vector2i(0, 2);
+			return Vector2i(0, FS_TRANSP_BORDER);
 		} else {
-			return Vector2i(2, 0);
+			return Vector2i(FS_TRANSP_BORDER, 0);
 		}
 	}
 }
@@ -2045,6 +2047,13 @@ void DisplayServerWindows::gl_window_make_current(DisplayServerEnums::WindowID p
 #endif
 	if (gl_manager_native) {
 		gl_manager_native->window_make_current(p_window_id);
+	}
+	if (windows.has(p_window_id)) {
+		WindowData &wd = windows[p_window_id];
+		Vector2i off = (wd.multiwindow_fs || (!wd.fullscreen && wd.borderless && wd.maximized)) ? _get_screen_expand_offset(window_get_current_screen(p_window_id)) : Vector2i();
+		RasterizerGLES3::set_screen_y_offset(off.y);
+	} else {
+		RasterizerGLES3::set_screen_y_offset(0);
 	}
 #endif
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/122100

