### PR TITLE
Fix reflection probe ambient light blend factor in Compatibility renderer

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -2486,7 +2486,7 @@ void main() {
 
 #ifndef DISABLE_REFLECTION_PROBE
 		if (ambient_accum.a > 0.0) {
-			ambient_light = mix(ambient_light, (ambient_accum.rgb / ambient_accum.a) * scene_data_block.data.ambient_light_color_energy.a, scene_data_block.data.ambient_color_sky_mix);
+			ambient_light = mix(ambient_light, (ambient_accum.rgb / ambient_accum.a) * scene_data_block.data.ambient_light_color_energy.a, ambient_accum.a);
 		}
 #endif // DISABLE_REFLECTION_PROBE
 	}


### PR DESCRIPTION
## What problem(s) does this PR solve?
- Closes #118698

ReflectionProbe ambient light was blending incorrectly with sky lighting
in the Compatibility (GLES3) renderer, producing a black tint near the
edges of a probe's blend region instead of correctly fading to the sky.
This did not happen in Forward+ or Mobile.

## Additional information

In `drivers/gles3/shaders/scene.glsl`, the final ambient light mix was
using `scene_data_block.data.ambient_color_sky_mix` (the environment's
unrelated "Ambient Sky Contribution" setting) as the blend factor between
the probe's ambient contribution and the base ambient light, instead of
using the probe's own coverage value (`ambient_accum.a`), which reflects
how much of the probe's blend distance is actually applied at a given
point. Since `ambient_color_sky_mix` doesn't change as a point moves
through the probe's blend region, the base ambient light never had a
chance to show through near the edges, causing the black tint.

Fixed by using `ambient_accum.a` as the mix factor, matching how the
same computation works in the Forward+/Mobile (RD) shaders
(`scene_forward_lights_inc.glsl`), where the ambient contribution is
accumulated based on coverage and the remainder naturally falls back to
the base ambient light.

Tested with the MRP from the issue:
- Compatibility renderer: ReflectionProbe ambient now correctly fades to
  sky lighting near blend edges, for both Environment and custom-color
  ambient modes
- Forward+ / Mobile: unaffected, no regression

### AI disclosure
I used Claude (Anthropic) as a debugging assistant throughout this process.
I searched the codebase and ran the comparisons myself, and Claude helped
me navigate through the codebase then I've identified the root cause by comparing
 the Compatibility renderer's ambient blend logic against the equivalent Forward+/Mobile
 shader code, and  fixed it.