### PR TITLE
Prevent UB when freeing object during `_notification`

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -169,6 +169,12 @@ Object::Connection::Connection(const Variant &p_variant) {
 }
 
 bool Object::_predelete() {
+	// Prevent self-deletion during notification -- would cause UB.
+	if (unlikely(_notifying)) {
+		ERR_PRINT(vformat("Cannot free own object from notification handler. %s instance (id %d) will be leaked.", get_class(), (uint64_t)get_instance_id()));
+		return false;
+	}
+
 	_predelete_ok = true;
 	notification(NOTIFICATION_PREDELETE, true);
 	if (!_predelete_ok) {
@@ -2278,6 +2284,7 @@ void Object::_construct_object(bool p_reference) {
 	_block_signals = false;
 	_can_translate = true;
 	_emitting = false;
+	_notifying = false;
 	_is_queued_for_deletion = false;
 	_predelete_ok = false;
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -441,6 +441,7 @@ private:
 	bool _block_signals : 1;
 	bool _can_translate : 1;
 	bool _emitting : 1;
+	bool _notifying : 1;
 	bool _predelete_ok : 1;
 
 public:
@@ -724,11 +725,17 @@ public:
 	// - Forward calls subclasses in descending order (e.g. Object -> Node -> Node3D -> extension -> script).
 	//   Backward calls subclasses in descending order (e.g. script -> extension -> Node3D -> Node -> Object).
 	_FORCE_INLINE_ void notification(int p_notification, bool p_reversed = false) {
+		// Save/restore to support nested re-entrant notifications.
+		const bool prev_notifying = _notifying;
+		_notifying = true;
+
 		if (p_reversed) {
 			_notification_backward(p_notification);
 		} else {
 			_notification_forward(p_notification);
 		}
+
+		_notifying = prev_notifying;
 	}
 
 	String to_string();


### PR DESCRIPTION

## What problem(s) does this PR solve?

When calling `free()` on the own object during the `_notification` virtual function, the object is immediately destroyed, but quite a bit of follow-up logic is still running. This logic then accesses freed memory, causing UB. This includes lifecycle methods such as `_ready` or `_process`.

This often appears to work because previous object data may still be at the same memory location, so I could imagine fixing this would uncover some latent memory bugs in benign-looking GDScript code.

### Reproducing examples

This is the simplest case:

```gdscript
# (1) Self-free in _notification, 1 script level: UAF in Object::_notification_backward.
extends SceneTree

class MyClass extends Object:
	func _notification(what: int) -> void:
		if what == 1234:
			free()

func _initialize() -> void:
	MyClass.new().notification(1234, false) # forward OK
	MyClass.new().notification(1234, true)  # backward reports UB with ASan

	print("survived")
	quit()
```

_AI disclosure: I ran into this problem myself, but asked Claude to explore more GDScript scenarios that trigger it._

<details>
<summary>
Expand for more scenarios.
</summary>

```gdscript
# (2) Self-free in _notification, 2 script levels: GDScriptInstance::notification() calls _notification once
# per class, so the second call runs on the dead object -- UAF on p_instance->owner in GDScriptFunction::call.
extends SceneTree

class Base extends Object:
	func _notification(what: int) -> void:
		if what == 1234:
			free()

class Derived extends Base:
	func _notification(what: int) -> void:
		if what == 5678:
			free()

func _initialize() -> void:
	Derived.new().notification(1234, false) # forward: Base frees, Derived level follows
	Derived.new().notification(5678, true)  # backward: Derived frees, Base level follows

	print("survived")
	quit()
```
```gdscript
# (3) Self-free in engine-dispatched READY (after _initialize): UAF in Object::_notification_forward.
extends SceneTree

class FreeInReady extends Node:
	func _ready() -> void:
		free()

func _initialize() -> void:
	root.add_child(FreeInReady.new())

func _process(_delta: float) -> bool:
	print("survived")
	return true
```
```gdscript
# (4) Self-free in engine-dispatched PROCESS: UAF in Object::_notification_forward.
# FreeInProcess._process runs after this script's _process, hence 2 frames.
extends SceneTree

class FreeInProcess extends Node:
	func _process(_delta: float) -> void:
		free()

var frames := 0

func _initialize() -> void:
	root.add_child(FreeInProcess.new())

func _process(_delta: float) -> bool:
	frames += 1

	var done := frames >= 2
	if done:
		print("survived")

	return done
```
</details>

### ASan setup

I compiled Godot with the following command, and then ran the scripts:
```bash
scons target=editor dev_build=yes accesskit=no use_asan=yes
godot --headless --script script.gd
```
When running with AddressSanitizer, each of the above scripts reports use-after-free:

<details>
<summary>Report (1)</summary>

```
=================================================================
==75078==ERROR: AddressSanitizer: heap-use-after-free on address 0x7c1eb49fc958 at pc 0x00000d23d35b bp 0x7ffc50941220 sp 0x7ffc50941218
READ of size 8 at 0x7c1eb49fc958 thread T0
    #0 0x00000d23d35a in Object::_notification_backward(int) core/object/object.cpp:930
    #1 0x00000040dea0 in Object::notification(int, bool) core/object/object.h:728
    #2 0x0000014b42be in void call_with_validated_variant_args_helper<__UnexistingClass, int, bool, 0ul, 1ul>(__UnexistingClass*, void (__UnexistingClass::*)(int, bool), Variant const**, IndexSequence<0ul, 1ul>) core/variant/binder_common.h:119
    #3 0x0000014aaedd in void call_with_validated_object_instance_args<__UnexistingClass, int, bool>(__UnexistingClass*, void (__UnexistingClass::*)(int, bool), Variant const**) core/variant/binder_common.h:406
    #4 0x00000149b8f2 in MethodBindT<int, bool>::validated_call(Object*, Variant const**, Variant*) const core/object/method_bind_common.h:97
    #5 0x000001c9ffcc in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) modules/gdscript/gdscript_vm.cpp:2373
    #6 0x000001984d2d in GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) modules/gdscript/gdscript.cpp:1976
    #7 0x00000c468670 in MainLoop::_gdvirtual__initialize_call() core/os/main_loop.h:42
    #8 0x00000c467eb5 in MainLoop::initialize() core/os/main_loop.cpp:58
    #9 0x0000081e7eb2 in SceneTree::initialize() scene/main/scene_tree.cpp:589
    #10 0x000000420096 in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:984
    #11 0x00000044e535 in main platform/linuxbsd/godot_linuxbsd.cpp:122
    #12 0x7efeb52f3680 in __libc_start_call_main (/lib64/libc.so.6+0x3680) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #13 0x7efeb52f3797 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3797) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #14 0x00000040ad04 in _start (/home/jan/gamedev/godot/bin/san-orig+0x40ad04) (BuildId: 4706a25040d4df6e7a64b0fde5e0b05035016d57)

0x7c1eb49fc958 is located 24 bytes inside of 288-byte region [0x7c1eb49fc940,0x7c1eb49fca60)
freed by thread T0 here:
    #0 0x7efeb56ee4cf in free.part.0 (/lib64/libasan.so.8+0xee4cf) (BuildId: 5395ec74f54d9ec7bf97c06583dd39a96c230822)
    #1 0x00000c46b4ea in Memory::free_static(void*, bool) core/os/memory.cpp:201
    #2 0x0000006a90b7 in void memdelete<Object>(Object*) core/os/memory.h:169
    #3 0x00000d23be59 in Object::callp(StringName const&, Variant const**, int, Callable::CallError&) core/object/object.cpp:789
    #4 0x00000cae180b in Variant::callp(StringName const&, Variant const**, int, Variant&, Callable::CallError&) core/variant/variant_call.cpp:1406
    #5 0x000001c97acb in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) modules/gdscript/gdscript_vm.cpp:1975
    #6 0x000001985381 in GDScriptInstance::notification(int, bool) modules/gdscript/gdscript.cpp:2012
    #7 0x00000d23d335 in Object::_notification_backward(int) core/object/object.cpp:927
    #8 0x00000040dea0 in Object::notification(int, bool) core/object/object.h:728
    #9 0x0000014b42be in void call_with_validated_variant_args_helper<__UnexistingClass, int, bool, 0ul, 1ul>(__UnexistingClass*, void (__UnexistingClass::*)(int, bool), Variant const**, IndexSequence<0ul, 1ul>) core/variant/binder_common.h:119
    #10 0x0000014aaedd in void call_with_validated_object_instance_args<__UnexistingClass, int, bool>(__UnexistingClass*, void (__UnexistingClass::*)(int, bool), Variant const**) core/variant/binder_common.h:406
    #11 0x00000149b8f2 in MethodBindT<int, bool>::validated_call(Object*, Variant const**, Variant*) const core/object/method_bind_common.h:97
    #12 0x000001c9ffcc in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) modules/gdscript/gdscript_vm.cpp:2373
    #13 0x000001984d2d in GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) modules/gdscript/gdscript.cpp:1976
    #14 0x00000c468670 in MainLoop::_gdvirtual__initialize_call() core/os/main_loop.h:42
    #15 0x00000c467eb5 in MainLoop::initialize() core/os/main_loop.cpp:58
    #16 0x0000081e7eb2 in SceneTree::initialize() scene/main/scene_tree.cpp:589
    #17 0x000000420096 in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:984
    #18 0x00000044e535 in main platform/linuxbsd/godot_linuxbsd.cpp:122
    #19 0x7efeb52f3680 in __libc_start_call_main (/lib64/libc.so.6+0x3680) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #20 0x7efeb52f3797 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3797) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #21 0x00000040ad04 in _start (/home/jan/gamedev/godot/bin/san-orig+0x40ad04) (BuildId: 4706a25040d4df6e7a64b0fde5e0b05035016d57)

previously allocated by thread T0 here:
    #0 0x7efeb56ef41f in malloc (/lib64/libasan.so.8+0xef41f) (BuildId: 5395ec74f54d9ec7bf97c06583dd39a96c230822)
    #1 0x00000c46beaa in void* Memory::alloc_static<false>(unsigned long, bool) core/os/memory.cpp:101
    #2 0x00000c46abac in operator new(unsigned long, DefaultAllocator) core/os/memory.cpp:48
    #3 0x00000c45cb97 in Object* ClassDB::creator<Object>(bool) core/object/class_db.h:162
    #4 0x00000d1e3bcf in ClassDB::_instantiate_internal(StringName const&, bool, bool, bool, bool) core/object/class_db.cpp:648
    #5 0x00000d1e4022 in ClassDB::instantiate_no_placeholders(StringName const&) core/object/class_db.cpp:703
    #6 0x00000196c59d in GDScriptNativeClass::instantiate() modules/gdscript/gdscript.cpp:108
    #7 0x00000196db96 in GDScript::_new(Variant const**, int, Callable::CallError&) modules/gdscript/gdscript.cpp:236
    #8 0x0000019da556 in MethodBindVarArgTR<GDScript, Variant>::call(Object*, Variant const**, int, Callable::CallError&) const core/object/method_bind.h:264
    #9 0x000001c99863 in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) modules/gdscript/gdscript_vm.cpp:2078
    #10 0x000001984d2d in GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) modules/gdscript/gdscript.cpp:1976
    #11 0x00000c468670 in MainLoop::_gdvirtual__initialize_call() core/os/main_loop.h:42
    #12 0x00000c467eb5 in MainLoop::initialize() core/os/main_loop.cpp:58
    #13 0x0000081e7eb2 in SceneTree::initialize() scene/main/scene_tree.cpp:589
    #14 0x000000420096 in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:984
    #15 0x00000044e535 in main platform/linuxbsd/godot_linuxbsd.cpp:122
    #16 0x7efeb52f3680 in __libc_start_call_main (/lib64/libc.so.6+0x3680) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #17 0x7efeb52f3797 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3797) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #18 0x00000040ad04 in _start (/home/jan/gamedev/godot/bin/san-orig+0x40ad04) (BuildId: 4706a25040d4df6e7a64b0fde5e0b05035016d57)

SUMMARY: AddressSanitizer: heap-use-after-free core/object/object.cpp:930 in Object::_notification_backward(int)
Shadow bytes around the buggy address:
  0x7c1eb49fc680: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7c1eb49fc700: fd fd fd fd fd fd fd fd fd fa fa fa fa fa fa fa
  0x7c1eb49fc780: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x7c1eb49fc800: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7c1eb49fc880: fd fd fd fd fd fd fd fd fd fd fd fd fa fa fa fa
=>0x7c1eb49fc900: fa fa fa fa fa fa fa fa fd fd fd[fd]fd fd fd fd
  0x7c1eb49fc980: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7c1eb49fca00: fd fd fd fd fd fd fd fd fd fd fd fd fa fa fa fa
  0x7c1eb49fca80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7c1eb49fcb00: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7c1eb49fcb80: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==75078==ABORTING
```

</details>

<details>
<summary>Report (2)</summary>

```
=================================================================
==75451==ERROR: AddressSanitizer: heap-use-after-free on address 0x7ca823d43340 at pc 0x000001c756a5 bp 0x7ffd381f1a00 sp 0x7ffd381f19f8
READ of size 8 at 0x7ca823d43340 thread T0
    #0 0x000001c756a4 in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) modules/gdscript/gdscript_vm.cpp:652
    #1 0x000001985381 in GDScriptInstance::notification(int, bool) modules/gdscript/gdscript.cpp:2012
    #2 0x00000d23d27c in Object::_notification_forward(int) core/object/object.cpp:921
    #3 0x00000040deb3 in Object::notification(int, bool) core/object/object.h:730
    #4 0x0000014b42be in void call_with_validated_variant_args_helper<__UnexistingClass, int, bool, 0ul, 1ul>(__UnexistingClass*, void (__UnexistingClass::*)(int, bool), Variant const**, IndexSequence<0ul, 1ul>) core/variant/binder_common.h:119
    #5 0x0000014aaedd in void call_with_validated_object_instance_args<__UnexistingClass, int, bool>(__UnexistingClass*, void (__UnexistingClass::*)(int, bool), Variant const**) core/variant/binder_common.h:406
    #6 0x00000149b8f2 in MethodBindT<int, bool>::validated_call(Object*, Variant const**, Variant*) const core/object/method_bind_common.h:97
    #7 0x000001c9ffcc in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) modules/gdscript/gdscript_vm.cpp:2373
    #8 0x000001984d2d in GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) modules/gdscript/gdscript.cpp:1976
    #9 0x00000c468670 in MainLoop::_gdvirtual__initialize_call() core/os/main_loop.h:42
    #10 0x00000c467eb5 in MainLoop::initialize() core/os/main_loop.cpp:58
    #11 0x0000081e7eb2 in SceneTree::initialize() scene/main/scene_tree.cpp:589
    #12 0x000000420096 in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:984
    #13 0x00000044e535 in main platform/linuxbsd/godot_linuxbsd.cpp:122
    #14 0x7fc824af3680 in __libc_start_call_main (/lib64/libc.so.6+0x3680) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #15 0x7fc824af3797 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3797) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #16 0x00000040ad04 in _start (/home/jan/gamedev/godot/bin/san-orig+0x40ad04) (BuildId: 4706a25040d4df6e7a64b0fde5e0b05035016d57)

0x7ca823d43340 is located 32 bytes inside of 152-byte region [0x7ca823d43320,0x7ca823d433b8)
freed by thread T0 here:
    #0 0x7fc824eee4cf in free.part.0 (/lib64/libasan.so.8+0xee4cf) (BuildId: 5395ec74f54d9ec7bf97c06583dd39a96c230822)
    #1 0x00000c46b4ea in Memory::free_static(void*, bool) core/os/memory.cpp:201
    #2 0x00000d256fcc in void memdelete<ScriptInstance>(ScriptInstance*) core/os/memory.h:169
    #3 0x00000d236266 in Object::_predelete() core/object/object.cpp:183
    #4 0x00000d251d8e in predelete_handler(Object*) core/object/object.cpp:2366
    #5 0x0000006a9045 in void memdelete<Object>(Object*) core/os/memory.h:162
    #6 0x00000d23be59 in Object::callp(StringName const&, Variant const**, int, Callable::CallError&) core/object/object.cpp:789
    #7 0x00000cae180b in Variant::callp(StringName const&, Variant const**, int, Variant&, Callable::CallError&) core/variant/variant_call.cpp:1406
    #8 0x000001c97acb in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) modules/gdscript/gdscript_vm.cpp:1975
    #9 0x000001985381 in GDScriptInstance::notification(int, bool) modules/gdscript/gdscript.cpp:2012
    #10 0x00000d23d27c in Object::_notification_forward(int) core/object/object.cpp:921
    #11 0x00000040deb3 in Object::notification(int, bool) core/object/object.h:730
    #12 0x0000014b42be in void call_with_validated_variant_args_helper<__UnexistingClass, int, bool, 0ul, 1ul>(__UnexistingClass*, void (__UnexistingClass::*)(int, bool), Variant const**, IndexSequence<0ul, 1ul>) core/variant/binder_common.h:119
    #13 0x0000014aaedd in void call_with_validated_object_instance_args<__UnexistingClass, int, bool>(__UnexistingClass*, void (__UnexistingClass::*)(int, bool), Variant const**) core/variant/binder_common.h:406
    #14 0x00000149b8f2 in MethodBindT<int, bool>::validated_call(Object*, Variant const**, Variant*) const core/object/method_bind_common.h:97
    #15 0x000001c9ffcc in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) modules/gdscript/gdscript_vm.cpp:2373
    #16 0x000001984d2d in GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) modules/gdscript/gdscript.cpp:1976
    #17 0x00000c468670 in MainLoop::_gdvirtual__initialize_call() core/os/main_loop.h:42
    #18 0x00000c467eb5 in MainLoop::initialize() core/os/main_loop.cpp:58
    #19 0x0000081e7eb2 in SceneTree::initialize() scene/main/scene_tree.cpp:589
    #20 0x000000420096 in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:984
    #21 0x00000044e535 in main platform/linuxbsd/godot_linuxbsd.cpp:122
    #22 0x7fc824af3680 in __libc_start_call_main (/lib64/libc.so.6+0x3680) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #23 0x7fc824af3797 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3797) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #24 0x00000040ad04 in _start (/home/jan/gamedev/godot/bin/san-orig+0x40ad04) (BuildId: 4706a25040d4df6e7a64b0fde5e0b05035016d57)

previously allocated by thread T0 here:
    #0 0x7fc824eef41f in malloc (/lib64/libasan.so.8+0xef41f) (BuildId: 5395ec74f54d9ec7bf97c06583dd39a96c230822)
    #1 0x00000c46beaa in void* Memory::alloc_static<false>(unsigned long, bool) core/os/memory.cpp:101
    #2 0x00000c46abac in operator new(unsigned long, DefaultAllocator) core/os/memory.cpp:48
    #3 0x00000196cdab in GDScript::_create_instance(Variant const**, int, Object*, Callable::CallError&) modules/gdscript/gdscript.cpp:159
    #4 0x00000196dd50 in GDScript::_new(Variant const**, int, Callable::CallError&) modules/gdscript/gdscript.cpp:251
    #5 0x0000019da556 in MethodBindVarArgTR<GDScript, Variant>::call(Object*, Variant const**, int, Callable::CallError&) const core/object/method_bind.h:264
    #6 0x000001c99863 in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) modules/gdscript/gdscript_vm.cpp:2078
    #7 0x000001984d2d in GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) modules/gdscript/gdscript.cpp:1976
    #8 0x00000c468670 in MainLoop::_gdvirtual__initialize_call() core/os/main_loop.h:42
    #9 0x00000c467eb5 in MainLoop::initialize() core/os/main_loop.cpp:58
    #10 0x0000081e7eb2 in SceneTree::initialize() scene/main/scene_tree.cpp:589
    #11 0x000000420096 in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:984
    #12 0x00000044e535 in main platform/linuxbsd/godot_linuxbsd.cpp:122
    #13 0x7fc824af3680 in __libc_start_call_main (/lib64/libc.so.6+0x3680) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #14 0x7fc824af3797 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3797) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #15 0x00000040ad04 in _start (/home/jan/gamedev/godot/bin/san-orig+0x40ad04) (BuildId: 4706a25040d4df6e7a64b0fde5e0b05035016d57)

SUMMARY: AddressSanitizer: heap-use-after-free modules/gdscript/gdscript_vm.cpp:652 in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*)
Shadow bytes around the buggy address:
  0x7ca823d43080: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7ca823d43100: fd fd fd fd fa fa fa fa fa fa fa fa fd fd fd fd
  0x7ca823d43180: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7ca823d43200: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x7ca823d43280: fd fd fd fd fd fd fd fd fd fd fd fa fa fa fa fa
=>0x7ca823d43300: fa fa fa fa fd fd fd fd[fd]fd fd fd fd fd fd fd
  0x7ca823d43380: fd fd fd fd fd fd fd fa fa fa fa fa fa fa fa fa
  0x7ca823d43400: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7ca823d43480: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7ca823d43500: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7ca823d43580: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==75451==ABORTING
```

</details>

<details>
<summary>Report (3)</summary>

```
ERROR: Parent node is busy adding/removing children, `remove_child()` can't be called at this time. Consider using `remove_child.call_deferred(child)` instead.
   at: remove_child (scene/main/node.cpp:1750)
   GDScript backtrace (most recent call first):
       [0] _ready (res://script3.gd:6)
ERROR: Condition "data.parent" is true.
   at: ~Node (scene/main/node.cpp:4170)
   GDScript backtrace (most recent call first):
       [0] _ready (res://script3.gd:6)
=================================================================
==88958==ERROR: AddressSanitizer: heap-use-after-free on address 0x7caf18947698 at pc 0x00000d23d069 bp 0x7fffa523b1b0 sp 0x7fffa523b1a8
READ of size 8 at 0x7caf18947698 thread T0
    #0 0x00000d23d068 in Object::_notification_forward(int) core/object/object.cpp:910
    #1 0x00000040deb3 in Object::notification(int, bool) core/object/object.h:730
    #2 0x00000813d895 in Node::_propagate_ready() scene/main/node.cpp:336
    #3 0x00000813d758 in Node::_propagate_ready() scene/main/node.cpp:327
    #4 0x000008162f5a in Node::_set_tree(SceneTree*) scene/main/node.cpp:3401
    #5 0x0000081e7ef6 in SceneTree::initialize() scene/main/scene_tree.cpp:590
    #6 0x000000420096 in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:984
    #7 0x00000044e535 in main platform/linuxbsd/godot_linuxbsd.cpp:122
    #8 0x7f3f194f3680 in __libc_start_call_main (/lib64/libc.so.6+0x3680) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #9 0x7f3f194f3797 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3797) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #10 0x00000040ad04 in _start (/home/jan/gamedev/godot/bin/san-orig+0x40ad04) (BuildId: 4706a25040d4df6e7a64b0fde5e0b05035016d57)

0x7caf18947698 is located 24 bytes inside of 760-byte region [0x7caf18947680,0x7caf18947978)
freed by thread T0 here:
    #0 0x7f3f198ee4cf in free.part.0 (/lib64/libasan.so.8+0xee4cf) (BuildId: 5395ec74f54d9ec7bf97c06583dd39a96c230822)
    #1 0x00000c46b4ea in Memory::free_static(void*, bool) core/os/memory.cpp:201
    #2 0x0000006a90b7 in void memdelete<Object>(Object*) core/os/memory.h:169
    #3 0x00000d23be59 in Object::callp(StringName const&, Variant const**, int, Callable::CallError&) core/object/object.cpp:789
    #4 0x00000cae180b in Variant::callp(StringName const&, Variant const**, int, Variant&, Callable::CallError&) core/variant/variant_call.cpp:1406
    #5 0x000001c97acb in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) modules/gdscript/gdscript_vm.cpp:1975
    #6 0x000001984d2d in GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) modules/gdscript/gdscript.cpp:1976
    #7 0x00000817cc66 in Node::_gdvirtual__ready_call() scene/main/node.h:437
    #8 0x00000813d096 in Node::_notification(int) scene/main/node.cpp:279
    #9 0x0000009caa2d in Node::_notification_forwardv(int) scene/main/node.h:55
    #10 0x00000d23d043 in Object::_notification_forward(int) core/object/object.cpp:908
    #11 0x00000040deb3 in Object::notification(int, bool) core/object/object.h:730
    #12 0x00000813d895 in Node::_propagate_ready() scene/main/node.cpp:336
    #13 0x00000813d758 in Node::_propagate_ready() scene/main/node.cpp:327
    #14 0x000008162f5a in Node::_set_tree(SceneTree*) scene/main/node.cpp:3401
    #15 0x0000081e7ef6 in SceneTree::initialize() scene/main/scene_tree.cpp:590
    #16 0x000000420096 in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:984
    #17 0x00000044e535 in main platform/linuxbsd/godot_linuxbsd.cpp:122
    #18 0x7f3f194f3680 in __libc_start_call_main (/lib64/libc.so.6+0x3680) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #19 0x7f3f194f3797 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3797) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #20 0x00000040ad04 in _start (/home/jan/gamedev/godot/bin/san-orig+0x40ad04) (BuildId: 4706a25040d4df6e7a64b0fde5e0b05035016d57)

previously allocated by thread T0 here:
    #0 0x7f3f198ef41f in malloc (/lib64/libasan.so.8+0xef41f) (BuildId: 5395ec74f54d9ec7bf97c06583dd39a96c230822)
    #1 0x00000c46beaa in void* Memory::alloc_static<false>(unsigned long, bool) core/os/memory.cpp:101
    #2 0x00000c46abac in operator new(unsigned long, DefaultAllocator) core/os/memory.cpp:48
    #3 0x00000800cba3 in Object* ClassDB::creator<Node>(bool) core/object/class_db.h:162
    #4 0x00000d1e3bcf in ClassDB::_instantiate_internal(StringName const&, bool, bool, bool, bool) core/object/class_db.cpp:648
    #5 0x00000d1e4022 in ClassDB::instantiate_no_placeholders(StringName const&) core/object/class_db.cpp:703
    #6 0x00000196c59d in GDScriptNativeClass::instantiate() modules/gdscript/gdscript.cpp:108
    #7 0x00000196db96 in GDScript::_new(Variant const**, int, Callable::CallError&) modules/gdscript/gdscript.cpp:236
    #8 0x0000019da556 in MethodBindVarArgTR<GDScript, Variant>::call(Object*, Variant const**, int, Callable::CallError&) const core/object/method_bind.h:264
    #9 0x000001c99863 in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) modules/gdscript/gdscript_vm.cpp:2078
    #10 0x000001984d2d in GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) modules/gdscript/gdscript.cpp:1976
    #11 0x00000c468670 in MainLoop::_gdvirtual__initialize_call() core/os/main_loop.h:42
    #12 0x00000c467eb5 in MainLoop::initialize() core/os/main_loop.cpp:58
    #13 0x0000081e7eb2 in SceneTree::initialize() scene/main/scene_tree.cpp:589
    #14 0x000000420096 in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:984
    #15 0x00000044e535 in main platform/linuxbsd/godot_linuxbsd.cpp:122
    #16 0x7f3f194f3680 in __libc_start_call_main (/lib64/libc.so.6+0x3680) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #17 0x7f3f194f3797 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3797) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #18 0x00000040ad04 in _start (/home/jan/gamedev/godot/bin/san-orig+0x40ad04) (BuildId: 4706a25040d4df6e7a64b0fde5e0b05035016d57)

SUMMARY: AddressSanitizer: heap-use-after-free core/object/object.cpp:910 in Object::_notification_forward(int)
Shadow bytes around the buggy address:
  0x7caf18947400: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7caf18947480: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7caf18947500: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7caf18947580: 00 00 03 fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7caf18947600: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x7caf18947680: fd fd fd[fd]fd fd fd fd fd fd fd fd fd fd fd fd
  0x7caf18947700: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7caf18947780: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7caf18947800: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7caf18947880: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7caf18947900: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==88958==ABORTING
```

</details>

<details>
<summary>Report (4)</summary>

```
=================================================================
==89124==ERROR: AddressSanitizer: heap-use-after-free on address 0x7d1de6547698 at pc 0x00000d23d069 bp 0x7ffe087d88c0 sp 0x7ffe087d88b8
READ of size 8 at 0x7d1de6547698 thread T0
    #0 0x00000d23d068 in Object::_notification_forward(int) core/object/object.cpp:910
    #1 0x00000040deb3 in Object::notification(int, bool) core/object/object.h:730
    #2 0x0000081ed802 in SceneTree::_process_group(SceneTree::ProcessGroup*, bool) scene/main/scene_tree.cpp:1230
    #3 0x0000081ee602 in SceneTree::_process(bool) scene/main/scene_tree.cpp:1307
    #4 0x0000081e8c9f in SceneTree::process(double) scene/main/scene_tree.cpp:719
    #5 0x00000069a5a2 in Main::iteration() main/main.cpp:4978
    #6 0x00000042013d in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:1000
    #7 0x00000044e535 in main platform/linuxbsd/godot_linuxbsd.cpp:122
    #8 0x7fade70f3680 in __libc_start_call_main (/lib64/libc.so.6+0x3680) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #9 0x7fade70f3797 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3797) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #10 0x00000040ad04 in _start (/home/jan/gamedev/godot/bin/san-orig+0x40ad04) (BuildId: 4706a25040d4df6e7a64b0fde5e0b05035016d57)

0x7d1de6547698 is located 24 bytes inside of 760-byte region [0x7d1de6547680,0x7d1de6547978)
freed by thread T0 here:
    #0 0x7fade74ee4cf in free.part.0 (/lib64/libasan.so.8+0xee4cf) (BuildId: 5395ec74f54d9ec7bf97c06583dd39a96c230822)
    #1 0x00000c46b4ea in Memory::free_static(void*, bool) core/os/memory.cpp:201
    #2 0x0000006a90b7 in void memdelete<Object>(Object*) core/os/memory.h:169
    #3 0x00000d23be59 in Object::callp(StringName const&, Variant const**, int, Callable::CallError&) core/object/object.cpp:789
    #4 0x00000cae180b in Variant::callp(StringName const&, Variant const**, int, Variant&, Callable::CallError&) core/variant/variant_call.cpp:1406
    #5 0x000001c97acb in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) modules/gdscript/gdscript_vm.cpp:1975
    #6 0x000001984d2d in GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) modules/gdscript/gdscript.cpp:1976
    #7 0x00000817a4ce in Node::_gdvirtual__process_call(double) scene/main/node.h:433
    #8 0x00000813af62 in Node::_notification(int) scene/main/node.cpp:100
    #9 0x0000009caa2d in Node::_notification_forwardv(int) scene/main/node.h:55
    #10 0x00000d23d043 in Object::_notification_forward(int) core/object/object.cpp:908
    #11 0x00000040deb3 in Object::notification(int, bool) core/object/object.h:730
    #12 0x0000081ed802 in SceneTree::_process_group(SceneTree::ProcessGroup*, bool) scene/main/scene_tree.cpp:1230
    #13 0x0000081ee602 in SceneTree::_process(bool) scene/main/scene_tree.cpp:1307
    #14 0x0000081e8c9f in SceneTree::process(double) scene/main/scene_tree.cpp:719
    #15 0x00000069a5a2 in Main::iteration() main/main.cpp:4978
    #16 0x00000042013d in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:1000
    #17 0x00000044e535 in main platform/linuxbsd/godot_linuxbsd.cpp:122
    #18 0x7fade70f3680 in __libc_start_call_main (/lib64/libc.so.6+0x3680) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #19 0x7fade70f3797 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3797) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #20 0x00000040ad04 in _start (/home/jan/gamedev/godot/bin/san-orig+0x40ad04) (BuildId: 4706a25040d4df6e7a64b0fde5e0b05035016d57)

previously allocated by thread T0 here:
    #0 0x7fade74ef41f in malloc (/lib64/libasan.so.8+0xef41f) (BuildId: 5395ec74f54d9ec7bf97c06583dd39a96c230822)
    #1 0x00000c46beaa in void* Memory::alloc_static<false>(unsigned long, bool) core/os/memory.cpp:101
    #2 0x00000c46abac in operator new(unsigned long, DefaultAllocator) core/os/memory.cpp:48
    #3 0x00000800cba3 in Object* ClassDB::creator<Node>(bool) core/object/class_db.h:162
    #4 0x00000d1e3bcf in ClassDB::_instantiate_internal(StringName const&, bool, bool, bool, bool) core/object/class_db.cpp:648
    #5 0x00000d1e4022 in ClassDB::instantiate_no_placeholders(StringName const&) core/object/class_db.cpp:703
    #6 0x00000196c59d in GDScriptNativeClass::instantiate() modules/gdscript/gdscript.cpp:108
    #7 0x00000196db96 in GDScript::_new(Variant const**, int, Callable::CallError&) modules/gdscript/gdscript.cpp:236
    #8 0x0000019da556 in MethodBindVarArgTR<GDScript, Variant>::call(Object*, Variant const**, int, Callable::CallError&) const core/object/method_bind.h:264
    #9 0x000001c99863 in GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) modules/gdscript/gdscript_vm.cpp:2078
    #10 0x000001984d2d in GDScriptInstance::callp(StringName const&, Variant const**, int, Callable::CallError&) modules/gdscript/gdscript.cpp:1976
    #11 0x00000c468670 in MainLoop::_gdvirtual__initialize_call() core/os/main_loop.h:42
    #12 0x00000c467eb5 in MainLoop::initialize() core/os/main_loop.cpp:58
    #13 0x0000081e7eb2 in SceneTree::initialize() scene/main/scene_tree.cpp:589
    #14 0x000000420096 in OS_LinuxBSD::run() platform/linuxbsd/os_linuxbsd.cpp:984
    #15 0x00000044e535 in main platform/linuxbsd/godot_linuxbsd.cpp:122
    #16 0x7fade70f3680 in __libc_start_call_main (/lib64/libc.so.6+0x3680) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #17 0x7fade70f3797 in __libc_start_main@GLIBC_2.2.5 (/lib64/libc.so.6+0x3797) (BuildId: 18472003bbf1c5f098a09b5016b9b8bd4c7c59f0)
    #18 0x00000040ad04 in _start (/home/jan/gamedev/godot/bin/san-orig+0x40ad04) (BuildId: 4706a25040d4df6e7a64b0fde5e0b05035016d57)

SUMMARY: AddressSanitizer: heap-use-after-free core/object/object.cpp:910 in Object::_notification_forward(int)
Shadow bytes around the buggy address:
  0x7d1de6547400: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7d1de6547480: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7d1de6547500: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x7d1de6547580: 00 00 03 fa fa fa fa fa fa fa fa fa fa fa fa fa
  0x7d1de6547600: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa
=>0x7d1de6547680: fd fd fd[fd]fd fd fd fd fd fd fd fd fd fd fd fd
  0x7d1de6547700: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7d1de6547780: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7d1de6547800: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7d1de6547880: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x7d1de6547900: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fa
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==89124==ABORTING
```

</details>

Running AddressSanitizer on my fixed version does not report UAF for all 4 script -- it does however report memory leaks and Godot prints the following error message (added as part of the PR):
```yaml
ERROR: Cannot free own object from notification handler. Node instance (id 161380050102) will be leaked.
```


## My fix

I tried to follow the existing model of `_emitting` and other flags in `Object`, and added `_notifying` to track whether a notification is currently in flight. This seemed like the least intrusive way -- it's an addition to `Object` but uses only 1 bit in the existing allocation (not increasing the class' size).

During `Object::_predelete`, I check for the flag being set, which would indicate an attempt to destroy the own object. Notably, `Object::_predelete` method calls `NOTIFICATION_PREDELETE` **inside**, so it's not itself invoked as a result of a notification (except for our `free` case).

There's a small issue that's pre-existing: these bits are not atomic, and being bitfields they share the same word in memory, so writing one bit from one thread _might_ overwrite another being written from another. This is already an issue for `_emitting` etc. and out of scope for this PR.