### PR TITLE
core: Use String::is_empty() in FileAccess::store_string()

### DIFF
--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -814,7 +814,7 @@ PackedStringArray FileAccess::get_extended_attributes_list(const String &p_file)
 }
 
 bool FileAccess::store_string(const String &p_string) {
-	if (p_string.length() == 0) {
+	if (p_string.is_empty()) {
 		return true;
 	}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

Replaces `p_string.length() == 0` with `p_string.is_empty()` in `FileAccess::store_string()`.

This does not change behavior and improves readability by using the dedicated helper.

## Additional information

AI assistance was used to help identify this small code style improvement and draft this pull request description. The final change was reviewed and applied manually.
