### PR TITLE
TextEdit: Make scrolling & zooming while selecting more responsive

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -973,6 +973,7 @@ void TextEdit::_notification(int p_what) {
 				} else {
 					set_v_scroll(get_v_scroll() + vel);
 				}
+				_selection_mode_update();
 			} else {
 				scrolling = false;
 				minimap_clicked = false;
@@ -2488,6 +2489,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					// Scroll 3 lines.
 					_scroll_up(3 * mb->get_factor(), true);
 				}
+				_selection_mode_update();
 			}
 			if (mb->get_button_index() == MouseButton::WHEEL_DOWN && !mb->is_command_or_control_pressed()) {
 				if (mb->is_shift_pressed()) {
@@ -2500,14 +2502,17 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 					// Scroll 3 lines.
 					_scroll_down(3 * mb->get_factor(), true);
 				}
+				_selection_mode_update();
 			}
 			if (mb->get_button_index() == MouseButton::WHEEL_LEFT) {
 				h_scroll->set_value(h_scroll->get_value() - (100 * mb->get_factor()));
 				queue_accessibility_update();
+				_selection_mode_update();
 			}
 			if (mb->get_button_index() == MouseButton::WHEEL_RIGHT) {
 				h_scroll->set_value(h_scroll->get_value() + (100 * mb->get_factor()));
 				queue_accessibility_update();
+				_selection_mode_update();
 			}
 
 			if (mb->get_button_index() == MouseButton::LEFT) {
@@ -2968,6 +2973,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 			time_since_motion = 0.0;
 			accept_event();
+			_selection_mode_update();
 		} else {
 			// Likely follow up from a double tap touch event; we apply similar logic as the mouse motion logic.
 			_on_drag_or_mouse_motion_event(drag->get_position(), true);
@@ -2993,6 +2999,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 		if (v_scroll->get_value() != prev_v_scroll || h_scroll->get_value() != prev_h_scroll) {
 			accept_event(); // Accept event if scroll changed.
 		}
+		_selection_mode_update();
 		queue_accessibility_update();
 
 		return;
@@ -3310,20 +3317,7 @@ void TextEdit::_on_drag_or_mouse_motion_event(Vector2i p_event_position, bool p_
 		}
 
 		if (!dragging_minimap && !has_ime_text()) {
-			switch (selecting_mode) {
-				case SelectionMode::SELECTION_MODE_POINTER: {
-					_update_selection_mode_pointer();
-				} break;
-				case SelectionMode::SELECTION_MODE_WORD: {
-					_update_selection_mode_word();
-				} break;
-				case SelectionMode::SELECTION_MODE_LINE: {
-					_update_selection_mode_line();
-				} break;
-				default: {
-					break;
-				}
-			}
+			_selection_mode_update();
 		}
 	}
 
