### PR TITLE
TextEdit: Reduce redraws when selecting

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6729,9 +6729,6 @@ void TextEdit::select(int p_origin_line, int p_origin_column, int p_caret_line, 
 	if (had_selection != activate) {
 		_selection_changed(p_caret);
 	}
-
-	queue_accessibility_update();
-	queue_redraw();
 }
 
 bool TextEdit::has_selection(int p_caret) const {
@@ -9621,7 +9618,6 @@ void TextEdit::_adjust_viewport_to_caret_horizontally(int p_caret, bool p_maximi
 	if (get_line_wrapping_mode() != LineWrappingMode::LINE_WRAPPING_NONE) {
 		first_visible_col = 0;
 		h_scroll->set_value(first_visible_col);
-		queue_redraw();
 		return;
 	}
 
@@ -9678,9 +9674,6 @@ void TextEdit::_adjust_viewport_to_caret_horizontally(int p_caret, bool p_maximi
 	}
 
 	h_scroll->set_value(first_visible_col);
-
-	queue_accessibility_update();
-	queue_redraw();
 }
 
 // Minimap


### PR DESCRIPTION
## What problem(s) does this PR solve?

Excessive `TextEdit` redraws when holding down the mouse, which aren't expensive, but not dirt cheap (around 1 ms on my mid-range laptop for an average GDScript)

## Overview

<img width="1005" height="589" alt="image" src="https://github.com/user-attachments/assets/4010ea55-23ae-4a7d-a42d-8de0c77cf519" />

The functions `set_caret_line`, `set_selection_origin_column`, ... queue a redraw when they change something, and `_selection_changed` always forces a redraw (called when selection is enabled/disabled). So the `select` function itself doesn't change anything and thus doesn't require a redraw.

<img width="716" height="148" alt="image" src="https://github.com/user-attachments/assets/e5844c74-b9b5-4e1c-9691-e67618e8f18f" />

~Only redraw when the value changes, I think it's pretty self-explanatory.~
EDIT: See review by kit for more info.

## Before (look at the output/console)

https://github.com/user-attachments/assets/a37c015c-6341-44fd-95d3-36443bfb626e

## After (look at the output/console)

https://github.com/user-attachments/assets/bfde827f-32a5-45eb-96ce-873fdc9f2f3a

## Additional info

Didn't see any behavioral changes in my testing.

EDIT: the PR number is funny 122222