### PR TITLE
Deduplicate context menu plugin data creation

### DIFF
--- a/doc/classes/EditorContextMenuPlugin.xml
+++ b/doc/classes/EditorContextMenuPlugin.xml
@@ -97,7 +97,7 @@
 		<constant name="CONTEXT_SLOT_SCRIPT_EDITOR" value="2" enum="ContextMenuSlot">
 			Context menu of Script editor's script tabs and Shader editor's shader tabs. The data [Dictionary] contains:
 			[code]&amp;"selected_resource": Resource[/code] - The currently selected resource. Can be a [Script], a [Shader], a text file, or [code]null[/code] in case of help pages.
-			[code]&amp;"resource_path": String[/code] - The path of the selected resource.
+			[code]&amp;"path": String[/code] - The path of the selected file. If a help page is selected, the path will be the name of the opened class, prefixed with [code]help:[/code].
 		</constant>
 		<constant name="CONTEXT_SLOT_FILESYSTEM_CREATE" value="3" enum="ContextMenuSlot">
 			The "Create..." submenu of FileSystem dock's context menu, or the "New" section of the main context menu when empty space is clicked. The data [Dictionary] contains:

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2192,6 +2192,19 @@ Vector<String> FileSystemDock::_file_list_get_selected() const {
 	return selected;
 }
 
