### PR TITLE
Fix errors when deleting internal vertices of a `Polygon2D`

### DIFF
--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -551,7 +551,9 @@ void Polygon2DEditor::_canvas_input(const Ref<InputEvent> &p_input) {
 					Vector2 pos = mtx.affine_inverse().xform(snap_point(mb->get_position()));
 
 					previous_polygon.push_back(pos);
-					previous_uv.push_back(pos);
+					if (previous_uv.size()) {
+						previous_uv.push_back(pos);
+					}
 					if (previous_colors.size()) {
 						previous_colors.push_back(Color(1, 1, 1));
 					}
@@ -608,7 +610,9 @@ void Polygon2DEditor::_canvas_input(const Ref<InputEvent> &p_input) {
 					}
 
 					previous_polygon.remove_at(closest);
-					previous_uv.remove_at(closest);
+					if (previous_uv.size()) {
+						previous_uv.remove_at(closest);
+					}
 					if (previous_colors.size()) {
 						previous_colors.remove_at(closest);
 					}


### PR DESCRIPTION
## What problem(s) does this PR solve?

Often times when deleting internal vertices of a `Polygon2D`, an error about the index being out of bounds showed up.

I'm not fully certain if this is the correct fix, as it's more of an educated guess: I think it's because it assumed that UV segments size matched with the polygons one, so I made that adding/removing internal vertices only modifies UV segments if they aren't empty. This is the same logic that the color segments follow.