### PR TITLE
Fix: Inspector Should Not Collapse On Resource Save

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2859,7 +2859,7 @@ void EditorNode::_dialog_action(String p_file) {
 			ObjectID current_id = editor_history.get_current();
 			Object *current_obj = current_id.is_valid() ? ObjectDB::get_instance(current_id) : nullptr;
 			ERR_FAIL_NULL(current_obj);
-			current_obj->notify_property_list_changed();
+			InspectorDock::get_inspector_singleton()->update_properties_recursive();
 		} break;
 		case LAYOUT_SAVE: {
 			if (p_file.is_empty()) {

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -873,6 +873,9 @@ void EditorProperty::update_property() {
 	GDVIRTUAL_CALL(_update_property);
 }
 
+void EditorProperty::update_properties_recursive() {
+}
+
 void EditorProperty::_set_read_only(bool p_read_only) {
 }
 
@@ -5361,6 +5364,14 @@ void EditorInspector::update_property(const String &p_prop) {
 	for (EditorInspectorSection *S : sections) {
 		if (S->is_checkable()) {
 			S->_property_edited(p_prop);
+		}
+	}
+}
+
+void EditorInspector::update_properties_recursive() {
+	for (const KeyValue<StringName, List<EditorProperty *>> &F : editor_property_map) {
+		for (EditorProperty *E : F.value) {
+			E->update_properties_recursive();
 		}
 	}
 }

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -270,6 +270,7 @@ public:
 
 	virtual void make_passthrough(bool p_passthrough);
 	virtual void update_property();
+	virtual void update_properties_recursive();
 	void update_editor_property_status();
 
 	virtual bool use_keying_next() const;
@@ -938,6 +939,7 @@ public:
 
 	void update_tree();
 	void update_property(const String &p_prop);
+	void update_properties_recursive();
 	void edit(Object *p_object);
 	Object *get_edited_object();
 	Object *get_next_edited_object();

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3784,6 +3784,13 @@ void EditorPropertyResource::set_use_filter(bool p_use) {
 	}
 }
 
+void EditorPropertyResource::update_properties_recursive() {
+	update_property();
+	if (sub_inspector) {
+		sub_inspector->update_properties_recursive();
+	}
+}
+
 void EditorPropertyResource::fold_resource() {
 	bool unfolded = get_edited_object()->editor_is_section_unfolded(get_edited_property());
 	if (unfolded) {

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -783,6 +783,7 @@ public:
 
 	void set_use_sub_inspector(bool p_enable);
 	void set_use_filter(bool p_use);
+	void update_properties_recursive() override;
 	void fold_resource();
 
 	virtual void set_keying(bool p_keying) override;

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -599,6 +599,14 @@ void EditorPropertyArray::update_property() {
 	}
 }
 
+void EditorPropertyArray::update_properties_recursive() {
+	for (const Slot &slot : slots) {
+		if (slot.prop) {
+			slot.prop->update_properties_recursive();
+		}
+	}
+}
+
 void EditorPropertyArray::_remove_pressed(int p_slot_index) {
 	Variant array = object->get_array().duplicate();
 	array.call("remove_at", slots[p_slot_index].index);
@@ -1526,6 +1534,17 @@ void EditorPropertyDictionary::update_property() {
 			container = nullptr;
 			add_panel = nullptr;
 			slots.clear();
+		}
+	}
+}
+
+void EditorPropertyDictionary::update_properties_recursive() {
+	for (const Slot &slot : slots) {
+		if (slot.prop) {
+			slot.prop->update_properties_recursive();
+		}
+		if (slot.prop_key) {
+			slot.prop_key->update_properties_recursive();
 		}
 	}
 }

--- a/editor/inspector/editor_properties_array_dict.h
+++ b/editor/inspector/editor_properties_array_dict.h
@@ -175,6 +175,7 @@ public:
 	void set_preview_value(bool p_preview_value);
 	virtual void make_passthrough(bool p_passthrough) override;
 	virtual void update_property() override;
+	virtual void update_properties_recursive() override;
 	virtual bool is_colored(ColorationMode p_mode) override;
 	EditorPropertyArray();
 };
@@ -274,6 +275,7 @@ public:
 	void set_preview_value(bool p_preview_value);
 	virtual void make_passthrough(bool p_passthrough) override;
 	virtual void update_property() override;
+	virtual void update_properties_recursive() override;
 	virtual bool is_colored(ColorationMode p_mode) override;
 	EditorPropertyDictionary();
 };


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #122174

## Additional information

Why was the inspector collapsing when the nested resource was saved? It wasn't, not technically. It was being rebuilt by `notify_property_list_changed`.

We can imagine a solution where we store what was folder or unfolder and unfold again. There is a simpler approach: Do not call `notify_property_list_changed`.

So, that's it, problem solved, right? Kind of. The resource is saved to a file, the inspector does not collapse, everything works, except we do not see changes reflected in the inspector. What changes? We should see resource file name.

Thus, we need a mechanism to update the inspector without rebuilding it. Turns out there is one, kind of. While testing with `notify_property_list_changed` removed I noticed that saving (Ctrl+S) would update the inspector correctly without folding or rebuilding it. Of course, I do not want to trigger a global save. So I needed to figure out how it did update the inspector. It took some experimentation to piece it together (I did try with `queue_redraw`, `emit_changed`...), what works is calling `update_property`, the problem is that I need to call `update_property` recursively and there isn't a reliable mechanism to do that (without doing other things). So I added one.

I do not know if the approach is welcome: what I added is a new `update_properties_recursive` virtual method and implementation. At the end I figured I'd post it and let it be reviewed.

| Before  | After |
| ------------- | ------------- |
|  <img width="368" height="624" alt="before" src="https://github.com/user-attachments/assets/55ae1352-dcfc-451f-8781-5f7b9649f403" /> | <img width="368" height="624" alt="after" src="https://github.com/user-attachments/assets/b408cbbb-395a-4a21-93ae-477b43597f65" /> |
