### PR TITLE
Fix: create_test.py captured the caller's original cwd and resolved args.path

### DIFF
--- a/tests/create_test.py
+++ b/tests/create_test.py
@@ -7,13 +7,12 @@ import sys
 
 
 def main():
-    # Capture the caller's original working directory before changing it below,
-    # so that relative paths passed by the caller resolve correctly.
-    original_cwd = os.getcwd()
-
-    # Change to the directory where the script is located,
-    # so that the script can be run from any location.
-    os.chdir(os.path.dirname(os.path.realpath(__file__)))
+    # Change to the directory where the script is located (the tests/ folder),
+    # so that the script can be run from any location and the path argument
+    # (which is documented as relative to the tests/ folder) resolves correctly
+    # regardless of the caller's original working directory.
+    tests_dir = os.path.dirname(os.path.realpath(__file__))
+    os.chdir(tests_dir)
 
     parser = argparse.ArgumentParser(description="Creates a new unit test file.")
     parser.add_argument(
@@ -30,9 +29,10 @@ def main():
     )
     args = parser.parse_args()
 
-    # Resolve the path argument against the caller's original working directory,
-    # not the script's own directory (which we chdir'd into above).
-    args.path = os.path.join(original_cwd, args.path)
+    # Resolve the path argument against the tests/ folder (the script's own
+    # directory), since it is documented as relative to tests/, not relative
+    # to the caller's original working directory.
+    args.path = os.path.join(tests_dir, args.path)
 
     snake_case_regex = re.compile(r"(?<!^)(?=[A-Z, 0-9])")
     # Replace 2D, 3D, and 4D with 2d, 3d, and 4d, respectively. This avoids undesired splits like node_3_d.

--- a/tests/create_test.py
+++ b/tests/create_test.py
@@ -7,6 +7,10 @@ import sys
 
 
 def main():
+    # Capture the caller's original working directory before changing it below,
+    # so that relative paths passed by the caller resolve correctly.
+    original_cwd = os.getcwd()
+
     # Change to the directory where the script is located,
     # so that the script can be run from any location.
     os.chdir(os.path.dirname(os.path.realpath(__file__)))
@@ -25,6 +29,10 @@ def main():
         default=".",
     )
     args = parser.parse_args()
+
+    # Resolve the path argument against the caller's original working directory,
+    # not the script's own directory (which we chdir'd into above).
+    args.path = os.path.join(original_cwd, args.path)
 
     snake_case_regex = re.compile(r"(?<!^)(?=[A-Z, 0-9])")
     # Replace 2D, 3D, and 4D with 2d, 3d, and 4d, respectively. This avoids undesired splits like node_3_d.

--- a/tests/python/test_create_test.py
+++ b/tests/python/test_create_test.py
@@ -7,34 +7,81 @@ import sys
 import tempfile
 
 
-def test_create_test_uses_callers_cwd():
+def _repo_root():
+    return os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+def test_create_test_default_path_relative_to_tests_dir():
     """
-    create_test.py chdir()s into its own directory before resolving the
-    "path" argument. Make sure that a relative default path ('.') is
-    resolved against the caller's original working directory, not against
-    the tests/ folder where the script itself lives.
+    The default path ('.') must always resolve relative to the tests/
+    folder, regardless of the caller's current working directory, since
+    create_test.py chdir()s into tests/ and the path argument is documented
+    as relative to the tests/ folder.
     """
-    repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    repo_root = _repo_root()
     script_path = os.path.join(repo_root, "tests", "create_test.py")
+    tests_dir = os.path.join(repo_root, "tests")
 
     with tempfile.TemporaryDirectory() as tmp_dir:
+        expected_file = os.path.join(tests_dir, "test_my_dummy_thing.cpp")
+        try:
+            result = subprocess.run(
+                [sys.executable, script_path, "MyDummyThing"],
+                cwd=tmp_dir,
+                capture_output=True,
+                text=True,
+            )
+
+            assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+            assert os.path.isfile(expected_file), (
+                f"Expected scaffolded file at {expected_file}, but it was not created there.\n"
+                f"stdout: {result.stdout}\nstderr: {result.stderr}"
+            )
+
+            # Make sure it was NOT created inside the caller's cwd instead.
+            wrong_file = os.path.join(tmp_dir, "test_my_dummy_thing.cpp")
+            assert not os.path.isfile(wrong_file), (
+                "The scaffolded file was incorrectly created in the caller's cwd instead of tests/."
+            )
+        finally:
+            if os.path.isfile(expected_file):
+                os.remove(expected_file)
+
+
+def test_create_test_explicit_relative_path_relative_to_tests_dir():
+    """
+    An explicit relative path argument (e.g. "core/math") must resolve
+    relative to the tests/ folder, not relative to the caller's original
+    working directory (e.g. the repo root).
+    """
+    repo_root = _repo_root()
+    script_path = os.path.join(repo_root, "tests", "create_test.py")
+    tests_dir = os.path.join(repo_root, "tests")
+
+    expected_file = os.path.join(tests_dir, "core", "math", "test_my_other_thing.cpp")
+    wrong_file = os.path.join(repo_root, "core", "math", "test_my_other_thing.cpp")
+    try:
         result = subprocess.run(
-            [sys.executable, script_path, "MyDummyThing"],
-            cwd=tmp_dir,
+            [sys.executable, script_path, "MyOtherThing", "core/math"],
+            cwd=repo_root,
             capture_output=True,
             text=True,
         )
 
         assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
 
-        expected_file = os.path.join(tmp_dir, "test_my_dummy_thing.cpp")
         assert os.path.isfile(expected_file), (
             f"Expected scaffolded file at {expected_file}, but it was not created there.\n"
             f"stdout: {result.stdout}\nstderr: {result.stderr}"
         )
 
-        # Make sure it was NOT created inside the tests/ folder instead.
-        wrong_file = os.path.join(repo_root, "tests", "test_my_dummy_thing.cpp")
         assert not os.path.isfile(wrong_file), (
-            "The scaffolded file was incorrectly created inside tests/ instead of the caller's cwd."
+            "The scaffolded file was incorrectly created relative to the repo root "
+            "instead of relative to tests/."
         )
+    finally:
+        if os.path.isfile(expected_file):
+            os.remove(expected_file)
+        if os.path.isfile(wrong_file):
+            os.remove(wrong_file)

--- a/tests/python/test_create_test.py
+++ b/tests/python/test_create_test.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Tests for tests/create_test.py."""
+
+import os
+import subprocess
+import sys
+import tempfile
+
+
+def test_create_test_uses_callers_cwd():
+    """
+    create_test.py chdir()s into its own directory before resolving the
+    "path" argument. Make sure that a relative default path ('.') is
+    resolved against the caller's original working directory, not against
+    the tests/ folder where the script itself lives.
+    """
+    repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    script_path = os.path.join(repo_root, "tests", "create_test.py")
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        result = subprocess.run(
+            [sys.executable, script_path, "MyDummyThing"],
+            cwd=tmp_dir,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0, f"stdout: {result.stdout}\nstderr: {result.stderr}"
+
+        expected_file = os.path.join(tmp_dir, "test_my_dummy_thing.cpp")
+        assert os.path.isfile(expected_file), (
+            f"Expected scaffolded file at {expected_file}, but it was not created there.\n"
+            f"stdout: {result.stdout}\nstderr: {result.stderr}"
+        )
+
+        # Make sure it was NOT created inside the tests/ folder instead.
+        wrong_file = os.path.join(repo_root, "tests", "test_my_dummy_thing.cpp")
+        assert not os.path.isfile(wrong_file), (
+            "The scaffolded file was incorrectly created inside tests/ instead of the caller's cwd."
+        )


### PR DESCRIPTION
## Summary
Removed resolution of args.path against the caller's original working directory. Instead, args.path is now joined against tests_dir (the script's own directory, captured right where os.chdir() is called), so both the default '.' and any explicit relative path like 'core/math' always resolve relative to tests/, regardless of the caller's cwd.

## Problem
godotengine/godot issue reference: godotengine/godot#121802

## Root Cause
create_test.py captured the caller's original cwd and resolved args.path against that cwd, even though the path argument is documented as relative to the tests/ folder (the script's own directory) and the script already chdir()s there. This caused both the default path and explicit relative paths to be resolved incorrectly relative to wherever the script was invoked from.

## Testing
PASS - both pytest tests pass, and the exact repro command from the feedback now creates the file at tests/core/math/test_test_thing_1_2_3.cpp (not at repo-root core/math/...). Cleaned up the stray untracked file core/math/test_test_thing_1_2_3.cpp left over from the previous buggy run.

## Related Issue
godotengine/godot#121802

> [!INFO]
> 🤖 This PR was prepared with AI assistance (Claude, via an autonomous engineering workflow with human review and approval gates). The fix was independently reviewed and manually verified by a human before submission.
