### PR TITLE
Add center of mass indicator for RigidBody2D and RigidBody3D in editor

### DIFF
--- a/editor/scene/3d/gizmos/physics/rigid_body_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/rigid_body_3d_gizmo_plugin.cpp
@@ -1,0 +1,89 @@
+/**************************************************************************/
+/*  rigid_body_3d_gizmo_plugin.cpp                                        */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "rigid_body_3d_gizmo_plugin.h"
+
+#include "scene/3d/physics/rigid_body_3d.h"
+
+RigidBody3DGizmoPlugin::RigidBody3DGizmoPlugin() {
+	// Materials for center of mass crosshair.
+	create_material("center_of_mass_material_custom", Color(1.0, 0.0, 1.0)); // Magenta
+	create_material("center_of_mass_material_auto", Color(1.0, 0.6, 0.0)); // Orange
+}
+
+bool RigidBody3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {
+	return Object::cast_to<RigidBody3D>(p_spatial) != nullptr;
+}
+
+String RigidBody3DGizmoPlugin::get_gizmo_name() const {
+	return "RigidBody3D";
+}
+
+int RigidBody3DGizmoPlugin::get_priority() const {
+	return -1;
+}
+
+void RigidBody3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
+	RigidBody3D *rigid_body = Object::cast_to<RigidBody3D>(p_gizmo->get_node_3d());
+	if (!rigid_body) {
+		return;
+	}
+
+	p_gizmo->clear();
+
+	if (!p_gizmo->is_selected()) {
+		return;
+	}
+
+	const Vector3 center_of_mass = rigid_body->get_center_of_mass();
+
+	// Length of the crosshair lines.
+	constexpr float extents = 0.1;
+
+	// Draw a crosshair at the center of mass position.
+	Vector<Vector3> lines;
+	// X line.
+	lines.push_back(center_of_mass + Vector3(-extents, 0, 0));
+	lines.push_back(center_of_mass + Vector3(+extents, 0, 0));
+	// Y line.
+	lines.push_back(center_of_mass + Vector3(0, -extents, 0));
+	lines.push_back(center_of_mass + Vector3(0, +extents, 0));
+	// Z line.
+	lines.push_back(center_of_mass + Vector3(0, 0, -extents));
+	lines.push_back(center_of_mass + Vector3(0, 0, +extents));
+
+	// Color of the center of mass indicator.
+	String mat_name = (rigid_body->get_center_of_mass_mode() == RigidBody3D::CENTER_OF_MASS_MODE_CUSTOM)
+			? "center_of_mass_material_custom"
+			: "center_of_mass_material_auto";
+
+	Ref<Material> material = get_material(mat_name, p_gizmo);
+	p_gizmo->add_lines(lines, material);
+}

--- a/editor/scene/3d/gizmos/physics/rigid_body_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/rigid_body_3d_gizmo_plugin.cpp
@@ -65,7 +65,7 @@ void RigidBody3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	const Vector3 center_of_mass = rigid_body->get_center_of_mass();
 
 	// Length of the crosshair lines.
-	constexpr float extents = 0.1;
+	constexpr float extents = 0.25;
 
 	// Draw a crosshair at the center of mass position.
 	Vector<Vector3> lines;

