### PR TITLE
Fix PopupMenu mouse click on disabled or separator items

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -505,6 +505,7 @@ void PopupMenu::_submenu_timeout() {
 
 void PopupMenu::_input_from_window(const Ref<InputEvent> &p_event) {
 	if (p_event.is_valid()) {
+		mouse_event = Ref<InputEventMouse>(p_event).is_valid();
 		_input_from_window_internal(p_event);
 	} else {
 		WARN_PRINT_ONCE("PopupMenu has received an invalid InputEvent. Consider filtering out invalid events.");
@@ -1113,7 +1114,7 @@ void PopupMenu::_update_search_bar_visibility() {
 }
 
 void PopupMenu::_items_focus_entered() {
-	if (mouse_over != -1) {
+	if (mouse_over != -1 || mouse_event) {
 		return;
 	}
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -134,6 +134,7 @@ class PopupMenu : public Popup {
 	BitField<MouseButtonMask> initial_button_mask = MouseButtonMask::NONE;
 	bool during_grabbed_click = false;
 	bool is_scrolling = false;
+	bool mouse_event = false;
 	int mouse_over = -1;
 	int prev_mouse_over = -1;
 	int submenu_over = -1;


### PR DESCRIPTION

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/15333

## Additional information

When you clicked with mouse on a disabled or a seperator item the Popupmenu would scroll to and select first valid item in list. This should no longer happen.

I could no recreate the problem demonstrated in https://github.com/godotengine/godot-proposals/issues/15333#issuecomment-5207312990, where it would also click on another item. So not sure if that is platform dependent or fixed.
