### PR TITLE
Allow toggling Debug Visible Paths at runtime

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -272,7 +272,6 @@
 		</member>
 		<member name="debug_paths_hint" type="bool" setter="set_debug_paths_hint" getter="is_debugging_paths_hint" default="false">
 			If [code]true[/code], curves from [Path2D] and [Path3D] nodes will be visible when running the game from the editor for debugging purposes.
-			[b]Note:[/b] This property is not designed to be changed at run-time. Changing the value of [member debug_paths_hint] while the project is running will not have the desired effect.
 		</member>
 		<member name="edited_scene_root" type="Node" setter="set_edited_scene_root" getter="get_edited_scene_root">
 			The root of the scene currently being edited in the editor. This is usually a direct child of [member root].

--- a/editor/debugger/debugger_editor_plugin.cpp
+++ b/editor/debugger/debugger_editor_plugin.cpp
@@ -157,10 +157,11 @@ void DebuggerEditorPlugin::_menu_option(int p_option) {
 
 		} break;
 		case RUN_DEBUG_PATHS: {
-			bool ischecked = debug_menu->is_item_checked(debug_menu->get_item_index(RUN_DEBUG_PATHS));
-			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_DEBUG_PATHS), !ischecked);
+			bool enable = !debug_menu->is_item_checked(debug_menu->get_item_index(RUN_DEBUG_PATHS));
+			debug_menu->set_item_checked(debug_menu->get_item_index(RUN_DEBUG_PATHS), enable);
 			if (!initializing) {
-				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_paths", !ischecked);
+				EditorSettings::get_singleton()->set_project_metadata("debug_options", "run_debug_paths", enable);
+				EditorDebuggerNode::get_singleton()->set_debug_paths(enable);
 			}
 
 		} break;

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -928,6 +928,12 @@ void EditorDebuggerNode::set_debug_collisions(bool p_enabled) {
 	});
 }
 
+void EditorDebuggerNode::set_debug_paths(bool p_enabled) {
+	_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
+		dbg->set_debug_paths(p_enabled);
+	});
+}
+
 void EditorDebuggerNode::set_camera_override(CameraOverride p_override) {
 	_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
 		dbg->set_camera_override(p_override);

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -218,6 +218,7 @@ public:
 	bool get_debug_mute_audio() const;
 
 	void set_debug_collisions(bool p_enabled);
+	void set_debug_paths(bool p_enabled);
 
 	void set_camera_override(CameraOverride p_override);
 	CameraOverride get_camera_override();

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1719,6 +1719,11 @@ void ScriptEditorDebugger::set_debug_collisions(bool p_enable) {
 	_put_msg("scene:set_debug_collisions", msg);
 }
 
+void ScriptEditorDebugger::set_debug_paths(bool p_enable) {
+	Array msg = { p_enable };
+	_put_msg("scene:set_debug_paths", msg);
+}
+
 CameraOverride ScriptEditorDebugger::get_camera_override() const {
 	return camera_override;
 }

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -373,6 +373,7 @@ public:
 	void set_debug_mute_audio(bool p_mute);
 
 	void set_debug_collisions(bool p_enable);
+	void set_debug_paths(bool p_enable);
 
 	EditorDebuggerNode::CameraOverride get_camera_override() const;
 	void set_camera_override(EditorDebuggerNode::CameraOverride p_override);

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -91,7 +91,7 @@ void Path2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 #ifdef DEBUG_ENABLED
-			_debug_create();
+			_debug_update();
 #endif
 		} break;
 
@@ -100,10 +100,17 @@ void Path2D::_notification(int p_what) {
 			_debug_free();
 #endif
 		} break;
+
 		// Draw the curve if path debugging is enabled.
 		case NOTIFICATION_DRAW: {
 #ifdef DEBUG_ENABLED
 			_debug_update();
+#endif
+		} break;
+
+		case NOTIFICATION_DEBUG_PATHS_HINT_CHANGED: {
+#ifdef DEBUG_ENABLED
+			queue_redraw();
 #endif
 		} break;
 	}
