### PR TITLE
RID_Owner: Show type name in 'element limit reached' error message.

### DIFF
--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -116,11 +116,7 @@ class RID_Alloc : public RID_AllocBase {
 			uint32_t chunk_count = alloc_count == 0 ? 0 : (max_alloc / elements_in_chunk);
 			if (THREAD_SAFE && chunk_count == chunk_limit) {
 				mutex.unlock();
-				if (description != nullptr) {
-					ERR_FAIL_V_MSG(RID(), vformat("Element limit for RID of type '%s' reached.", String(description)));
-				} else {
-					ERR_FAIL_V_MSG(RID(), "Element limit reached.");
-				}
+				ERR_FAIL_V_MSG(RID(), vformat("Element limit for RID of type '%s' reached.", description ? description : typeid(T).name()));
 			}
 
 			//grow chunks

--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -38,7 +38,12 @@
 #include "core/variant/variant.h"
 
 #include <cstdio>
+#include <cstdlib>
 #include <typeinfo> // IWYU pragma: keep // Used in macro.
+
+#if defined(__GNUC__) && !defined(_MSC_VER)
+#include <cxxabi.h>
+#endif
 
 #ifdef TSAN_ENABLED
 #include <sanitizer/tsan_interface.h>
@@ -116,7 +121,7 @@ class RID_Alloc : public RID_AllocBase {
 			uint32_t chunk_count = alloc_count == 0 ? 0 : (max_alloc / elements_in_chunk);
 			if (THREAD_SAFE && chunk_count == chunk_limit) {
 				mutex.unlock();
-				ERR_FAIL_V_MSG(RID(), vformat("Element limit for RID of type '%s' reached.", description ? description : typeid(T).name()));
+				ERR_FAIL_V_MSG(RID(), vformat("Element limit for RID of type '%s' reached.", get_description()));
 			}
 
 			//grow chunks
@@ -407,6 +412,36 @@ public:
 		description = p_description;
 	}
 
+	// Gets the description, falling back to the element type name.
+	String get_description() const {
+		if (description) {
+			return String(description);
+		}
+
+		const char *type_name_ptr = typeid(T).name();
+#if defined(__GNUC__) && !defined(_MSC_VER)
+		// GCC/Clang: need to manually de-mangle the name. The return type has to be
+		// a String so the demangled buffer can be freed before returning.
+		String type_name;
+		int status;
+		char *demangled = abi::__cxa_demangle(type_name_ptr, nullptr, nullptr, &status);
+
+		if (status == 0 && demangled) {
+			type_name = demangled;
+		} else {
+			type_name = type_name_ptr;
+		}
+
+		if (demangled) {
+			::free(demangled);
+		}
+		return type_name;
+#else
+		// MSVC automatically de-mangles the type name.
+		return String(type_name_ptr);
+#endif
+	}
+
 	RID_Alloc(uint32_t p_target_chunk_byte_size = 65536, uint32_t p_maximum_number_of_elements = 262144) {
 		elements_in_chunk = sizeof(T) > p_target_chunk_byte_size ? 1 : (p_target_chunk_byte_size / sizeof(T));
 		if constexpr (THREAD_SAFE) {
@@ -424,7 +459,7 @@ public:
 
 		if (alloc_count) {
 			print_error(vformat("ERROR: %d RID allocations of type '%s' were leaked at exit.",
-					alloc_count, description ? description : typeid(T).name()));
+					alloc_count, get_description()));
 
 			for (size_t i = 0; i < max_alloc; i++) {
 				uint32_t validator = chunks[i / elements_in_chunk][i % elements_in_chunk].validator;

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -9916,6 +9916,12 @@ RenderingDevice::RenderingDevice() {
 		singleton = this;
 	}
 
+	// Give unique descriptions to the RID_Owners of Buffers.
+	uniform_buffer_owner.set_description("UniformBuffer");
+	storage_buffer_owner.set_description("StorageBuffer");
+	texture_buffer_owner.set_description("TextureBuffer");
+	vertex_buffer_owner.set_description("VertexBuffer");
+
 	render_thread_id = Thread::get_caller_id();
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

This error is logged when some `RID_Owner` hits its maximum allocation limit. The message now includes the name of the element type, making it significantly easier to understand what went wrong.

This also demangles type names in both the error message and the pre-existing leak messages, and adds special-cased descriptions for `RenderingDevice` buffer owners, which would otherwise ambiguously print "`Buffer`" as the type.

## What problem(s) does this PR solve?

- Closes #122078

## Additional information

Note: The bulk of the work here is actually in demangling the names. If that is too much, it can be taken out (the mangled names are still readable). Note that for now I have separated out the three pieces of work into separate commits, which can be squashed post-review.

While the demangling logic is very low-level, there is precedent for it, in `platform/*/crash_handler_*` (e.g. [`platform/windows/crash_handler_windows_signal.cpp`](https://github.com/godotengine/godot/blob/master/platform/windows/crash_handler_windows_signal.cpp)), all of which use `abi::__cxa_demangle` for the same purpose. Note that my code has the additional complexity of needing to avoid calling `__cxa_demangle` in MSVC, which `crash_handler_windows_signal.cpp` doesn't have to worry about because it only compiles in GCC/Clang.

### Example of error log message

(Running the MRP from #122078)

Before (4.8-dev2):

```
ERROR: Element limit reached.
```

After:

```
ERROR: Element limit for RID of type 'struct RendererCanvasCull::Canvas' reached.
```

### Example of shutdown message

The focus of this PR is to fix the overflow messages, but the demangling also improves the existing at-exit leak detector messages.

(Running a complex project with RID leaks; filtering out the messages that use their own custom leak detector and don't go through the modified code path.)

Before (4.8-dev2):

```
ERROR: 10 RID allocations of type 'N10RendererRD14TextureStorage7TextureE' were leaked at exit.
ERROR: 79 RID allocations of type 'PN18TextServerAdvanced22ShapedTextDataAdvancedE' were leaked at exit.
ERROR: 18 RID allocations of type 'PN18TextServerAdvanced12FontAdvancedE' were leaked at exit.
ERROR: 1 RID allocations of type 'PN18TextServerAdvanced27FontAdvancedLinkedVariationE' were leaked at exit.
```

After:

```
ERROR: 10 RID allocations of type 'RendererRD::TextureStorage::Texture' were leaked at exit.
ERROR: 79 RID allocations of type 'TextServerAdvanced::ShapedTextDataAdvanced*' were leaked at exit.
ERROR: 18 RID allocations of type 'TextServerAdvanced::FontAdvanced*' were leaked at exit.
ERROR: 1 RID allocations of type 'TextServerAdvanced::FontAdvancedLinkedVariation*' were leaked at exit.
```