### PR TITLE
Fix SFINAE on `has_hash_method` and `has_is_same_method`.

### DIFF
--- a/core/templates/hashfuncs.h
+++ b/core/templates/hashfuncs.h
@@ -164,7 +164,7 @@ template <typename, typename = std::void_t<>>
 struct has_hash_method : std::false_type {};
 
 template <typename T>
-struct has_hash_method<T, std::void_t<std::is_same<decltype(std::declval<const T>().hash()), uint32_t>>> : std::true_type {};
+struct has_hash_method<T, std::enable_if_t<std::is_same_v<decltype(std::declval<const T>().hash()), uint32_t>>> : std::true_type {};
 
 template <typename T>
 constexpr bool has_hash_method_v = has_hash_method<T>::value;
@@ -285,7 +285,7 @@ template <typename, typename = std::void_t<>>
 struct has_is_same_method : std::false_type {};
 
 template <typename T>
-struct has_is_same_method<T, std::void_t<std::is_same<decltype(std::declval<const T>().is_same(std::declval<const T>())), uint32_t>>> : std::true_type {};
+struct has_is_same_method<T, std::enable_if_t<std::is_same_v<decltype(std::declval<const T>().is_same(std::declval<const T>())), bool>>> : std::true_type {};
 
 template <typename T>
 constexpr bool has_is_same_method_v = has_is_same_method<T>::value;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes source-level bug from https://github.com/godotengine/godot/pull/111361

The SFINAE currently does not actually check the return type, making the check weaker than I intended.

## Additional information

This is unlikely to ever be hit in practice because `is_same` probably returns `bool` and `hash()` probably returns `uint32_t`. Still worth fixing imo.

> Author Disclosure: Bug identified by AI. I wrote the fix.