### PR TITLE
Disable fog when using Unshaded debug draw mode in Compatibility renderer

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2826,7 +2826,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 			spec_constant_base_flags |= SceneShaderGLES3::DISABLE_LIGHT_DIRECTIONAL;
 		}
 
-		if (render_data.environment.is_null() || (render_data.environment.is_valid() && !environment_get_fog_enabled(render_data.environment))) {
+		if (render_data.environment.is_null() || (render_data.environment.is_valid() && !environment_get_fog_enabled(render_data.environment)) || get_debug_draw_mode() == RSE::VIEWPORT_DEBUG_DRAW_UNSHADED) {
 			spec_constant_base_flags |= SceneShaderGLES3::DISABLE_FOG;
 		}
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -766,6 +766,7 @@ void RasterizerSceneGLES3::_setup_sky(const RenderDataGLES3 *p_render_data, cons
 
 		if (material_data->uniform_set_updated) {
 			material_data->uniform_set_updated = false;
+
 			sky->reflection_dirty = true;
 		}
 
@@ -2826,7 +2827,7 @@ void RasterizerSceneGLES3::render_scene(const Ref<RenderSceneBuffers> &p_render_
 			spec_constant_base_flags |= SceneShaderGLES3::DISABLE_LIGHT_DIRECTIONAL;
 		}
 
-		if (render_data.environment.is_null() || (render_data.environment.is_valid() && !environment_get_fog_enabled(render_data.environment))) {
+		if (render_data.environment.is_null() || (render_data.environment.is_valid() && !environment_get_fog_enabled(render_data.environment)) || get_debug_draw_mode() == RSE::VIEWPORT_DEBUG_DRAW_UNSHADED) {
 			spec_constant_base_flags |= SceneShaderGLES3::DISABLE_FOG;
 		}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?
- Closes #115018

Fog was not being disabled when using the "Display Unshaded" debug draw
mode in the Compatibility (GLES3) renderer. This worked correctly in the
Forward+ renderer and in Godot 3.x, but was missing in the Compatibility
renderer's fog handling.

## Additional information

The `DISABLE_FOG` spec constant flag in `rasterizer_scene_gles3.cpp` was
only being set based on whether fog was enabled in the environment, but
did not check for `VIEWPORT_DEBUG_DRAW_UNSHADED`. Added that check so fog
is disabled in Unshaded mode, consistent with how lights and reflection
probes are already skipped in that mode elsewhere in the same file.

Tested on Linux with the MRP from the issue:
- Compatibility renderer: fog now correctly hidden in Unshaded mode
- Forward+ renderer: unaffected, still works as before

### AI disclosure
I used Claude (Anthropic) as a debugging assistant to help me navigate
the codebase once I got help locating the related area I have located the error
, I've fixed and reviewed it by myself through testing the mrp again. 