### PR TITLE
Remove unused include in X11 Display Server

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -51,7 +51,6 @@
 #include "servers/rendering/dummy/rasterizer_dummy.h"
 
 #include <X11/Xatom.h>
-#include <X11/Xresource.h>
 
 #ifdef SOWRAP_ENABLED
 #include "x11/dynwrappers/xext-so_wrap.h"


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Some leftover from #122109
Makes the engine fail to compile for me.
<img width="480" height="42" alt="image" src="https://github.com/user-attachments/assets/ecfbe4df-9a82-4204-bf0c-6bc272e67bcf" />
It compiles normally after removing the include. Please test.

## Additional information

openSUSE Tumbleweed 20260804