### PR TITLE
Add binding for `OpenXRStructureBase::get_header()`

### DIFF
--- a/modules/openxr/doc_classes/OpenXRStructureBase.xml
+++ b/modules/openxr/doc_classes/OpenXRStructureBase.xml
@@ -15,6 +15,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_header">
+			<return type="int" />
+			<param index="0" name="next" type="int" />
+			<description>
+				Returns the structure pointer (any OpenXR structure that has an [code]XrStructureType[/code]) used for this structure. The pointer is valid as long as the instance exists.
+			</description>
+		</method>
 		<method name="get_structure_type">
 			<return type="int" />
 			<description>

--- a/modules/openxr/openxr_structure.cpp
+++ b/modules/openxr/openxr_structure.cpp
@@ -33,6 +33,7 @@
 #include "core/object/class_db.h"
 
 void OpenXRStructureBase::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_header", "next"), &OpenXRStructureBase::_get_headergd);
 	ClassDB::bind_method(D_METHOD("get_structure_type"), &OpenXRStructureBase::_get_structure_type);
 
 	ClassDB::bind_method(D_METHOD("set_next", "entity"), &OpenXRStructureBase::set_next);
@@ -77,6 +78,11 @@ XrStructureType OpenXRStructureBase::get_structure_type() {
 	} else {
 		return *header;
 	}
+}
+
+// For exposing this to GDExtension
+uint64_t OpenXRStructureBase::_get_headergd(uint64_t p_next) {
+	return (uint64_t)get_header((void *)p_next);
 }
 
 // Return structure type as uint64_t to GDScript

--- a/modules/openxr/openxr_structure.h
+++ b/modules/openxr/openxr_structure.h
@@ -72,5 +72,6 @@ protected:
 private:
 	Ref<OpenXRStructureBase> next;
 
+	uint64_t _get_headergd(uint64_t p_next);
 	uint64_t _get_structure_type();
 };


### PR DESCRIPTION
## What problem(s) does this PR solve?
GDExtensions currently are able to override `OpenXRStructureBase::get_header()` through the virtual `OpenXRStructureBase::_get_header()` method, but they cannot call `OpenXRStructureBase::get_header()`.
This PR allows GDExtensions to call `OpenXRStructureBase::get_header()` too.

## Additional information
I'm open to other names for the bound method.