### PR TITLE
Project Manager: Add Compact Mode Setting

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1378,6 +1378,12 @@
 			If [code]true[/code], enable TLSv1.3 negotiation.
 			[b]Note:[/b] Only supported when using Mbed TLS 3.0 or later (Linux distribution packages may be compiled against older system Mbed TLS packages), otherwise the maximum supported TLS version is always TLSv1.2.
 		</member>
+		<member name="project_manager/compact_mode" type="bool" setter="" getter="">
+			If [code]true[/code] enables hiding the Project List Sidebar when the Project Manager is shrunk, horizontally, below a set value. That value is specified in [member project_manager/compact_mode_threshold].
+		</member>
+		<member name="project_manager/compact_mode_threshold" type="int" setter="" getter="">
+			Sets the threshold, in pixels, beyond which, shrinking the Project Manager will collapse the Project List Sidebar. This only has an effect if [member project_manager/compact_mode] is set to [code]true[/code].
+		</member>
 		<member name="project_manager/default_renderer" type="String" setter="" getter="">
 			The renderer type that will be checked off by default when creating a new project. Accepted strings are "forward_plus", "mobile" or "gl_compatibility".
 		</member>

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -424,18 +424,17 @@ void ProjectListItemControl::set_is_grayed(bool p_grayed) {
 	}
 }
 
