### PR TITLE
Don't auto-translate favorite nodes

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -1747,6 +1747,7 @@ void SceneTreeDock::_notification(int p_what) {
 			button_ui->connect(SceneStringName(pressed), callable_mp(this, &SceneTreeDock::_tool_selected).bind(TOOL_CREATE_USER_INTERFACE, false));
 
 			favorite_node_shortcuts = memnew(VBoxContainer);
+			favorite_node_shortcuts->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 			node_shortcuts->add_child(favorite_node_shortcuts);
 
 			button_custom = memnew(Button);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

When creating new scene, favorite nodes could get translated.
<img width="461" height="163" alt="img-2026-08-10 13 59 02" src="https://github.com/user-attachments/assets/323c4527-3a6b-4e24-973b-15aff6233b22" />

## Additional information

I feel like a fix or report for this problem already exists somewhere 🤔