### PR TITLE
TextEdit: Refactor Folded EOL Icon code & fix position

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -646,9 +646,8 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				if (is_line_folded(line)) {
 					int wrap_index = get_line_wrap_index_at_column(line, col);
 					if (wrap_index == get_line_wrap_count(line)) {
-						int eol_icon_width = theme_cache.folded_eol_icon->get_width();
-						int left_margin = get_total_gutter_width() + eol_icon_width + get_line_width(line, wrap_index) - get_h_scroll();
-						if (mpos.x > left_margin && mpos.x <= left_margin + eol_icon_width + 3) {
+						Rect2 rect = _get_folded_eol_icon_rect(get_line_width(line, wrap_index));
+						if (mpos.x > rect.position.x && mpos.x <= rect.position.x + rect.size.x + 3) {
 							unfold_line(line);
 							return;
 						}
@@ -928,9 +927,8 @@ Control::CursorShape CodeEdit::get_cursor_shape(const Point2 &p_pos) const {
 	if (line != -1 && is_line_folded(line)) {
 		int wrap_index = get_line_wrap_index_at_column(line, col);
 		if (wrap_index == get_line_wrap_count(line)) {
-			int eol_icon_width = theme_cache.folded_eol_icon->get_width();
-			int left_margin = get_total_gutter_width() + eol_icon_width + get_line_width(line, wrap_index) - get_h_scroll();
-			if (p_pos.x > left_margin && p_pos.x <= left_margin + eol_icon_width + 3) {
+			Rect2 rect = _get_folded_eol_icon_rect(get_line_width(line, wrap_index));
+			if (p_pos.x > rect.position.x && p_pos.x <= rect.position.x + rect.size.x + 3) {
 				return CURSOR_POINTING_HAND;
 			}
 		}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1913,12 +1913,12 @@ void TextEdit::_notification(int p_what) {
 
 					// is_line_folded
 					if (line_wrap_index == line_wrap_amount && line < text.size() - 1 && _is_line_hidden(line + 1)) {
-						int xofs = char_ofs + char_margin + (_get_folded_eol_icon()->get_width() / 2);
-						if (xofs >= xmargin_beg && xofs < xmargin_end) {
-							int yofs = (text_height - _get_folded_eol_icon()->get_height()) / 2 - ldata->get_line_ascent(line_wrap_index);
+						Rect2 rect = _get_folded_eol_icon_rect(char_ofs);
+						if (rect.position.x >= xmargin_beg && rect.position.x < xmargin_end) {
+							rect.position.y = Math::round(ofs_y + (text_height - rect.size.y) / 2 - ldata->get_line_ascent(line_wrap_index));
 							Color eol_color = _get_code_folding_color();
 							eol_color.a = 1;
-							_get_folded_eol_icon()->draw(text_ci, Point2(xofs, ofs_y + yofs), eol_color);
+							_get_folded_eol_icon()->draw_rect(text_ci, rect, false, eol_color);
 						}
 					}
 
@@ -8473,6 +8473,15 @@ void TextEdit::_set_symbol_lookup_word(const String &p_symbol) {
 
 	lookup_symbol_word = p_symbol;
 	queue_redraw();
+}
+
+// Theme items.
+Rect2 TextEdit::_get_folded_eol_icon_rect(int p_line_width) const {
+	Size2 icon_size = _get_folded_eol_icon()->get_size();
+	Rect2 rect;
+	rect.position = Point2(get_total_gutter_width() + icon_size.x / 2 + p_line_width - get_h_scroll(), 0);
+	rect.size = icon_size;
+	return rect;
 }
 
 /* Text manipulation */

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -794,6 +794,7 @@ protected:
 	virtual Color _get_brace_mismatch_color() const { return Color(); }
 	virtual Color _get_code_folding_color() const { return Color(); }
 	virtual Ref<Texture2D> _get_folded_eol_icon() const { return Ref<Texture2D>(); }
+	virtual Rect2 _get_folded_eol_icon_rect(int p_line_width) const;
 
 	/* Text manipulation */
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Actual positions of the mouse checks being diffrent from the drawn position
<img width="507" height="294" alt="image" src="https://github.com/user-attachments/assets/ff5bc4c7-6bc2-41ea-833d-15aba4fe2a72" />

Also makes it easier to add icon resizing (planned for a future PR).

## Additional information

Adds a function `_get_folded_eol_icon_rect` to `TextEdit`, which calculates the icon position and size (note that the `y` position isn't calculated). This removes code duplication between `TextEdit` and `CodeEdit`, which weren't synced (one used `icon_width/2` and one only `icon_width`).
