### PR TITLE
GDScript: Make range for "not all code paths" error span return type

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -2051,7 +2051,23 @@ void GDScriptAnalyzer::resolve_function_body(GDScriptParser::FunctionNode *p_fun
 		p_function->return_type_constraint = p_function->body->suite_type;
 	} else if (p_function->return_type_constraint.is_hard_type() && (p_function->return_type_constraint.kind != GDScriptParser::DataType::BUILTIN || p_function->return_type_constraint.builtin_type != Variant::NIL)) {
 		if (!p_function->body->has_return && (p_is_lambda || p_function->identifier->name != GDScriptLanguage::get_singleton()->strings._init)) {
-			push_error(R"(Not all code paths return a value.)", p_function);
+			int start_line = p_function->start_line;
+			int start_column = p_function->start_column;
+			int end_line = p_function->end_line;
+			int end_column = p_function->end_column;
+
+			// NOTE: We don't use the TypeNode range because it currently includes the `->` symbol.
+			// This bug should ultimately be fixed in the parser, but for now using elements from the
+			// type chain works well enough.
+			if (p_function->return_type && !p_function->return_type->type_chain.is_empty()) {
+				const LocalVector<GDScriptParser::IdentifierNode *> &type_chain = p_function->return_type->type_chain;
+				start_line = type_chain[0]->start_line;
+				start_column = type_chain[0]->start_column;
+				end_line = type_chain[type_chain.size() - 1]->end_line;
+				end_column = type_chain[type_chain.size() - 1]->end_column;
+			}
+
+			push_error(R"(Not all code paths return a value.)", p_function, start_line, start_column, end_line, end_column);
 		}
 	}
 
@@ -6577,6 +6593,11 @@ bool GDScriptAnalyzer::check_type_compatibility(const GDScriptParser::DataType &
 void GDScriptAnalyzer::push_error(const String &p_message, const GDScriptParser::Node *p_origin) const {
 	mark_node_unsafe(p_origin);
 	parser->push_error(p_message, p_origin);
+}
+
+void GDScriptAnalyzer::push_error(const String &p_message, const GDScriptParser::Node *p_origin, int p_start_line, int p_start_column, int p_end_line, int p_end_column) const {
+	mark_node_unsafe(p_origin);
+	parser->push_error(p_message, p_start_line, p_start_column, p_end_line, p_end_column);
 }
 
 void GDScriptAnalyzer::mark_node_unsafe(const GDScriptParser::Node *p_node) const {

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -149,6 +149,7 @@ class GDScriptAnalyzer {
 	bool is_type_compatible(const GDScriptParser::DataType &p_target, const GDScriptParser::DataType &p_source, bool p_allow_implicit_conversion = false, const GDScriptParser::Node *p_source_node = nullptr);
 	bool is_type_compatible_strict_collections(const GDScriptParser::DataType &p_target, const GDScriptParser::DataType &p_source);
 	void push_error(const String &p_message, const GDScriptParser::Node *p_origin = nullptr) const;
+	void push_error(const String &p_message, const GDScriptParser::Node *p_origin, int p_start_line, int p_start_column, int p_end_line, int p_end_column) const;
 	void mark_node_unsafe(const GDScriptParser::Node *p_node) const;
 	void downgrade_node_type_source(GDScriptParser::ExpressionNode *p_node);
 	void mark_lambda_use_self();


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/15356#issuecomment-5244455985

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

With this PR, the "Not all code paths return a value" error squiggles/underline appears underneath the function's specified return type. This works with types that have multiple components, and across multiple lines:

<img width="416" height="366" alt="CleanShot 2026-08-10 at 12 52 11@2x" src="https://github.com/user-attachments/assets/88584a17-93cc-4d33-b59d-29dadc207fa2" />

To facilitate this, `GDScriptAnalyzer::push_error()` has a new overload which takes the line/column range instead of inferring it from the passed-in node.