### PR TITLE
Fix PrimitiveMesh flip_faces for non-indexed meshes

### DIFF
--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -79,31 +79,31 @@ void PrimitiveMesh::_update() const {
 	Vector<int> indices = arr[RSE::ARRAY_INDEX];
 
 	if (flip_faces) {
-	Vector<Vector3> normals = arr[RSE::ARRAY_NORMAL];
+		Vector<Vector3> normals = arr[RSE::ARRAY_NORMAL];
 
-	if (normals.size()) {
-		int nc = normals.size();
-		Vector3 *w = normals.ptrw();
-		for (int i = 0; i < nc; i++) {
-			w[i] = -w[i];
+		if (normals.size()) {
+			int nc = normals.size();
+			Vector3 *w = normals.ptrw();
+			for (int i = 0; i < nc; i++) {
+				w[i] = -w[i];
+			}
+			arr[RSE::ARRAY_NORMAL] = normals;
 		}
-		arr[RSE::ARRAY_NORMAL] = normals;
-	}
 
-	if (indices.size()) {
-		int ic = indices.size();
-		int *w = indices.ptrw();
-		for (int i = 0; i < ic; i += 3) {
-			SWAP(w[i + 0], w[i + 1]);
+		if (indices.size()) {
+			int ic = indices.size();
+			int *w = indices.ptrw();
+			for (int i = 0; i < ic; i += 3) {
+				SWAP(w[i + 0], w[i + 1]);
+			}
+			arr[RSE::ARRAY_INDEX] = indices;
+		} else {
+			for (int i = 0; i < points.size(); i += 3) {
+				SWAP(points.write[i + 0], points.write[i + 1]);
+			}
+			arr[RSE::ARRAY_VERTEX] = points;
 		}
-		arr[RSE::ARRAY_INDEX] = indices;
-	} else {
-		for (int i = 0; i < points.size(); i += 3) {
-			SWAP(points.write[i + 0], points.write[i + 1]);
-		}
-		arr[RSE::ARRAY_VERTEX] = points;
 	}
-}
 
 	if (add_uv2) {
 		// _create_mesh_array should populate our UV2, this is a fallback in case it doesn't.

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -79,28 +79,26 @@ void PrimitiveMesh::_update() const {
 	Vector<int> indices = arr[RSE::ARRAY_INDEX];
 
 	if (flip_faces) {
-		Vector<Vector3> normals = arr[RSE::ARRAY_NORMAL];
+	Vector<Vector3> normals = arr[RSE::ARRAY_NORMAL];
 
-		if (normals.size() && indices.size()) {
-			{
-				int nc = normals.size();
-				Vector3 *w = normals.ptrw();
-				for (int i = 0; i < nc; i++) {
-					w[i] = -w[i];
-				}
-			}
-
-			{
-				int ic = indices.size();
-				int *w = indices.ptrw();
-				for (int i = 0; i < ic; i += 3) {
-					SWAP(w[i + 0], w[i + 1]);
-				}
-			}
-			arr[RSE::ARRAY_NORMAL] = normals;
-			arr[RSE::ARRAY_INDEX] = indices;
+	if (normals.size()) {
+		int nc = normals.size();
+		Vector3 *w = normals.ptrw();
+		for (int i = 0; i < nc; i++) {
+			w[i] = -w[i];
 		}
+		arr[RSE::ARRAY_NORMAL] = normals;
 	}
+
+	if (indices.size()) {
+		int ic = indices.size();
+		int *w = indices.ptrw();
+		for (int i = 0; i < ic; i += 3) {
+			SWAP(w[i + 0], w[i + 1]);
+		}
+		arr[RSE::ARRAY_INDEX] = indices;
+	}
+}
 
 	if (add_uv2) {
 		// _create_mesh_array should populate our UV2, this is a fallback in case it doesn't.

--- a/scene/resources/3d/primitive_meshes.cpp
+++ b/scene/resources/3d/primitive_meshes.cpp
@@ -97,6 +97,11 @@ void PrimitiveMesh::_update() const {
 			SWAP(w[i + 0], w[i + 1]);
 		}
 		arr[RSE::ARRAY_INDEX] = indices;
+	} else {
+		for (int i = 0; i < points.size(); i += 3) {
+			SWAP(points.write[i + 0], points.write[i + 1]);
+		}
+		arr[RSE::ARRAY_VERTEX] = points;
 	}
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121927

`PrimitiveMesh.flip_faces` did not work correctly for meshes without an index array.

This change makes `flip_faces` work for non-indexed meshes by swapping the vertex order when no indices are available. It also allows face flipping when normals are missing by handling normals and indices independently.

## Additional information

I used AI assistance to help understand the issue and review the changes.

Previously, `flip_faces` only applied when both normals and indices existed. As a result, non-indexed meshes ignored the setting completely.

This keeps the existing behavior for indexed meshes while adding support for non-indexed meshes.