### PR TITLE
Remove `ScriptLanguage::get_core_type_words`

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -583,43 +583,6 @@ Vector<Ref<ScriptBacktrace>> ScriptServer::capture_script_backtraces(bool p_incl
 
 ////////////////////
 
-void ScriptLanguage::get_core_type_words(List<String> *p_core_type_words) const {
-	p_core_type_words->push_back("String");
-	p_core_type_words->push_back("Vector2");
-	p_core_type_words->push_back("Vector2i");
-	p_core_type_words->push_back("Rect2");
-	p_core_type_words->push_back("Rect2i");
-	p_core_type_words->push_back("Vector3");
-	p_core_type_words->push_back("Vector3i");
-	p_core_type_words->push_back("Transform2D");
-	p_core_type_words->push_back("Vector4");
-	p_core_type_words->push_back("Vector4i");
-	p_core_type_words->push_back("Plane");
-	p_core_type_words->push_back("Quaternion");
-	p_core_type_words->push_back("AABB");
-	p_core_type_words->push_back("Basis");
-	p_core_type_words->push_back("Transform3D");
-	p_core_type_words->push_back("Projection");
-	p_core_type_words->push_back("Color");
-	p_core_type_words->push_back("StringName");
-	p_core_type_words->push_back("NodePath");
-	p_core_type_words->push_back("RID");
-	p_core_type_words->push_back("Callable");
-	p_core_type_words->push_back("Signal");
-	p_core_type_words->push_back("Dictionary");
-	p_core_type_words->push_back("Array");
-	p_core_type_words->push_back("PackedByteArray");
-	p_core_type_words->push_back("PackedInt32Array");
-	p_core_type_words->push_back("PackedInt64Array");
-	p_core_type_words->push_back("PackedFloat32Array");
-	p_core_type_words->push_back("PackedFloat64Array");
-	p_core_type_words->push_back("PackedStringArray");
-	p_core_type_words->push_back("PackedVector2Array");
-	p_core_type_words->push_back("PackedVector3Array");
-	p_core_type_words->push_back("PackedColorArray");
-	p_core_type_words->push_back("PackedVector4Array");
-}
-
 void ScriptLanguage::frame() {
 }
 

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -281,7 +281,6 @@ public:
 		}
 	};
 
-	void get_core_type_words(List<String> *p_core_type_words) const;
 	virtual Vector<String> get_reserved_words() const = 0;
 	virtual bool is_control_flow_keyword(const String &p_string) const = 0;
 	virtual Vector<String> get_comment_delimiters() const = 0;

--- a/editor/script/syntax_highlighters.cpp
+++ b/editor/script/syntax_highlighters.cpp
@@ -120,15 +120,15 @@ void EditorStandardSyntaxHighlighter::_update_cache() {
 		}
 	}
 
-	if (scr_lang != nullptr) {
-		/* Core types. */
-		const Color basetype_color = EDITOR_GET("text_editor/theme/highlighting/base_type_color");
-		List<String> core_types;
-		scr_lang->get_core_type_words(&core_types);
-		for (const String &E : core_types) {
-			highlighter->add_keyword_color(E, basetype_color);
+	/* Variant types. */
+	const Color basetype_color = EDITOR_GET("text_editor/theme/highlighting/base_type_color");
+	for (int type = 0; type < Variant::Type::VARIANT_MAX; type++) {
+		if (type != Variant::Type::NIL && type != Variant::Type::OBJECT) {
+			highlighter->add_keyword_color(Variant::get_type_name((Variant::Type)type), basetype_color);
 		}
+	}
 
+	if (scr_lang != nullptr) {
 		/* Reserved words. */
 		const Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
 		const Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -799,19 +799,15 @@ void GDScriptSyntaxHighlighter::_update_cache() {
 
 	const GDScriptLanguage *gdscript = GDScriptLanguage::get_singleton();
 
-	/* Core types. */
+	/* Variant types. */
 	const Color basetype_color = EDITOR_GET("text_editor/theme/highlighting/base_type_color");
-	List<String> core_types;
-	gdscript->get_core_type_words(&core_types);
-	for (const String &E : core_types) {
-		class_names[StringName(E)] = basetype_color;
+	for (int type = 0; type < Variant::Type::VARIANT_MAX; type++) {
+		if (type != Variant::Type::NIL && type != Variant::Type::OBJECT) {
+			class_names[Variant::get_type_name((Variant::Type)type)] = basetype_color;
+		}
 	}
 	class_names[SNAME("Variant")] = basetype_color;
 	class_names[SNAME("void")] = basetype_color;
-	// `get_core_type_words()` doesn't return primitive types.
-	class_names[SNAME("bool")] = basetype_color;
-	class_names[SNAME("int")] = basetype_color;
-	class_names[SNAME("float")] = basetype_color;
 
 	/* Reserved words. */
 	const Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Part of https://github.com/godotengine/godot-proposals/issues/14566 (though removing makes more sense in this case).
- Supersedes and closes https://github.com/godotengine/godot/pull/106595

## Additional information

This method basically introduced the concept of "core types" which I've never seen anywhere else. I roughly conceptualized this as `Variant::Type - {Object, nil, bool, float, int}`. After that I was wondering "Why are we doing this again?".

Turns out it's only used by highlighters and the GDScript highlighter adds bool, float and int back anyway and for the basic multi-purpose highlighter this wouldn't hurt as well. So instead we can simply base this on the reflection we already have for variant types. No need to formalize it in `EditorLanguage`. Placing it there wouldn't make any sense from an OOP perspective anyway.