--- a/editor/scene/3d/gizmos/physics/rigid_body_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/rigid_body_3d_gizmo_plugin.cpp
@@ -34,8 +34,8 @@
 
 RigidBody3DGizmoPlugin::RigidBody3DGizmoPlugin() {
 	// Materials for center of mass crosshair.
-	create_material("center_of_mass_material_custom", Color(1.0, 0.3, 1.0)); // Magenta
-	create_material("center_of_mass_material_auto", Color(1.0, 0.6, 0.0)); // Orange
+	create_material("center_of_mass_material_custom", Color(1.0, 0.3, 1.0), false, true); // Magenta
+	create_material("center_of_mass_material_auto", Color(1.0, 0.6, 0.0), false, true); // Orange
 }
 
 bool RigidBody3DGizmoPlugin::has_gizmo(Node3D *p_spatial) {

--- a/editor/scene/3d/gizmos/physics/rigid_body_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/rigid_body_3d_gizmo_plugin.cpp
@@ -34,7 +34,7 @@
 
 RigidBody3DGizmoPlugin::RigidBody3DGizmoPlugin() {
 	// Materials for center of mass crosshair.
-	create_material("center_of_mass_material_custom", Color(1.0, 0.0, 1.0)); // Magenta
+	create_material("center_of_mass_material_custom", Color(1.0, 0.3, 1.0)); // Magenta
 	create_material("center_of_mass_material_auto", Color(1.0, 0.6, 0.0)); // Orange
 }
 

--- a/editor/scene/3d/gizmos/physics/rigid_body_3d_gizmo_plugin.h
+++ b/editor/scene/3d/gizmos/physics/rigid_body_3d_gizmo_plugin.h
@@ -1,0 +1,45 @@
+/**************************************************************************/
+/*  rigid_body_3d_gizmo_plugin.h                                          */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "editor/scene/3d/node_3d_editor_gizmos.h"
+
+class RigidBody3DGizmoPlugin : public EditorNode3DGizmoPlugin {
+	GDCLASS(RigidBody3DGizmoPlugin, EditorNode3DGizmoPlugin);
+
+public:
+	virtual bool has_gizmo(Node3D *p_spatial) override;
+	virtual String get_gizmo_name() const override;
+	virtual int get_priority() const override;
+	virtual void redraw(EditorNode3DGizmo *p_gizmo) override;
+
+	RigidBody3DGizmoPlugin();
+};

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -72,6 +72,7 @@
 #include "editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/physics/physics_bone_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/physics/ray_cast_3d_gizmo_plugin.h"
+#include "editor/scene/3d/gizmos/physics/rigid_body_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/physics/shape_cast_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/physics/soft_body_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/physics/spring_arm_3d_gizmo_plugin.h"
@@ -2875,6 +2876,7 @@ void Node3DEditor::_register_all_gizmos() {
 	add_gizmo_plugin(Ref<CollisionShape3DGizmoPlugin>(memnew(CollisionShape3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<CollisionPolygon3DGizmoPlugin>(memnew(CollisionPolygon3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<Joint3DGizmoPlugin>(memnew(Joint3DGizmoPlugin)));
+	add_gizmo_plugin(Ref<RigidBody3DGizmoPlugin>(memnew(RigidBody3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<SoftBody3DGizmoPlugin>(memnew(SoftBody3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<ShapeCast3DGizmoPlugin>(memnew(ShapeCast3DGizmoPlugin)));
 	add_gizmo_plugin(Ref<SpringArm3DGizmoPlugin>(memnew(SpringArm3DGizmoPlugin)));

--- a/scene/2d/physics/rigid_body_2d.cpp
+++ b/scene/2d/physics/rigid_body_2d.cpp
@@ -364,6 +364,7 @@ void RigidBody2D::set_center_of_mass_mode(CenterOfMassMode p_mode) {
 	}
 
 	notify_property_list_changed();
+	queue_redraw();
 }
 
 RigidBody2D::CenterOfMassMode RigidBody2D::get_center_of_mass_mode() const {
@@ -379,6 +380,7 @@ void RigidBody2D::set_center_of_mass(const Vector2 &p_center_of_mass) {
 	center_of_mass = p_center_of_mass;
 
 	PhysicsServer2D::get_singleton()->body_set_param(get_rid(), PS2DE::BODY_PARAM_CENTER_OF_MASS, center_of_mass);
+	queue_redraw();
 }
 
 const Vector2 &RigidBody2D::get_center_of_mass() const {
@@ -642,6 +644,25 @@ void RigidBody2D::_notification(int p_what) {
 
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
 			update_configuration_warnings();
+		} break;
+
+		case NOTIFICATION_DRAW: {
+			if (!is_inside_tree()) {
+				break;
+			}
+			if (!Engine::get_singleton()->is_editor_hint()) {
+				break;
+			}
+			// Draw a crosshair at the center of mass position.
+			const Vector2 com = get_center_of_mass();
+			const float extents = 5.0;
+			Color com_color = (center_of_mass_mode == CENTER_OF_MASS_MODE_CUSTOM)
+					? Color(1.0, 0.3, 1.0, 0.95) // Magenta
+					: Color(1.0, 0.6, 0.0, 0.8); // Orange
+			const float line_width = 0.5;
+
+			draw_line(com + Vector2(-extents, 0), com + Vector2(extents, 0), com_color, line_width);
+			draw_line(com + Vector2(0, -extents), com + Vector2(0, extents), com_color, line_width);
 		} break;
 	}
 #endif

--- a/scene/3d/physics/rigid_body_3d.cpp
+++ b/scene/3d/physics/rigid_body_3d.cpp
@@ -384,6 +384,7 @@ void RigidBody3D::set_center_of_mass_mode(CenterOfMassMode p_mode) {
 	}
 
 	notify_property_list_changed();
+	update_gizmos();
 }
 
 RigidBody3D::CenterOfMassMode RigidBody3D::get_center_of_mass_mode() const {
@@ -399,6 +400,7 @@ void RigidBody3D::set_center_of_mass(const Vector3 &p_center_of_mass) {
 	center_of_mass = p_center_of_mass;
 
 	PhysicsServer3D::get_singleton()->body_set_param(get_rid(), PS3DE::BODY_PARAM_CENTER_OF_MASS, center_of_mass);
+	update_gizmos();
 }
 
 const Vector3 &RigidBody3D::get_center_of_mass() const {


### PR DESCRIPTION
This replaces and builds on an apparently abandoned PR: #115493 by @LandonFerg

> Adds a `show_center_of_mass` property to both `RigidBody2D` and `RigidBody3D` that displays an orange gizmo / crosshair indicator at the center of mass position in the editor.
> 
> **Note** This is an editor only addition, did not implement a debug for center of mass at runtime

All commits from that PR have been squashed into the first commit. I have made 3 small additions in separate commits, and will squash them if approved.

## Additional changes

1. Adjusted the magenta color as per review comment by @Calinou https://github.com/godotengine/godot/pull/115493#pullrequestreview-3877933560
2. Made the gizmo always draw on top (like the transform gizmo) so that it's visible even inside solid objects (I imagine this is a common scenario) - note: only in 3D, I didn't touch or test the 2D version.
3. Increased the size of the crosshair in 3D from 0.1 to 0.25 (matches e.g. Marker3D). This might be personal preference, but it was too small at the current size for my use case. I think ideally the gizmo would have a fixed screen space size, but I wasnt sure how best to achieve this without adding too much complexity in the form of a vertex shader.

* *Bugsquad edit, Closes https://github.com/godotengine/godot-proposals/issues/2579*