### PR TITLE
LinkButton: Make `get_minimum_size()` a public method

### DIFF
--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -79,7 +79,6 @@ private:
 
 protected:
 	virtual void pressed() override;
-	virtual Size2 get_minimum_size() const override;
 
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -87,6 +86,8 @@ protected:
 	virtual String _get_accessibility_name() const override;
 
 public:
+	virtual Size2 get_minimum_size() const override;
+
 	void set_text(const String &p_text);
 	String get_text() const;
 	void set_uri(const String &p_uri);


### PR DESCRIPTION
## What problem(s) does this PR solve?

`get_minimum_size()` is a public method of `Control`, that's exposed, but in `LinkButton` it's a protected method, preventing `link_button->get_minimum_size()`. The current workaround is `link_button->call(SNAME("get_minimum_size"))`, but it's clearly a mistake that should be fixed.
