### PR TITLE
A child control is considered valid when it is visible in the tree for `SplitContainer`

### DIFF
--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -1149,7 +1149,7 @@ void SplitContainer::add_child_notify(Node *p_child) {
 	}
 
 	child->connect(SceneStringName(visibility_changed), callable_mp(this, &SplitContainer::_on_child_visibility_changed).bind(child));
-	if (child->is_visible()) {
+	if (child->is_visible_in_tree()) {
 		_add_valid_child(child);
 	}
 }


### PR DESCRIPTION


<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

This allows for the avoidance of redundant calculations when adding child, particularly when constructing a node tree outside of the scene tree.  Construct the node tree first, then add it to the scene tree.

In this case, the same calculation will be performed when the `visibility_changed` signal of the child control is received for the first time.

## Additional information

Before:

<img width="1920" height="1022" alt="002" src="https://github.com/user-attachments/assets/8c816bff-42f8-4127-ac06-11c04322dc6e" />

After:

<img width="1920" height="1022" alt="004" src="https://github.com/user-attachments/assets/6db19393-1c69-4299-b375-11f15a3a4bf3" />


<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
