### PR TITLE
[3.x] `Image` fix conversion from RGBA5551

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -2658,9 +2658,9 @@ Color Image::get_pixel(int p_x, int p_y) const {
 		}
 		case FORMAT_RGBA5551: {
 			uint16_t u = ((uint16_t *)ptr)[ofs];
-			float r = ((u >> 11) & 0x1F) / 15.0;
-			float g = ((u >> 6) & 0x1F) / 15.0;
-			float b = ((u >> 1) & 0x1F) / 15.0;
+			float r = ((u >> 11) & 0x1F) / 31.0;
+			float g = ((u >> 6) & 0x1F) / 31.0;
+			float b = ((u >> 1) & 0x1F) / 31.0;
 			float a = (u & 0x1) / 1.0;
 			return Color(r, g, b, a);
 		}


### PR DESCRIPTION
Denominator should be 31, not 15.

## What problem(s) does this PR solve?
With 5 bits in RGBA5551, the maximum value for 1.0 is 31.0 rather than 15.0 (15 is correct for 4 bits).
Probably originally a copy pasta error.

This would have previously resulted in double bright converted pixels.

## Additional information
* Bug had existed for 9 years...
* Not a widely used format :grin: 
* Just one of a few things I noticed during fixing up `Image`

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