-void ProjectListItemControl::set_project_title_index(int p_title_index) {
-	project_title_index = p_title_index;
-}
-
 void ProjectListItemControl::set_project_title_autowrap() {
-	title_fullsize_cache = project_title->get_size().x;
-	window_size_cache = get_window()->get_size().x;
+	ProjectList *pl = get_list();
 
-	int tag_size = 0;
+	title_fullsize_cache = project_title->get_size().x;
+	pl->window_size_cache = get_window()->get_size().x;
+
 	int tag_maxsize = 0;
+	int tag_size = 0;
 	for (Node *child : tag_container->iterate_children()) {
-		ProjectTag *tag = Object::cast_to<ProjectTag>(child);
+		ProjectTag *tag = cast_to<ProjectTag>(child);
+
 		tag_size += tag->get_size().x;
 
 		if (tag_maxsize == 0) {
@@ -443,53 +442,37 @@ void ProjectListItemControl::set_project_title_autowrap() {
 		}
 	}
 	tag_size_cache = MIN(tag_size, tag_maxsize);
-	int &title_size_cache = get_list()->title_size_cache[project_title_index];
 
-	int size_check = 800 * EDSCALE;
-	if (title_size_cache == 0) {
-		title_size_cache = size_check;
+	int &title_size = pl->title_size_cache;
+	const int size_check = 800 * EDSCALE;
+	if (title_size == 0) {
+		title_size = size_check;
 	}
 
 	if (title_fullsize_cache > size_check - tag_size_cache) {
-		resize_project_title();
+		resize_project_title(title_size);
 	}
 }
 
-void ProjectListItemControl::resize_project_title() {
-	if (get_window() == nullptr) {
-		return;
-	}
-
-	int window_size = get_window()->get_size().x;
-	int difference = window_size - window_size_cache;
-	window_size_cache = window_size;
-
-	int &title_size_cache = get_list()->title_size_cache[project_title_index];
-	title_size_cache += difference;
-
-	if (title_size_cache > title_fullsize_cache + tag_size_cache) {
+void ProjectListItemControl::resize_project_title(const int p_title_size) {
+	bool autowrap = project_title->get_autowrap_mode() != TextServer::AUTOWRAP_OFF;
+	if (autowrap && p_title_size > title_fullsize_cache + tag_size_cache) {
 		project_title->set_custom_maximum_size(Vector2(-1, -1));
 		project_title->set_custom_minimum_size(Vector2(0, 0));
 		project_title->set_autowrap_mode(TextServer::AUTOWRAP_OFF);
 
 		return;
 	}
-	ProjectTag tag = ProjectTag("dummy");
-	int tag_maxsize = tag.get_custom_maximum_size().x;
-	int title_maxsize = title_size_cache - tag_size_cache;
-	int title_minsize = title_size_cache - tag_maxsize;
 
 	int abs_minsize = (200 * EDSCALE);
-	if (title_fullsize_cache > abs_minsize) {
-		if (title_minsize < abs_minsize) {
-			title_minsize = abs_minsize + tag_maxsize - tag_size_cache;
-		}
-		if (title_maxsize < title_minsize) {
-			project_title->set_custom_maximum_size(Vector2(title_minsize, -1));
-		} else {
-			project_title->set_custom_maximum_size(Vector2(title_maxsize, -1));
-		}
-		project_title->set_custom_minimum_size(Vector2(title_minsize, 0));
+	if (title_fullsize_cache > abs_minsize && p_title_size < title_fullsize_cache + tag_size_cache) {
+		ProjectTag tag = ProjectTag("dummy");
+		int tag_maxsize = tag.get_custom_maximum_size().x;
+		int title_maxsize = p_title_size - tag_size_cache;
+		int title_minsize = abs_minsize + tag_maxsize - tag_size_cache;
+
+		project_title->set_custom_maximum_size(Vector2(MAX(title_maxsize, title_minsize), -1));
+		project_title->set_custom_minimum_size(Vector2(MAX(title_maxsize, title_minsize), 0));
 		project_title->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
 	}
 }
@@ -936,14 +919,12 @@ void ProjectList::update_project_list() {
 	// If you have 150 projects, it may read through 150 files on your disk at once + load 150 icons.
 	// FIXME: Does it really have to be a full, hard reload? Runtime updates should be made much cheaper.
 
-	int temp_title_index = -1;
 	if (ProjectManager::get_singleton()->is_initialized()) {
 		// Clear whole list
 		for (int i = 0; i < _projects.size(); ++i) {
 			Item &project = _projects.write[i];
 			CRASH_COND(project.control == nullptr);
 
-			temp_title_index = project.project_title_index;
 			memdelete(project.control); // Why not queue_free()?
 		}
 
@@ -956,9 +937,6 @@ void ProjectList::update_project_list() {
 
 	// Create controls
 	for (int i = 0; i < _projects.size(); ++i) {
-		Item &item = _projects.write[i];
-		item.project_title_index = temp_title_index;
-
 		_create_project_item_control(i);
 	}
 
@@ -1232,15 +1210,6 @@ void ProjectList::_create_project_item_control(int p_index) {
 	hb->connect("explore_pressed", callable_mp(this, &ProjectList::_on_explore_pressed).bind(item.path));
 #endif
 	hb->connect("request_menu", callable_mp(this, &ProjectList::_open_menu).bind(hb));
-
-	if (item.project_title_index == -1) {
-		project_title_index_count++;
-		title_size_cache[project_title_index_count] = 0;
-		item.project_title_index = project_title_index_count;
-		hb->set_project_title_index(project_title_index_count);
-	} else {
-		hb->set_project_title_index(item.project_title_index);
-	}
 
 	project_list_vbox->add_child(hb);
 }
@@ -1597,8 +1566,16 @@ void ProjectList::erase_selected_projects(bool p_delete_project_contents) {
 // Resize project titles.
 
 void ProjectList::resize_project_titles() {
+	if (window_size_cache == 0) {
+		return;
+	}
+	const int window_size = get_window()->get_size().x;
+	const int difference = window_size - window_size_cache;
+	window_size_cache = window_size;
+
+	title_size_cache += difference;
 	for (Item &item : _projects) {
-		item.control->resize_project_title();
+		item.control->resize_project_title(title_size_cache);
 	}
 }
 

--- a/editor/project_manager/project_list.cpp
+++ b/editor/project_manager/project_list.cpp
@@ -1573,6 +1573,20 @@ void ProjectList::resize_project_titles() {
 	const int difference = window_size - window_size_cache;
 	window_size_cache = window_size;
 
+	if (compact_mode_cache && !compact_mode && !sb_visible_cache) {
+		title_size_cache -= compact_size_cache;
+		sb_visible_cache = true;
+	} else if (compact_mode) {
+		bool sb_visible = ProjectManager::get_singleton()->is_project_list_sidebar_visible();
+		if (sb_visible && !sb_visible_cache) {
+			title_size_cache -= compact_size_cache;
+		} else if (!sb_visible && sb_visible_cache) {
+			title_size_cache += compact_size_cache;
+		}
+		sb_visible_cache = sb_visible;
+	}
+	compact_mode_cache = compact_mode;
+
 	title_size_cache += difference;
 	for (Item &item : _projects) {
 		item.control->resize_project_title(title_size_cache);

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -98,7 +98,6 @@ private:
 
 	int title_fullsize_cache = 0;
 	int tag_size_cache = 0;
-	int window_size_cache = 0;
 
 protected:
 	void _notification(int p_what);
@@ -120,10 +119,9 @@ public:
 	void set_is_favorite(bool p_favorite);
 	void set_is_missing(bool p_missing);
 	void set_is_grayed(bool p_grayed);
-	void set_project_title_index(int p_title_index);
 	void set_project_title_autowrap();
 
-	void resize_project_title();
+	void resize_project_title(const int p_title_size);
 
 	ProjectListItemControl();
 };
@@ -221,8 +219,8 @@ public:
 		String get_last_edited_string() const;
 	};
 
-	HashMap<int, int> title_size_cache;
-	int project_title_index_count = -1;
+	int title_size_cache = 0;
+	int window_size_cache = 0;
 
 private:
 	String _config_path;

--- a/editor/project_manager/project_list.h
+++ b/editor/project_manager/project_list.h
@@ -305,6 +305,13 @@ public:
 
 	static bool project_feature_looks_like_version(const String &p_feature);
 
+	// Compact mode.
+
+	bool compact_mode = false;
+	bool compact_mode_cache = false;
+	bool sb_visible_cache = false;
+	int compact_size_cache = 0;
+
 	// Initialization & loading.
 
 	void save_config();

--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -112,7 +112,12 @@ void ProjectManager::_notification(int p_what) {
 			_select_main_view(MAIN_VIEW_PROJECTS);
 			_update_list_placeholder();
 			_titlebar_resized();
-			_update_compact_mode(true);
+
+			if (compact_mode) {
+				_update_compact_mode(true);
+			}
+			project_list->sb_visible_cache = is_project_list_sidebar_visible();
+			project_list->compact_size_cache = project_list_sidebar->get_size().x;
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {
@@ -144,11 +149,15 @@ void ProjectManager::_notification(int p_what) {
 			if (EditorThemeManager::is_generated_theme_outdated()) {
 				_update_theme();
 			}
+			_update_project_manager_settings();
 			_update_list_placeholder();
 		} break;
+
 		case NOTIFICATION_RESIZED: {
+			if (compact_mode) {
+				_update_compact_mode();
+			}
 			project_list->resize_project_titles();
-			_update_compact_mode();
 		} break;
 	}
 }
@@ -186,19 +195,20 @@ void ProjectManager::_build_icon_type_cache(Ref<Theme> p_theme) {
 
 // Hides certain parts of the Project Manager when window width gets smaller than combined_minimum_size.
 void ProjectManager::_update_compact_mode(bool p_reset_threshold) {
+#ifdef ANDRIOD_ENABLED
 	if (p_reset_threshold) {
 		project_list_sidebar->show();
 		compact_mode_threshold = root_container->get_combined_minimum_size().width;
 	}
-
-	bool compact_mode = get_size().width < compact_mode_threshold;
-	project_list_sidebar->set_visible(!compact_mode);
+#endif
+	bool compact = get_size().width < compact_mode_threshold;
+	project_list_sidebar->set_visible(!compact);
 }
 
 void ProjectManager::_update_size_limits() {
 	const Size2 default_minimum_size = Size2(720, 450) * EDSCALE;
 	const Size2 display_size = DisplayServer::get_singleton()->screen_get_usable_rect(DisplayServerEnums::SCREEN_OF_MAIN_WINDOW).size;
-	const real_t smallest_display_dimension = display_size.width < display_size.height ? display_size.width : display_size.height;
+	const real_t smallest_display_dimension = MIN(display_size.width, display_size.height);
 	const Size2 minimum_size = default_minimum_size.minf(smallest_display_dimension);
 
 	// Define a minimum window size to prevent UI elements from overlapping or being cut off.
@@ -1358,6 +1368,31 @@ void ProjectManager::_titlebar_resized() {
 	}
 }
 
+bool ProjectManager::is_project_list_sidebar_visible() {
+	return project_list_sidebar->is_visible();
+}
+
+Vector2 ProjectManager::get_project_list_sidebar_size() {
+	return project_list_sidebar->get_size();
+}
+
+void ProjectManager::_update_project_manager_settings() {
+	// Compact Mode setting.
+	{
+		compact_mode = EDITOR_GET("project_manager/compact_mode");
+		if (compact_mode) {
+#ifndef ANDRIOD_ENABLED
+			compact_mode_threshold = EDITOR_GET("project_manager/compact_mode_threshold");
+#endif
+			_update_compact_mode();
+		} else if (!project_list_sidebar->is_visible()) {
+			project_list_sidebar->set_visible(true);
+		}
+		project_list->compact_mode = compact_mode;
+		project_list->resize_project_titles();
+	}
+}
+
 void ProjectManager::_open_donate_page() {
 	OS::get_singleton()->shell_open("https://fund.godotengine.org/?ref=project_manager");
 }
@@ -2025,6 +2060,11 @@ ProjectManager::ProjectManager() {
 		title_bar->set_can_move_window(true);
 		title_bar->connect(SceneStringName(item_rect_changed), callable_mp(this, &ProjectManager::_titlebar_resized));
 	}
+
+	compact_mode = EDITOR_GET("project_manager/compact_mode");
+	const int threshold = EDITOR_GET("project_manager/compact_mode_threshold");
+	compact_mode_threshold = compact_mode ? threshold : 0;
+	project_list->compact_mode = compact_mode;
 
 	_update_size_limits();
 }

--- a/editor/project_manager/project_manager.h
+++ b/editor/project_manager/project_manager.h
@@ -75,6 +75,10 @@ class ProjectManager : public Control {
 
 	// Main layout.
 
+	bool compact_mode = false;
+	int compact_mode_threshold = 0;
+	void _update_compact_mode(bool p_reset_threshold = false);
+
 	Ref<Theme> theme;
 
 	void _update_size_limits();
@@ -94,9 +98,6 @@ class ProjectManager : public Control {
 	HBoxContainer *main_view_toggles = nullptr;
 	Button *quick_settings_button = nullptr;
 	VBoxContainer *project_list_sidebar = nullptr;
-
-	int compact_mode_threshold = 0;
-	void _update_compact_mode(bool p_reset_threshold = false);
 
 	enum MainViewTab {
 		MAIN_VIEW_PROJECTS,
@@ -272,6 +273,9 @@ class ProjectManager : public Control {
 
 	void _files_dropped(PackedStringArray p_files);
 
+	// Editor Settings.
+	void _update_project_manager_settings();
+
 protected:
 	void _notification(int p_what);
 
@@ -289,6 +293,11 @@ public:
 	// Project tag management.
 
 	void add_new_tag(const String &p_tag);
+
+	// Compact mode.
+
+	bool is_project_list_sidebar_visible();
+	Vector2 get_project_list_sidebar_size();
 
 	// Theme.
 	Ref<Theme> get_theme() const { return theme; }

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1200,6 +1200,13 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "project_manager/sorting_order", 0, "Last Edited,Name,Path")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "project_manager/directory_naming_convention", 1, "No Convention,kebab-case,snake_case,camelCase,PascalCase,Title Case")
 
+#if defined(ANDRIOD_ENABLED)
+	_initial_set("project_manager/compact_mode", true, true);
+#elif !defined(ANDRIOD_ENABLED)
+	_initial_set("project_manager/compact_mode", false, true);
+	_initial_set("project_manager/compact_mode_threshold", 0, true);
+#endif
+
 #if defined(WEB_ENABLED)
 	// Web platform only supports `gl_compatibility`.
 	const String default_renderer = "gl_compatibility";


### PR DESCRIPTION
Closes: #122092 
Fixes: #122257

The bug in that issue was caused by #121387 as it introduced a compact mode which hid the sidebar when the project manager was shrunk beyond a threshold. This PR does two things:

- Adds Compact Mode setting: `project_manager/compact_mode`.
- Adds Compact Mode Threshold setting: `project_manager/compact_mode_threshold` which set the point to hide the project manager sidebar.

My reasoning
- Since the mentioned PR was andriod focused, a compact mode setting builds upon the PR, it is set to `on` by default on the intended mobile devices and `off` on desktop devices.
- Because desktop devices have more real-estate, the `compact_mode_threshold` gives users more fine grained control. 

Project Titles also wrap properly, using the extra space given by the collapsed sidebar and dynamically resizes when the setting is turned on or off at any size.

https://github.com/user-attachments/assets/b36e6be2-40e2-4105-917e-25de57b7407c