### PR TITLE
Remove extra margin from favorites in the "Create New *" dialog

### DIFF
--- a/editor/gui/create_dialog.cpp
+++ b/editor/gui/create_dialog.cpp
@@ -1010,6 +1010,7 @@ CreateDialog::CreateDialog() {
 	favorites->connect("cell_selected", callable_mp(this, &CreateDialog::_favorite_selected));
 	favorites->connect("item_activated", callable_mp(this, &CreateDialog::_favorite_activated));
 	favorites->add_theme_constant_override("draw_guides", 1);
+	favorites->add_theme_constant_override("h_separation", 0);
 	favorites->set_theme_type_variation("TreeSecondary");
 	SET_DRAG_FORWARDING_GCD(favorites, CreateDialog);
 	fav_vb->add_margin_child(TTR("Favorites:"), favorites, true);


### PR DESCRIPTION
## What problem(s) does this PR solve?

|PR|`master`|
|-|-|
|<img width="156" height="146" alt="Screenshot_20260810_124742" src="https://github.com/user-attachments/assets/86a335ea-9aab-4386-963b-12f782fcfb11" />|<img width="156" height="146" alt="image" src="https://github.com/user-attachments/assets/b3593675-8a49-4f51-9f75-d5616aca3e73" />|