### PR TITLE
Harfbuzz: Exclude UCD when building with builtin ICU

### DIFF
--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -149,6 +149,8 @@ if env["builtin_harfbuzz"]:
                 ("U_HAVE_LIB_SUFFIX", 1),
                 ("U_LIB_SUFFIX_C_NAME", "_godot"),
                 "HAVE_ICU_BUILTIN",
+                # Harfbuzz can use ICU to get unicode data, we don't need to include its own subset: https://github.com/harfbuzz/harfbuzz/blob/main/CONFIG.md#unicode-functions
+                "HB_NO_UCD",
             ]
         )
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Removes around 50kb from a standard release template build.

## Additional information

Harfbuzz includes around 50kb of unicode data to function properly. However, if icu4c is builtin, harfbuzz can use that data instead. Which allows us to remove the default data that comes bundled with harfbuzz.

See https://github.com/harfbuzz/harfbuzz/blob/main/CONFIG.md#unicode-functions