### PR TITLE
Binormal handling changes to properly handle mikktspace normal maps and mirrored objects

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1364,7 +1364,7 @@ MaterialStorage::MaterialStorage() {
 
 		actions.usage_defines["NORMAL"] = "#define NORMAL_USED\n";
 		actions.usage_defines["TANGENT"] = "#define TANGENT_USED\n";
-		actions.usage_defines["BINORMAL"] = "@TANGENT";
+		actions.usage_defines["BINORMAL"] = "#define BINORMAL_USED";
 		actions.usage_defines["RIM"] = "#define LIGHT_RIM_USED\n";
 		actions.usage_defines["RIM_TINT"] = "@RIM";
 		actions.usage_defines["CLEARCOAT"] = "#define LIGHT_CLEARCOAT_USED\n";

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -972,8 +972,8 @@ void RenderForwardClustered::_fill_render_list(RenderListType p_render_list, con
 
 		if (inst->non_uniform_scale) {
 			flags |= INSTANCE_DATA_FLAGS_NON_UNIFORM_SCALE;
-			flags |= inst->mirror ? 0 : INSTANCE_DATA_FLAG_POSITIVE_DET;
 		}
+		flags |= inst->mirror ? 0 : INSTANCE_DATA_FLAG_POSITIVE_DET;
 		bool uses_lightmap = false;
 		bool uses_gi = false;
 		bool uses_motion = false;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -972,6 +972,7 @@ void RenderForwardClustered::_fill_render_list(RenderListType p_render_list, con
 
 		if (inst->non_uniform_scale) {
 			flags |= INSTANCE_DATA_FLAGS_NON_UNIFORM_SCALE;
+			flags |= inst->mirror ? 0 : INSTANCE_DATA_FLAG_POSITIVE_DET;
 		}
 		bool uses_lightmap = false;
 		bool uses_gi = false;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -271,6 +271,7 @@ private:
 
 	// When changing any of these enums, remember to change the corresponding enums in the shader files as well.
 	enum {
+		INSTANCE_DATA_FLAG_POSITIVE_DET = 1 << 0,
 		INSTANCE_DATA_FLAG_MULTIMESH_INDIRECT = 1 << 2,
 		INSTANCE_DATA_FLAGS_DYNAMIC = 1 << 3,
 		INSTANCE_DATA_FLAGS_NON_UNIFORM_SCALE = 1 << 4,

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -810,7 +810,7 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 
 		actions.usage_defines["NORMAL"] = "#define NORMAL_USED\n";
 		actions.usage_defines["TANGENT"] = "#define TANGENT_USED\n";
-		actions.usage_defines["BINORMAL"] = "@TANGENT";
+		actions.usage_defines["BINORMAL"] = "#define BINORMAL_USED";
 		actions.usage_defines["RIM"] = "#define LIGHT_RIM_USED\n";
 		actions.usage_defines["RIM_TINT"] = "@RIM";
 		actions.usage_defines["CLEARCOAT"] = "#define LIGHT_CLEARCOAT_USED\n";

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -750,7 +750,7 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 
 		actions.usage_defines["NORMAL"] = "#define NORMAL_USED\n";
 		actions.usage_defines["TANGENT"] = "#define TANGENT_USED\n";
-		actions.usage_defines["BINORMAL"] = "@TANGENT";
+		actions.usage_defines["BINORMAL"] = "#define BINORMAL_USED";
 		actions.usage_defines["RIM"] = "#define LIGHT_RIM_USED\n";
 		actions.usage_defines["RIM_TINT"] = "@RIM";
 		actions.usage_defines["CLEARCOAT"] = "#define LIGHT_CLEARCOAT_USED\n";

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -218,6 +218,13 @@ uint multimesh_stride() {
 	return stride;
 }
 
+mat3 adjugate(in mat4 m) {
+	return mat3(
+			cross(m[1].xyz, m[2].xyz),
+			cross(m[2].xyz, m[0].xyz),
+			cross(m[0].xyz, m[1].xyz));
+}
+
 void vertex_shader(vec3 vertex_input,
 #ifdef NORMAL_USED
 		in vec3 normal_input,
@@ -251,7 +258,8 @@ void vertex_shader(vec3 vertex_input,
 
 	mat3 model_normal_matrix;
 	if (bool(instances.data[instance_index].flags & INSTANCE_FLAGS_NON_UNIFORM_SCALE)) {
-		model_normal_matrix = transpose(inverse(mat3(model_matrix)));
+		float dsign = bool(instances.data[instance_index].flags & INSTANCE_FLAGS_POSITIVE_DET) ? 1.0 : -1.0;
+		model_normal_matrix = dsign * adjugate(model_matrix);
 	} else {
 		model_normal_matrix = mat3(model_matrix);
 	}

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -76,13 +76,13 @@ layout(location = 13) in vec4 previous_normal_attrib;
 
 #endif // MOTION_VECTORS
 
-void axis_angle_to_tbn(vec3 axis, float angle, out vec3 tangent, out vec3 binormal, out vec3 normal) {
+void axis_angle_to_tn(vec3 axis, float angle, out vec3 tangent, out vec3 normal) {
 	float c = cos(angle);
 	float s = sin(angle);
 	vec3 omc_axis = (1.0 - c) * axis;
 	vec3 s_axis = s * axis;
 	tangent = omc_axis.xxx * axis + vec3(c, -s_axis.z, s_axis.y);
-	binormal = omc_axis.yyy * axis + vec3(s_axis.z, c, -s_axis.x);
+	//binormal = omc_axis.yyy * axis + vec3(s_axis.z, c, -s_axis.x);
 	normal = omc_axis.zzz * axis + vec3(-s_axis.y, s_axis.x, c);
 }
 
@@ -107,13 +107,12 @@ layout(location = 4) out vec2 uv2_interp;
 #endif
 
 #ifdef TANGENT_USED
-layout(location = 5) out vec3 tangent_interp;
-layout(location = 6) out vec3 binormal_interp;
+layout(location = 5) out vec4 tangent_interp;
 #endif
 
 #ifdef MOTION_VECTORS
-layout(location = 7) out vec4 screen_position;
-layout(location = 8) out vec4 prev_screen_position;
+layout(location = 6) out vec4 screen_position;
+layout(location = 7) out vec4 prev_screen_position;
 #endif
 
 #ifdef MATERIAL_UNIFORMS_USED
@@ -128,11 +127,11 @@ float global_time;
 
 #ifdef MODE_DUAL_PARABOLOID
 
-layout(location = 9) out float dp_clip;
+layout(location = 8) out float dp_clip;
 
 #endif
 
-layout(location = 10) out flat uint instance_index_interp;
+layout(location = 9) out flat uint instance_index_interp;
 
 #ifdef USE_MULTIVIEW
 #extension GL_EXT_multiview : enable
@@ -144,7 +143,7 @@ vec3 multiview_uv(vec2 uv) {
 ivec3 multiview_uv(ivec2 uv) {
 	return ivec3(uv, int(ViewIndex));
 }
-layout(location = 11) out vec4 combined_projected;
+layout(location = 10) out vec4 combined_projected;
 #else // USE_MULTIVIEW
 #define ViewIndex 0
 vec2 multiview_uv(vec2 uv) {
@@ -156,8 +155,8 @@ ivec2 multiview_uv(ivec2 uv) {
 #endif //USE_MULTIVIEW
 
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
-layout(location = 12) out vec4 diffuse_light_interp;
-layout(location = 13) out vec4 specular_light_interp;
+layout(location = 11) out vec4 diffuse_light_interp;
+layout(location = 12) out vec4 specular_light_interp;
 
 #include "../scene_forward_vertex_lights_inc.glsl"
 
@@ -178,7 +177,7 @@ uint cluster_get_range_clip_mask(uint i, uint z_min, uint z_max) {
 #endif // !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
 
 #if defined(POINT_SIZE_USED) && defined(POINT_COORD_USED)
-layout(location = 14) out vec2 point_coord_interp;
+layout(location = 13) out vec2 point_coord_interp;
 #endif
 
 invariant gl_Position;
@@ -224,8 +223,7 @@ void vertex_shader(vec3 vertex_input,
 		in vec3 normal_input,
 #endif
 #ifdef TANGENT_USED
-		in vec3 tangent_input,
-		in vec3 binormal_input,
+		in vec4 tangent_input,
 #endif
 		in uint instance_index, in uint multimesh_offset, in SceneData scene_data, in mat3x4 in_model_matrix,
 #ifdef USE_DOUBLE_PRECISION
@@ -351,8 +349,7 @@ void vertex_shader(vec3 vertex_input,
 #endif
 
 #ifdef TANGENT_USED
-	vec3 tangent = tangent_input;
-	vec3 binormal = binormal_input;
+	vec3 tangent = tangent_input.xyz;
 #endif
 
 #ifdef UV_USED
@@ -400,9 +397,7 @@ void vertex_shader(vec3 vertex_input,
 #endif
 
 #ifdef TANGENT_USED
-	// For non-uniform scale, this produces non-orthogonal TBNs; ideally binormal should be reconstructed in fragment shader with cross
 	tangent = mat3(model_matrix) * tangent;
-	binormal = mat3(model_matrix) * binormal;
 #endif
 #endif
 
@@ -465,9 +460,7 @@ void vertex_shader(vec3 vertex_input,
 #endif
 
 #ifdef TANGENT_USED
-	// For non-uniform scale, this produces non-orthogonal TBNs; ideally binormal should be reconstructed in fragment shader with cross
 	tangent = mat3(modelview) * tangent;
-	binormal = mat3(modelview) * binormal;
 #endif
 #endif // !defined(SKIP_TRANSFORM_USED) && !defined(VERTEX_WORLD_COORDS_USED)
 
@@ -480,7 +473,6 @@ void vertex_shader(vec3 vertex_input,
 #endif
 
 #ifdef TANGENT_USED
-	binormal = (read_view_matrix * vec4(binormal, 0.0)).xyz;
 	tangent = (read_view_matrix * vec4(tangent, 0.0)).xyz;
 #endif
 #endif
@@ -493,8 +485,7 @@ void vertex_shader(vec3 vertex_input,
 #endif
 
 #ifdef TANGENT_USED
-	tangent_interp = normalize(tangent);
-	binormal_interp = normalize(binormal);
+	tangent_interp = vec4(normalize(tangent), tangent_input.w);
 #endif
 
 #ifdef MODE_RENDER_DEPTH
@@ -552,7 +543,6 @@ void vertex_shader(vec3 vertex_input,
 	uint cluster_z = uint(clamp((-vertex_interp.z / scene_data.z_far) * 32.0, 0.0, 31.0));
 
 	{ //omni lights
-
 		uint cluster_omni_offset = cluster_offset;
 
 		uint item_min;
@@ -622,7 +612,6 @@ void vertex_shader(vec3 vertex_input,
 	}
 
 	{ // Directional light.
-
 		// We process the first directional light separately as it may have shadows.
 		vec3 directional_diffuse = vec3(0.0);
 		vec3 directional_specular = vec3(0.0);
@@ -731,8 +720,7 @@ void _unpack_vertex_attributes(vec4 p_vertex_in, vec3 p_compressed_aabb_position
 #ifdef NORMAL_USED
 		out vec3 r_normal,
 #endif
-		out vec3 r_tangent,
-		out vec3 r_binormal,
+		out vec4 r_tangent,
 #endif
 		out vec3 r_vertex) {
 
@@ -742,25 +730,20 @@ void _unpack_vertex_attributes(vec4 p_vertex_in, vec3 p_compressed_aabb_position
 #endif
 
 #if defined(NORMAL_USED) || defined(TANGENT_USED)
-
-	float binormal_sign;
-
 	// This works because the oct value (0, 1) maps onto (0, 0, -1) which encodes to (1, 1).
 	// Accordingly, if p_normal_in.z contains octahedral values, it won't equal (0, 1).
 	if (p_normal_in.z > 0.0 || p_normal_in.w < 1.0) {
 		// Uncompressed format.
 		vec2 signed_tangent_attrib = p_normal_in.zw * 2.0 - 1.0;
-		r_tangent = oct_to_vec3(vec2(signed_tangent_attrib.x, abs(signed_tangent_attrib.y) * 2.0 - 1.0));
-		binormal_sign = sign(signed_tangent_attrib.y);
-		r_binormal = normalize(cross(r_normal, r_tangent) * binormal_sign);
+		r_tangent = vec4(oct_to_vec3(vec2(signed_tangent_attrib.x, abs(signed_tangent_attrib.y) * 2.0 - 1.0)), sign(signed_tangent_attrib.y));
 	} else {
 		// Compressed format.
 		float angle = p_vertex_in.w;
-		binormal_sign = angle > 0.5 ? 1.0 : -1.0; // 0.5 does not exist in UNORM16, so values are either greater or smaller.
+		float binormal_sign = angle > 0.5 ? 1.0 : -1.0; // 0.5 does not exist in UNORM16, so values are either greater or smaller.
 		angle = abs(angle * 2.0 - 1.0) * M_PI; // 0.5 is basically zero, allowing to encode both signs reliably.
 		vec3 axis = r_normal;
-		axis_angle_to_tbn(axis, angle, r_tangent, r_binormal, r_normal);
-		r_binormal *= binormal_sign;
+		axis_angle_to_tn(axis, angle, r_tangent.xyz, r_normal);
+		r_tangent.w = binormal_sign;
 	}
 #endif
 }
@@ -780,8 +763,7 @@ void main() {
 	vec3 prev_normal;
 #endif
 #if defined(NORMAL_USED) || defined(TANGENT_USED)
-	vec3 prev_tangent;
-	vec3 prev_binormal;
+	vec4 prev_tangent;
 #endif
 
 	_unpack_vertex_attributes(
@@ -795,7 +777,6 @@ void main() {
 			prev_normal,
 #endif
 			prev_tangent,
-			prev_binormal,
 #endif
 			prev_vertex);
 
@@ -806,7 +787,6 @@ void main() {
 #endif
 #ifdef TANGENT_USED
 			prev_tangent,
-			prev_binormal,
 #endif
 			instance_index, draw_call.multimesh_motion_vectors_previous_offset, scene_data_block.prev_data, instances.data[instance_index].prev_transform,
 #ifdef USE_DOUBLE_PRECISION
@@ -823,8 +803,7 @@ void main() {
 	vec3 normal;
 #endif
 #if defined(NORMAL_USED) || defined(TANGENT_USED)
-	vec3 tangent;
-	vec3 binormal;
+	vec4 tangent;
 #endif
 
 	_unpack_vertex_attributes(
@@ -837,7 +816,6 @@ void main() {
 			normal,
 #endif
 			tangent,
-			binormal,
 #endif
 			vertex);
 
@@ -849,7 +827,6 @@ void main() {
 #endif
 #ifdef TANGENT_USED
 			tangent,
-			binormal,
 #endif
 			instance_index, draw_call.multimesh_motion_vectors_current_offset, scene_data_block.data, instances.data[instance_index].transform,
 #ifdef USE_DOUBLE_PRECISION
@@ -899,22 +876,21 @@ layout(location = 4) in vec2 uv2_interp;
 #endif
 
 #ifdef TANGENT_USED
-layout(location = 5) in vec3 tangent_interp;
-layout(location = 6) in vec3 binormal_interp;
+layout(location = 5) in vec4 tangent_interp;
 #endif
 
 #ifdef MOTION_VECTORS
-layout(location = 7) in vec4 screen_position;
-layout(location = 8) in vec4 prev_screen_position;
+layout(location = 6) in vec4 screen_position;
+layout(location = 7) in vec4 prev_screen_position;
 #endif
 
 #ifdef MODE_DUAL_PARABOLOID
 
-layout(location = 9) in float dp_clip;
+layout(location = 8) in float dp_clip;
 
 #endif
 
-layout(location = 10) in flat uint instance_index_interp;
+layout(location = 9) in flat uint instance_index_interp;
 
 #ifdef USE_LIGHTMAP
 // w0, w1, w2, and w3 are the four cubic B-spline basis functions
@@ -986,7 +962,7 @@ vec3 multiview_uv(vec2 uv) {
 ivec3 multiview_uv(ivec2 uv) {
 	return ivec3(uv, int(ViewIndex));
 }
-layout(location = 11) in vec4 combined_projected;
+layout(location = 10) in vec4 combined_projected;
 #else // USE_MULTIVIEW
 #define ViewIndex 0
 vec2 multiview_uv(vec2 uv) {
@@ -997,12 +973,12 @@ ivec2 multiview_uv(ivec2 uv) {
 }
 #endif // !USE_MULTIVIEW
 #if !defined(MODE_RENDER_DEPTH) && !defined(MODE_UNSHADED) && defined(USE_VERTEX_LIGHTING)
-layout(location = 12) in vec4 diffuse_light_interp;
-layout(location = 13) in vec4 specular_light_interp;
+layout(location = 11) in vec4 diffuse_light_interp;
+layout(location = 12) in vec4 specular_light_interp;
 #endif
 
 #if defined(POINT_SIZE_USED) && defined(POINT_COORD_USED)
-layout(location = 14) in vec2 point_coord_interp;
+layout(location = 13) in vec2 point_coord_interp;
 #endif
 
 //defines to keep compatibility with vertex
@@ -1247,14 +1223,6 @@ void fragment_shader(in SceneData scene_data) {
 
 	float alpha_highp = float(instances.data[instance_index].flags >> INSTANCE_FLAGS_FADE_SHIFT) / float(255.0);
 
-#ifdef TANGENT_USED
-	vec3 binormal = binormal_interp;
-	vec3 tangent = tangent_interp;
-#else
-	vec3 binormal = vec3(0.0);
-	vec3 tangent = vec3(0.0);
-#endif
-
 #ifdef NORMAL_USED
 	vec3 normal_highp = normal_interp;
 #if defined(DO_SIDE_CHECK)
@@ -1263,6 +1231,14 @@ void fragment_shader(in SceneData scene_data) {
 	}
 #endif // DO_SIDE_CHECK
 #endif // NORMAL_USED
+
+#ifdef TANGENT_USED
+	vec3 tangent = tangent_interp.xyz;
+	vec3 binormal = cross(normal_highp, tangent) * tangent_interp.w;
+#else
+	vec3 tangent = vec3(0.0);
+	vec3 binormal = vec3(0.0);
+#endif
 
 #ifdef UV_USED
 	vec2 uv = uv_interp;

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -448,6 +448,10 @@ void vertex_shader(vec3 vertex_input,
 	float point_size = 1.0;
 #endif
 
+#ifdef BINORMAL_USED
+	vec3 binormal = normalize(cross(normal_highp, tangent) * tangent_input.w);
+#endif
+
 	{
 #CODE : VERTEX
 	}
@@ -788,6 +792,9 @@ void main() {
 #endif
 			prev_vertex);
 
+#if defined(NORMAL_USED) || defined(TANGENT_USED)
+	prev_tangent.w *= bool(instances.data[instance_index].flags & INSTANCE_FLAGS_POSITIVE_DET) ? 1.0 : -1.0;
+#endif
 	global_time = scene_data_block.prev_data.time;
 	vertex_shader(prev_vertex,
 #ifdef NORMAL_USED
@@ -828,6 +835,10 @@ void main() {
 			vertex);
 
 	// Current vertex.
+
+#if defined(NORMAL_USED) || defined(TANGENT_USED)
+	tangent.w *= bool(instances.data[instance_index].flags & INSTANCE_FLAGS_POSITIVE_DET) ? 1.0 : -1.0;
+#endif
 	global_time = scene_data_block.data.time;
 	vertex_shader(vertex,
 #ifdef NORMAL_USED

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
@@ -19,7 +19,7 @@
 #endif
 #endif
 
-#if !defined(TANGENT_USED) && (defined(NORMAL_MAP_USED) || defined(BENT_NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED))
+#if !defined(TANGENT_USED) && (defined(NORMAL_MAP_USED) || defined(BINORMAL_USED) || defined(BENT_NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED))
 #define TANGENT_USED
 #endif
 

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
@@ -175,6 +175,7 @@ layout(constant_id = 2) const bool sc_emulate_point_size = false;
 
 layout(set = 0, binding = 2) uniform sampler shadow_sampler;
 
+#define INSTANCE_FLAGS_POSITIVE_DET (1 << 0)
 #define INSTANCE_FLAGS_DYNAMIC (1 << 3)
 #define INSTANCE_FLAGS_NON_UNIFORM_SCALE (1 << 4)
 #define INSTANCE_FLAGS_USE_GI_BUFFERS (1 << 5)


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/84145

Addresses comment in https://github.com/godotengine/godot/pull/121012#issuecomment-4895005557 CC @zeux 

This PR is intended as a quality improvement for a bug in our normal mapping implementation. However in order to avoid making performance worse, I took the chance to do some performance optimizations that we have been holding off on. So the end result is code that is more robust (fewer edge cases) and faster (in theory).

_Master: MRP from https://github.com/godotengine/godot/issues/84145_
<img width="922" height="495" alt="Screenshot from 2026-08-05 14-57-14" src="https://github.com/user-attachments/assets/f48e8d05-0e0b-40fe-b857-e4f2763d1a2f" />

_This PR_
<img width="922" height="495" alt="Screenshot from 2026-08-05 14-56-59" src="https://github.com/user-attachments/assets/bc51e42b-a2cc-4392-a58a-d6b3b772fc51" />

_This PR without using the determinant using a negative scale to mirror the object_
<img width="922" height="495" alt="Screenshot from 2026-08-05 14-59-14" src="https://github.com/user-attachments/assets/7d5e0a34-19ea-4295-a5a8-6bbdae77aab6" />


_mirroring with this PR_
<img width="922" height="495" alt="Screenshot from 2026-08-05 15-18-31" src="https://github.com/user-attachments/assets/2cf92550-47f5-4c31-a498-faa4e2297341" />

Performance Data:

As expected it reduces the size of the vertex shader considerably, with only a small increase in the size of the fragment shader. This data misses the benefit of avoiding a full interpolator which can be significant. 
|                   | VGPR | SGPR | OPCODES |
|-------------------|------|------|---------|
| Master - Vertex   | 51   | 60   | 588     |
| PR - Vertex       | 50   | 60   | 518     |
| Master - Fragment | 75   | 98   | 6897    |
| PR - Fragment     | 75   | 98   | 6906    |

Mali Offline Compiler

Master - Vertex:
```
Work registers: 61 (95% used at 50% occupancy)
Uniform registers: 48 (37% used)
Stack spilling: false
16-bit arithmetic: 0%

                                A      LS       T    Bound
Total instruction cycles:    2.52   17.00    0.00       LS
Shortest path cycles:        0.94    7.00    0.00       LS
Longest path cycles:         2.24   17.00    0.00       LS

A = Arithmetic, LS = Load/Store, T = Texture
```

PR - Vertex:
```
Work registers: 64 (100% used at 50% occupancy)
Uniform registers: 46 (35% used)
Stack spilling: false
16-bit arithmetic: 0%

                                A      LS       T    Bound
Total instruction cycles:    2.16   17.00    0.00       LS
Shortest path cycles:        0.83    7.00    0.00       LS
Longest path cycles:         1.99   17.00    0.00       LS
```

Here you can see the decrease in varying pressure corresponds to the increase in ALU pressure

Master - Fragment:
```
Work registers: 64 (100% used at 50% occupancy)
Uniform registers: 128 (100% used)
Stack spilling: 94 bytes
16-bit arithmetic: 0%

                                A      LS       V       T    Bound
Total instruction cycles:   22.02  164.00    0.47    3.88       LS
Shortest path cycles:        1.48   10.00    0.47    0.50       LS
Longest path cycles:          N/A     N/A     N/A     N/A      N/A

A = Arithmetic, LS = Load/Store, V = Varying, T = Texture
```

PR - fragment
```
Work registers: 64 (100% used at 50% occupancy)
Uniform registers: 128 (100% used)
Stack spilling: 94 bytes
16-bit arithmetic: 0%

                                A      LS       V       T    Bound
Total instruction cycles:   22.08  164.00    0.41    3.88       LS
Shortest path cycles:        1.53   10.00    0.41    0.50       LS
Longest path cycles:          N/A     N/A     N/A     N/A      N/A
```

Profiling

Running a heavy scene with thousands of Meshes I see improvement in the depth prepass and the opaque pass of about 5%. Which is not huge, but it is a nice benefit