### PR TITLE
GDExtension: Copy and null-terminate buffer in XMLParser open_buffer binding 

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -1081,7 +1081,17 @@ static void gdextension_string_name_new_with_utf8_chars_and_len(GDExtensionUnini
 
 static GDExtensionInt gdextension_xml_parser_open_buffer(GDExtensionObjectPtr p_instance, const uint8_t *p_buffer, size_t p_size) {
 	XMLParser *xml = (XMLParser *)p_instance;
-	return (GDExtensionInt)xml->_open_buffer(p_buffer, p_size);
+	if (xml == nullptr || p_buffer == nullptr || p_size == 0) {
+		return (GDExtensionInt)ERR_INVALID_DATA;
+	}
+
+	// Use the safe public method; this causes an extra copy, but it's harmless
+	// and ensures the buffer is properly null-terminated.
+	Vector<uint8_t> buf;
+	buf.resize(p_size);
+	memcpy(buf.ptrw(), p_buffer, p_size);
+
+	return (GDExtensionInt)xml->open_buffer(buf);
 }
 
 static void gdextension_file_access_store_buffer(GDExtensionObjectPtr p_instance, const uint8_t *p_src, uint64_t p_length) {

--- a/tests/core/io/test_xml_parser.cpp
+++ b/tests/core/io/test_xml_parser.cpp
@@ -231,4 +231,20 @@ TEST_CASE("[XMLParser] CDATA") {
 	CHECK_EQ(parser.get_node_name(), "a");
 }
 
+TEST_CASE("[XMLParser] Non-null-terminated buffer via open_buffer") {
+	const uint8_t input_data[] = { '<', 'a', '>', '<', '/', 'a', '>' }; // No null terminator
+	Vector<uint8_t> input;
+	input.resize(sizeof(input_data));
+	memcpy(input.ptrw(), input_data, sizeof(input_data));
+
+	XMLParser parser;
+	REQUIRE_EQ(parser.open_buffer(input), OK);
+	REQUIRE_EQ(parser.read(), OK);
+	CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT);
+	CHECK_EQ(parser.get_node_name(), "a");
+	REQUIRE_EQ(parser.read(), OK);
+	CHECK_EQ(parser.get_node_type(), XMLParser::NodeType::NODE_ELEMENT_END);
+	CHECK_EQ(parser.get_node_name(), "a");
+}
+
 } // namespace TestXMLParser


### PR DESCRIPTION
While poking around gdextension_xml_parser_open_buffer I saw it was shoving the raw extension‑supplied buffer straight into _open_buffer. That internal guy just assumes the buffer is already null‑terminated and will stay alive forever—neither of which is really true for data coming from outside the engine. 

If the extension didn't null‑terminate, the parser would happily walk off the end; if the extension freed the buffer early, we'd get a sweet use‑after‑free. I just made the wrapper copy the bytes into a temp vector and call the public open_buffer instead. That does a safe copy + null‑termination and owns the memory from there on.

 There’s a tiny double‑copy happening but it’s harmless and I left a note about it so nobody freaks out later. Also threw in a test that feeds a non‑null‑terminated buffer into open_buffer to make sure it holds.

