### PR TITLE
Implement Project Relocation Option

### DIFF
--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -110,7 +110,7 @@ void ProjectDialog::_validate_path() {
 	String target_path = path;
 	InputType target_path_input_type = PROJECT_PATH;
 
-	if (mode == MODE_IMPORT) {
+	if (mode == MODE_IMPORT || mode == MODE_RELOCATE) {
 		if (path.get_file().strip_edges() == "project.godot") {
 			path = path.get_base_dir();
 			project_path->set_text(path);
@@ -124,7 +124,7 @@ void ProjectDialog::_validate_path() {
 			zip_path = "";
 		}
 
-		if (!zip_path.is_empty()) {
+		if (mode == MODE_IMPORT && !zip_path.is_empty()) {
 			target_path = install_path->get_text().simplify_path();
 			target_path_input_type = INSTALL_PATH;
 
@@ -181,7 +181,16 @@ void ProjectDialog::_validate_path() {
 			create_dir->hide();
 			install_path_container->hide();
 
-			_set_message(TTRC("Please choose a \"project.godot\", a directory with one, or a \".zip\" file."), MESSAGE_ERROR);
+			switch (mode) {
+				case MODE_IMPORT:
+					_set_message(TTRC("Please choose a \"project.godot\", a directory with one, or a \".zip\" file."), MESSAGE_ERROR);
+					break;
+				case MODE_RELOCATE:
+					_set_message(TTRC("Please choose a \"project.godot\" or a directory with one."), MESSAGE_ERROR);
+					break;
+				default:
+					break;
+			}
 			return;
 		}
 	}
@@ -212,6 +221,15 @@ void ProjectDialog::_validate_path() {
 	String documents_dir = OS::get_singleton()->get_system_dir(OS::SYSTEM_DIR_DOCUMENTS);
 	if (target_path == home_dir || target_path == documents_dir) {
 		_set_message(TTRC("You cannot save a project at the selected path. Please create a subfolder or choose a new path."), MESSAGE_ERROR, target_path_input_type);
+		return;
+	}
+
+	if (mode == MODE_RELOCATE) {
+		if (!d->dir_exists(target_path)) {
+			_set_message(TTRC("The path specified doesn't exist."), MESSAGE_ERROR, target_path_input_type);
+		} else {
+			_set_message(TTRC("The selected path will be used as the new project path."), MESSAGE_SUCCESS, target_path_input_type);
+		}
 		return;
 	}
 
@@ -293,7 +311,7 @@ void ProjectDialog::_validate_path() {
 }
 
 String ProjectDialog::_get_target_path() {
-	if (mode == MODE_NEW || mode == MODE_INSTALL || mode == MODE_DUPLICATE) {
+	if (mode == MODE_NEW || mode == MODE_INSTALL || mode == MODE_DUPLICATE || mode == MODE_RELOCATE) {
 		return project_path->get_text();
 	} else if (mode == MODE_IMPORT) {
 		return install_path->get_text();
@@ -302,7 +320,7 @@ String ProjectDialog::_get_target_path() {
 	}
 }
 void ProjectDialog::_set_target_path(const String &p_text) {
-	if (mode == MODE_NEW || mode == MODE_INSTALL || mode == MODE_DUPLICATE) {
+	if (mode == MODE_NEW || mode == MODE_INSTALL || mode == MODE_DUPLICATE || mode == MODE_RELOCATE) {
 		project_path->set_text(p_text);
 	} else if (mode == MODE_IMPORT) {
 		install_path->set_text(p_text);
@@ -419,11 +437,13 @@ void ProjectDialog::_browse_project_path() {
 		fdialog_project->set_current_dir(path);
 	}
 
-	if (mode == MODE_IMPORT) {
+	if (mode == MODE_IMPORT || mode == MODE_RELOCATE) {
 		fdialog_project->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_ANY);
 		fdialog_project->clear_filters();
 		fdialog_project->add_filter("project.godot", vformat("%s %s", GODOT_VERSION_NAME, TTR("Project")));
-		fdialog_project->add_filter("*.zip", TTR("ZIP File"));
+		if (mode == MODE_IMPORT) {
+			fdialog_project->add_filter("*.zip", TTR("ZIP File"));
+		}
 	} else {
 		fdialog_project->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_DIR);
 	}
@@ -487,7 +507,11 @@ void ProjectDialog::_install_path_selected(const String &p_path) {
 }
 
 void ProjectDialog::_reset_name() {
-	project_name->set_text(TTR("New Game Project"));
+	if (mode == MODE_RELOCATE) {
+		project_name->set_text(TTR("Relocate Game Project"));
+	} else {
+		project_name->set_text(TTR("New Game Project"));
+	}
 }
 
 void ProjectDialog::_renderer_selected() {
@@ -815,6 +839,8 @@ void ProjectDialog::ok_pressed() {
 		emit_signal(SNAME("project_duplicated"), original_project_path, path, edit_check_box->is_visible() && edit_check_box->is_pressed());
 	} else if (mode == MODE_RENAME) {
 		emit_signal(SNAME("projects_updated"));
+	} else if (mode == MODE_RELOCATE) {
+		emit_signal(SNAME("project_relocated"), path, edit_check_box->is_pressed());
 	}
 }
 
@@ -854,7 +880,7 @@ void ProjectDialog::ask_for_path_and_show() {
 void ProjectDialog::show_dialog(bool p_reset_name, bool p_is_confirmed) {
 	_update_ok_button();
 
-	if (mode == MODE_IMPORT && !p_is_confirmed) {
+	if ((mode == MODE_IMPORT || mode == MODE_RELOCATE) && !p_is_confirmed) {
 		return;
 	}
 	if (mode == MODE_RENAME) {
@@ -894,7 +920,7 @@ void ProjectDialog::show_dialog(bool p_reset_name, bool p_is_confirmed) {
 				project_path->set_text(fav_dir);
 				install_path->set_text(fav_dir);
 				fdialog_project->set_current_dir(fav_dir);
-			} else {
+			} else if (mode != MODE_RELOCATE) {
 				Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 				project_path->set_text(d->get_current_dir());
 				install_path->set_text(d->get_current_dir());
@@ -906,9 +932,15 @@ void ProjectDialog::show_dialog(bool p_reset_name, bool p_is_confirmed) {
 		project_status_rect->show();
 		project_browse->show();
 
-		if (mode == MODE_IMPORT) {
-			set_title(TTRC("Import Existing Project"));
-			set_ok_button_text(TTRC("Import"));
+		if (mode == MODE_IMPORT || mode == MODE_RELOCATE) {
+			if (mode == MODE_IMPORT) {
+				set_title(TTRC("Import Existing Project"));
+				set_ok_button_text(TTRC("Import"));
+			} else {
+				set_title(TTRC("Relocate Missing Project"));
+				set_ok_button_text(TTRC("Confirm"));
+				create_dir->hide();
+			}
 
 			name_container->hide();
 			install_path_container->hide();
@@ -1015,6 +1047,7 @@ void ProjectDialog::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("project_created"));
 	ADD_SIGNAL(MethodInfo("project_duplicated"));
 	ADD_SIGNAL(MethodInfo("projects_updated"));
+	ADD_SIGNAL(MethodInfo("project_relocated"));
 }
 
 ProjectDialog::ProjectDialog() {

--- a/editor/project_manager/project_dialog.h
+++ b/editor/project_manager/project_dialog.h
@@ -50,6 +50,7 @@ public:
 		MODE_INSTALL,
 		MODE_RENAME,
 		MODE_DUPLICATE,
+		MODE_RELOCATE,
 	};
 
 private:

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -1398,6 +1398,7 @@ void ProjectList::_open_menu(const Vector2 &p_at, Control *p_hb) {
 		project_context_menu->add_item(TTRC("Manage Tags"), MENU_MANAGE_TAGS);
 		project_context_menu->add_item(TTRC("Duplicate"), MENU_DUPLICATE);
 		project_context_menu->add_item(TTRC("Remove from Project List"), MENU_REMOVE);
+		project_context_menu->add_item(TTRC("Relocate"), MENU_RELOCATE);
 		add_child(project_context_menu);
 		project_context_menu->connect(SceneStringName(id_pressed), callable_mp(this, &ProjectList::_menu_option));
 		_update_menu_icons();
@@ -1440,6 +1441,7 @@ void ProjectList::_update_menu_icons() {
 	project_context_menu->set_item_icon(project_context_menu->get_item_index(MENU_MANAGE_TAGS), get_editor_theme_icon("Script"));
 	project_context_menu->set_item_icon(project_context_menu->get_item_index(MENU_DUPLICATE), get_editor_theme_icon("Duplicate"));
 	project_context_menu->set_item_icon(project_context_menu->get_item_index(MENU_REMOVE), get_editor_theme_icon("Remove"));
+	project_context_menu->set_item_icon(project_context_menu->get_item_index(MENU_RELOCATE), get_editor_theme_icon("Search"));
 }
 
 // Project list selection.
@@ -1636,6 +1638,15 @@ void ProjectList::erase_missing_projects() {
 
 	print_line("Removed " + itos(deleted_count) + " projects from the list, remaining " + itos(remaining_count) + " projects");
 	save_config();
+}
+
+void ProjectList::erase_project(const String &p_dir_path) {
+	for (int i = 0; i < _projects.size(); ++i) {
+		if (_projects[i].path == p_dir_path) {
+			_remove_project(i, true);
+			break;
+		}
+	}
 }
 
 // Project list sorting and filtering.

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -153,6 +153,7 @@ public:
 		MENU_MANAGE_TAGS,
 		MENU_DUPLICATE,
 		MENU_REMOVE,
+		MENU_RELOCATE,
 	};
 
 	// Can often be passed by copy.
@@ -349,6 +350,7 @@ public:
 
 	bool is_any_project_missing() const;
 	void erase_missing_projects();
+	void erase_project(const String &p_dir_path);
 
 	// Project list sorting and filtering.
 

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -469,6 +469,10 @@ void ProjectManager::_project_list_menu_option(int p_option) {
 		case ProjectList::MENU_REMOVE:
 			_erase_project();
 			break;
+
+		case ProjectList::MENU_RELOCATE:
+			_relocate_project();
+			break;
 	}
 }
 
@@ -749,6 +753,7 @@ void ProjectManager::_open_selected_projects_check_recovery_mode() {
 
 	const ProjectList::Item &project = selected_projects[0];
 	if (project.missing) {
+		_relocate_project();
 		return;
 	}
 
@@ -833,6 +838,20 @@ void ProjectManager::_duplicate_project_with_action(PostDuplicateAction p_post_a
 	project_dialog->set_original_project_path(project.path);
 	project_dialog->set_duplicate_can_edit(p_post_action == POST_DUPLICATE_ACTION_NONE);
 	project_dialog->show_dialog(false);
+}
+
+void ProjectManager::_relocate_project() {
+	const Vector<ProjectList::Item> &selected_list = project_list->get_selected_projects();
+
+	if (selected_list.is_empty()) {
+		return;
+	}
+
+	const ProjectList::Item &project = selected_list[0];
+
+	project_dialog->set_project_path(project.path);
+	project_dialog->set_mode(ProjectDialog::MODE_RELOCATE);
+	project_dialog->ask_for_path_and_show();
 }
 
 void ProjectManager::_show_project_in_file_manager() {
@@ -1006,6 +1025,34 @@ void ProjectManager::_on_project_duplicated(const String &p_original_path, const
 	}
 
 	post_duplicate_action = POST_DUPLICATE_ACTION_NONE;
+}
+
+void ProjectManager::_on_project_relocated(const String &p_new_path, const bool p_edit) {
+	const Vector<ProjectList::Item> &selected_list = project_list->get_selected_projects();
+
+	if (selected_list.is_empty()) {
+		return;
+	}
+
+	const ProjectList::Item &project = selected_list[0];
+	project_list->erase_project(project.path);
+	project_list->refresh_project(project.path);
+
+	project_list->add_project(p_new_path, false);
+	project_list->save_config();
+	int i = project_list->refresh_project(p_new_path);
+	project_list->ensure_project_visible(i);
+	project_list->select_project(i);
+
+	search_box->clear();
+
+	_update_list_placeholder();
+
+	if (p_edit) {
+		_open_selected_projects_check_warnings();
+	}
+
+	project_list->update_dock_menu();
 }
 
 void ProjectManager::_on_order_option_changed(int p_idx) {
@@ -1899,6 +1946,7 @@ ProjectManager::ProjectManager() {
 		project_dialog->connect("projects_updated", callable_mp(this, &ProjectManager::_on_projects_updated));
 		project_dialog->connect("project_created", callable_mp(this, &ProjectManager::_on_project_created));
 		project_dialog->connect("project_duplicated", callable_mp(this, &ProjectManager::_on_project_duplicated));
+		project_dialog->connect("project_relocated", callable_mp(this, &ProjectManager::_on_project_relocated));
 		add_child(project_dialog);
 
 		error_dialog = memnew(AcceptDialog);

--- a/editor/project_manager/project_manager.h
+++ b/editor/project_manager/project_manager.h
@@ -200,6 +200,7 @@ class ProjectManager : public Control {
 	void _rename_project();
 	void _duplicate_project();
 	void _duplicate_project_with_action(PostDuplicateAction p_action);
+	void _relocate_project();
 	void _show_project_in_file_manager();
 	void _erase_project();
 	void _erase_missing_projects();
@@ -212,6 +213,7 @@ class ProjectManager : public Control {
 
 	void _on_project_created(const String &dir, bool edit);
 	void _on_project_duplicated(const String &p_original_path, const String &p_duplicate_path, bool p_edit);
+	void _on_project_relocated(const String &p_new_path, bool p_edit);
 	void _on_projects_updated();
 	void _on_open_options_selected(int p_option);
 	void _on_recovery_mode_popup_open_normal();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/9829#issue-2318338949

Implements the ability to point a project from the project list to a new project location. Intended especially to relocate projects which are marked as missing, being more intuitive than removing and re-adding it.

## Additional information

Relocation can always be triggered via a context menu option or when trying to open a missing project. It turned out to be technically challenging to conditionally disable or remove the context menu option when right-clicking a non-missing project, so it is alyways possible. The use-case is there anyways (Moving a project while the list is opened does not update the item as missing, which would otherwise prevent the option from being useable and require a restart).