### PR TITLE
For EditorAudioBus/EditorAudioBuses, enable processing only when visible in the tree

### DIFF
--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -133,7 +133,6 @@ void EditorAudioBus::_notification(int p_what) {
 
 		case NOTIFICATION_READY: {
 			update_bus();
-			set_process(true);
 		} break;
 
 		case NOTIFICATION_DRAW: {
@@ -1332,6 +1331,7 @@ void EditorAudioBuses::_notification(int p_what) {
 			if (is_visible_in_tree()) {
 				_update_file_label();
 			}
+			set_process(is_visible_in_tree());
 		} break;
 	}
 }
@@ -1630,8 +1630,6 @@ EditorAudioBuses::EditorAudioBuses() {
 	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &EditorAudioBuses::_rebuild_buses));
 	AudioServer::get_singleton()->connect("bus_renamed", callable_mp(this, &EditorAudioBuses::_rebuild_buses).unbind(3));
 	FileSystemDock::get_singleton()->connect("files_moved", callable_mp(this, &EditorAudioBuses::_file_moved));
-
-	set_process(true);
 }
 
 void EditorAudioBuses::open_layout(const String &p_path) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Fixed `EditorAudioBuses`/`EditorAudioBus` having processing enabled by default when not visible in the tree.

## Additional information

After launching the editor, `NOTIFICATION_PROCESS` continues to be emitted even when the Audio dock is not open, persisting until the Audio dock is opened and then closed.

Before (51105ccbe58381774ecd7a7486d564b202a5192e):

https://github.com/user-attachments/assets/d64dc668-81ad-4a9a-803b-d7b925255f5d

This PR:

https://github.com/user-attachments/assets/ed727b0e-f5ec-4acf-8ff4-161787e390f4

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
