### PR TITLE
Add notes to `NOTIFICATION_PROCESS` and `NOTIFICATION_PHYSICS_PROCESS`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -1183,9 +1183,11 @@
 		</constant>
 		<constant name="NOTIFICATION_PHYSICS_PROCESS" value="16">
 			Notification received from the tree every physics frame when [method is_physics_processing] returns [code]true[/code]. See [method _physics_process].
+			[b]Note:[/b] using this notification in [method Object._notification] doesn't automatically call [code]set_physics_process(true)[/code]. You must call it yourself on [method _ready].
 		</constant>
 		<constant name="NOTIFICATION_PROCESS" value="17">
 			Notification received from the tree every rendered frame when [method is_processing] returns [code]true[/code]. See [method _process].
+			[b]Note:[/b] using this notification in [method Object._notification] doesn't automatically call [code]set_process(true)[/code]. You must call it yourself on [method _ready].
 		</constant>
 		<constant name="NOTIFICATION_PARENTED" value="18">
 			Notification received when the node is set as a child of another node (see [method add_child] and [method add_sibling]).

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -1183,11 +1183,11 @@
 		</constant>
 		<constant name="NOTIFICATION_PHYSICS_PROCESS" value="16">
 			Notification received from the tree every physics frame when [method is_physics_processing] returns [code]true[/code]. See [method _physics_process].
-			[b]Note:[/b] using this notification in [method Object._notification] doesn't automatically call [code]set_physics_process(true)[/code]. You must call it yourself on [method _ready].
+			[b]Note:[/b] If [method _physics_process] isn't overriden, physics processing isn't automatically enabled. Use [method set_physics_process] instead.
 		</constant>
 		<constant name="NOTIFICATION_PROCESS" value="17">
 			Notification received from the tree every rendered frame when [method is_processing] returns [code]true[/code]. See [method _process].
-			[b]Note:[/b] using this notification in [method Object._notification] doesn't automatically call [code]set_process(true)[/code]. You must call it yourself on [method _ready].
+			[b]Note:[/b] If [method _process] isn't overriden, processing isn't automatically enabled. Use [method set_process] instead.
 		</constant>
 		<constant name="NOTIFICATION_PARENTED" value="18">
 			Notification received when the node is set as a child of another node (see [method add_child] and [method add_sibling]).


### PR DESCRIPTION
Added notes regarding the need to call set_process(true) or set_physics_process(true) when using these notifications

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Even though navigating through a few links _could_ have you understand that you need to call `set_process(true)` when using `NOTIFICATION_PROCESS`, having it be explicit should be easier to find and understand
- This is solution number two of: https://github.com/godotengine/godot-proposals/issues/15327


## Additional information

- No AI used in the contribution
- First-time contribution, may need to reword the notes.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