@@ -7174,11 +7168,6 @@ HScrollBar *TextEdit::get_h_scroll_bar() const {
 
 void TextEdit::set_v_scroll(double p_scroll) {
 	v_scroll->set_value(p_scroll);
-	int max_v_scroll = v_scroll->get_max() - v_scroll->get_page();
-	if (p_scroll >= max_v_scroll - 1.0) {
-		_scroll_moved(v_scroll->get_value());
-	}
-	queue_accessibility_update();
 }
 
 double TextEdit::get_v_scroll() const {
@@ -7186,11 +7175,7 @@ double TextEdit::get_v_scroll() const {
 }
 
 void TextEdit::set_h_scroll(int p_scroll) {
-	if (p_scroll < 0) {
-		p_scroll = 0;
-	}
 	h_scroll->set_value(p_scroll);
-	queue_accessibility_update();
 }
 
 int TextEdit::get_h_scroll() const {
@@ -9197,6 +9182,22 @@ void TextEdit::_click_selection_held() {
 	}
 }
 
+void TextEdit::_selection_mode_update() {
+	switch (get_selection_mode()) {
+		case SelectionMode::SELECTION_MODE_POINTER: {
+			_update_selection_mode_pointer();
+		} break;
+		case SelectionMode::SELECTION_MODE_WORD: {
+			_update_selection_mode_word();
+		} break;
+		case SelectionMode::SELECTION_MODE_LINE: {
+			_update_selection_mode_line();
+		} break;
+		default:
+			break;
+	}
+}
+
 void TextEdit::_update_selection_mode_pointer(bool p_initial) {
 	Point2i pos = get_line_column_at_pos(get_local_mouse_pos());
 	int line = pos.y;
@@ -9594,6 +9595,8 @@ void TextEdit::_scroll_lines_up() {
 		}
 	}
 	merge_overlapping_carets();
+
+	_selection_mode_update();
 }
 
 void TextEdit::_scroll_lines_down() {
@@ -9615,6 +9618,8 @@ void TextEdit::_scroll_lines_down() {
 		}
 	}
 	merge_overlapping_carets();
+
+	_selection_mode_update();
 }
 
 void TextEdit::_adjust_viewport_to_caret_horizontally(int p_caret, bool p_maximize_selection) {
@@ -10101,6 +10106,9 @@ TextEdit::TextEdit(const String &p_placeholder) {
 
 	h_scroll->connect(SceneStringName(value_changed), callable_mp(this, &TextEdit::_scroll_moved));
 	v_scroll->connect(SceneStringName(value_changed), callable_mp(this, &TextEdit::_scroll_moved));
+
+	h_scroll->connect(CoreStringName(changed), callable_mp(this, &TextEdit::_selection_mode_update));
+	v_scroll->connect(CoreStringName(changed), callable_mp(this, &TextEdit::_selection_mode_update));
 
 	v_scroll->connect("scrolling", callable_mp(this, &TextEdit::_v_scroll_input));
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -560,6 +560,8 @@ private:
 	void _selection_changed(int p_caret = -1);
 	void _click_selection_held();
 
+	void _selection_mode_update();
+
 	void _update_selection_mode_pointer(bool p_initial = false);
 	void _update_selection_mode_word(bool p_initial = false);
 	void _update_selection_mode_line(bool p_initial = false);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Currently, when the mouse isn't moving, the selection updates on a timer than runs 20 times a second. This obviosely isn't that smooth on a high refresh rate display like 120 hz.

Now it also updates when the mouse scrolls, and on some other events. That means that it updates when needed, so up to 120 times a second on a 120 Hz screen. You can see this a little bit in the video, but the diffrence on 60 FPS isn't as big (but still very noticable in person).

## Before

https://github.com/user-attachments/assets/d907a528-aba4-49e2-90f6-d1ea83a95b26

## After

https://github.com/user-attachments/assets/18ea7974-4195-4839-afe3-f495b0298ca4

## Additional information

Also removed some relevant dead code:

1) `->set_value` already calls `_scroll_moved`, and the input parameter to it isn't even used in the actual method.

```diff
 void TextEdit::set_v_scroll(double p_scroll) {
        v_scroll->set_value(p_scroll);
-       int max_v_scroll = v_scroll->get_max() - v_scroll->get_page();
-       if (p_scroll >= max_v_scroll - 1.0) {
-               _scroll_moved(v_scroll->get_value());
-       }
        queue_accessibility_update();
 }
```

2) `0.0` is the default minimum value for `Range`, and isn't modified anywhere, so even if `p_scroll` is negative, `set_value` clamps it to 0. If we want to keep this redundent check, it should be added to `set_v_scroll` aswell for consistency.

```diff
 void TextEdit::set_h_scroll(int p_scroll) {
-       if (p_scroll < 0) {
-               p_scroll = 0;
-       }
        h_scroll->set_value(p_scroll);
```

If these are far too out-of-scope for this PR, I'll happily remove them.

No AI was used.