### PR TITLE
Exclude `RemoteDebugger` from release templates

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -41,6 +41,7 @@
 #include "core/math/geometry_2d.h"
 #include "core/math/geometry_3d.h"
 #include "core/object/class_db.h"
+#include "core/object/script_language.h"
 #include "core/os/keyboard.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
@@ -2234,18 +2235,30 @@ bool EngineDebugger::has_capture(const StringName &p_name) {
 }
 
 void EngineDebugger::send_message(const String &p_msg, const Array &p_data) {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(!::EngineDebugger::is_active(), "Can't send message. No active debugger");
 	::EngineDebugger::get_singleton()->send_message(p_msg, p_data);
+#else
+	ERR_FAIL_MSG("Can't send message. No active debugger");
+#endif
 }
 
 void EngineDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(!::EngineDebugger::is_active(), "Can't send debug. No active debugger");
 	::EngineDebugger::get_singleton()->debug(p_can_continue, p_is_error_breakpoint);
+#else
+	ERR_FAIL_MSG("Can't send debug. No active debugger");
+#endif
 }
 
 void EngineDebugger::script_debug(ScriptLanguage *p_lang, bool p_can_continue, bool p_is_error_breakpoint) {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(!::EngineDebugger::get_script_debugger(), "Can't send debug. No active debugger");
 	::EngineDebugger::get_script_debugger()->debug(p_lang, p_can_continue, p_is_error_breakpoint);
+#else
+	ERR_FAIL_MSG("Can't send debug. No active debugger");
+#endif
 }
 
 Error EngineDebugger::call_capture(void *p_user, const String &p_cmd, const Array &p_data, bool &r_captured) {
@@ -2270,48 +2283,84 @@ void EngineDebugger::line_poll() {
 }
 
 void EngineDebugger::set_lines_left(int p_lines) {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(!::EngineDebugger::get_script_debugger(), "Can't set lines left. No active debugger");
 	::EngineDebugger::get_script_debugger()->set_lines_left(p_lines);
+#else
+	ERR_FAIL_MSG("Can't set lines left. No active debugger");
+#endif
 }
 
 int EngineDebugger::get_lines_left() const {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_V_MSG(!::EngineDebugger::get_script_debugger(), 0, "Can't get lines left. No active debugger");
 	return ::EngineDebugger::get_script_debugger()->get_lines_left();
+#else
+	ERR_FAIL_V_MSG(0, "Can't get lines left. No active debugger");
+#endif
 }
 
 void EngineDebugger::set_depth(int p_depth) {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(!::EngineDebugger::get_script_debugger(), "Can't set depth. No active debugger");
 	::EngineDebugger::get_script_debugger()->set_depth(p_depth);
+#else
+	ERR_FAIL_MSG("Can't set depth. No active debugger");
+#endif
 }
 
 int EngineDebugger::get_depth() const {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_V_MSG(!::EngineDebugger::get_script_debugger(), 0, "Can't get depth. No active debugger");
 	return ::EngineDebugger::get_script_debugger()->get_depth();
+#else
+	ERR_FAIL_V_MSG(0, "Can't get depth. No active debugger");
+#endif
 }
 
 bool EngineDebugger::is_breakpoint(int p_line, const StringName &p_source) const {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_V_MSG(!::EngineDebugger::get_script_debugger(), false, "Can't check breakpoint. No active debugger");
 	return ::EngineDebugger::get_script_debugger()->is_breakpoint(p_line, p_source);
+#else
+	ERR_FAIL_V_MSG(false, "Can't check breakpoint. No active debugger");
+#endif
 }
 
 bool EngineDebugger::is_skipping_breakpoints() const {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_V_MSG(!::EngineDebugger::get_script_debugger(), false, "Can't check skipping breakpoint. No active debugger");
 	return ::EngineDebugger::get_script_debugger()->is_skipping_breakpoints();
+#else
+	ERR_FAIL_V_MSG(false, "Can't check skipping breakpoint. No active debugger");
+#endif
 }
 
 void EngineDebugger::insert_breakpoint(int p_line, const StringName &p_source) {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(!::EngineDebugger::get_script_debugger(), "Can't insert breakpoint. No active debugger");
 	::EngineDebugger::get_script_debugger()->insert_breakpoint(p_line, p_source);
+#else
+	ERR_FAIL_MSG("Can't insert breakpoint. No active debugger");
+#endif
 }
 
 void EngineDebugger::remove_breakpoint(int p_line, const StringName &p_source) {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(!::EngineDebugger::get_script_debugger(), "Can't remove breakpoint. No active debugger");
 	::EngineDebugger::get_script_debugger()->remove_breakpoint(p_line, p_source);
+#else
+	ERR_FAIL_MSG("Can't remove breakpoint. No active debugger");
+#endif
 }
 
 void EngineDebugger::clear_breakpoints() {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(!::EngineDebugger::get_script_debugger(), "Can't clear breakpoints. No active debugger");
 	::EngineDebugger::get_script_debugger()->clear_breakpoints();
+#else
+	ERR_FAIL_MSG("Can't clear breakpoints. No active debugger");
+#endif
 }
 
 EngineDebugger::~EngineDebugger() {

--- a/core/debugger/debugger_marshalls.cpp
+++ b/core/debugger/debugger_marshalls.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifdef DEBUG_ENABLED
+
 #include "debugger_marshalls.h"
 
 #include "core/io/marshalls.h"
@@ -205,3 +207,5 @@ String DebuggerMarshalls::parse_type_from_variant(const Variant &p_variant) {
 
 	return name;
 }
+
+#endif

--- a/core/debugger/debugger_marshalls.h
+++ b/core/debugger/debugger_marshalls.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#ifdef DEBUG_ENABLED
+
 #include "core/input/shortcut.h"
 #include "core/object/script_language.h"
 
@@ -74,3 +76,5 @@ struct DebuggerMarshalls {
 
 	static String parse_type_from_variant(const Variant &p_variant);
 };
+
+#endif

--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -63,10 +63,12 @@ void EngineDebugger::unregister_message_capture(const StringName &p_name) {
 	captures.erase(p_name);
 }
 
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 void EngineDebugger::register_uri_handler(const String &p_protocol, CreatePeerFunc p_func) {
 	ERR_FAIL_COND_MSG(protocols.has(p_protocol), vformat("Protocol handler already registered: '%s'.", p_protocol));
 	protocols.insert(p_protocol, p_func);
 }
+#endif
 
 void EngineDebugger::profiler_enable(const StringName &p_name, bool p_enabled, const Array &p_opts) {
 	ERR_FAIL_COND_MSG(!profilers.has(p_name), vformat("Can't change profiler state, no profiler: '%s'.", p_name));
@@ -121,9 +123,11 @@ void EngineDebugger::iteration(uint64_t p_frame_ticks, uint64_t p_process_ticks,
 }
 
 void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, bool p_ignore_error_breaks, const Vector<String> &p_breakpoints, void (*p_allow_focus_steal_fn)()) {
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	register_uri_handler("tcp://", RemoteDebuggerPeerTCP::create_tcp); // TCP is the default protocol. Platforms/modules can add more.
 #ifdef UNIX_ENABLED
 	register_uri_handler("unix://", RemoteDebuggerPeerTCP::create_unix);
+#endif
 #endif
 	if (p_uri.is_empty()) {
 		return;
@@ -133,7 +137,9 @@ void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, bo
 		script_debugger = memnew(ScriptDebugger);
 		// Tell the OS that we want to handle termination signals.
 		OS::get_singleton()->initialize_debugging();
-	} else if (p_uri.contains("://")) {
+	}
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
+	else if (p_uri.contains("://")) {
 		const String proto = p_uri.substr(0, p_uri.find("://") + 3);
 		CreatePeerFunc *create_fn = protocols.getptr(proto);
 		ERR_FAIL_NULL_MSG(create_fn, vformat("Invalid protocol: %s.", proto));
@@ -148,6 +154,7 @@ void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, bo
 		Array msg = { OS::get_singleton()->get_process_id() };
 		singleton->send_message("set_pid", msg);
 	}
+#endif // defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	if (!singleton) {
 		return;
 	}
@@ -187,7 +194,9 @@ void EngineDebugger::deinitialize() {
 	// Clear profilers/captures/protocol handlers.
 	profilers.clear();
 	captures.clear();
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	protocols.clear();
+#endif
 }
 
 EngineDebugger::~EngineDebugger() {

--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -121,7 +121,7 @@ void EngineDebugger::iteration(uint64_t p_frame_ticks, uint64_t p_process_ticks,
 	}
 	singleton->poll_events(true);
 }
-
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, bool p_ignore_error_breaks, const Vector<String> &p_breakpoints, void (*p_allow_focus_steal_fn)()) {
 #if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	register_uri_handler("tcp://", RemoteDebuggerPeerTCP::create_tcp); // TCP is the default protocol. Platforms/modules can add more.
@@ -174,6 +174,7 @@ void EngineDebugger::initialize(const String &p_uri, bool p_skip_breakpoints, bo
 
 	allow_focus_steal_fn = p_allow_focus_steal_fn;
 }
+#endif
 
 void EngineDebugger::deinitialize() {
 	if (singleton) {
@@ -200,7 +201,9 @@ void EngineDebugger::deinitialize() {
 }
 
 EngineDebugger::~EngineDebugger() {
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	memdelete(script_debugger);
 	script_debugger = nullptr;
+#endif
 	singleton = nullptr;
 }

--- a/core/debugger/engine_debugger.h
+++ b/core/debugger/engine_debugger.h
@@ -97,7 +97,9 @@ protected:
 
 	static inline HashMap<StringName, Profiler> profilers;
 	static inline HashMap<StringName, Capture> captures;
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	static inline HashMap<String, CreatePeerFunc> protocols;
+#endif
 
 	static void (*allow_focus_steal_fn)();
 
@@ -119,7 +121,9 @@ public:
 	static void unregister_message_capture(const StringName &p_name);
 	static bool has_capture(const StringName &p_name);
 
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	static void register_uri_handler(const String &p_protocol, CreatePeerFunc p_func);
+#endif
 
 	void iteration(uint64_t p_frame_ticks, uint64_t p_process_ticks, uint64_t p_physics_ticks, double p_physics_frame_time);
 	void profiler_enable(const StringName &p_name, bool p_enabled, const Array &p_opts = Array());

--- a/core/debugger/engine_debugger.h
+++ b/core/debugger/engine_debugger.h
@@ -38,7 +38,9 @@
 #include "core/variant/array.h"
 
 class RemoteDebuggerPeer;
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 class ScriptDebugger;
+#endif
 
 class EngineDebugger {
 public:
@@ -93,7 +95,9 @@ private:
 
 protected:
 	static inline EngineDebugger *singleton = nullptr;
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	static inline ScriptDebugger *script_debugger = nullptr;
+#endif
 
 	static inline HashMap<StringName, Profiler> profilers;
 	static inline HashMap<StringName, Capture> captures;
@@ -105,11 +109,19 @@ protected:
 
 public:
 	_FORCE_INLINE_ static EngineDebugger *get_singleton() { return singleton; }
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	_FORCE_INLINE_ static bool is_active() { return singleton != nullptr && script_debugger != nullptr; }
+#else
+	_FORCE_INLINE_ static bool is_active() { return false; }
+#endif
 
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	_FORCE_INLINE_ static ScriptDebugger *get_script_debugger() { return script_debugger; }
+#endif
 
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	static void initialize(const String &p_uri, bool p_skip_breakpoints, bool p_ignore_error_breaks, const Vector<String> &p_breakpoints, void (*p_allow_focus_steal_fn)());
+#endif
 	static void deinitialize();
 	static void register_profiler(const StringName &p_name, const Profiler &p_profiler);
 	static void unregister_profiler(const StringName &p_name);

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -30,6 +30,8 @@
 
 #include "local_debugger.h"
 
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
+
 #include "core/debugger/script_debugger.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
@@ -397,3 +399,5 @@ LocalDebugger::~LocalDebugger() {
 	unregister_profiler("scripts");
 	memdelete(scripts_profiler);
 }
+
+#endif

--- a/core/debugger/local_debugger.h
+++ b/core/debugger/local_debugger.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
+
 #include "core/debugger/engine_debugger.h"
 #include "core/templates/list.h"
 
@@ -53,3 +55,5 @@ public:
 	LocalDebugger();
 	~LocalDebugger();
 };
+
+#endif

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -30,6 +30,8 @@
 
 #include "remote_debugger.h"
 
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
+
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/debugger/debugger_marshalls.h"
@@ -805,3 +807,5 @@ RemoteDebugger::~RemoteDebugger() {
 	remove_print_handler(&phl);
 	remove_error_handler(&eh);
 }
+
+#endif

--- a/core/debugger/remote_debugger.h
+++ b/core/debugger/remote_debugger.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
+
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/remote_debugger_peer.h"
@@ -117,3 +119,5 @@ public:
 	explicit RemoteDebugger(Ref<RemoteDebuggerPeer> p_peer);
 	~RemoteDebugger();
 };
+
+#endif

--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -30,6 +30,8 @@
 
 #include "remote_debugger_peer.h"
 
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
+
 #include "core/config/project_settings.h"
 #include "core/io/marshalls.h"
 #include "core/io/stream_peer_socket.h"
@@ -269,3 +271,5 @@ void RemoteDebuggerPeerTCP::_disconnect_with_error(const String &p_reason) {
 	ERR_PRINT(p_reason);
 	tcp_client->disconnect_from_host();
 }
+
+#endif

--- a/core/debugger/remote_debugger_peer.h
+++ b/core/debugger/remote_debugger_peer.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
+
 #include "core/object/ref_counted.h"
 #include "core/os/mutex.h"
 #include "core/os/thread.h"
@@ -98,3 +100,5 @@ public:
 	RemoteDebuggerPeerTCP();
 	~RemoteDebuggerPeerTCP();
 };
+
+#endif

--- a/core/debugger/script_debugger.cpp
+++ b/core/debugger/script_debugger.cpp
@@ -30,6 +30,8 @@
 
 #include "script_debugger.h"
 
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
+
 #include "core/debugger/engine_debugger.h"
 
 thread_local Vector<ScriptDebugger::StackInfo> ScriptDebugger::error_stack_info;
@@ -105,3 +107,5 @@ Vector<ScriptLanguage::StackInfo> ScriptDebugger::get_error_stack_info() const {
 ScriptLanguage *ScriptDebugger::get_break_language() const {
 	return break_lang;
 }
+
+#endif

--- a/core/debugger/script_debugger.h
+++ b/core/debugger/script_debugger.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
+
 #include "core/object/script_language.h"
 #include "core/string/string_name.h"
 #include "core/templates/hash_set.h"
@@ -83,3 +85,5 @@ public:
 	void send_error(const String &p_func, const String &p_file, int p_line, const String &p_err, const String &p_descr, bool p_editor_notify, ErrorHandlerType p_type, const Vector<StackInfo> &p_stack_info);
 	Vector<StackInfo> get_error_stack_info() const;
 };
+
+#endif

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -114,9 +114,11 @@ Dictionary Script::_get_script_constant_map() {
 }
 
 void Script::_set_debugger_break_language() {
+#ifdef DEBUG_ENABLED
 	if (EngineDebugger::is_active()) {
 		EngineDebugger::get_script_debugger()->set_break_language(get_language());
 	}
+#endif
 }
 
 int Script::get_script_method_argument_count(const StringName &p_method, bool *r_is_valid) const {

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -34,6 +34,7 @@
 
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
+#include "core/object/script_backtrace.h"
 #include "core/string/char_utils.h"
 #include "drivers/unix/dir_access_unix.h"
 #include "drivers/unix/file_access_unix.h"
@@ -123,6 +124,7 @@ static void _setup_clock() {
 struct sigaction old_action;
 
 static void handle_interrupt(int sig) {
+#ifdef DEBUG_ENABLED
 	if (!EngineDebugger::is_active()) {
 		return;
 	}
@@ -134,6 +136,7 @@ static void handle_interrupt(int sig) {
 	if (old_action.sa_handler && old_action.sa_handler != SIG_IGN && old_action.sa_handler != SIG_DFL) {
 		old_action.sa_handler(sig);
 	}
+#endif
 }
 
 void OS_Unix::initialize_debugging() {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -425,9 +425,11 @@ ScriptInstance *GDScript::instance_create(Object *p_this) {
 
 	if (top->native.is_valid()) {
 		if (!p_this->is_class(top->native->get_name())) {
+#ifdef DEBUG_ENABLED
 			if (EngineDebugger::is_active()) {
 				GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), 1, "Script inherits from native type '" + String(top->native->get_name()) + "', so it can't be assigned to an object of type: '" + p_this->get_class() + "'");
 			}
+#endif
 			ERR_FAIL_V_MSG(nullptr, "Script inherits from native type '" + String(top->native->get_name()) + "', so it can't be assigned to an object of type '" + p_this->get_class() + "'" + ".");
 		}
 	}
@@ -829,9 +831,11 @@ Error GDScript::reload(bool p_keep_state) {
 		err = parser.parse(source, path, false);
 	}
 	if (err) {
+#ifdef DEBUG_ENABLED
 		if (EngineDebugger::is_active()) {
 			GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), parser.get_errors().front()->get().start_line, "Parser Error: " + parser.get_errors().front()->get().message);
 		}
+#endif
 		// TODO: Show all error messages.
 		_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), parser.get_errors().front()->get().start_line, ("Parse Error: " + parser.get_errors().front()->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
 		reloading = false;
@@ -842,9 +846,11 @@ Error GDScript::reload(bool p_keep_state) {
 	err = analyzer.analyze();
 
 	if (err) {
+#ifdef DEBUG_ENABLED
 		if (EngineDebugger::is_active()) {
 			GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), parser.get_errors().front()->get().start_line, "Parser Error: " + parser.get_errors().front()->get().message);
 		}
+#endif
 
 		const List<GDScriptParser::ParserError>::Element *e = parser.get_errors().front();
 		while (e != nullptr) {
@@ -864,9 +870,11 @@ Error GDScript::reload(bool p_keep_state) {
 		// TODO: Provide the script function as the first argument.
 		_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), compiler.get_error_line(), ("Compile Error: " + compiler.get_error()).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
 		if (can_run) {
+#ifdef DEBUG_ENABLED
 			if (EngineDebugger::is_active()) {
 				GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), compiler.get_error_line(), "Parser Error: " + compiler.get_error());
 			}
+#endif
 			reloading = false;
 			return ERR_COMPILATION_FAILED;
 		} else {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -465,8 +465,10 @@ class GDScriptLanguage : public ScriptLanguage {
 #endif
 
 public:
+#ifdef DEBUG_ENABLED
 	bool debug_break(const String &p_error, bool p_allow_continue = true);
 	bool debug_break_parse(const String &p_file, int p_line, const String &p_error);
+#endif
 
 	_FORCE_INLINE_ void enter_function(CallLevel *call_level, GDScriptInstance *p_instance, GDScriptFunction *p_function, Variant *p_stack, int *p_ip, int *p_line) {
 		if (!track_call_stack) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -270,6 +270,7 @@ thread_local int GDScriptLanguage::_debug_parse_err_line = -1;
 thread_local String GDScriptLanguage::_debug_parse_err_file;
 thread_local String GDScriptLanguage::_debug_error;
 
+#ifdef DEBUG_ENABLED
 bool GDScriptLanguage::debug_break_parse(const String &p_file, int p_line, const String &p_error) {
 	// break because of parse error
 
@@ -302,6 +303,7 @@ bool GDScriptLanguage::debug_break(const String &p_error, bool p_allow_continue)
 		return false;
 	}
 }
+#endif
 
 String GDScriptLanguage::debug_get_error() const {
 	return _debug_error;

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -3924,6 +3924,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				line = _code_ptr[ip + 1];
 				ip += 2;
 
+#ifdef DEBUG_ENABLED
 				if (EngineDebugger::is_active()) {
 					// line
 					bool do_break = false;
@@ -3947,6 +3948,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 					EngineDebugger::get_singleton()->line_poll();
 				}
+#endif
 			}
 			DISPATCH_OPCODE;
 

--- a/modules/websocket/register_types.cpp
+++ b/modules/websocket/register_types.cpp
@@ -70,8 +70,10 @@ void initialize_websocket_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(WebSocketMultiplayerPeer);
 		ClassDB::register_custom_instance_class<WebSocketPeer>();
 
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 		EngineDebugger::register_uri_handler("ws://", RemoteDebuggerPeerWebSocket::create);
 		EngineDebugger::register_uri_handler("wss://", RemoteDebuggerPeerWebSocket::create);
+#endif
 	}
 
 #ifdef TOOLS_ENABLED

--- a/modules/websocket/remote_debugger_peer_websocket.cpp
+++ b/modules/websocket/remote_debugger_peer_websocket.cpp
@@ -30,6 +30,8 @@
 
 #include "remote_debugger_peer_websocket.h"
 
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
+
 #include "core/config/project_settings.h"
 
 Error RemoteDebuggerPeerWebSocket::connect_to_host(const String &p_uri) {
@@ -139,3 +141,5 @@ Ref<RemoteDebuggerPeer> RemoteDebuggerPeerWebSocket::create(const String &p_uri)
 	}
 	return peer;
 }
+
+#endif

--- a/modules/websocket/remote_debugger_peer_websocket.h
+++ b/modules/websocket/remote_debugger_peer_websocket.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
+
 #include "websocket_peer.h"
 
 #include "core/debugger/remote_debugger_peer.h"
@@ -59,3 +61,5 @@ public:
 
 	RemoteDebuggerPeerWebSocket(const Ref<WebSocketPeer> &p_peer = Ref<WebSocketPeer>());
 };
+
+#endif

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -30,6 +30,8 @@
 
 #include "scene_debugger.h"
 
+#ifdef DEBUG_ENABLED
+
 #include "core/config/engine.h"
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/engine_debugger.h"
@@ -92,14 +94,14 @@ SceneDebugger::~SceneDebugger() {
 	singleton = nullptr;
 }
 
+#ifdef DEBUG_ENABLED
 void SceneDebugger::initialize() {
 	if (EngineDebugger::is_active()) {
-#ifdef DEBUG_ENABLED
 		_init_message_handlers();
-#endif
 		memnew(SceneDebugger);
 	}
 }
+#endif
 
 void SceneDebugger::deinitialize() {
 	memdelete(singleton);
@@ -146,8 +148,10 @@ void SceneDebugger::_on_output_max_linear_value_changed(float max_linear_value) 
 }
 
 Error SceneDebugger::_msg_setup_scene(const Array &p_args) {
+#ifdef DEBUG_ENABLED
 	SceneTree::get_singleton()->get_root()->connect(SceneStringName(window_input), callable_mp_static(SceneDebugger::_handle_input).bind(DebuggerMarshalls::deserialize_key_shortcut(p_args)));
 	return OK;
+#endif
 }
 
 Error SceneDebugger::_msg_setup_game_view(const Array &p_args) {
@@ -311,6 +315,7 @@ Error SceneDebugger::_msg_reload_cached_files(const Array &p_args) {
 }
 
 Error SceneDebugger::_msg_setup_embedded_shortcuts(const Array &p_args) {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_V(p_args.is_empty() || p_args[0].get_type() != Variant::DICTIONARY, ERR_INVALID_DATA);
 	Dictionary dict = p_args[0];
 	LocalVector<Variant> keys = dict.get_key_list();
@@ -321,6 +326,7 @@ Error SceneDebugger::_msg_setup_embedded_shortcuts(const Array &p_args) {
 
 	SceneTree::get_singleton()->get_root()->connect(SceneStringName(window_input), callable_mp_static(SceneDebugger::_handle_embed_input).bind(dict));
 	return OK;
+#endif
 }
 
 // region Live editing.
@@ -792,9 +798,11 @@ void SceneDebugger::add_to_cache(const String &p_filename, Node *p_node) {
 		return;
 	}
 
+#ifdef DEBUG_ENABLED
 	if (EngineDebugger::get_script_debugger() && !p_filename.is_empty()) {
 		debugger->live_scene_edit_cache[p_filename].insert(p_node);
 	}
+#endif
 }
 
 void SceneDebugger::remove_from_cache(const String &p_filename, Node *p_node) {
@@ -1339,3 +1347,4 @@ void LiveEditor::_reparent_node_func(const NodePath &p_at, const NodePath &p_new
 	}
 }
 #endif // DEBUG_ENABLED
+#endif

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -33,6 +33,8 @@
 #include "core/object/ref_counted.h"
 #include "core/string/ustring.h"
 
+#ifdef DEBUG_ENABLED
+
 class Array;
 class InputEvent;
 class Node;
@@ -129,6 +131,8 @@ public:
 	static void reload_cached_files(const PackedStringArray &p_files);
 #endif
 };
+
+#endif
 
 #ifdef DEBUG_ENABLED
 class LiveEditor {

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -1308,7 +1308,9 @@ void register_scene_types() {
 		GraphEdit::init_shaders();
 	}
 
+#ifdef DEBUG_ENABLED
 	SceneDebugger::initialize();
+#endif
 
 	OS::get_singleton()->benchmark_end_measure("Scene", "Register Types");
 }
@@ -1316,7 +1318,9 @@ void register_scene_types() {
 void unregister_scene_types() {
 	OS::get_singleton()->benchmark_begin_measure("Scene", "Unregister Types");
 
+#ifdef DEBUG_ENABLED
 	SceneDebugger::deinitialize();
+#endif
 
 	if constexpr (GD_IS_CLASS_ENABLED(TextureLayered)) {
 		ResourceLoader::remove_resource_format_loader(resource_loader_texture_layered);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Removes around 280kb from release templates. (Fedora 44: `scons production=yes target=template_release`)

## Additional information

The code which leads to initializing remote debugging is guarded in `main.cpp`: https://github.com/HolonProduction/godot/blob/d19eed75f63e632dcb473abca6d138448107b6b1/main/main.cpp#L1855

So there is no need to include classes related to remote debugging in non-debug and non-tool builds.

Putting as draft, since I want to do some more due diligence on this. I also want to check if the local debugger has any chance of working correctly in exported builds. If not we might just want to exclude that stuff as well.

> [!NOTE]
> In case someone is concerned: This does not break call stack tracking via `debug/settings/gdscript/always_track_call_stacks` and `debug/settings/gdscript/always_track_local_variables`.
