### PR TITLE
Fix `FileSystem` history navigation

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1479,12 +1479,18 @@ void FileSystemDock::_update_history() {
 	current_path = history[history_pos];
 	_set_current_path_line_edit_text(current_path);
 
+	file_list_search_box->clear();
+	tree_search_box->clear();
+	searched_tokens.clear();
+
 	if (tree->is_visible()) {
+		tree->deselect_all();
 		_update_tree(get_uncollapsed_paths());
 		tree->grab_focus(true);
 	}
 
 	if (file_list_vb->is_visible()) {
+		files->deselect_all();
 		_update_file_list(false);
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

When FileSystem dock has some filter text, the back/forward buttons weren't functional (at least if the previous file did not match the filter)

[Nagranie ekranu_20260809_230038.webm](https://github.com/user-attachments/assets/5285283e-06d2-48d3-bc95-5dba72abd19f)

Also going back to the previous file did not deselect the previous file.


<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