+Dictionary FileSystemDock::_get_context_data(const PackedStringArray &p_selected_files) {
+	EditorContextMenuPlugin::OptionsData context_data;
+	context_data["selected_files"] = p_selected_files;
+	return context_data;
+}
+
+Dictionary FileSystemDock::_get_context_data_for_create(const String &p_base_dir, bool p_needs_prefix) {
+	EditorContextMenuPlugin::OptionsData context_data;
+	context_data["base_directory"] = p_base_dir;
+	context_data["needs_prefix"] = p_needs_prefix;
+	return context_data;
+}
+
 Vector<String> FileSystemDock::_remove_self_included_paths(Vector<String> selected_strings) {
 	// Remove paths or files that are included into another.
 	if (selected_strings.size() > 1) {
@@ -3686,9 +3699,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 #endif
 
 	if (EditorContextMenuPluginManager::get_singleton()->has_plugins_for_slot(EditorContextMenuPlugin::CONTEXT_SLOT_FILESYSTEM)) {
-		EditorContextMenuPlugin::OptionsData context_data;
-		context_data["selected_files"] = p_paths;
-		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(p_popup, EditorContextMenuPlugin::CONTEXT_SLOT_FILESYSTEM, context_data);
+		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(p_popup, EditorContextMenuPlugin::CONTEXT_SLOT_FILESYSTEM, FileSystemDock::_get_context_data(p_paths));
 
 #ifndef DISABLE_DEPRECATED
 		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(p_popup, EditorContextMenuPlugin::CONTEXT_SLOT_FILESYSTEM, p_paths, p_paths, 1000);
@@ -3710,10 +3721,8 @@ void FileSystemDock::_add_create_options(PopupMenu *p_popup, const String &p_bas
 	p_popup->set_item_shortcut(-1, ED_GET_SHORTCUT("filesystem_dock/new_textfile"));
 	// Options for CONTEXT_SLOT_FILESYSTEM_CREATE are added with an offset, to avoid conflicts in case plugins add options for both FileSystem slots.
 	if (EditorContextMenuPluginManager::get_singleton()->has_plugins_for_slot(EditorContextMenuPlugin::CONTEXT_SLOT_FILESYSTEM_CREATE)) {
-		EditorContextMenuPlugin::OptionsData context_data;
-		context_data["base_directory"] = prefix_new ? "res://" : p_base_folder;
-		context_data["needs_prefix"] = prefix_new;
-		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(p_popup, EditorContextMenuPlugin::CONTEXT_SLOT_FILESYSTEM_CREATE, context_data, 500);
+		const String base_directory = prefix_new ? "res://" : p_base_folder;
+		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(p_popup, EditorContextMenuPlugin::CONTEXT_SLOT_FILESYSTEM_CREATE, FileSystemDock::_get_context_data_for_create(base_directory, prefix_new), 500);
 
 #ifndef DISABLE_DEPRECATED
 		const PackedStringArray legacy_data = prefix_new ? PackedStringArray() : PackedStringArray{ p_base_folder };
@@ -3984,13 +3993,9 @@ bool FileSystemDock::_handle_custom_context_callback(Ref<InputEvent> p_event, co
 	}
 #endif
 
-	EditorContextMenuPlugin::OptionsData context_data;
-	if (create) {
-		context_data["base_directory"] = base_dir;
-		context_data["needs_prefix"] = p_selected.is_empty();
-	} else {
-		context_data["selected_files"] = p_selected;
-	}
+	EditorContextMenuPlugin::OptionsData context_data = create
+			? FileSystemDock::_get_context_data_for_create(base_dir, p_selected.is_empty())
+			: FileSystemDock::_get_context_data(p_selected);
 	EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, context_data);
 
 	return true;

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -389,6 +389,8 @@ private:
 
 	Vector<String> _tree_get_selected(bool remove_self_inclusion = true, bool p_include_unselected_cursor = false) const;
 	Vector<String> _file_list_get_selected() const;
+	static Dictionary _get_context_data(const PackedStringArray &p_selected_files);
+	static Dictionary _get_context_data_for_create(const String &p_base_dir, bool p_needs_prefix);
 
 	bool _is_file_type_disabled_by_feature_profile(const StringName &p_class);
 

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -262,23 +262,15 @@ void SceneTreeDock::shortcut_input(const Ref<InputEvent> &p_event) {
 	} else {
 		const Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TREE, p_event);
 		if (custom_callback.is_valid()) {
-			const List<Node *> selection = editor_selection->get_top_selected_node_list();
-			TypedArray<Node> selected_nodes;
-			selected_nodes.reserve(selection.size());
-			for (const Node *node : selection) {
-				selected_nodes.push_back(node);
-			}
+			EditorContextMenuPlugin::OptionsData context_data = SceneTreeDock::_get_context_data(editor_selection->get_top_selected_node_list());
 
 #ifndef DISABLE_DEPRECATED
 			if (p_event->get_meta("_legacy_shortcut", false)) {
-				EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, selected_nodes);
+				EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, context_data["selected_nodes"]);
 				accept_event();
 				return;
 			}
 #endif
-
-			EditorContextMenuPlugin::OptionsData context_data;
-			context_data["selected_nodes"] = selected_nodes;
 			EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, context_data);
 		} else {
 			return;
@@ -3881,10 +3873,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 		menu->add_icon_shortcut(get_editor_theme_icon(SNAME("Instance")), ED_GET_SHORTCUT("scene_tree/instantiate_scene"), TOOL_INSTANTIATE);
 
 		if (EditorContextMenuPluginManager::get_singleton()->has_plugins_for_slot(EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TREE)) {
-			EditorContextMenuPlugin::OptionsData context_data;
-			context_data["selected_nodes"] = TypedArray<Node>();
-
-			EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(menu, EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TREE, context_data);
+			EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(menu, EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TREE, SceneTreeDock::_get_context_data(List<Node *>()));
 #ifndef DISABLE_DEPRECATED
 			EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(menu, EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TREE, PackedStringArray(), TypedArray<Node>(), 500);
 #endif
@@ -4162,13 +4151,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 #undef END_SECTION
 
 	if (EditorContextMenuPluginManager::get_singleton()->has_plugins_for_slot(EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TREE)) {
-		TypedArray<Node> selected_nodes;
-		selected_nodes.reserve(selection.size());
-		for (const Node *node : selection) {
-			selected_nodes.append(node);
-		}
-		EditorContextMenuPlugin::OptionsData context_data;
-		context_data["selected_nodes"] = selected_nodes;
+		EditorContextMenuPlugin::OptionsData context_data = SceneTreeDock::_get_context_data(selection);
 		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(menu, EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TREE, context_data);
 
 #ifndef DISABLE_DEPRECATED
@@ -4178,7 +4161,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 			const String node_path = (String)root->get_path().rel_path_to(node->get_path());
 			p_paths.push_back(node_path);
 		}
-		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(menu, EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TREE, p_paths, selected_nodes, 500);
+		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(menu, EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TREE, p_paths, context_data["selected_nodes"], 500);
 #endif
 	}
 
@@ -4988,6 +4971,17 @@ void SceneTreeDock::_update_configuration_warning() {
 	if (singleton) {
 		callable_mp(singleton->scene_tree, &SceneTreeEditor::update_warning).call_deferred();
 	}
+}
+
+Dictionary SceneTreeDock::_get_context_data(const List<Node *> &p_selected_nodes) {
+	TypedArray<Node> selected_nodes;
+	selected_nodes.reserve(p_selected_nodes.size());
+	for (const Node *node : p_selected_nodes) {
+		selected_nodes.append(node);
+	}
+	EditorContextMenuPlugin::OptionsData context_data;
+	context_data["selected_nodes"] = selected_nodes;
+	return context_data;
 }
 
 SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selection, EditorData &p_editor_data) {

--- a/editor/docks/scene_tree_dock.h
+++ b/editor/docks/scene_tree_dock.h
@@ -303,6 +303,7 @@ class SceneTreeDock : public EditorDock {
 	bool determine_path_automatically = true;
 
 	static void _update_configuration_warning();
+	static Dictionary _get_context_data(const List<Node *> &p_selected_nodes);
 
 	bool _update_node_path(Node *p_root_node, NodePath &r_node_path, HashMap<Node *, NodePath> *p_renames) const;
 	void _check_object_properties_recursive(Node *p_root_node, Object *p_obj, HashMap<Node *, NodePath> *p_renames, bool p_inside_resource = false) const;

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -1106,6 +1106,14 @@ void EditorProperty::_focusable_focused(int p_index) {
 	}
 }
 
+Dictionary EditorProperty::_get_context_data() {
+	EditorContextMenuPlugin::OptionsData context_data;
+	context_data["property"] = this;
+	context_data["object"] = get_edited_object();
+	context_data["property_name"] = get_edited_property();
+	return context_data;
+}
+
 void EditorProperty::add_focusable(Control *p_control) {
 	p_control->connect(SceneStringName(focus_entered), callable_mp(this, &EditorProperty::_focusable_focused).bind(focusables.size()));
 	focusables.push_back(p_control);
@@ -1339,13 +1347,7 @@ void EditorProperty::shortcut_input(const Ref<InputEvent> &p_event) {
 				return;
 			}
 #endif
-
-			EditorContextMenuPlugin::OptionsData context_data;
-			context_data["property"] = this;
-			context_data["object"] = get_edited_object();
-			context_data["property_name"] = get_edited_property();
-
-			EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, context_data);
+			EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, _get_context_data());
 			accept_event();
 		}
 	}
