### PR TITLE
Allow setting style of (or disabling) GDScript warning/error underlines in editor

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1487,6 +1487,20 @@
 		<member name="text_editor/appearance/minimap/show_minimap" type="bool" setter="" getter="">
 			If [code]true[/code], draws an overview of the script near the scroll bar. The minimap can be left-clicked to scroll directly to a location in an "absolute" manner.
 		</member>
+		<member name="text_editor/appearance/underlining/error_underline_style" type="int" setter="" getter="">
+			The style to draw error underlines in the script editor with.
+			- [b]None:[/b] Does not draw anything under errors.
+			- [b]Straight:[/b] Draws a simple flat line under errors.
+			- [b]Squiggle:[/b] Draws a squiggly zig-zag line under errors.
+			For setting the color of the error underlines, see [member text_editor/theme/highlighting/error_underline_color].
+		</member>
+		<member name="text_editor/appearance/underlining/warning_underline_style" type="int" setter="" getter="">
+			The style to draw warning underlines in the script editor with.
+			- [b]None:[/b] Does not draw anything under warnings.
+			- [b]Straight:[/b] Draws a simple flat line under warnings.
+			- [b]Squiggle:[/b] Draws a squiggly zig-zag line under warnings.
+			For setting the color of the error underlines, see [member text_editor/theme/highlighting/warning_underline_color].
+		</member>
 		<member name="text_editor/appearance/whitespace/draw_spaces" type="bool" setter="" getter="">
 			If [code]true[/code], draws space characters as centered points.
 		</member>

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -752,8 +752,8 @@ void ScriptTextEditor::_update_background_color() {
 			int warning_end_column = warning.end_column - 1;
 			int folded_line_header = te->get_folded_line_header(warning_start_line);
 
-			if (warning_underline_color.a != 0.0) {
-				te->add_underline(warning_underline_color, warning_start_line, warning_start_column, warning_end_line, warning_end_column);
+			if (warning_underline_style != TextEdit::UNDERLINE_STYLE_NONE && warning_underline_color.a != 0.0) {
+				te->add_underline(warning_underline_color, warning_underline_style, warning_start_line, warning_start_column, warning_end_line, warning_end_column);
 			}
 
 			if (warning_line_color.a != 0.0) {
@@ -779,8 +779,8 @@ void ScriptTextEditor::_update_background_color() {
 			int error_end_column = error.end_column - 1;
 			int folded_line_header = te->get_folded_line_header(error_start_line);
 
-			if (error_underline_color.a != 0.0) {
-				te->add_underline(error_underline_color, error_start_line, error_start_column, error_end_line, error_end_column);
+			if (error_underline_style != TextEdit::UNDERLINE_STYLE_NONE && error_underline_color.a != 0.0) {
+				te->add_underline(error_underline_color, error_underline_style, error_start_line, error_start_column, error_end_line, error_end_column);
 			}
 
 			if (marked_line_color.a != 0.0) {
@@ -812,6 +812,8 @@ void ScriptTextEditor::update_settings() {
 	} else {
 		code_editor->get_text_editor()->set_inline_object_handlers(Callable(), Callable(), Callable());
 	}
+	warning_underline_style = (TextEdit::UnderlineStyle)EDITOR_GET("text_editor/appearance/underlining/warning_underline_style");
+	error_underline_style = (TextEdit::UnderlineStyle)EDITOR_GET("text_editor/appearance/underlining/error_underline_style");
 	TextEditorBase::update_settings();
 }
 

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -96,6 +96,9 @@ class ScriptTextEditor : public CodeEditorBase {
 	Color warning_underline_color = Color(1, 1, 1);
 	Color error_underline_color = Color(1, 1, 1);
 
+	TextEdit::UnderlineStyle warning_underline_style = TextEdit::UNDERLINE_STYLE_SQUIGGLY;
+	TextEdit::UnderlineStyle error_underline_style = TextEdit::UNDERLINE_STYLE_SQUIGGLY;
+
 	bool theme_loaded = false;
 
 	enum {

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -824,6 +824,10 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/appearance/whitespace/draw_spaces", false, true);
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/appearance/whitespace/line_spacing", 4, "-10,50,1")
 
+	// Appearance: Underlining
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/appearance/underlining/warning_underline_style", 2, "None,Straight,Squiggle")
+	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/appearance/underlining/error_underline_style", 2, "None,Straight,Squiggle")
+
 	// Behavior
 	// Behavior: General
 	_initial_set("text_editor/behavior/general/empty_selection_clipboard", true);

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1835,76 +1835,15 @@ void TextEdit::_notification(int p_what) {
 							continue;
 						}
 
-						int start_column = u.start_column;
-						int end_column = u.end_column;
-
-						if (line != u.start_line) {
-							start_column = 0;
-						}
-						if (line != u.end_line) {
-							end_column = last_visible_char;
-						}
-
-						const Vector<Vector2> underline = TS->shaped_text_get_selection(rid, start_column, end_column);
-						Rect2 combined_rect;
-						for (int j = 0; j < underline.size(); j++) {
-							Rect2 rect = Rect2(
-									underline[j].x + char_margin,
-									ofs_y + theme_cache.font->get_underline_position(theme_cache.font_size),
-									underline[j].y - underline[j].x,
-									theme_cache.font_size * 0.1);
-
-							combined_rect = j == 0 ? rect : combined_rect.merge(rect);
-						}
-
-						PackedVector2Array points;
-						PackedColorArray colors;
-
-						float squiggle_top_y = combined_rect.position.y;
-						float squiggle_center_y = combined_rect.position.y + (combined_rect.size.y / 2.0);
-						float squiggle_bottom_y = combined_rect.position.y + combined_rect.size.y;
-
-						float distance = combined_rect.position.x;
-						float end_position = combined_rect.position.x + combined_rect.size.x;
-
-						bool use_top_squiggle = false;
-
-						// Add first point.
-						if (distance >= xmargin_beg && distance <= xmargin_end) {
-							points.append(Vector2(distance, squiggle_center_y));
-							distance += char_w * 0.25;
-						}
-
-						while (true) {
-							if (distance >= xmargin_beg && distance <= xmargin_end) {
-								float y_pos = use_top_squiggle ? squiggle_top_y : squiggle_bottom_y;
-								// Ensure the underline ends at the end of the text.
-								if (distance >= end_position) {
-									if (points.is_empty()) {
-										break;
-									}
-									Vector2 prev_point = points.get(points.size() - 1);
-									float prev_distance = prev_point.x;
-									float ratio_across = (end_position - prev_distance) / (distance - prev_distance);
-									float prev_y = prev_point.y;
-									float mid_y = Math::lerp(prev_y, y_pos, ratio_across);
-									points.append(Vector2(end_position, mid_y));
-									break;
-								}
-								points.append(Vector2(distance, y_pos));
-							}
-							if (distance >= end_position) {
+						switch (u.style) {
+							case UNDERLINE_STYLE_STRAIGHT:
+								_do_underline_straight(u, line, last_visible_char, rid, char_margin, ofs_y, xmargin_beg, xmargin_end, char_w);
 								break;
-							}
-							distance += char_w * 0.5;
-							use_top_squiggle = !use_top_squiggle;
-						}
-
-						if (points.size() >= 2) {
-							colors.append(u.color);
-							// theme_cache.base_scale is not necessary here, as font size is already dependent on editor scale.
-							// See https://github.com/godotengine/godot/pull/119588#pullrequestreview-4618459305 for more info.
-							RS::get_singleton()->canvas_item_add_polyline(text_ci, points, colors, MAX(theme_cache.font->get_underline_thickness(theme_cache.font_size), 1), true);
+							case UNDERLINE_STYLE_SQUIGGLY:
+								_do_underline_squiggly(u, line, last_visible_char, rid, char_margin, ofs_y, xmargin_beg, xmargin_end, char_w);
+								break;
+							default:
+								break;
 						}
 					}
 
@@ -2215,6 +2154,129 @@ void TextEdit::_notification(int p_what) {
 				queue_redraw();
 			}
 		} break;
+	}
+}
+
+void TextEdit::_do_underline_straight(const Underline &p_ul, int p_line, int p_last_visible_char, RID p_rid, int p_char_margin, int p_ofs_y, int p_xmargin_beg, int p_xmargin_end, float p_char_w) {
+	int start_column = p_ul.start_column;
+	int end_column = p_ul.end_column;
+
+	if (p_line != p_ul.start_line) {
+		start_column = 0;
+	}
+	if (p_line != p_ul.end_line) {
+		end_column = p_last_visible_char;
+	}
+
+	// NOTE: Do we need to iterate over every item in here? Or could we just use
+	// the first and last to define the box with O(1) time instead of O(underline.size()) time?
+	const Vector<Vector2> underline = TS->shaped_text_get_selection(p_rid, start_column, end_column);
+	const float underline_pos = theme_cache.font->get_underline_position(theme_cache.font_size);
+	Rect2 combined_rect;
+	for (int j = 0; j < underline.size(); j++) {
+		Rect2 rect = Rect2(
+				underline[j].x + p_char_margin,
+				p_ofs_y + underline_pos,
+				underline[j].y - underline[j].x,
+				theme_cache.font_size * 0.1);
+
+		combined_rect = j == 0 ? rect : combined_rect.merge(rect);
+	}
+
+	float center_y = combined_rect.position.y + (combined_rect.size.y / 2.0);
+
+	float start_x = combined_rect.position.x;
+	float end_x = combined_rect.position.x + combined_rect.size.x;
+
+	// If the underline starts beyond the right edge or ends before the left edge,
+	// then no need to draw anything.
+	if (start_x >= p_xmargin_end || end_x <= p_xmargin_beg) {
+		return;
+	}
+
+	// Otherwise, start the underline at either the left edge or the beginning of
+	// the text to be underlined.
+	RS::get_singleton()->canvas_item_add_line(
+			text_ci,
+			Vector2(MAX(p_xmargin_beg, start_x), center_y),
+			Vector2(MIN(p_xmargin_end, end_x), center_y),
+			p_ul.color,
+			MAX(theme_cache.font->get_underline_thickness(theme_cache.font_size), 1),
+			true);
+}
+
+void TextEdit::_do_underline_squiggly(const Underline &p_ul, int p_line, int p_last_visible_char, RID p_rid, int p_char_margin, int p_ofs_y, int p_xmargin_beg, int p_xmargin_end, float p_char_w) {
+	int start_column = p_ul.start_column;
+	int end_column = p_ul.end_column;
+
+	if (p_line != p_ul.start_line) {
+		start_column = 0;
+	}
+	if (p_line != p_ul.end_line) {
+		end_column = p_last_visible_char;
+	}
+
+	const Vector<Vector2> underline = TS->shaped_text_get_selection(p_rid, start_column, end_column);
+	const float underline_pos = theme_cache.font->get_underline_position(theme_cache.font_size);
+	Rect2 combined_rect;
+	for (int j = 0; j < underline.size(); j++) {
+		Rect2 rect = Rect2(
+				underline[j].x + p_char_margin,
+				p_ofs_y + underline_pos,
+				underline[j].y - underline[j].x,
+				theme_cache.font_size * 0.1);
+
+		combined_rect = j == 0 ? rect : combined_rect.merge(rect);
+	}
+
+	PackedVector2Array points;
+	PackedColorArray colors;
+
+	float squiggle_top_y = combined_rect.position.y;
+	float squiggle_center_y = combined_rect.position.y + (combined_rect.size.y / 2.0);
+	float squiggle_bottom_y = combined_rect.position.y + combined_rect.size.y;
+
+	float distance = combined_rect.position.x;
+	float end_position = combined_rect.position.x + combined_rect.size.x;
+
+	bool use_top_squiggle = false;
+
+	// Add first point.
+	if (distance >= p_xmargin_beg && distance <= p_xmargin_end) {
+		points.append(Vector2(distance, squiggle_center_y));
+		distance += p_char_w * 0.25;
+	}
+
+	while (true) {
+		if (distance >= p_xmargin_beg && distance <= p_xmargin_end) {
+			float y_pos = use_top_squiggle ? squiggle_top_y : squiggle_bottom_y;
+			// Ensure the underline ends at the end of the text.
+			if (distance >= end_position) {
+				if (points.is_empty()) {
+					break;
+				}
+				Vector2 prev_point = points.get(points.size() - 1);
+				float prev_distance = prev_point.x;
+				float ratio_across = (end_position - prev_distance) / (distance - prev_distance);
+				float prev_y = prev_point.y;
+				float mid_y = Math::lerp(prev_y, y_pos, ratio_across);
+				points.append(Vector2(end_position, mid_y));
+				break;
+			}
+			points.append(Vector2(distance, y_pos));
+		}
+		if (distance >= end_position) {
+			break;
+		}
+		distance += p_char_w * 0.5;
+		use_top_squiggle = !use_top_squiggle;
+	}
+
+	if (points.size() >= 2) {
+		colors.append(p_ul.color);
+		// theme_cache.base_scale is not necessary here, as font size is already dependent on editor scale.
+		// See https://github.com/godotengine/godot/pull/119588#pullrequestreview-4618459305 for more info.
+		RS::get_singleton()->canvas_item_add_polyline(text_ci, points, colors, MAX(theme_cache.font->get_underline_thickness(theme_cache.font_size), 1), true);
 	}
 }
 

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -121,6 +121,13 @@ public:
 		SEARCH_BACKWARDS = 4
 	};
 
+	/* Styles to use for code underlines. */
+	enum UnderlineStyle {
+		UNDERLINE_STYLE_NONE, // Redundant, but helps keep other areas of the code a bit smoother.
+		UNDERLINE_STYLE_STRAIGHT,
+		UNDERLINE_STYLE_SQUIGGLY
+	};
+
 private:
 	struct GutterInfo {
 		GutterType type = GutterType::GUTTER_TYPE_STRING;
@@ -315,6 +322,8 @@ private:
 		int end_line;
 		int end_column;
 
+		UnderlineStyle style;
+
 		bool contains_line(int p_line) const {
 			return start_line <= p_line && p_line <= end_line;
 		}
@@ -322,6 +331,9 @@ private:
 	LocalVector<Underline> underlines;
 	Vector<Underline> _cut_line_from_underline(const Underline &p_ul, int p_line);
 	Vector<Underline> _get_underline_data_for_line(int p_line);
+
+	void _do_underline_straight(const Underline &u, int line, int last_visible_char, RID rid, int char_margin, int ofs_y, int xmargin_beg, int xmargin_end, float char_w);
+	void _do_underline_squiggly(const Underline &u, int line, int last_visible_char, RID rid, int char_margin, int ofs_y, int xmargin_beg, int xmargin_end, float char_w);
 
 	// Placeholder
 	String placeholder_text = "";
@@ -826,9 +838,10 @@ protected:
 
 public:
 	void clear_underlines() { underlines.clear(); }
-	void add_underline(const Color &p_color, int p_start_line, int p_start_column, int p_end_line, int p_end_column) {
+	void add_underline(const Color &p_color, UnderlineStyle p_style, int p_start_line, int p_start_column, int p_end_line, int p_end_column) {
 		Underline u;
 		u.color = p_color;
+		u.style = p_style;
 		u.start_line = p_start_line;
 		u.start_column = p_start_column;
 		u.end_line = p_end_line;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/15352
- Supersedes https://github.com/godotengine/godot/pull/122235

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

As stated in https://github.com/godotengine/godot-proposals/issues/15352, the new warning/error underline squiggles introduced in https://github.com/godotengine/godot/pull/119588 cannot currently be disabled (or rather, they _can_, but [the process to do so is not well-documented and is more of a nice side effect of an optimization than an intended method of disabling the behavior](https://github.com/godotengine/godot-proposals/issues/15352#issuecomment-5232169930)). Furthermore, from the linked proposal it seems possible that the squiggle-calculation algorithm may be taxing on low-end systems. (Note I have not profiled the algorithm myself to determine precise bottlenecks.)

This PR introduces settings for how to draw warning and error underlines:

| Style | Appearance |
| - | - |
| None | <img width="676" height="158" alt="CleanShot 2026-08-09 at 22 18 47@2x" src="https://github.com/user-attachments/assets/f87f334c-4ea9-499d-9f51-231c7eefd633" /> |
| Straight | <img width="671" height="159" alt="CleanShot 2026-08-09 at 22 18 11@2x" src="https://github.com/user-attachments/assets/d479f190-e1c8-4667-b025-8d7e16d37a71" /> |
| Squiggle | <img width="695" height="161" alt="CleanShot 2026-08-09 at 22 17 33@2x" src="https://github.com/user-attachments/assets/ac39d0ca-a9ab-408d-9768-f6fc1ff6dd6c" /> |

When **None** is selected, the warnings or errors' underline-drawing code is skipped entirely. The **Straight** setting uses a much simpler algorithm, which should hopefully provide a nice compromise for users on low-end systems where they can see the precise locations of warnings and/or errors, but the process of drawing the underlines doesn't cause lag for their editor. (And maybe some people would just prefer the look of the straight lines, I suppose!)

> [!note]
> In the images here, I've set both warnings and errors to use the same squiggle style. Currently, these settings are independent; if you want, you can make warnings use straight underlines and errors use squiggly underlines. If people would prefer it to all be one setting, I can easily make that change.

## Unsure points
The `TextEdit::UnderlineStyle` enum has a `UNDERLINE_STYLE_NONE` value, which causes `TextEdit`'s drawing to ignore underlines that use it. This behavior from `TextEdit` itself is technically unused in this PR, as `ScriptTextEditor` first detects when it is the set style, and avoids even submitting underlines to the `TextEdit` in that case. I chose to take this approach as it seemed like it'd be cleaner than trying to convert between enum types (one which includes a "none" option, and another that doesn't), but I can change it to use a different approach if that would be better.

As stated in `TextEdit::_do_underline_straight()`, I'm unsure if we could further optimize this by using only the first and last entries returned by `TS->shaped_text_get_selection()` to define the bounding box that we in turn use to draw the underline. I see a distinct possibility that such an approach might break down with things like RTL languages, but I am not experienced enough with them to say for sure.