### PR TITLE
Fix signal connections dialog to handle global classes

### DIFF
--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -355,9 +355,16 @@ List<MethodInfo> ConnectDialog::_filter_method_list(const List<MethodInfo> &p_me
 					break;
 				}
 
-				if (stype == Variant::OBJECT && mtype == Variant::OBJECT && !ClassDB::is_parent_class(effective_args[i].second, mi.arguments[i].class_name)) {
-					type_mismatch = true;
-					break;
+				if (stype == Variant::OBJECT && mtype == Variant::OBJECT && effective_args[i].second != mi.arguments[i].class_name) {
+					if (ScriptServer::is_global_class(effective_args[i].second) == true || ScriptServer::is_global_class(mi.arguments[i].class_name) == true) {
+						if (EditorNode::get_editor_data().script_class_is_parent(effective_args[i].second, mi.arguments[i].class_name) == false) {
+							type_mismatch = true;
+							break;
+						}
+					} else if (ClassDB::is_parent_class(effective_args[i].second, mi.arguments[i].class_name) == false) {
+						type_mismatch = true;
+						break;
+					}
 				}
 			}
 


### PR DESCRIPTION
Fixes #84058 by checking global classes as well as ClassDB.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #84058

### Technical Overview

- This PR fixes the above by adding a check for global classes. It checks whether the method or signal classes are global classes, then uses `script_class_is_parent` to do the equivalent of what `is_parent_class` does from ClassDB. If it is not a global class, it simply uses the original check with `is_parent_class`.


<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
