### PR TITLE
[TabContainer] Fix visible popup button when `tabs_visible` is false

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -838,7 +838,7 @@ void TabContainer::set_tabs_visible(bool p_visible) {
 	}
 
 	tabs_visible = p_visible;
-	tab_bar->set_visible(tabs_visible);
+	internal_container->set_visible(tabs_visible);
 
 	_repaint_call_deferred();
 	queue_redraw();


### PR DESCRIPTION


## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/122187

## Additional information

This now changes visibility of the internal container where TabBar and the button for popup is added.
