### PR TITLE
Fix ImageTexture docs on why Image.load_from_file() fails after export

### DIFF
--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -11,12 +11,12 @@
 		$Sprite2D.texture = texture
 		[/codeblock]
 		This way, textures can be created at run-time by loading images both from within the editor and externally.
-		[b]Warning:[/b] Prefer to load imported textures with [method @GDScript.load] over loading them from within the filesystem dynamically with [method Image.load], as it may not work in exported projects:
+		[b]Warning:[/b] When working with imported images, prefer to load them with [method @GDScript.load] over loading their source files at run-time with [method Image.load_from_file], as the latter may not work in exported projects:
 		[codeblock]
 		var texture = load("res://icon.svg")
 		$Sprite2D.texture = texture
 		[/codeblock]
-		This is because images have to be imported as a [CompressedTexture2D] first to be loaded with [method @GDScript.load]. If you'd still like to load an image file just like any other [Resource], import it as an [Image] resource instead, and then load it normally using the [method @GDScript.load] method.
+		This is because source files are not included in exported projects. [method @GDScript.load] returns the imported resource, not the source file itself. By default, images are imported as a [CompressedTexture2D], which is why [method @GDScript.load] gives you a texture. If you'd rather have [method @GDScript.load] return a raw [Image], change the file's importer to [b]Image[/b] in the Import dock.
 		[b]Note:[/b] The image can be retrieved from an imported texture using the [method Texture2D.get_image] method, which returns a copy of the image:
 		[codeblock]
 		var texture = load("res://icon.svg")


### PR DESCRIPTION
The warning claimed images "have to be imported as a CompressedTexture2D first to be loaded with load()", which is not why the code fails in an exported project — source files are not included in the PCK by default.

Also references Image.load_from_file() instead of Image.load(), matching the static call used in the example above it.
