### PR TITLE
New "ACCUMULATED_COLOR" built-in for the light function in Canvas-Item shaders 

### DIFF
--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -399,7 +399,8 @@ vec4 light_compute(
 		inout vec4 shadow_modulate,
 		vec2 screen_uv,
 		vec2 uv,
-		vec4 color, bool is_directional) {
+		vec4 color, bool is_directional,
+		vec4 accumulated_color) {
 	vec4 light = vec4(0.0);
 	vec3 light_direction = vec3(0.0);
 
@@ -729,7 +730,8 @@ void main() {
 #ifdef LIGHT_CODE_USED
 
 		vec4 shadow_modulate = vec4(1.0);
-		light_color = light_compute(light_vertex, vec3(direction, light_array[light_base].height), normal, light_color, light_color.a, specular_shininess, shadow_modulate, screen_uv, uv, base_color, true);
+		vec4 accumulated_color = color;
+		light_color = light_compute(light_vertex, vec3(direction, light_array[light_base].height), normal, light_color, light_color.a, specular_shininess, shadow_modulate, screen_uv, uv, base_color, true, accumulated_color);
 #else
 
 		if (normal_used) {
@@ -797,9 +799,10 @@ void main() {
 
 		vec4 shadow_modulate = vec4(1.0);
 		vec3 light_position = vec3(light_array[light_base].position, light_array[light_base].height);
+		vec4 accumulated_color = color;
 
 		light_color.rgb *= light_base_color.rgb;
-		light_color = light_compute(light_vertex, light_position, normal, light_color, light_base_color.a, specular_shininess, shadow_modulate, screen_uv, uv, base_color, false);
+		light_color = light_compute(light_vertex, light_position, normal, light_color, light_base_color.a, specular_shininess, shadow_modulate, screen_uv, uv, base_color, false, accumulated_color);
 #else
 
 		light_color.rgb *= light_base_color.rgb * light_base_color.a;

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1218,6 +1218,7 @@ MaterialStorage::MaterialStorage() {
 		actions.renames["CUSTOM0"] = "custom0";
 		actions.renames["CUSTOM1"] = "custom1";
 
+		actions.renames["ACCUMULATED_COLOR"] = "accumulated_color";
 		actions.renames["LIGHT_POSITION"] = "light_position";
 		actions.renames["LIGHT_DIRECTION"] = "light_direction";
 		actions.renames["LIGHT_IS_DIRECTIONAL"] = "is_directional";

--- a/modules/visual_shader/visual_shader.cpp
+++ b/modules/visual_shader/visual_shader.cpp
@@ -3421,6 +3421,7 @@ const VisualShaderNodeInput::Port VisualShaderNodeInput::ports[] = {
 
 	// Canvas Item, Light
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_4D, "color", "COLOR" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_4D, "accumulated_color", "ACCUMULATED_COLOR" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_4D, "fragcoord", "FRAGCOORD" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_4D, "light", "LIGHT" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_4D, "light_color", "LIGHT_COLOR" },

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1806,6 +1806,7 @@ RendererCanvasRenderRD::RendererCanvasRenderRD() {
 		actions.renames["CUSTOM0"] = "custom0";
 		actions.renames["CUSTOM1"] = "custom1";
 
+		actions.renames["ACCUMULATED_COLOR"] = "accumulated_color";
 		actions.renames["LIGHT_POSITION"] = "light_position";
 		actions.renames["LIGHT_DIRECTION"] = "light_direction";
 		actions.renames["LIGHT_IS_DIRECTIONAL"] = "is_directional";

--- a/servers/rendering/renderer_rd/shaders/canvas.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas.glsl
@@ -412,7 +412,8 @@ vec4 light_compute(
 		inout vec4 shadow_modulate,
 		vec2 screen_uv,
 		vec2 uv,
-		vec4 color, bool is_directional) {
+		vec4 color, bool is_directional,
+		vec4 accumulated_color) {
 	vec4 light = vec4(0.0);
 	vec3 light_direction = vec3(0.0);
 
@@ -733,7 +734,8 @@ void main() {
 #ifdef LIGHT_CODE_USED
 
 			vec4 shadow_modulate = vec4(1.0);
-			light_color = light_compute(light_vertex, vec3(direction, light_array.data[light_base].height), normal, light_color, light_color.a, specular_shininess, shadow_modulate, screen_uv, uv, base_color, true);
+			vec4 accumulated_color = color;
+			light_color = light_compute(light_vertex, vec3(direction, light_array.data[light_base].height), normal, light_color, light_color.a, specular_shininess, shadow_modulate, screen_uv, uv, base_color, true, accumulated_color);
 #else
 
 			if (normal_used) {
@@ -786,9 +788,10 @@ void main() {
 
 			vec4 shadow_modulate = vec4(1.0);
 			vec3 light_position = vec3(light_array.data[light_base].position, light_array.data[light_base].height);
+			vec4 accumulated_color = color;
 
 			light_color.rgb *= light_base_color.rgb;
-			light_color = light_compute(light_vertex, light_position, normal, light_color, light_base_color.a, specular_shininess, shadow_modulate, screen_uv, uv, base_color, false);
+			light_color = light_compute(light_vertex, light_position, normal, light_color, light_base_color.a, specular_shininess, shadow_modulate, screen_uv, uv, base_color, false, accumulated_color);
 #else
 
 			light_color.rgb *= light_base_color.rgb * light_base_color.a;

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -337,6 +337,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RSE::SHADER_CANVAS_ITEM].functions["light"].built_ins["FRAGCOORD"] = constt(ShaderLanguage::TYPE_VEC4);
 	shader_modes[RSE::SHADER_CANVAS_ITEM].functions["light"].built_ins["NORMAL"] = constt(ShaderLanguage::TYPE_VEC3);
 	shader_modes[RSE::SHADER_CANVAS_ITEM].functions["light"].built_ins["COLOR"] = constt(ShaderLanguage::TYPE_VEC4);
+	shader_modes[RSE::SHADER_CANVAS_ITEM].functions["light"].built_ins["ACCUMULATED_COLOR"] = constt(ShaderLanguage::TYPE_VEC4);
 	shader_modes[RSE::SHADER_CANVAS_ITEM].functions["light"].built_ins["UV"] = constt(ShaderLanguage::TYPE_VEC2);
 	shader_modes[RSE::SHADER_CANVAS_ITEM].functions["light"].built_ins["SPECULAR_SHININESS"] = constt(ShaderLanguage::TYPE_VEC4);
 	shader_modes[RSE::SHADER_CANVAS_ITEM].functions["light"].built_ins["LIGHT_COLOR"] = constt(ShaderLanguage::TYPE_VEC4);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

During light passes for canvas shaders, only the colour of the pixel prior to any light passes is passed to the developer (as the `COLOR` built-in. This PR also allows the developer to access the colour of the pixel with all previous light passes already applied (as the `ACCUMULATED_COLOR` built-in), allowing for more interesting lighting effects and for custom behaviour with lights interacting with each other. 

This was not possible to do without modifying the internals as the GLES3 and RenderingDevice canvas shaders simply don't pass that data into the `light_compute` method so there would've been no way to access that information from inside a GDShader, and so modifying it was necessary.

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

I'm fairly sure I've made all the edits to all files necessary to include the new built-in, but I'm not familiar with how to add it to the docs, and I would also appreciate someone more familiar with the graphics internals of Godot to check the code!