@@ -1802,11 +1804,7 @@ void EditorProperty::_update_popup() {
 	}
 
 	if (EditorContextMenuPluginManager::get_singleton() && EditorContextMenuPluginManager::get_singleton()->has_plugins_for_slot(EditorContextMenuPlugin::CONTEXT_SLOT_INSPECTOR_PROPERTY)) {
-		EditorContextMenuPlugin::OptionsData context_data;
-		context_data["property"] = this;
-		context_data["object"] = get_edited_object();
-		context_data["property_name"] = get_edited_property();
-		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(menu, EditorContextMenuPlugin::CONTEXT_SLOT_INSPECTOR_PROPERTY, context_data);
+		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(menu, EditorContextMenuPlugin::CONTEXT_SLOT_INSPECTOR_PROPERTY, _get_context_data());
 
 #ifndef DISABLE_DEPRECATED
 		Vector<String> property_paths = { String::num_int64(get_edited_object()->get_instance_id()), property_path };

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -193,6 +193,7 @@ private:
 	void _update_popup();
 	void _focusable_focused(int p_index);
 	int _get_v_separation() const { return bottom_editor && bottom_editor_seperation ? theme_cache.vertical_separation : 0; }
+	Dictionary _get_context_data();
 
 	bool selectable = true;
 	bool selected = false;

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -559,26 +559,14 @@ void CanvasItemEditor::shortcut_input(const Ref<InputEvent> &p_ev) {
 
 			const Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_2D_EDITOR, p_ev);
 			if (custom_callback.is_valid()) {
-				Vector<SelectResult> currently_hovered;
-				_get_canvas_items_at_pos(transform.affine_inverse().xform(viewport->get_local_mouse_position()), currently_hovered, true);
-
-				TypedArray<CanvasItem> items;
-				items.reserve(currently_hovered.size());
-				for (const SelectResult &result : currently_hovered) {
-					items.append(result.item);
-				}
-
+				EditorContextMenuPlugin::OptionsData context_data = _get_context_data();
 #ifndef DISABLE_DEPRECATED
 				if (p_ev->get_meta("_legacy_shortcut", false)) {
-					EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, items);
+					EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, context_data["hovered_nodes"]);
 					accept_event();
 					return;
 				}
 #endif
