### PR TITLE
Add scroll hints to the Project and Editor Settings dialogs

### DIFF
--- a/editor/inspector/editor_sectioned_inspector.cpp
+++ b/editor/inspector/editor_sectioned_inspector.cpp
@@ -368,6 +368,7 @@ SectionedInspector::SectionedInspector() :
 	sections->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	sections->set_v_size_flags(SIZE_EXPAND_FILL);
 	sections->set_hide_root(true);
+	sections->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
 	sections->set_theme_type_variation("TreeSecondary");
 
 	left_vb->add_child(sections, true);

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -1093,6 +1093,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	shortcuts->set_column_titles_visible(true);
 	shortcuts->set_column_title(0, TTRC("Name"));
 	shortcuts->set_column_title(1, TTRC("Binding"));
+	shortcuts->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_TOP);
 	shortcuts->connect("button_clicked", callable_mp(this, &EditorSettingsDialog::_shortcut_button_pressed));
 	shortcuts->connect("item_activated", callable_mp(this, &EditorSettingsDialog::_shortcut_cell_double_clicked));
 	mc->add_child(shortcuts);


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR adds scroll hints to the top of the sections in both the Project and Editor Settings dialogs, and in the Shortcuts list inside the latter. In the same vein as #120795, this is done for aesthetic reasons.