### PR TITLE
[3.x][Buildsystem] Ping `master` cache after saving cache

### DIFF
--- a/.github/actions/godot-build/action.yml
+++ b/.github/actions/godot-build/action.yml
@@ -17,7 +17,7 @@ inputs:
     default: ""
   scons-cache:
     description: The scons cache path.
-    default: "${{ github.workspace }}/.scons-cache/"
+    default: "${{ github.workspace }}/.scons_cache/"
   scons-cache-limit:
     description: The scons cache size limit.
     # actions/cache has 10 GiB limit, and GitHub runners have a 14 GiB disk.

--- a/.github/actions/godot-cache-restore/action.yml
+++ b/.github/actions/godot-cache-restore/action.yml
@@ -6,12 +6,12 @@ inputs:
     default: "${{github.job}}"
   scons-cache:
     description: The scons cache path.
-    default: "${{github.workspace}}/.scons-cache/"
+    default: "${{github.workspace}}/.scons_cache/"
 runs:
   using: "composite"
   steps:
     - name: Restore .scons_cache directory
-      uses: actions/cache/restore@v4
+      uses: actions/cache/restore@v6
       with:
         path: ${{inputs.scons-cache}}
         key: ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}

--- a/.github/actions/godot-cache-save/action.yml
+++ b/.github/actions/godot-cache-save/action.yml
@@ -6,12 +6,23 @@ inputs:
     default: "${{github.job}}"
   scons-cache:
     description: The scons cache path.
-    default: "${{github.workspace}}/.scons-cache/"
+    default: "${{github.workspace}}/.scons_cache/"
 runs:
   using: "composite"
   steps:
     - name: Save .scons_cache directory
-      uses: actions/cache/save@v4
+      uses: actions/cache/save@v6
       with:
         path: ${{inputs.scons-cache}}
         key: ${{inputs.cache-name}}-${{env.GODOT_BASE_BRANCH}}-${{github.ref}}-${{github.sha}}
+
+    # This is done after saving the new cache so that the base cache remains more relevant, to reduce
+    # the risk of the cache being purged when multiple large PRs are pushed/merged at the same time.
+    - name: Ping default cache
+      uses: actions/cache/restore@v6
+      if: github.ref_name != github.event.repository.default_branch
+      with:
+        path: ${{ inputs.scons-cache }}
+        key: ${{ inputs.cache-name }}|${{ github.event.repository.default_branch }}|${{ github.sha }}
+        restore-keys: ${{ inputs.cache-name }}|${{ github.event.repository.default_branch }}
+        lookup-only: true


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Stripped down 3.x version of https://github.com/godotengine/godot/pull/121973, also updates the action version to `v6` to ensure compatibility.

Also changed the default cache path used for the action to ensure compatibility (it won't load the cache if the path doesn't match, could change it individually for the ping action but I think it doesn't matter either way and this makes it consistent)

Didn't add a ping on cache restore, the critical point is after the new cache has been saved and PRs on the 3.x branch can't use the master cache

## Additional information

AI was not used in creating this PR.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
