### PR TITLE
Fix opengl3_angle renderer crashing if render thread is enabled

### DIFF
--- a/drivers/egl/egl_manager.cpp
+++ b/drivers/egl/egl_manager.cpp
@@ -350,6 +350,7 @@ void EGLManager::release_current() {
 	GLDisplay &current_display = displays[current_window->gldisplay_id];
 
 	eglMakeCurrent(current_display.egl_display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT);
+	current_window = nullptr;
 }
 
 void EGLManager::swap_buffers() {


### PR DESCRIPTION
With opengl3_angle and a separate render thread enabled, release_current() detaches the EGL
context but keeps a stale current_window pointer. This causes
window_make_current() to skip rebinding the context on the render thread, so
opengl3_angle initialization runs without a current context and crashes. 
Setting current_window to nullptr in release_current fixes this issue.