-
-				EditorContextMenuPlugin::OptionsData context_data;
-				context_data["hovered_nodes"] = items;
-				context_data["mouse_position"] = transform.affine_inverse().xform(viewport->get_local_mouse_position());
 				EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, context_data);
 				accept_event();
 			}
@@ -828,6 +816,24 @@ void CanvasItemEditor::_find_canvas_items_in_rect(const Rect2 &p_rect, Node *p_n
 			}
 		}
 	}
+}
+
+Dictionary CanvasItemEditor::_get_context_data() {
+	const Vector2 mouse_pos = transform.affine_inverse().xform(viewport->get_local_mouse_position());
+
+	Vector<SelectResult> currently_hovered;
+	_get_canvas_items_at_pos(mouse_pos, currently_hovered, true);
+
+	TypedArray<CanvasItem *> items;
+	items.reserve(currently_hovered.size());
+	for (const SelectResult &result : currently_hovered) {
+		items.push_back(result.item);
+	}
+
+	EditorContextMenuPlugin::OptionsData context_data;
+	context_data["hovered_nodes"] = items;
+	context_data["mouse_position"] = mouse_pos;
+	return context_data;
 }
 
 bool CanvasItemEditor::_select_click_on_item(CanvasItem *item, Point2 p_click_pos, bool p_append) {
@@ -2573,25 +2579,16 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 			}
 
 			if (EditorContextMenuPluginManager::get_singleton()->has_plugins_for_slot(EditorContextMenuPlugin::CONTEXT_SLOT_2D_EDITOR)) {
-				Vector<SelectResult> currently_hovered;
-				_get_canvas_items_at_pos(transform.affine_inverse().xform(b->get_position()), currently_hovered, true);
-
-				TypedArray<CanvasItem *> items;
-				items.reserve(currently_hovered.size());
-				for (const SelectResult &result : currently_hovered) {
-					items.push_back(result.item);
-				}
-
-				EditorContextMenuPlugin::OptionsData context_data;
-				context_data["hovered_nodes"] = items;
-				context_data["mouse_position"] = transform.affine_inverse().xform(b->get_position());
+				EditorContextMenuPlugin::OptionsData context_data = _get_context_data();
 				EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(add_node_menu, EditorContextMenuPlugin::CONTEXT_SLOT_2D_EDITOR, context_data);
 
 #ifndef DISABLE_DEPRECATED
+				TypedArray<CanvasItem> items = context_data["hovered_nodes"];
 				PackedStringArray paths;
-				paths.reserve_exact(currently_hovered.size());
-				for (const SelectResult &result : currently_hovered) {
-					paths.append((String)result.item->get_path());
+				paths.reserve_exact(items.size());
+				for (const Variant &v : items) {
+					CanvasItem *ci = Object::cast_to<CanvasItem>(v);
+					paths.append((String)ci->get_path());
 				}
 				EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(add_node_menu, EditorContextMenuPlugin::CONTEXT_SLOT_2D_EDITOR, paths, items, 500);
 #endif

--- a/editor/scene/canvas_item_editor_plugin.h
+++ b/editor/scene/canvas_item_editor_plugin.h
@@ -419,6 +419,7 @@ private:
 	bool _is_node_movable(const Node *p_node, bool p_popup_warning = false);
 	void _get_canvas_items_at_pos(const Point2 &p_pos, Vector<SelectResult> &r_items, bool p_allow_locked = false);
 	void _find_canvas_items_in_rect(const Rect2 &p_rect, Node *p_node, List<CanvasItem *> *r_items, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D());
+	Dictionary _get_context_data();
 
 	bool _select_click_on_item(CanvasItem *item, Point2 p_click_pos, bool p_append);
 

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -234,13 +234,11 @@ void EditorSceneTabs::_update_context_menu(int p_index) {
 #undef DISABLE_LAST_OPTION_IF
 
 	if (EditorContextMenuPluginManager::get_singleton()->has_plugins_for_slot(EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TABS)) {
-		EditorContextMenuPlugin::OptionsData context_data;
-		context_data["selected_scene"] = (tab_id >= 0 ? EditorNode::get_editor_data().get_scene_path(tab_id) : String());
-		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(scene_tabs_context_menu, EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TABS, context_data);
+		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(scene_tabs_context_menu, EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TABS, _get_context_data(tab_id));
 
 #ifndef DISABLE_DEPRECATED
 		const PackedStringArray paths = tab_id >= 0 ? PackedStringArray{ EditorNode::get_editor_data().get_scene_path(tab_id) } : PackedStringArray();
-		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(scene_tabs_context_menu, EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TABS, paths, context_data["selected_scene"], 500);
+		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(scene_tabs_context_menu, EditorContextMenuPlugin::CONTEXT_SLOT_SCENE_TABS, paths, tab_id >= 0 ? paths[0] : String(), 500);
 #endif
 	}
 
@@ -402,6 +400,12 @@ void EditorSceneTabs::_tab_preview_done(const String &p_path, const Ref<Texture2
 	}
 }
 
+Dictionary EditorSceneTabs::_get_context_data(int p_current_tab) {
+	EditorContextMenuPlugin::OptionsData context_data;
+	context_data["selected_scene"] = (p_current_tab >= 0 ? EditorNode::get_editor_data().get_scene_path(p_current_tab) : String());
+	return context_data;
+}
+
 void EditorSceneTabs::_global_menu_scene(const Variant &p_tag) {
 	int idx = (int)p_tag;
 	scene_tabs->set_current_tab(idx);
@@ -441,11 +445,7 @@ void EditorSceneTabs::shortcut_input(const Ref<InputEvent> &p_event) {
 				return;
 			}
 #endif
-
-			EditorContextMenuPlugin::OptionsData context_data;
-			context_data["selected_scene"] = (get_current_tab() >= 0 ? EditorNode::get_editor_data().get_scene_path(get_current_tab()) : String());
-			EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, context_data);
-
+			EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, EditorSceneTabs::_get_context_data(get_current_tab()));
 			accept_event();
 		}
 	}