@@ -146,7 +153,7 @@ void Path2D::_debug_update() {
 	ERR_FAIL_NULL(SceneTree::get_singleton());
 	ERR_FAIL_NULL(RenderingServer::get_singleton());
 
-	const bool path_debug_enabled = (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_paths_hint());
+	const bool path_debug_enabled = (Engine::get_singleton()->is_editor_hint() || (get_tree() && get_tree()->is_debugging_paths_hint()));
 
 	if (!path_debug_enabled) {
 		_debug_free();

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -40,21 +40,12 @@
 Path3D::Path3D() {
 	SceneTree *st = SceneTree::get_singleton();
 	if (st && st->is_debugging_paths_hint()) {
-		debug_instance = RS::get_singleton()->instance_create();
-		set_notify_transform(true);
-		_update_debug_mesh();
+		_create_debug_mesh();
 	}
 }
 
 Path3D::~Path3D() {
-	if (debug_instance.is_valid()) {
-		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RS::get_singleton()->free_rid(debug_instance);
-	}
-	if (debug_mesh.is_valid()) {
-		ERR_FAIL_NULL(RenderingServer::get_singleton());
-		RS::get_singleton()->free_rid(debug_mesh->get_rid());
-	}
+	_free_debug_mesh();
 }
 
 void Path3D::set_update_callback(Callable p_callback) {
@@ -64,17 +55,17 @@ void Path3D::set_update_callback(Callable p_callback) {
 void Path3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			SceneTree *st = SceneTree::get_singleton();
-			if (st && st->is_debugging_paths_hint()) {
-				_update_debug_mesh();
-			}
+			_update_debug_mesh();
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			SceneTree *st = SceneTree::get_singleton();
-			if (st && st->is_debugging_paths_hint()) {
+			if (debug_instance.is_valid()) {
 				RS::get_singleton()->instance_set_visible(debug_instance, false);
 			}
+		} break;
+
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			_update_debug_mesh();
 		} break;
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
@@ -86,17 +77,50 @@ void Path3D::_notification(int p_what) {
 				update_callback.call();
 			}
 		} break;
+
+		case NOTIFICATION_DEBUG_PATHS_HINT_CHANGED: {
+			SceneTree *st = SceneTree::get_singleton();
+			if (st && st->is_debugging_paths_hint()) {
+				_create_debug_mesh();
+			} else {
+				_free_debug_mesh();
+			}
+		} break;
 	}
 }
 
