### PR TITLE
Docs: Add notes about disabling GDScript warning/error squiggles by setting color alpha to 0

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1759,6 +1759,7 @@
 		</member>
 		<member name="text_editor/theme/highlighting/error_underline_color" type="Color" setter="" getter="">
 			The script editor's color for the squiggly lines shown under code producing errors.
+			[note]To disable error underlines completely, set the color's alpha value to [code]0.0[/code]. This may improve editor performance on certain hardware.[/note]
 		</member>
 		<member name="text_editor/theme/highlighting/executing_line_color" type="Color" setter="" getter="">
 			The script editor's color for the debugger's executing line icon (displayed in the gutter).
@@ -1844,6 +1845,7 @@
 		</member>
 		<member name="text_editor/theme/highlighting/warning_underline_color" type="Color" setter="" getter="">
 			The script editor's color for the squiggly lines shown under code producing warnings.
+			[note]To disable warning underlines completely, set the color's alpha value to 0. This may improve editor performance on certain hardware.[/note]
 		</member>
 		<member name="text_editor/theme/highlighting/word_highlighted_color" type="Color" setter="" getter="">
 			The script editor's color for words highlighted by selecting them. Only visible if [member text_editor/appearance/caret/highlight_all_occurrences] is [code]true[/code].


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Addresses https://github.com/godotengine/godot-proposals/issues/15352 (not sure if it fully closes it)

## Additional information

The _calculation of the_ warning and error squiggles (not just their visual appearance) introduced in https://github.com/godotengine/godot/pull/119588 for the script editor can be disabled by setting their colors' alphas to 0 in **Editor Settings > Text Editor > Theme > Highlighting > Warning/Error Underline Color**. Currently, the docs don't explicitly note this, and I think it would be reasonable enough for someone to assume that setting the alpha to 0 would simply make the editor draw fully transparent squiggles.

This PR adds notes (yay new admonitions!) to the documentation for the color settings, telling the user that they can fully disable the underline functionality by setting the alpha value to 0.

<img width="1006" height="294" alt="CleanShot 2026-08-09 at 08 26 34@2x" src="https://github.com/user-attachments/assets/a2c15939-1dfd-4718-8fee-f7918cefa58c" />


> [!note]
> I've also included an extra bit stating it may help with performance since all the associated calculations (coming up with the list of vertices for the squiggly underline, drawing it on the screen) are skipped.
> 
> Admittedly I haven't actually been able to test this and see a difference in performance firsthand. My computer is likely too powerful to be slowed down noticeably by the squiggles. 
> 
> I'm also not a _huge_ fan of introducing a feature and then implying/stating "it's gonna slow down your computer, turn it off if you want your computer to run better", so I could probably go about 50/50 on removing that sentence.