### PR TITLE
Fix Shader Editor crash when theme doesn't use `StyleBoxFlat`

### DIFF
--- a/editor/shader/shader_text_editor.cpp
+++ b/editor/shader/shader_text_editor.cpp
@@ -765,7 +765,9 @@ void ShaderTextEditor::_notification(int p_what) {
 			Ref<StyleBoxFlat> tab_style = get_theme_stylebox(SNAME("tab_selected"), "TabBar");
 			Ref<StyleBoxFlat> preview_style = memnew(StyleBoxFlat);
 			preview_style->set_bg_color(get_theme_color(SNAME("dark_color_1"), EditorStringName(Editor)));
-			preview_style->set_corner_radius_all(tab_style->get_corner_radius(CORNER_TOP_LEFT));
+			if (tab_style.is_valid()) {
+				preview_style->set_corner_radius_all(tab_style->get_corner_radius(CORNER_TOP_LEFT));
+			}
 			preview_panel->add_theme_style_override(SceneStringName(panel), preview_style);
 
 			update_params_btn->set_button_icon(get_editor_theme_icon(SNAME("Reload")));


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Fixes https://github.com/godotengine/godot/issues/121562

## Additional information

When `tab_selected` isn't a StyleBoxFlat, it crashes.
It was used to set corner radius of preview panel, I just skipped that it if it isn't a StyleBoxFlat.

Tested with the theme from the issue, it no longer crashes.

<img width="1063" height="438" alt="image" src="https://github.com/user-attachments/assets/804eeede-53dc-4cab-8e08-bc33adc00fac" />


Edit: Probably not possible to cherrypick as is, since the line was moved recently, but the fix would be the same.
