### PR TITLE
Clarify JetBrains Mono OpenType feature/variation docs in EditorSettings

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1064,11 +1064,12 @@
 		</member>
 		<member name="interface/editor/fonts/code_font_custom_opentype_features" type="String" setter="" getter="">
 			List of custom OpenType features to use, if supported by the currently configured code font. Not all fonts include support for custom OpenType features. The string should follow the OpenType specification.
-			[b]Note:[/b] The default editor code font ([url=https://www.jetbrains.com/lp/mono/]JetBrains Mono[/url]) has custom OpenType features in its font file, but there is no documented list yet.
+			[b]Note:[/b] [member interface/editor/fonts/code_font_contextual_ligatures] must be set to [b]Use Custom OpenType Feature Set[/b] for this setting to take effect, as the other options only toggle the [code]calt[/code] feature and ignore this custom feature string.
+			[b]Note:[/b] The default editor code font ([url=https://www.jetbrains.com/lp/mono/]JetBrains Mono[/url]) has custom OpenType features in its font file. Supported features can be found in the [url=https://github.com/JetBrains/JetBrainsMono/wiki/OpenType-features]JetBrains Mono OpenType features list[/url].
 		</member>
 		<member name="interface/editor/fonts/code_font_custom_variations" type="String" setter="" getter="">
-			List of alternative characters to use, if supported by the currently configured code font. Not all fonts include support for custom variations. The string should follow the OpenType specification.
-			[b]Note:[/b] The default editor code font ([url=https://www.jetbrains.com/lp/mono/]JetBrains Mono[/url]) has alternate characters in its font file, but there is no documented list yet.
+			List of variable font axis values to use, if the currently configured code font is a variable font. The string should follow the OpenType specification.
+			[b]Note:[/b] The default editor code font ([url=https://www.jetbrains.com/lp/mono/]JetBrains Mono[/url]) is not a variable font, so this setting has no effect unless a custom variable code font is configured in [member interface/editor/fonts/code_font].
 		</member>
 		<member name="interface/editor/fonts/code_font_size" type="int" setter="" getter="">
 			The size of the font in the script editor. This setting does not impact the font size of the Output panel (see [member run/output/font_size]).


### PR DESCRIPTION
## Summary
- Link to the official [JetBrains Mono OpenType features list](https://github.com/JetBrains/JetBrainsMono/wiki/OpenType-features) in `code_font_custom_opentype_features` instead of saying there is "no documented list yet", matching the style already used for the `main_font` / Inter entry.
- Document that `code_font_custom_opentype_features` only takes effect when `code_font_contextual_ligatures` is set to **Use Custom OpenType Feature Set** — the other two options only toggle the `calt` feature and never read the custom feature string (verified in `editor/themes/editor_fonts.cpp`, the `ot_mode` switch).
- Correct `code_font_custom_variations`: the bundled JetBrains Mono is **not** a variable font, so the note claiming it has "alternate characters... but no documented list yet" was misleading. The setting only has an effect if the user configures a custom variable code font.

Fixes #122159.

## Test plan
- [x] Confirmed the gating behavior between `code_font_contextual_ligatures` and `code_font_custom_opentype_features` by reading `editor/themes/editor_fonts.cpp` (the `ot_mode` switch on `interface/editor/fonts/code_font_contextual_ligatures`).
- [x] Confirmed the enum option label ("Use Custom OpenType Feature Set") against `editor/settings/editor_settings.cpp`.
- [x] Validated `doc/classes/EditorSettings.xml` is still well-formed XML after the edit.
- Docs-only change; no code behavior affected.