### PR TITLE
GDScript: De-bloat `export_annotations` template

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4661,6 +4661,10 @@ static StringName _find_narrowest_native_or_global_class(const GDScriptParser::D
 
 template <PropertyHint t_hint, Variant::Type t_type>
 bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class) {
+	return _export_annotations(p_annotation, p_target, p_class, t_hint, t_type);
+}
+
+bool GDScriptParser::_export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class, PropertyHint p_hint, Variant::Type p_type) {
 	ERR_FAIL_COND_V_MSG(p_target->type != Node::VARIABLE, false, vformat(R"("%s" annotation can only be applied to variables.)", p_annotation->name));
 	ERR_FAIL_NULL_V(p_class, false);
 
@@ -4676,8 +4680,8 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 
 	variable->exported = true;
 
-	variable->export_info.type = t_type;
-	variable->export_info.hint = t_hint;
+	variable->export_info.type = p_type;
+	variable->export_info.hint = p_hint;
 
 	String hint_string;
 	for (int i = 0; i < p_annotation->resolved_arguments.size(); i++) {
@@ -4973,10 +4977,10 @@ bool GDScriptParser::export_annotations(AnnotationNode *p_annotation, Node *p_ta
 
 	if (use_default_variable_type_check) {
 		// Validate variable type with export.
-		if (!export_type.is_variant() && (export_type.kind != DataType::BUILTIN || export_type.builtin_type != t_type)) {
+		if (!export_type.is_variant() && (export_type.kind != DataType::BUILTIN || export_type.builtin_type != p_type)) {
 			// Allow float/int conversion.
-			if ((t_type != Variant::FLOAT || export_type.builtin_type != Variant::INT) && (t_type != Variant::INT || export_type.builtin_type != Variant::FLOAT)) {
-				Vector<Variant::Type> expected_types = { t_type };
+			if ((p_type != Variant::FLOAT || export_type.builtin_type != Variant::INT) && (p_type != Variant::INT || export_type.builtin_type != Variant::FLOAT)) {
+				Vector<Variant::Type> expected_types = { p_type };
 				push_error(_get_annotation_error_string(p_annotation->name, expected_types, variable->type_constraint), p_annotation);
 				return false;
 			}

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1600,6 +1600,7 @@ private:
 	bool onready_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	template <PropertyHint t_hint, Variant::Type t_type>
 	bool export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
+	bool _export_annotations(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class, PropertyHint p_hint, Variant::Type p_type);
 	bool export_storage_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool export_custom_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);
 	bool export_tool_button_annotation(AnnotationNode *p_annotation, Node *p_target, ClassNode *p_class);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Removes around 300kb from release templates. (Fedora 44: `scons production=yes target=template_release`) To put that into perspective, that's around 17% of the GDScript module.

## Additional information

The code is not performance critical. It's a callback that's called during GDScript compilation to apply a specific annotation. The cost of GDScript compilation is dominated by other factors, the additional call is irrelevant.