-void Path3D::_update_debug_mesh() {
-	SceneTree *st = SceneTree::get_singleton();
-	if (!(st && st->is_debugging_paths_hint())) {
-		return;
+void Path3D::_create_debug_mesh() {
+	if (debug_instance.is_null()) {
+		debug_instance = RS::get_singleton()->instance_create();
 	}
 
 	if (debug_mesh.is_null()) {
 		debug_mesh.instantiate();
+	}
+
+	RS::get_singleton()->instance_set_base(debug_instance, debug_mesh->get_rid());
+	set_notify_transform(true);
+
+	_update_debug_mesh();
+}
+
+void Path3D::_free_debug_mesh() {
+	if (debug_instance.is_valid()) {
+		ERR_FAIL_NULL(RenderingServer::get_singleton());
+		RS::get_singleton()->free_rid(debug_instance);
+		debug_instance = RID();
+	}
+	if (debug_mesh.is_valid()) {
+		debug_mesh.unref();
+	}
+}
+
+void Path3D::_update_debug_mesh() {
+	if (debug_instance.is_null()) {
+		return;
+	}
+	if (!is_inside_tree()) {
+		return;
 	}
 
 	if (curve.is_null()) {
@@ -169,12 +193,9 @@ void Path3D::_update_debug_mesh() {
 	debug_mesh->surface_set_material(0, debug_material);
 	debug_mesh->surface_set_material(1, debug_material);
 
-	RS::get_singleton()->instance_set_base(debug_instance, debug_mesh->get_rid());
-	if (is_inside_tree()) {
-		RS::get_singleton()->instance_set_scenario(debug_instance, get_world_3d()->get_scenario());
-		RS::get_singleton()->instance_set_transform(debug_instance, get_global_transform());
-		RS::get_singleton()->instance_set_visible(debug_instance, is_visible_in_tree());
-	}
+	RS::get_singleton()->instance_set_scenario(debug_instance, get_world_3d()->get_scenario());
+	RS::get_singleton()->instance_set_transform(debug_instance, get_global_transform());
+	RS::get_singleton()->instance_set_visible(debug_instance, is_visible_in_tree());
 }
 
 void Path3D::set_debug_custom_color(const Color &p_color) {
@@ -232,10 +253,8 @@ void Path3D::_curve_changed() {
 			}
 		}
 	}
-	SceneTree *st = SceneTree::get_singleton();
-	if (st && st->is_debugging_paths_hint()) {
-		_update_debug_mesh();
-	}
+
+	_update_debug_mesh();
 }
 
 void Path3D::set_curve(const Ref<Curve3D> &p_curve) {

--- a/scene/3d/path_3d.h
+++ b/scene/3d/path_3d.h
@@ -48,6 +48,8 @@ private:
 
 	Callable update_callback; // Used only by CSG currently.
 
+	void _create_debug_mesh();
+	void _free_debug_mesh();
 	void _update_debug_mesh();
 	void _update_debug_path_material();
 	void _curve_changed();

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -277,6 +277,13 @@ Error SceneDebugger::_msg_set_debug_collisions(const Array &p_args) {
 	return OK;
 }
 
+Error SceneDebugger::_msg_set_debug_paths(const Array &p_args) {
+	ERR_FAIL_COND_V(p_args.is_empty(), ERR_INVALID_DATA);
+	bool enabled = p_args[0];
+	SceneTree::get_singleton()->set_debug_paths_hint(enabled);
+	return OK;
+}
+
 Error SceneDebugger::_msg_override_cameras(const Array &p_args) {
 	ERR_FAIL_COND_V(p_args.is_empty(), ERR_INVALID_DATA);
 	bool enable = p_args[0];
@@ -629,6 +636,7 @@ void SceneDebugger::_init_message_handlers() {
 	message_handlers["hdr_output_request_state"] = _msg_hdr_output_request_state;
 	message_handlers["hdr_output_toggle_requested"] = _msg_hdr_output_toggle_requested;
 	message_handlers["set_debug_collisions"] = _msg_set_debug_collisions;
+	message_handlers["set_debug_paths"] = _msg_set_debug_paths;
 	message_handlers["override_cameras"] = _msg_override_cameras;
 	message_handlers["transform_camera_2d"] = _msg_transform_camera_2d;
 #ifndef _3D_DISABLED

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -86,6 +86,7 @@ private:
 	static Error _msg_hdr_output_request_state(const Array &p_args);
 	static Error _msg_hdr_output_toggle_requested(const Array &p_args);
 	static Error _msg_set_debug_collisions(const Array &p_args);
+	static Error _msg_set_debug_paths(const Array &p_args);
 	static Error _msg_override_cameras(const Array &p_args);
 	static Error _msg_set_object_property(const Array &p_args);
 	static Error _msg_set_object_property_field(const Array &p_args);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -509,6 +509,7 @@ public:
 
 		// Debug-related notifications.
 		NOTIFICATION_DEBUG_COLLISIONS_HINT_CHANGED = 4000,
+		NOTIFICATION_DEBUG_PATHS_HINT_CHANGED = 4001,
 
 		// Editor specific node notifications.
 		NOTIFICATION_EDITOR_PRE_SAVE = 9001,

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -980,7 +980,13 @@ bool SceneTree::is_debugging_collisions_hint() const {
 }
 
 void SceneTree::set_debug_paths_hint(bool p_enabled) {
+	if (debug_paths_hint == p_enabled) {
+		return;
+	}
 	debug_paths_hint = p_enabled;
+	if (root) {
+		root->propagate_notification(Node::NOTIFICATION_DEBUG_PATHS_HINT_CHANGED);
+	}
 }
 
 bool SceneTree::is_debugging_paths_hint() const {


### PR DESCRIPTION
## What problem(s) does this PR solve?

Since #119816, we can toggle visible collision shapes at runtime. For paths (i.e. `Path2D` and `Path3D`), admittedly it's a niche use case, but it's good UX to be consistent and allow runtime toggling here too.

## Additional information

Just following the same approach as in #119816. CC @KoBeWi and @Mickeon who reviewed that one.

The logic was not consistent between `Path2D` and `Path3D`, and still isn't. I've tried to make it not consume any resources when debug paths aren't visible.