### PR TITLE
[ScrollBar] Fix drag scrolling interfering with mouse on touchscreen

### DIFF
--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -583,19 +583,19 @@ void ScrollBar::_drag_node_input(const Ref<InputEvent> &p_input) {
 		return;
 	}
 
-	Ref<InputEventMouseButton> mb = p_input;
+	if (p_input->get_device() == InputEvent::DEVICE_ID_EMULATION) {
+		return;
+	}
 
-	if (mb.is_valid()) {
-		if (mb->get_button_index() != MouseButton::LEFT) {
-			return;
-		}
+	Ref<InputEventScreenTouch> touch = p_input;
 
-		if (mb->is_pressed()) {
+	if (touch.is_valid()) {
+		if (touch->is_pressed()) {
 			drag_node_speed = Vector2();
 			drag_node_accum = Vector2();
 			last_drag_node_accum = Vector2();
 			drag_node_from = Vector2(orientation == HORIZONTAL ? get_value() : 0, orientation == VERTICAL ? get_value() : 0);
-			drag_node_touching = DisplayServer::get_singleton()->is_touchscreen_available();
+			drag_node_touching = true;
 			drag_node_touching_deaccel = false;
 			time_since_motion = 0;
 
@@ -617,11 +617,11 @@ void ScrollBar::_drag_node_input(const Ref<InputEvent> &p_input) {
 		}
 	}
 
-	Ref<InputEventMouseMotion> mm = p_input;
+	Ref<InputEventScreenDrag> s_drag = p_input;
 
-	if (mm.is_valid()) {
+	if (s_drag.is_valid()) {
 		if (drag_node_touching && !drag_node_touching_deaccel) {
-			Vector2 motion = mm->get_relative();
+			Vector2 motion = s_drag->get_relative();
 
 			drag_node_accum -= motion;
 			Vector2 diff = drag_node_from + drag_node_accum;


### PR DESCRIPTION
- Fixes https://github.com/godotengine/godot/issues/122154

This drag scrolling logic is specifically for touch input and only works on touchscreens. This PR updates the logic to use touch based events so now it won't interfere with mouse events.