--- a/editor/scene/editor_scene_tabs.h
+++ b/editor/scene/editor_scene_tabs.h
@@ -88,6 +88,7 @@ private:
 	void _update_scene_list();
 
 	void _tab_preview_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, int p_tab);
+	static Dictionary _get_context_data(int p_current_tab);
 
 	void _global_menu_scene(const Variant &p_tag);
 	void _global_menu_new_window(const Variant &p_tag);

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -365,23 +365,12 @@ void DocumentList::_show_context_menu() {
 
 	// Context menu plugin.
 	if (EditorContextMenuPluginManager::get_singleton()->has_plugins_for_slot(EditorContextMenuPlugin::CONTEXT_SLOT_SCRIPT_EDITOR)) {
-		Ref<Resource> current_resource;
-		String res_path;
-		ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(script_editor->tab_container->get_tab_control(selected));
-		if (seb) {
-			current_resource = seb->get_edited_resource();
-			if (current_resource.is_valid()) {
-				res_path = current_resource->get_path();
-			}
-		}
-
-		EditorContextMenuPlugin::OptionsData context_data;
-		context_data["selected_resource"] = current_resource;
-		context_data["resource_path"] = res_path;
+		EditorContextMenuPlugin::OptionsData context_data = ScriptEditor::get_context_data(script_editor->tab_container->get_tab_control(selected));
 		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(context_menu, EditorContextMenuPlugin::CONTEXT_SLOT_SCRIPT_EDITOR, context_data);
 
 #ifndef DISABLE_DEPRECATED
 		Vector<String> selected_paths;
+		Ref<Resource> current_resource = context_data["selected_resource"];
 		if (current_resource.is_valid()) {
 			selected_paths.push_back(current_resource->get_path());
 		}
@@ -1593,6 +1582,27 @@ TypedArray<Script> ScriptEditor::_get_open_scripts() const {
 		ret.push_back(scripts[idx_script]);
 	}
 	return ret;
+}
+
+Dictionary ScriptEditor::get_context_data(Control *p_tab_control) {
+	Ref<Resource> current_resource;
+	String res_path;
+	ScriptEditorBase *seb = Object::cast_to<ScriptEditorBase>(p_tab_control);
+	if (seb) {
+		current_resource = seb->get_edited_resource();
+		if (current_resource.is_valid()) {
+			res_path = current_resource->get_path();
+		}
+	} else {
+		EditorHelp *help = Object::cast_to<EditorHelp>(p_tab_control);
+		if (help) {
+			res_path = "help:" + help->get_class().unquote();
+		}
+	}
+	EditorContextMenuPlugin::OptionsData context_data;
+	context_data["selected_resource"] = current_resource;
+	context_data["path"] = res_path;
+	return context_data;
 }
 
 bool ScriptEditor::toggle_files_panel() {
@@ -3172,25 +3182,15 @@ void ScriptEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 
 	const Callable custom_callback = EditorContextMenuPluginManager::get_singleton()->match_custom_shortcut(EditorContextMenuPlugin::CONTEXT_SLOT_SCRIPT_EDITOR, p_event);
 	if (custom_callback.is_valid()) {
-		Ref<Resource> current_resource;
-		if (ScriptEditorBase *current = _get_current_editor()) {
-			current_resource = current->get_edited_resource();
-		}
-
+		EditorContextMenuPlugin::OptionsData context_data = ScriptEditor::get_context_data(tab_container->get_current_tab_control());
 #ifndef DISABLE_DEPRECATED
 		if (p_event->get_meta("_legacy_shortcut", false)) {
-			Ref<Script> current_script = current_resource;
-			EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, current_script);
+			EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, context_data["selected_resource"]);
 			accept_event();
 			return;
 		}
 #endif
-
-		EditorContextMenuPlugin::OptionsData context_data;
-		context_data["selected_resource"] = current_resource;
-		context_data["resource_path"] = current_resource.is_valid() ? current_resource->get_path() : String();
 		EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, context_data);
