### PR TITLE
Documentation: Expand enum/bitfield validation

### DIFF
--- a/doc/class.xsd
+++ b/doc/class.xsd
@@ -154,6 +154,8 @@
 												<xs:attribute type="xs:byte" name="index" />
 												<xs:attribute type="xs:string" name="name" />
 												<xs:attribute type="xs:string" name="type" />
+												<xs:attribute type="xs:string" name="enum" use="optional" />
+												<xs:attribute type="xs:boolean" name="is_bitfield" use="optional" />
 												<xs:attribute type="xs:string" name="keywords" use="optional" />
 											</xs:complexType>
 										</xs:element>


### PR DESCRIPTION
- Required for #121895

## What problem(s) does this PR solve?

Despite `class.xsd` listing both `signals` and `theme_item` as accepting `type`, they do not have enum specifications. As noted by bruvzg[^1], signals support being bound as enums, so this is an error in our schema definitions & not the binder itself. This PR makes ~~all areas with a `type` attribute~~ `signals` now optionally accept `enum` and `is_bitfield` as well.

## Additional information

~~There's not currently a scenario where `theme_item` needs an enum, but there wasn't any real reason to exclude it during this pass.~~ **EDIT:** Might not be supported, so leaving it as just `signals` instead

[^1]: https://github.com/godotengine/godot/pull/121895#discussion_r3718571854