### PR TITLE
[Core]: Remove extra loads when using `compare_exchange_weak` in `SafeNumeric`

### DIFF
--- a/core/templates/safe_refcount.h
+++ b/core/templates/safe_refcount.h
@@ -121,8 +121,8 @@ public:
 	}
 
 	_ALWAYS_INLINE_ T exchange_if_greater(T p_value) {
+		T tmp = value.load(std::memory_order_acquire);
 		while (true) {
-			T tmp = value.load(std::memory_order_acquire);
 			if (tmp >= p_value) {
 				return tmp; // already greater, or equal
 			}
@@ -134,8 +134,8 @@ public:
 	}
 
 	_ALWAYS_INLINE_ T conditional_increment() {
+		T c = value.load(std::memory_order_acquire);
 		while (true) {
-			T c = value.load(std::memory_order_acquire);
 			if (c == 0) {
 				return 0;
 			}


### PR DESCRIPTION
## What problem(s) does this PR solve?

Acquire loads needs to be synchronized with concurrent release operations, which will make the code slower, so if we can remove extra loads in a hot path easily without changing the behaviour, we should remove them. 

This PR removes them by lifting the first load acquire outside of the loop, as we only need it to load the initial current value. After that `compare_exchange_weak` will write the newest value into `expected` on failure with acquire memory ordering because we use a single `std::memory_order_acq_rel` argument. So in the next iteration we will have the newest value again.

## Additional information

Per https://en.cppreference.com/cpp/atomic/atomic/compare_exchange `compare_exchange_weak` loads new data into `expected` on failure. See the last sentence.

> Atomically compares the object representation of `*this` with that of `expected`. If those are bitwise-equal, replaces the former with `desired` (performs read-modify-write operation). Otherwise, **loads the actual value stored in `*this` into `expected`** (performs load operation).

Relevant table snippet for the currently used overload, the operations in quote in the brackets `(performs * operation)` matches the operations in the columns:
| read‑modify‑write operation | load operation |
|  :---: |  :---: |
| `order` | <ul><li>`std::memory_order_acquire` if `order` is `std::memory_order_acq_rel`</li><li>`std::memory_order_relaxed` if `order` is `std::memory_order_release`</li><li>otherwise `order`</li></ul>|

I can also add `std::memory_order_acquire` into the argument for a memory order on failure directly to be more explicit if it is preferred.

## Benchmark

Tests the worst case scenario, 8 threads modifying the same variable at the same time.

```
scons target=template_release optimize=speed accesskit=no use_llvm=yes linker=lld production=yes tests=yes
```

<details>

<summary>Code</summary>

Modified from https://redirect.github.com/godotengine/godot-docs/pull/12200

```c++

#include "core/os/semaphore.h"
#include "core/os/thread.h"
#include "tests/test_macros.h"

#include <algorithm>

TEST_FORCE_LINK(test_user_bench)

#include <chrono>
#include <cstdio>

const int THREAD_NUMS = 8;
const uint64_t N = 800'000'000;

static Semaphore thread_sem;
static SafeNumeric<uint64_t> counter;
static SafeFlag run_while_flag;
static SafeFlag only_adds;

double results[THREAD_NUMS];

struct ThreadData {
	uint64_t num_per_thread;
	uint32_t thread_idx;
};

static void thread_func(void *userdata) {
	ThreadData data = *(ThreadData *)userdata;
	uint64_t num_per_thread = data.num_per_thread;
	uint32_t thread_idx = data.thread_idx;

	thread_sem.wait();
	auto t0 = std::chrono::steady_clock::now();
	for (uint64_t i = 0; i < num_per_thread; i++) {
		counter.conditional_increment();
		counter.decrement();
	}
	auto t1 = std::chrono::steady_clock::now();
	results[thread_idx] = std::chrono::duration<double, std::nano>(t1 - t0).count() / N;
}

static void thread_func_while(void *) {
	thread_sem.wait();
	while (run_while_flag.is_set()) {
		if (only_adds.is_set()) {
			counter.conditional_increment();
			continue;
		}
		if (counter.conditional_increment()) {
			counter.decrement();
		}
	}
}

static void user_bench() {
	Thread threads[THREAD_NUMS] = {};

	// --------- Speed ---------
	uint64_t num_per_thread = N / THREAD_NUMS;
	ThreadData data[THREAD_NUMS] = {};
	for (uint32_t i = 0; i < THREAD_NUMS; i++) {
		data[i] = { num_per_thread, i };
		threads[i].start(thread_func, data + i);
	}

	counter.set(1);
	thread_sem.post(THREAD_NUMS);
	for (uint32_t i = 0; i < THREAD_NUMS; i++) {
		threads[i].wait_to_finish();
	}

	double ns_per_op = *std::max_element(results, results + THREAD_NUMS);
	printf("Benchmark result: %.1f ns/op (counter %zu)\n", ns_per_op, (size_t)counter.get());
	if (counter.get() != 1) {
		printf("Should be 1 when in pairs.");
	}
	// --------- Speed ---------
	
	// --------- Correctness ---------
	for (uint32_t i = 0; i < THREAD_NUMS; i++) {
		threads[i].start(thread_func_while, nullptr);
	}
	counter.set(1);
	run_while_flag.set();
	only_adds.clear();
	thread_sem.post(THREAD_NUMS);
	std::this_thread::sleep_for(std::chrono::microseconds(1000));
	uint64_t current_counter = counter.postdecrement();
	std::this_thread::sleep_for(std::chrono::microseconds(500));
	only_adds.set();
	std::this_thread::sleep_for(std::chrono::microseconds(500));
	run_while_flag.clear();

	for (uint32_t i = 0; i < THREAD_NUMS; i++) {
		threads[i].wait_to_finish();
	}
	if (current_counter == 0) {
		printf("Should never be 0 when valid.");
	}
	if (counter.get() != 0) {
		printf("Should be 0 after decrement.");
	}
	// --------- Correctness ---------
}

REGISTER_TEST_COMMAND("user-bench", &user_bench)
```
</details>

I run it 2 times.
| Run | PR | master |
|  --- |  --- | --- |
|  1   |  125.7 ns/op | 173.1 ns/op |
| 2   | 112.0 ns/op | 174.0 ns/op |
 
No AI used

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