-
 		accept_event();
 	}
 }

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -287,7 +287,6 @@ class ScriptEditor : public PanelContainer {
 
 	static int script_editor_func_count;
 	static CreateScriptEditorFunc script_editor_funcs[SCRIPT_EDITOR_FUNC_MAX];
-
 	Vector<Ref<EditorSyntaxHighlighter>> syntax_highlighters;
 
 	struct ScriptHistory {
@@ -459,6 +458,8 @@ protected:
 public:
 	static ScriptEditor *get_singleton() { return script_editor; }
 	static ScriptEditor *get_bottom_script_editor() { return bottom_script_editor; }
+
+	static Dictionary get_context_data(Control *p_tab_control);
 
 	bool toggle_files_panel();
 	bool is_files_panel_toggled();

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1684,11 +1684,7 @@ void ScriptTextEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 			return;
 		}
 #endif
-		EditorContextMenuPlugin::OptionsData context_data;
-		context_data["code_edit"] = code_editor->get_text_editor();
-		context_data["file_path"] = get_edited_resource()->get_path();
-
-		EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, context_data);
+		EditorContextMenuPluginManager::get_singleton()->invoke_callback(custom_callback, _get_context_data());
 		accept_event();
 	}
 }
@@ -2532,12 +2528,7 @@ void ScriptTextEditor::_make_ste_context_menu(bool p_selection, bool p_color, bo
 	}
 
 	if (EditorContextMenuPluginManager::get_singleton()->has_plugins_for_slot(EditorContextMenuPlugin::CONTEXT_SLOT_SCRIPT_EDITOR_CODE)) {
-		EditorContextMenuPlugin::OptionsData context_data;
-		context_data["code_edit"] = code_editor->get_text_editor();
-		context_data["file_path"] = get_edited_resource()->get_path();
-
-		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(context_menu, EditorContextMenuPlugin::CONTEXT_SLOT_SCRIPT_EDITOR_CODE, context_data);
-
+		EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(context_menu, EditorContextMenuPlugin::CONTEXT_SLOT_SCRIPT_EDITOR_CODE, _get_context_data());
 #ifndef DISABLE_DEPRECATED
 		const PackedStringArray paths = { String(code_editor->get_text_editor()->get_path()) };
 		Ref<Script> edited_script = get_edited_resource();
@@ -2546,6 +2537,13 @@ void ScriptTextEditor::_make_ste_context_menu(bool p_selection, bool p_color, bo
 	}
 
 	_show_context_menu(p_position);
+}
+
+Dictionary ScriptTextEditor::_get_context_data() const {
+	EditorContextMenuPlugin::OptionsData context_data;
+	context_data["code_edit"] = code_editor->get_text_editor();
+	context_data["file_path"] = get_edited_resource()->get_path();
+	return context_data;
 }
 
 void ScriptTextEditor::register_editor() {

--- a/editor/script/script_text_editor.h
+++ b/editor/script/script_text_editor.h
@@ -186,6 +186,7 @@ protected:
 	void _goto_line(int p_line);
 
 	void _make_ste_context_menu(bool p_selection, bool p_color, bool p_foldable, bool p_open_docs, const Vector2 &p_pos);
+	Dictionary _get_context_data() const;
 
 	virtual void _text_edit_gui_input(const Ref<InputEvent> &p_ev) override;
 	virtual bool _edit_option(int p_op) override;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Follow-up to #118569

The editor creates OptionsData for each context in 2 places, which is not good (it already caused a bug in the original PR). This PR adds `_get_context_data()` to each relevant class, for the purpose of removing code duplication.

I also added support for help pages in CONTEXT_SLOT_SCRIPT_EDITOR, which wasn't included before.

## Additional information

I came up with this improvement after #118569 was approved, so I decided to make a separate PR to not delay it any further 🙃 Aside from the help page change, this is only internal.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
