### PR TITLE
`ScriptLanguage`: Remove `get_recognized_extensions` in favor of `get_extension`

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -409,7 +409,6 @@ public:
 	virtual void reload_tool_script(const Ref<Script> &p_script) = 0;
 	/* LOADER FUNCTIONS */
 
-	virtual void get_recognized_extensions(List<String> *p_extensions) const = 0;
 	virtual void get_public_functions(List<MethodInfo> *p_functions) const = 0;
 	virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const = 0;
 	virtual void get_public_annotations(List<MethodInfo> *p_annotations) const = 0;

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -668,15 +668,9 @@ public:
 	}
 	/* LOADER FUNCTIONS */
 
-	GDVIRTUAL0RC_REQUIRED(PackedStringArray, _get_recognized_extensions)
-
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override {
-		PackedStringArray ret;
-		GDVIRTUAL_CALL(_get_recognized_extensions, ret);
-		for (int i = 0; i < ret.size(); i++) {
-			p_extensions->push_back(ret[i]);
-		}
-	}
+#ifndef DISABLE_DEPRECATED
+	GDVIRTUAL0RC(PackedStringArray, _get_recognized_extensions)
+#endif
 
 	GDVIRTUAL0RC_REQUIRED(TypedArray<Dictionary>, _get_public_functions)
 	virtual void get_public_functions(List<MethodInfo> *p_functions) const override {

--- a/doc/classes/ScriptLanguageExtension.xml
+++ b/doc/classes/ScriptLanguageExtension.xml
@@ -189,7 +189,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="_get_recognized_extensions" qualifiers="virtual required const">
+		<method name="_get_recognized_extensions" qualifiers="virtual const" deprecated="This method is not called by the engine.">
 			<return type="PackedStringArray" />
 			<description>
 			</description>

--- a/editor/script/script_create_dialog.cpp
+++ b/editor/script/script_create_dialog.cpp
@@ -280,22 +280,12 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 	}
 
 	// Check file extension.
-	String extension = p.get_extension();
-	List<String> extensions;
-
-	// Get all possible extensions for script.
-	for (int l = 0; l < language_menu->get_item_count(); l++) {
-		ScriptServer::get_language(l)->get_recognized_extensions(&extensions);
-	}
-
 	bool found = false;
 	bool match = false;
-	for (const String &E : extensions) {
-		if (E.nocasecmp_to(extension) == 0) {
+	for (int l = 0; l < language_menu->get_item_count(); l++) {
+		if (p.has_extension(ScriptServer::get_language(l)->get_extension())) {
 			found = true;
-			if (E == ScriptServer::get_language(language_menu->get_selected())->get_extension()) {
-				match = true;
-			}
+			match = l == language_menu->get_selected();
 			break;
 		}
 	}
@@ -466,15 +456,9 @@ void ScriptCreateDialog::_browse_path(bool browse_parent, bool p_save) {
 	}
 
 	file_browse->set_customization_flag_enabled(FileDialog::CUSTOMIZATION_OVERWRITE_WARNING, false);
+
 	file_browse->clear_filters();
-	List<String> extensions;
-
-	int lang = language_menu->get_selected();
-	ScriptServer::get_language(lang)->get_recognized_extensions(&extensions);
-
-	for (const String &E : extensions) {
-		file_browse->add_filter("*." + E);
-	}
+	file_browse->add_filter("*." + ScriptServer::get_language(language_menu->get_selected())->get_extension());
 
 	file_browse->set_current_path(file_path->get_text());
 	file_browse->popup_file_dialog();

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
@@ -36,7 +36,7 @@
 #include "core/io/resource_loader.h"
 
 void GDScriptEditorTranslationParserPlugin::get_recognized_extensions(List<String> *r_extensions) const {
-	GDScriptLanguage::get_singleton()->get_recognized_extensions(r_extensions);
+	r_extensions->push_back(GDScriptLanguage::get_singleton()->get_extension());
 }
 
 Error GDScriptEditorTranslationParserPlugin::parse_file(const String &p_path, Vector<Vector<String>> *r_translations) {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -638,10 +638,6 @@ public:
 	virtual int profiling_get_accumulated_data(ProfilingInfo *p_info_arr, int p_info_max) override;
 	virtual int profiling_get_frame_data(ProfilingInfo *p_info_arr, int p_info_max) override;
 
-	/* LOADER FUNCTIONS */
-
-	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
-
 	/* GLOBAL CLASSES */
 
 	virtual bool handles_global_class_type(const String &p_type) const override;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -478,10 +478,6 @@ String GDScriptLanguage::debug_parse_stack_level_expression(int p_level, const S
 	return String();
 }
 
-void GDScriptLanguage::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("gd");
-}
-
 void GDScriptLanguage::get_public_functions(List<MethodInfo> *p_functions) const {
 	List<StringName> functions;
 	GDScriptUtilityFunctions::get_function_list(&functions);

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1030,10 +1030,6 @@ void CSharpLanguage::reload_assemblies() {
 }
 #endif
 
-void CSharpLanguage::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("cs");
-}
-
 #ifdef TOOLS_ENABLED
 Error CSharpLanguage::open_in_external_editor(const Ref<Script> &p_script, int p_line, int p_col) {
 	return (Error)(int)get_godotsharp_editor()->call("OpenInExternalEditor", p_script, p_line, p_col);

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -563,9 +563,6 @@ public:
 	void reload_scripts(const Array &p_scripts) override;
 	void reload_tool_script(const Ref<Script> &p_script) override;
 
-	/* LOADER FUNCTIONS */
-	void get_recognized_extensions(List<String> *p_extensions) const override;
-
 #ifdef TOOLS_ENABLED
 	Error open_in_external_editor(const Ref<Script> &p_script, int p_line, int p_col) override;
 	bool overrides_external_editor() override;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- `ScriptLanguage` did have both `get_recognized_extensions` and `get_extension` (both dating back to GODOT IS OPEN SOURCE), which is duplication in the API. `get_extension` is used far more often. In practice that means, that while it was technically possible to return multiple extensions from one of them, there never was support for that usecase, since `get_recognized_extensions` is only used in the script create dialog.

This PR updates the two usages of `get_recognized_extensions` to use `get_extension` instead and removes the method.

In case someone is wondering about compat, the only behavior change is in the script create dialogue. Also the dialog did already use `get_extension` for validation, so a secondary extension that was in `get_recognized_extensions` could never have been used. The changes in behaviour are thus limited to:
- when using a path with a secondary extension the error message will now say `Invalid extension.` instead of `Extension doesn't match chosen language.`
- Secondary extensions will not be accepted by the file picker dialogue, previously you could select them and validation would fail after that.

## Additional information

Moving this method to `EditorLanguage` is not an option since it is used in debugger related code, and debug functionality should stay in `ScriptLanguage`.
