### PR TITLE
Add copy-to-clipboard hotkey to tree items in import settings window

### DIFF
--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -1214,6 +1214,26 @@ void SceneImportSettingsDialog::_scene_tree_selected() {
 	_select(scene_tree, type, import_id);
 }
 
+void SceneImportSettingsDialog::_tree_gui_input(const Ref<InputEvent> &p_event, Tree *p_tree) {
+	const Ref<InputEventKey> &key = p_event;
+	if (key.is_valid() && key->is_pressed() && !key->is_echo()) {
+		if (ED_IS_SHORTCUT("scene_import_settings/copy_name", p_event)) {
+			_copy_selected_tree_item_name(p_tree);
+		}
+	}
+}
+
+void SceneImportSettingsDialog::_copy_selected_tree_item_name(Tree *p_tree) {
+	if (p_tree == nullptr) {
+		return;
+	}
+	TreeItem *item = p_tree->get_selected();
+	if (item == nullptr) {
+		return;
+	}
+	DisplayServer::get_singleton()->clipboard_set(item->get_text(0));
+}
+
 void SceneImportSettingsDialog::_cleanup() {
 	skeletons.clear();
 	if (animation_player != nullptr) {
@@ -1722,11 +1742,14 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 	tree_split->add_child(property_split);
 	property_split->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 
+	ED_SHORTCUT("scene_import_settings/copy_name", TTRC("Copy Name"), KeyModifierMask::CMD_OR_CTRL | Key::C);
+
 	scene_tree = memnew(Tree);
 	scene_tree->set_name(TTR("Scene"));
 	scene_tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	data_mode->add_child(scene_tree);
 	scene_tree->connect("cell_selected", callable_mp(this, &SceneImportSettingsDialog::_scene_tree_selected));
+	scene_tree->connect(SceneStringName(gui_input), callable_mp(this, &SceneImportSettingsDialog::_tree_gui_input).bind(scene_tree));
 
 	mesh_tree = memnew(Tree);
 	mesh_tree->set_name(TTR("Meshes"));
@@ -1734,12 +1757,14 @@ SceneImportSettingsDialog::SceneImportSettingsDialog() {
 	data_mode->add_child(mesh_tree);
 	mesh_tree->set_hide_root(true);
 	mesh_tree->connect("cell_selected", callable_mp(this, &SceneImportSettingsDialog::_mesh_tree_selected));
+	mesh_tree->connect(SceneStringName(gui_input), callable_mp(this, &SceneImportSettingsDialog::_tree_gui_input).bind(mesh_tree));
 
 	material_tree = memnew(Tree);
 	material_tree->set_name(TTR("Materials"));
 	material_tree->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	data_mode->add_child(material_tree);
 	material_tree->connect("cell_selected", callable_mp(this, &SceneImportSettingsDialog::_material_tree_selected));
+	material_tree->connect(SceneStringName(gui_input), callable_mp(this, &SceneImportSettingsDialog::_tree_gui_input).bind(material_tree));
 
 	material_tree->set_hide_root(true);
 

--- a/editor/import/3d/scene_import_settings.h
+++ b/editor/import/3d/scene_import_settings.h
@@ -193,6 +193,8 @@ class SceneImportSettingsDialog : public ConfirmationDialog {
 	void _material_tree_selected();
 	void _mesh_tree_selected();
 	void _scene_tree_selected();
+	void _tree_gui_input(const Ref<InputEvent> &p_event, Tree *p_tree);
+	void _copy_selected_tree_item_name(Tree *p_tree);
 	void _skeleton_tree_entered(Skeleton3D *p_skeleton);
 	void _cleanup();
 	void _on_light_1_switch_pressed();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- When working with a 3d model file (.glb), I can open the file from FileSystem dock to see all the data it contains, including animations. Any item in the tree can be selected, and my expectation would be that I can copy its name via hotkey, so I can use that to refer to it in code. Copying the name is not implemented right now however.

To visualize, on this screenshot the model `Rig_Medium_General.glb` is opened, its animation `Use_Item` is selected and so ctrl/cmd+c would copy its name into clipboard


<img width="1214" height="990" alt="Screenshot 2026-08-10 at 11 40 33" src="https://github.com/user-attachments/assets/a1dc69c4-d97c-4847-84a3-0f30ed2482a4" />


## Additional information

- AI used for code review and checking the coding standards