### PR TITLE
Core: Fix UndoRedo silently dropping Callables bound to global functions

### DIFF
--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -353,7 +353,7 @@ void UndoRedo::_process_operation_list(List<Operation>::Element *r_elements, boo
 		Operation &op = r_elements->get();
 
 		Object *obj = ObjectDB::get_instance(op.object);
-		if (!obj) { //may have been deleted and this is fine
+		if (op.object.is_valid() && !obj) { // May have been deleted and this is fine.
 			continue;
 		}
 


### PR DESCRIPTION
Fixes #107727

`UndoRedo::_process_operation_list()` treated any operation whose `Object` lookup failed as "the bound object was deleted, skip it" and silently continued. That assumption doesn't hold for Callables that were never bound to an `Object` in the first place — a GDScript reference to a global/utility function (`print`, `randomize`, `seed`, etc.) has `GDScriptUtilityCallable::get_object()` always return an empty `ObjectID` by design. The result: `add_do_method(print.bind(...))` and similar were silently no-ops instead of running, as reported in #107727.

Only skip the operation when it previously had a valid, now-deleted object, so callables that were never object-bound still execute.

## Test plan
- Reproduced the exact silent-drop behavior from #107727 on current master (`print.bind("finished!")` never fired), confirmed the fix resolves it in a real headless run, not just a compile check.
- Verified no regression on the original "object was deleted" protection this code exists for: both the add-time validity check (`add_do_method` rejecting an already-freed object's callable) and the mid-list case (an object freed by an earlier operation in the same action, then referenced by a later one) still safely no-op instead of crashing.