### PR TITLE
Asset Library: Use Autowrap for `library_message`

### DIFF
--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -2271,6 +2271,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	library_message = memnew(Label);
 	library_message->set_focus_mode(FOCUS_ACCESSIBILITY);
 	library_message->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	library_message->set_autowrap_mode(TextServer::AUTOWRAP_WORD);
 	library_message_box->add_child(library_message);
 
 	library_message_button = memnew(Button);


### PR DESCRIPTION
## What problem(s) does this PR solve?

With the recent (dev3) addition of portrait mode for the Project Manager on Android, this can happen: (text off-screen)

<img width="305" height="678" alt="image" src="https://github.com/user-attachments/assets/324f102a-7542-469d-9713-072549198a2f" />

This simply adds autowrapping for the `Label` shown.

Note that this is probably Android specific, as on the other platforms the minimum width prevents this from happening.

## After

<img width="305" height="678" alt="image" src="https://github.com/user-attachments/assets/875d46e3-bbcb-4cc9-bf10-7a31f36b8d33" />

## Additional information

No AI was used.
