### PR TITLE
[WinRT, 4.7] Add exception handling to `DispatcherQueueOptions` init.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -7806,11 +7806,6 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Dis
 	}
 	native_menu = memnew(NativeMenuWindows);
 
-	has_winrt_queue = WinRTUtils::create_queue();
-
-	// Enforce default keep screen on value.
-	screen_set_keep_on(GLOBAL_GET("display/window/energy_saving/keep_screen_on"));
-
 	// Load Windows version info.
 	ZeroMemory(&os_ver, sizeof(OSVERSIONINFOW));
 	os_ver.dwOSVersionInfoSize = sizeof(OSVERSIONINFOW);
@@ -7833,6 +7828,13 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Dis
 		}
 		FreeLibrary(nt_lib);
 	}
+
+	if (os_ver.dwBuildNumber >= 16299) { // Windows 10 Redstone 3 (1709)+ only.
+		has_winrt_queue = WinRTUtils::create_queue();
+	}
+
+	// Enforce default keep screen on value.
+	screen_set_keep_on(GLOBAL_GET("display/window/energy_saving/keep_screen_on"));
 
 	// Load UXTheme.
 	if (os_ver.dwBuildNumber >= 10240) { // Not available on Wine, use only if real Windows 10/11 detected.

--- a/platform/windows/winrt_utils.cpp
+++ b/platform/windows/winrt_utils.cpp
@@ -127,18 +127,22 @@ class WinRTWindowData {
 };
 
 bool WinRTUtils::create_queue() {
-	HMODULE coremessaging = LoadLibraryW(L"coremessaging.dll");
-	if (!coremessaging) {
-		return false;
-	}
-	CreateDispatcherQueueController = (CreateDispatcherQueueControllerPtr)(void *)GetProcAddress(coremessaging, "CreateDispatcherQueueController");
-	if (!CreateDispatcherQueueController) {
-		return false;
-	}
+	try {
+		HMODULE coremessaging = LoadLibraryW(L"coremessaging.dll");
+		if (!coremessaging) {
+			return false;
+		}
+		CreateDispatcherQueueController = (CreateDispatcherQueueControllerPtr)(void *)GetProcAddress(coremessaging, "CreateDispatcherQueueController");
+		if (!CreateDispatcherQueueController) {
+			return false;
+		}
 
-	DispatcherQueueOptions options{ sizeof(options), DQTYPE_THREAD_CURRENT, DQTAT_COM_NONE };
-	HRESULT res = CreateDispatcherQueueController(options, winrt::put_abi(controller));
-	return SUCCEEDED(res);
+		DispatcherQueueOptions options{ sizeof(options), DQTYPE_THREAD_CURRENT, DQTAT_COM_NONE };
+		HRESULT res = CreateDispatcherQueueController(options, winrt::put_abi(controller));
+		return SUCCEEDED(res);
+	} catch (...) {
+		return false;
+	}
 }
 
 void WinRTUtils::destroy_queue() {


### PR DESCRIPTION
## What problem(s) does this PR solve?

Backport of https://github.com/godotengine/godot/pull/121361
