### PR TITLE
Fix project settings dialog size when opened from `LocalizationEditor`

### DIFF
--- a/editor/translations/localization_editor.cpp
+++ b/editor/translations/localization_editor.cpp
@@ -415,7 +415,7 @@ void LocalizationEditor::_template_generate_command() {
 		_template_generate(current_path);
 		EditorToaster::get_singleton()->popup_str(TTR("Template generated."));
 	} else {
-		ProjectSettingsEditor::get_singleton()->popup_centered();
+		ProjectSettingsEditor::get_singleton()->popup_project_settings();
 		_template_generate_open();
 	}
 }


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

When you run translation template generator using Command Palette, without opening project settings first, the project settings dialog will be opened with a very small size.

[Nagranie ekranu_20260805_120543.webm](https://github.com/user-attachments/assets/84237461-62c7-4b9f-98ec-44c7daccecec)

What's worse, the editor will remember this size.


<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
