### PR TITLE
Fix shader code completion suggesting already declared functions

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -10533,9 +10533,15 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 
 				_set_tkpos(prev_pos);
 
-				_get_completable_identifier(nullptr, COMPLETION_MAIN_FUNCTION, name);
+				bool completion_id = _get_completable_identifier(nullptr, COMPLETION_MAIN_FUNCTION, name);
 
 				if (name == StringName()) {
+					if (completion_id) {
+						// A code completion was triggered while parsing a function or constant name.
+						// Skip the incomplete declaration and continue parsing the rest of the shader,
+						// so declarations that appear after the completion position are still registered.
+						break;
+					}
 					if (is_constant) {
 						_set_error(RTR("Expected an identifier or '[' after type."));
 					} else {


### PR DESCRIPTION
Fixes #122087

## Summary

When adding a new function *before* an already declared one (e.g. typing `void` on a line above the existing `fragment()`), code completion suggested main function names that were already declared. This happened because the parser aborts on the incomplete function declaration at the completion position, so `shader->vfunctions` never contains the functions that appear after the caret, and the `COMPLETION_MAIN_FUNCTION` filter cannot exclude them.

## Changes

- `servers/rendering/shader_language.cpp`: when a code completion is triggered while parsing a function/constant name with an empty identifier, skip the incomplete declaration (`break` out of the top-level parse switch) instead of returning a parse error. Parsing resumes right after the caret, so declarations below the completion position are registered normally.
- Non-completion parses are unaffected: the skip is guarded by `_get_completable_identifier()` returning `true` (a completion cursor is present), otherwise the previous error path is kept.

## Verification

- Reproduced from the issue: new shader, `void` on a line above the existing `fragment()`, trigger completion with an empty function name. Before: `fragment` was suggested. After: only still-missing main functions (e.g. `vertex`, `light`) are suggested.
- Adding a function below an existing one keeps the existing behavior.
