### PR TITLE
Fix iOS landscape orientation, which is behaving opposite to Android

### DIFF
--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -545,13 +545,13 @@ String EditorExportPlatformAppleEmbedded::_process_config_file_line(const Ref<Ed
 
 		switch (screen_orientation) {
 			case DisplayServerEnums::SCREEN_LANDSCAPE:
-				orientations += "<string>UIInterfaceOrientationLandscapeLeft</string>\n";
+				orientations += "<string>UIInterfaceOrientationLandscapeRight</string>\n";
 				break;
 			case DisplayServerEnums::SCREEN_PORTRAIT:
 				orientations += "<string>UIInterfaceOrientationPortrait</string>\n";
 				break;
 			case DisplayServerEnums::SCREEN_REVERSE_LANDSCAPE:
-				orientations += "<string>UIInterfaceOrientationLandscapeRight</string>\n";
+				orientations += "<string>UIInterfaceOrientationLandscapeLeft</string>\n";
 				break;
 			case DisplayServerEnums::SCREEN_REVERSE_PORTRAIT:
 				orientations += "<string>UIInterfaceOrientationPortraitUpsideDown</string>\n";


### PR DESCRIPTION

## What problem(s) does this PR solve?

- Closes #93710 

## Additional information
Landscape should place the notch on the left, and Reverse Landscape on the right. While Android behaves as expected, iOS is doing the exact opposite.

Minimum Reproduction Project (MRP) : The Godot splash screen would be sufficient to check the orientation in any demo project.   


