### PR TITLE
Android: Unable to clean-up EGL resources at exit without a valid EGL surface

### DIFF
--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/gl/GLSurfaceView.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/gl/GLSurfaceView.java
@@ -1648,6 +1648,15 @@ public class GLSurfaceView extends SurfaceView implements SurfaceHolder.Callback
 				 */
 				synchronized (sGLThreadManager) {
 					Log.d("GLThread", "Exiting render thread");
+
+					// In order to correctly clean up GL resources, we need a current EGL surface.
+					if (mHaveEglContext && !mHaveEglSurface) {
+						mHaveEglSurface = mEglHelper.createSurface();
+						if (!mHaveEglSurface) {
+							Log.w("GLThread", "Could not make an EGL surface current for shutdown, GL resources will not be explicitly released");
+						}
+					}
+
 					GLSurfaceView view = mGLSurfaceViewWeakRef.get();
 					if (view != null) {
 						view.mRenderer.onRenderThreadExiting();


### PR DESCRIPTION
This is split off of https://github.com/godotengine/godot/pull/121910

Using OpenGL on Android, when Godot is shutting down, all of our code to clean-up various OpenGL resources (ie all the `glDeleteTextures()`, `glDeleteFramebuffers()`, etc) are effectively no-op's (and there's a message in `adb logcat` to this effect on Android XR) because we don't have a valid EGL surface during shutdown (at least in my testing, it's possible there are cases when there would still be a valid EGL surface?)

I think this is because when the app is "paused", we call `stopEglSurfaceLocked()` which will destroy the EGL surface. Generally, when you quit an Android app, you switch to some system manager to do so, which will pause the app.

Now, I don't know if making sure our clean-up code runs is actually important? Since the app is being quit, will all the textures and framebuffers we created get cleaned up anyway? If so, maybe this doesn't actually even matter, but it seems like it would be good to clean up after ourselves during shutdown

And, while this PR has worked in my limited testing (including getting rid of the log messages on Android XR), it worries me that recreating the EGL surface just before shutdown could maybe cause issues on some platforms? But I don't really know...