### PR TITLE
Specify how rounding works for halfway cases with `snapped*`

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1274,7 +1274,7 @@
 			<param index="0" name="x" type="Variant" />
 			<param index="1" name="step" type="Variant" />
 			<description>
-				Returns the multiple of [param step] that is the closest to [param x]. This can also be used to round a floating-point number to an arbitrary number of decimals.
+				Returns the multiple of [param step] that is the closest to [param x], with halfway cases rounded up for a positive [param step] and down for a negative [param step]. This can also be used to round a floating-point number to an arbitrary number of decimals.
 				The returned value is the same type of [Variant] as [param step]. Supported types: [int], [float], [Vector2], [Vector2i], [Vector3], [Vector3i], [Vector4], [Vector4i].
 				[codeblock]
 				snapped(100, 32)  # Returns 96
@@ -1291,7 +1291,7 @@
 			<param index="0" name="x" type="float" />
 			<param index="1" name="step" type="float" />
 			<description>
-				Returns the multiple of [param step] that is the closest to [param x]. This can also be used to round a floating-point number to an arbitrary number of decimals.
+				Returns the multiple of [param step] that is the closest to [param x], with halfway cases rounded up for a positive [param step] and down for a negative [param step]. This can also be used to round a floating-point number to an arbitrary number of decimals.
 				A type-safe version of [method snapped], returning a [float].
 				[codeblock]
 				snappedf(32.0, 2.5)  # Returns 32.5
@@ -1304,7 +1304,7 @@
 			<param index="0" name="x" type="float" />
 			<param index="1" name="step" type="int" />
 			<description>
-				Returns the multiple of [param step] that is the closest to [param x].
+				Returns the multiple of [param step] that is the closest to [param x], with halfway cases rounded up for a positive [param step] and down for a negative [param step].
 				A type-safe version of [method snapped], returning an [int].
 				[codeblock]
 				snappedi(53, 16)  # Returns 48

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -406,14 +406,14 @@
 			<return type="Vector2" />
 			<param index="0" name="step" type="Vector2" />
 			<description>
-				Returns a new vector with each component snapped to the nearest multiple of the corresponding component in [param step]. This can also be used to round the components to an arbitrary number of decimals.
+				Returns a new vector with each component snapped to the nearest multiple of the corresponding component in [param step], with halfway cases rounded up for a positive [param step] and down for a negative [param step]. This can also be used to round the components to an arbitrary number of decimals.
 			</description>
 		</method>
 		<method name="snappedf" qualifiers="const">
 			<return type="Vector2" />
 			<param index="0" name="step" type="float" />
 			<description>
-				Returns a new vector with each component snapped to the nearest multiple of [param step]. This can also be used to round the components to an arbitrary number of decimals.
+				Returns a new vector with each component snapped to the nearest multiple of [param step], with halfway cases rounded up for a positive [param step] and down for a negative [param step]. This can also be used to round the components to an arbitrary number of decimals.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -150,14 +150,14 @@
 			<return type="Vector2i" />
 			<param index="0" name="step" type="Vector2i" />
 			<description>
-				Returns a new vector with each component snapped to the closest multiple of the corresponding component in [param step].
+				Returns a new vector with each component snapped to the closest multiple of the corresponding component in [param step], with halfway cases rounded up for a positive [param step] and down for a negative [param step].
 			</description>
 		</method>
 		<method name="snappedi" qualifiers="const">
 			<return type="Vector2i" />
 			<param index="0" name="step" type="int" />
 			<description>
-				Returns a new vector with each component snapped to the closest multiple of [param step].
+				Returns a new vector with each component snapped to the closest multiple of [param step], with halfway cases rounded up for a positive [param step] and down for a negative [param step].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -398,14 +398,14 @@
 			<return type="Vector3" />
 			<param index="0" name="step" type="Vector3" />
 			<description>
-				Returns a new vector with each component snapped to the nearest multiple of the corresponding component in [param step]. This can also be used to round the components to an arbitrary number of decimals.
+				Returns a new vector with each component snapped to the nearest multiple of the corresponding component in [param step], with halfway cases rounded up for a positive [param step] and down for a negative [param step]. This can also be used to round the components to an arbitrary number of decimals.
 			</description>
 		</method>
 		<method name="snappedf" qualifiers="const">
 			<return type="Vector3" />
 			<param index="0" name="step" type="float" />
 			<description>
-				Returns a new vector with each component snapped to the nearest multiple of [param step]. This can also be used to round the components to an arbitrary number of decimals.
+				Returns a new vector with each component snapped to the nearest multiple of [param step]. This can also be used to round the components to an arbitrary number of decimals, with halfway cases rounded up for a positive [param step] and down for a negative [param step].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -145,14 +145,14 @@
 			<return type="Vector3i" />
 			<param index="0" name="step" type="Vector3i" />
 			<description>
-				Returns a new vector with each component snapped to the closest multiple of the corresponding component in [param step].
+				Returns a new vector with each component snapped to the closest multiple of the corresponding component in [param step], with halfway cases rounded up for a positive [param step] and down for a negative [param step].
 			</description>
 		</method>
 		<method name="snappedi" qualifiers="const">
 			<return type="Vector3i" />
 			<param index="0" name="step" type="int" />
 			<description>
-				Returns a new vector with each component snapped to the closest multiple of [param step].
+				Returns a new vector with each component snapped to the closest multiple of [param step], with halfway cases rounded up for a positive [param step] and down for a negative [param step].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -261,14 +261,14 @@
 			<return type="Vector4" />
 			<param index="0" name="step" type="Vector4" />
 			<description>
-				Returns a new vector with each component snapped to the nearest multiple of the corresponding component in [param step]. This can also be used to round the components to an arbitrary number of decimals.
+				Returns a new vector with each component snapped to the nearest multiple of the corresponding component in [param step], with halfway cases rounded up for a positive [param step] and down for a negative [param step]. This can also be used to round the components to an arbitrary number of decimals.
 			</description>
 		</method>
 		<method name="snappedf" qualifiers="const">
 			<return type="Vector4" />
 			<param index="0" name="step" type="float" />
 			<description>
-				Returns a new vector with each component snapped to the nearest multiple of [param step]. This can also be used to round the components to an arbitrary number of decimals.
+				Returns a new vector with each component snapped to the nearest multiple of [param step]. This can also be used to round the components to an arbitrary number of decimals, with halfway cases rounded up for a positive [param step] and down for a negative [param step].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Vector4i.xml
+++ b/doc/classes/Vector4i.xml
@@ -143,14 +143,14 @@
 			<return type="Vector4i" />
 			<param index="0" name="step" type="Vector4i" />
 			<description>
-				Returns a new vector with each component snapped to the closest multiple of the corresponding component in [param step].
+				Returns a new vector with each component snapped to the closest multiple of the corresponding component in [param step], with halfway cases rounded up for a positive [param step] and down for a negative [param step].
 			</description>
 		</method>
 		<method name="snappedi" qualifiers="const">
 			<return type="Vector4i" />
 			<param index="0" name="step" type="int" />
 			<description>
-				Returns a new vector with each component snapped to the closest multiple of [param step].
+				Returns a new vector with each component snapped to the closest multiple of [param step], with halfway cases rounded up for a positive [param step] and down for a negative [param step].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes godotengine/godot-docs#12113

## Additional information

It's mentioned what happens for `round*`, so it should probably be mentioned here, too, especially since it's less intuitive.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
