### PR TITLE
Wayland: Fixing short reads and FD leaks in embedder

### DIFF
--- a/platform/linuxbsd/wayland/wayland_embedder.cpp
+++ b/platform/linuxbsd/wayland/wayland_embedder.cpp
@@ -860,6 +860,11 @@ void WaylandEmbedder::cleanup_socket(int p_socket) {
 		}
 	}
 
+	// prevent unclaimed FDs received from SCM_RIGHTS from leaking
+	for (int fd : client.fds) {
+		close(fd);
+	}
+
 	uint32_t eclient_id = client.embedded_client_id;
 
 	clients.erase(client.socket);
@@ -2762,6 +2767,12 @@ void WaylandEmbedder::shutdown() {
 		}
 	}
 
+	// Prevent unclaimed FD leak
+	for (int fd : compositor_fds) {
+		close(fd);
+	}
+	compositor_fds.clear();
+
 	close(compositor_socket);
 	compositor_socket = -1;
 
@@ -3038,7 +3049,27 @@ Error WaylandEmbedder::handle_sock(int p_fd) {
 		head_msg.msg_iov = &vec;
 		head_msg.msg_iovlen = 1;
 
-		ssize_t head_rec = recvmsg(p_fd, &head_msg, MSG_PEEK);
+		ssize_t head_rec;
+		while (true) {
+			// MSG_WAITALL makes kernel block until 1.) full header is queued
+			// to peek 2.) error occurs or 3.) peer disconnects (instead of
+			// returning as soon as any data is available which was the default
+			// recvmsg behavour for stream sockets and caused short reads here).
+			head_rec = recvmsg(p_fd, &head_msg, MSG_PEEK | MSG_WAITALL);
+
+			if (head_rec == -1 && errno == EINTR) {
+				continue;
+			}
+
+			if (head_rec > 0 && (size_t)head_rec != vec.iov_len) {
+				// MSG_WAITALL isnt a full protection against short reads as
+				// signals can still cut it short. SImply try again by peeking
+				// as that restarts from queue head
+				continue;
+			}
+
+			break;
+		}
 
 		if (head_rec == 0) {
 			// Client disconnected.
@@ -3054,8 +3085,6 @@ Error WaylandEmbedder::handle_sock(int p_fd) {
 
 			ERR_FAIL_V_MSG(FAILED, vformat("Can't read message header: %s", strerror(errno)));
 		}
-
-		ERR_FAIL_COND_V_MSG(((size_t)head_rec) != vec.iov_len, ERR_CONNECTION_ERROR, vformat("Should've received %d bytes, instead got %d bytes", vec.iov_len, head_rec));
 
 		// Header is two 32-bit words: first is ID, second has size in most significant
 		// half and opcode in the other half.
@@ -3076,70 +3105,92 @@ Error WaylandEmbedder::handle_sock(int p_fd) {
 	{
 		full_msg.msg_iov = &vec;
 		full_msg.msg_iovlen = 1;
-		full_msg.msg_control = ancillary_buf.ptr();
-		full_msg.msg_controllen = ancillary_buf.size();
 
-		ssize_t full_rec = recvmsg(p_fd, &full_msg, 0);
+		// Loop instead of trusting a single recvmsg to fill the whole
+		// message. A blocking SOCK_STREAM socket thats only guaranteed with
+		// MSG_WAITALL, and even that can still be cut short by a signal.
+		// SCM_RIGHTS data can arrive attached to whichever chunk carried it,
+		// so handling it on every iteration.
+		size_t total_rec = 0;
+		while (total_rec < info.size) {
+			vec.iov_base = (uint8_t *)msg_buf.ptr() + total_rec;
+			vec.iov_len = info.size - total_rec;
+			full_msg.msg_control = ancillary_buf.ptr();
+			full_msg.msg_controllen = ancillary_buf.size();
 
-		if (full_rec == -1) {
-			if (errno == ECONNRESET) {
+			// MSG_CMSG_CLOEXEC sets FD_CLOEXEC on any FDs received via
+			// SCM_RIGHTS on creation to prevent it from leaking into child
+			// if this process forks+execs before its manually closed.
+			ssize_t full_rec = recvmsg(p_fd, &full_msg, MSG_WAITALL | MSG_CMSG_CLOEXEC);
+
+			if (full_rec == -1) {
+				if (errno == EINTR) {
+					continue;
+				}
+
 				// No need to print the error, the client forcefully disconnected, that's
 				// fine.
+				if (errno == ECONNRESET) {
+					return ERR_CONNECTION_ERROR;
+				}
+
+				ERR_FAIL_V_MSG(FAILED, vformat("Can't read message: %s", strerror(errno)));
+			}
+
+			if (full_rec == 0) {
 				return ERR_CONNECTION_ERROR;
 			}
 
-			ERR_FAIL_V_MSG(FAILED, vformat("Can't read message: %s", strerror(errno)));
-		}
+			if (full_msg.msg_controllen > 0) {
+				struct cmsghdr *cmsg = CMSG_FIRSTHDR(&full_msg);
+				while (cmsg) {
+					// TODO: Check for validity of message fields.
+					size_t data_len = cmsg->cmsg_len - sizeof *cmsg;
 
-		ERR_FAIL_COND_V_MSG(((size_t)full_rec) != info.size, ERR_CONNECTION_ERROR, "Invalid message length.");
+					if (cmsg->cmsg_type == SCM_RIGHTS) {
+						// NOTE: Linux docs say that we can't just cast data to pointer type because
+						// of alignment concerns. So we have to memcpy into a new buffer.
+						int *cmsg_fds = (int *)malloc(data_len);
+						memcpy(cmsg_fds, CMSG_DATA(cmsg), data_len);
+
+						size_t cmsg_fds_count = data_len / sizeof *cmsg_fds;
+						for (size_t i = 0; i < cmsg_fds_count; ++i) {
+							int fd = cmsg_fds[i];
+
+							if (info.direction == ProxyDirection::COMPOSITOR) {
+								clients[p_fd].fds.push_back(fd);
+							} else {
+								compositor_fds.push_back(fd);
+							}
+						}
+
+#ifdef WAYLAND_EMBED_VERBOSE_LOGS_ENABLED
+						printf("[PROXY] Received %ld file descriptors: ", cmsg_fds_count);
+						for (size_t i = 0; i < cmsg_fds_count; ++i) {
+							printf("%d ", cmsg_fds[i]);
+						}
+						printf("\n");
+#endif
+
+						free(cmsg_fds);
+					}
+
+					cmsg = CMSG_NXTHDR(&full_msg, cmsg);
+				}
+			}
+
+			total_rec += full_rec;
+		}
 
 		DEBUG_LOG_WAYLAND_EMBED_VERBOSE(" === START PACKET === ");
 
 #ifdef WAYLAND_EMBED_VERBOSE_LOGS_ENABLED
 		printf("[PROXY] Received bytes: ");
-		for (ssize_t i = 0; i < full_rec; ++i) {
+		for (size_t i = 0; i < info.size; ++i) {
 			printf("%.2x", ((const uint8_t *)msg_buf.ptr())[i]);
 		}
 		printf("\n");
 #endif
-	}
-
-	if (full_msg.msg_controllen > 0) {
-		struct cmsghdr *cmsg = CMSG_FIRSTHDR(&full_msg);
-		while (cmsg) {
-			// TODO: Check for validity of message fields.
-			size_t data_len = cmsg->cmsg_len - sizeof *cmsg;
-
-			if (cmsg->cmsg_type == SCM_RIGHTS) {
-				// NOTE: Linux docs say that we can't just cast data to pointer type because
-				// of alignment concerns. So we have to memcpy into a new buffer.
-				int *cmsg_fds = (int *)malloc(data_len);
-				memcpy(cmsg_fds, CMSG_DATA(cmsg), data_len);
-
-				size_t cmsg_fds_count = data_len / sizeof *cmsg_fds;
-				for (size_t i = 0; i < cmsg_fds_count; ++i) {
-					int fd = cmsg_fds[i];
-
-					if (info.direction == ProxyDirection::COMPOSITOR) {
-						clients[p_fd].fds.push_back(fd);
-					} else {
-						compositor_fds.push_back(fd);
-					}
-				}
-
-#ifdef WAYLAND_EMBED_VERBOSE_LOGS_ENABLED
-				printf("[PROXY] Received %ld file descriptors: ", cmsg_fds_count);
-				for (size_t i = 0; i < cmsg_fds_count; ++i) {
-					printf("%d ", cmsg_fds[i]);
-				}
-				printf("\n");
-#endif
-
-				free(cmsg_fds);
-			}
-
-			cmsg = CMSG_NXTHDR(&full_msg, cmsg);
-		}
 	}
 	full_msg.msg_control = nullptr;
 	full_msg.msg_controllen = 0;
@@ -3332,7 +3383,10 @@ void WaylandEmbedder::handle_fd(int p_fd, int p_revents) {
 	if (p_fd == compositor_socket && p_revents & POLLIN) {
 		Error err = handle_sock(p_fd);
 
-		if (err == ERR_BUG) {
+		if (err != OK) {
+			// No clientside cleanup_socket equivalent exists so any error here
+			// must bring the whole embedder down rather than silently keep
+			// polling a socket that may be desynced or closed now.
 			ERR_PRINT("Unexpected error while handling socket, shutting down.");
 			shutdown();
 			return;

--- a/platform/linuxbsd/wayland/wayland_embedder.cpp
+++ b/platform/linuxbsd/wayland/wayland_embedder.cpp
@@ -3054,7 +3054,7 @@ Error WaylandEmbedder::handle_sock(int p_fd) {
 			// MSG_WAITALL makes kernel block until 1.) full header is queued
 			// to peek 2.) error occurs or 3.) peer disconnects (instead of
 			// returning as soon as any data is available which was the default
-			// recvmsg behavour for stream sockets and caused short reads here).
+			// recvmsg behaviour for stream sockets and caused short reads here).
 			head_rec = recvmsg(p_fd, &head_msg, MSG_PEEK | MSG_WAITALL);
 
 			if (head_rec == -1 && errno == EINTR) {
@@ -3062,7 +3062,7 @@ Error WaylandEmbedder::handle_sock(int p_fd) {
 			}
 
 			if (head_rec > 0 && (size_t)head_rec != vec.iov_len) {
-				// MSG_WAITALL isnt a full protection against short reads as
+				// MSG_WAITALL isn't a full protection against short reads as
 				// signals can still cut it short. SImply try again by peeking
 				// as that restarts from queue head
 				continue;
@@ -3107,7 +3107,7 @@ Error WaylandEmbedder::handle_sock(int p_fd) {
 		full_msg.msg_iovlen = 1;
 
 		// Loop instead of trusting a single recvmsg to fill the whole
-		// message. A blocking SOCK_STREAM socket thats only guaranteed with
+		// message. A blocking SOCK_STREAM socket that's only guaranteed with
 		// MSG_WAITALL, and even that can still be cut short by a signal.
 		// SCM_RIGHTS data can arrive attached to whichever chunk carried it,
 		// so handling it on every iteration.

--- a/platform/linuxbsd/wayland/wayland_embedder.cpp
+++ b/platform/linuxbsd/wayland/wayland_embedder.cpp
@@ -3054,7 +3054,7 @@ Error WaylandEmbedder::handle_sock(int p_fd) {
 			// MSG_WAITALL makes kernel block until 1.) full header is queued
 			// to peek 2.) error occurs or 3.) peer disconnects (instead of
 			// returning as soon as any data is available which was the default
-			// recvmsg behaviour for stream sockets and caused short reads here).
+			// recvmsg behavior for stream sockets and caused short reads here).
 			head_rec = recvmsg(p_fd, &head_msg, MSG_PEEK | MSG_WAITALL);
 
 			if (head_rec == -1 && errno == EINTR) {

--- a/platform/linuxbsd/wayland/wayland_embedder.cpp
+++ b/platform/linuxbsd/wayland/wayland_embedder.cpp
@@ -3040,160 +3040,126 @@ Error WaylandEmbedder::handle_sock(int p_fd) {
 	ERR_FAIL_COND_V(p_fd < 0, ERR_INVALID_PARAMETER);
 
 	struct msg_info info = {};
+	info.direction = p_fd != compositor_socket ? ProxyDirection::COMPOSITOR : ProxyDirection::CLIENT;
 
-	{
-		struct msghdr head_msg = {};
-		uint32_t header[2];
-		struct iovec vec = { header, sizeof header };
+	// Header is two 32-bit words: first is ID, second has size in most
+	// significant half and opcode in the other half. Make sure msg_buf can
+	// hold at least that much before we know the full message size.
+	if (msg_buf.size() < 2) {
+		msg_buf.resize(2);
+	}
 
-		head_msg.msg_iov = &vec;
-		head_msg.msg_iovlen = 1;
+	struct msghdr msg = {};
+	struct iovec vec = {};
+	msg.msg_iov = &vec;
+	msg.msg_iovlen = 1;
 
-		ssize_t head_rec;
-		while (true) {
-			// MSG_WAITALL makes kernel block until 1.) full header is queued
-			// to peek 2.) error occurs or 3.) peer disconnects (instead of
-			// returning as soon as any data is available which was the default
-			// recvmsg behavior for stream sockets and caused short reads here).
-			head_rec = recvmsg(p_fd, &head_msg, MSG_PEEK | MSG_WAITALL);
+	// Read the header first, then keep going until the whole message (as
+	// declared by the header) has arrived, growing msg_buf once the size is
+	// known. Deliberately never uses MSG_PEEK. Combined with MSG_WAITALL, it
+	// isn't reliable on AF_UNIX SOCK_STREAM sockets and can return short
+	// reads that never grow no matter how many times it's retried.
+	// SCM_RIGHTS data can arrive attached to whatever chunk carried it, so
+	// it's handled on every iteration with header.
+	size_t total_rec = 0;
+	size_t target_size = WL_WORD_SIZE * 2;
+	while (total_rec < target_size) {
+		vec.iov_base = (uint8_t *)msg_buf.ptr() + total_rec;
+		vec.iov_len = target_size - total_rec;
+		msg.msg_control = ancillary_buf.ptr();
+		msg.msg_controllen = ancillary_buf.size();
 
-			if (head_rec == -1 && errno == EINTR) {
+		// MSG_CMSG_CLOEXEC sets FD_CLOEXEC on any FDs received via
+		// SCM_RIGHTS on creation to prevent it from leaking into child
+		// if this process forks+execs before its manually closed.
+		ssize_t rec = recvmsg(p_fd, &msg, MSG_WAITALL | MSG_CMSG_CLOEXEC);
+
+		if (rec == -1) {
+			if (errno == EINTR) {
 				continue;
 			}
 
-			if (head_rec > 0 && (size_t)head_rec != vec.iov_len) {
-				// MSG_WAITALL isn't a full protection against short reads as
-				// signals can still cut it short. SImply try again by peeking
-				// as that restarts from queue head
-				continue;
+			// No need to print the error, the client forcefully disconnected, that's
+			// fine.
+			if (errno == ECONNRESET) {
+				return ERR_CONNECTION_ERROR;
 			}
 
-			break;
+			ERR_FAIL_V_MSG(FAILED, vformat("Can't read message: %s", strerror(errno)));
 		}
 
-		if (head_rec == 0) {
+		if (rec == 0) {
 			// Client disconnected.
 			return ERR_CONNECTION_ERROR;
 		}
 
-		if (head_rec == -1) {
-			if (errno == ECONNRESET) {
-				// No need to print the error, the client forcefully disconnected, that's
-				// fine.
-				return ERR_CONNECTION_ERROR;
-			}
+		if (msg.msg_controllen > 0) {
+			struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+			while (cmsg) {
+				// TODO: Check for validity of message fields.
+				size_t data_len = cmsg->cmsg_len - sizeof *cmsg;
 
-			ERR_FAIL_V_MSG(FAILED, vformat("Can't read message header: %s", strerror(errno)));
-		}
+				if (cmsg->cmsg_type == SCM_RIGHTS) {
+					// NOTE: Linux docs say that we can't just cast data to pointer type because
+					// of alignment concerns. So we have to memcpy into a new buffer.
+					int *cmsg_fds = (int *)malloc(data_len);
+					memcpy(cmsg_fds, CMSG_DATA(cmsg), data_len);
 
-		// Header is two 32-bit words: first is ID, second has size in most significant
-		// half and opcode in the other half.
-		info.raw_id = header[0];
-		info.size = header[1] >> 16;
-		info.opcode = header[1] & 0xFFFF;
-		info.direction = p_fd != compositor_socket ? ProxyDirection::COMPOSITOR : ProxyDirection::CLIENT;
-	}
+					size_t cmsg_fds_count = data_len / sizeof *cmsg_fds;
+					for (size_t i = 0; i < cmsg_fds_count; ++i) {
+						int fd = cmsg_fds[i];
 
-	if (msg_buf.size() < info.words()) {
-		msg_buf.resize(info.words());
-	}
-
-	ERR_FAIL_COND_V_MSG(info.size % WL_WORD_SIZE != 0, ERR_CONNECTION_ERROR, "Invalid message length.");
-
-	struct msghdr full_msg = {};
-	struct iovec vec = { msg_buf.ptr(), info.size };
-	{
-		full_msg.msg_iov = &vec;
-		full_msg.msg_iovlen = 1;
-
-		// Loop instead of trusting a single recvmsg to fill the whole
-		// message. A blocking SOCK_STREAM socket that's only guaranteed with
-		// MSG_WAITALL, and even that can still be cut short by a signal.
-		// SCM_RIGHTS data can arrive attached to whichever chunk carried it,
-		// so handling it on every iteration.
-		size_t total_rec = 0;
-		while (total_rec < info.size) {
-			vec.iov_base = (uint8_t *)msg_buf.ptr() + total_rec;
-			vec.iov_len = info.size - total_rec;
-			full_msg.msg_control = ancillary_buf.ptr();
-			full_msg.msg_controllen = ancillary_buf.size();
-
-			// MSG_CMSG_CLOEXEC sets FD_CLOEXEC on any FDs received via
-			// SCM_RIGHTS on creation to prevent it from leaking into child
-			// if this process forks+execs before its manually closed.
-			ssize_t full_rec = recvmsg(p_fd, &full_msg, MSG_WAITALL | MSG_CMSG_CLOEXEC);
-
-			if (full_rec == -1) {
-				if (errno == EINTR) {
-					continue;
-				}
-
-				// No need to print the error, the client forcefully disconnected, that's
-				// fine.
-				if (errno == ECONNRESET) {
-					return ERR_CONNECTION_ERROR;
-				}
-
-				ERR_FAIL_V_MSG(FAILED, vformat("Can't read message: %s", strerror(errno)));
-			}
-
-			if (full_rec == 0) {
-				return ERR_CONNECTION_ERROR;
-			}
-
-			if (full_msg.msg_controllen > 0) {
-				struct cmsghdr *cmsg = CMSG_FIRSTHDR(&full_msg);
-				while (cmsg) {
-					// TODO: Check for validity of message fields.
-					size_t data_len = cmsg->cmsg_len - sizeof *cmsg;
-
-					if (cmsg->cmsg_type == SCM_RIGHTS) {
-						// NOTE: Linux docs say that we can't just cast data to pointer type because
-						// of alignment concerns. So we have to memcpy into a new buffer.
-						int *cmsg_fds = (int *)malloc(data_len);
-						memcpy(cmsg_fds, CMSG_DATA(cmsg), data_len);
-
-						size_t cmsg_fds_count = data_len / sizeof *cmsg_fds;
-						for (size_t i = 0; i < cmsg_fds_count; ++i) {
-							int fd = cmsg_fds[i];
-
-							if (info.direction == ProxyDirection::COMPOSITOR) {
-								clients[p_fd].fds.push_back(fd);
-							} else {
-								compositor_fds.push_back(fd);
-							}
+						if (info.direction == ProxyDirection::COMPOSITOR) {
+							clients[p_fd].fds.push_back(fd);
+						} else {
+							compositor_fds.push_back(fd);
 						}
-
-#ifdef WAYLAND_EMBED_VERBOSE_LOGS_ENABLED
-						printf("[PROXY] Received %ld file descriptors: ", cmsg_fds_count);
-						for (size_t i = 0; i < cmsg_fds_count; ++i) {
-							printf("%d ", cmsg_fds[i]);
-						}
-						printf("\n");
-#endif
-
-						free(cmsg_fds);
 					}
 
-					cmsg = CMSG_NXTHDR(&full_msg, cmsg);
+#ifdef WAYLAND_EMBED_VERBOSE_LOGS_ENABLED
+					printf("[PROXY] Received %ld file descriptors: ", cmsg_fds_count);
+					for (size_t i = 0; i < cmsg_fds_count; ++i) {
+						printf("%d ", cmsg_fds[i]);
+					}
+					printf("\n");
+#endif
+
+					free(cmsg_fds);
 				}
+
+				cmsg = CMSG_NXTHDR(&msg, cmsg);
+			}
+		}
+
+		total_rec += rec;
+
+		if (total_rec == WL_WORD_SIZE * 2 && target_size == WL_WORD_SIZE * 2) {
+			// Header fully read. Parse and extend target to cover rest of message.
+			info.raw_id = msg_buf[0];
+			info.size = msg_buf[1] >> 16;
+			info.opcode = msg_buf[1] & 0xFFFF;
+
+			ERR_FAIL_COND_V_MSG(info.size % WL_WORD_SIZE != 0, ERR_CONNECTION_ERROR, "Invalid message length.");
+
+			if (msg_buf.size() < info.words()) {
+				msg_buf.resize(info.words());
 			}
 
-			total_rec += full_rec;
+			target_size = info.size;
 		}
+	}
+	msg.msg_control = nullptr;
+	msg.msg_controllen = 0;
 
-		DEBUG_LOG_WAYLAND_EMBED_VERBOSE(" === START PACKET === ");
+	DEBUG_LOG_WAYLAND_EMBED_VERBOSE(" === START PACKET === ");
 
 #ifdef WAYLAND_EMBED_VERBOSE_LOGS_ENABLED
-		printf("[PROXY] Received bytes: ");
-		for (size_t i = 0; i < info.size; ++i) {
-			printf("%.2x", ((const uint8_t *)msg_buf.ptr())[i]);
-		}
-		printf("\n");
-#endif
+	printf("[PROXY] Received bytes: ");
+	for (size_t i = 0; i < info.size; ++i) {
+		printf("%.2x", ((const uint8_t *)msg_buf.ptr())[i]);
 	}
-	full_msg.msg_control = nullptr;
-	full_msg.msg_controllen = 0;
+	printf("\n");
+#endif
 
 	Client *client = nullptr;
 	if (p_fd == compositor_socket) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #118212
- Closes #121831

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

### Cause

WaylandEmbedder::handle_sock() reads incoming messages assuming each read call would return exactly the number of bytes requested. Blocking SOCK_STREAM socket does not guarantee that. Kernel can sometimes hand back fewer bytes than requested. Old logic was unprepared for this case and treated it as fatal error.

The old logic also silently swallowed the issue by handle_fd() (only ERR_BUG triggered a shutdown), so the connection kept being polled afterward with its bytestream position desynced now. Next header read would then read garbage from middle of the previous message. That bad read would eventually raise a protocol error on the connection (104/ECONNRESET, 32/EPIPE, 24/EMFILE) which WaylandThread::_wl_display_check_error() treats as fatal.

Also: The EMFILE variant leads to a related bug. FDs received over the socket via SCM_RIGHTS were queued (client.fds / compositor_fds) to be claimed by a later message that needed them, but if a client disconnected (or the embedder shut down) before that followup message arrived, the queued FDs were never closed.

### Fix

- handle_sock() reads the header and body in a single MSG_WAITALL loop that resumes from the last offset across iterations and retries on EINTR instead of treating a short read as fatal. The header is read directly rather than peeked. MSG_PEEK with MSG_WAITALL turned out to be unreliable on AF_UNIX SOCK_STREAM sockets (could return a short read that never grew -> hanging connection).
- handle_fd() compositor socket logic now shuts the embedder down on any handle_sock() error (old logic just racted to ERR_BUG) since silently continuing on a desynced stream was never safe.
- cleanup_socket() and shutdown() now close FDs still sitting unclaimed in client.fds / compositor_fds.
- Added MSG_CMSG_CLOEXEC to the body read recvmsg() so received FDs cant leak into a forked+exec child before theyre explicitly closed or handed off.

## AI Disclosure

LLMs were use in following area/stages:

- Checking code changes for obvious bugs before submission
- Additional blast-radius check of code changes
- Used it to generate a few scripts used during local testing of changes