### PR TITLE
TextureButton: Make `get_minimum_size()` a public method

### DIFF
--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -34,33 +34,6 @@
 #include "core/object/class_db.h"
 #include "core/typedefs.h"
 
-Size2 TextureButton::get_minimum_size() const {
-	Size2 rscale = Control::get_minimum_size();
-
-	if (!ignore_texture_size) {
-		if (normal.is_null()) {
-			if (pressed.is_null()) {
-				if (hover.is_null()) {
-					if (click_mask.is_null()) {
-						rscale = Size2();
-					} else {
-						rscale = click_mask->get_size();
-					}
-				} else {
-					rscale = hover->get_size();
-				}
-			} else {
-				rscale = pressed->get_size();
-			}
-
-		} else {
-			rscale = normal->get_size();
-		}
-	}
-
-	return rscale.abs();
-}
-
 bool TextureButton::has_point(const Point2 &p_point) const {
 	if (click_mask.is_valid()) {
 		Point2 point = p_point;
@@ -287,6 +260,33 @@ void TextureButton::_bind_methods() {
 	BIND_ENUM_CONSTANT(STRETCH_KEEP_ASPECT);
 	BIND_ENUM_CONSTANT(STRETCH_KEEP_ASPECT_CENTERED);
 	BIND_ENUM_CONSTANT(STRETCH_KEEP_ASPECT_COVERED);
+}
+
+Size2 TextureButton::get_minimum_size() const {
+	Size2 rscale = Control::get_minimum_size();
+
+	if (!ignore_texture_size) {
+		if (normal.is_null()) {
+			if (pressed.is_null()) {
+				if (hover.is_null()) {
+					if (click_mask.is_null()) {
+						rscale = Size2();
+					} else {
+						rscale = click_mask->get_size();
+					}
+				} else {
+					rscale = hover->get_size();
+				}
+			} else {
+				rscale = pressed->get_size();
+			}
+
+		} else {
+			rscale = normal->get_size();
+		}
+	}
+
+	return rscale.abs();
 }
 
 void TextureButton::set_texture_normal(const Ref<Texture2D> &p_normal) {

--- a/scene/gui/texture_button.h
+++ b/scene/gui/texture_button.h
@@ -67,12 +67,13 @@ private:
 	void _texture_changed();
 
 protected:
-	virtual Size2 get_minimum_size() const override;
 	virtual bool has_point(const Point2 &p_point) const override;
 	void _notification(int p_what);
 	static void _bind_methods();
 
 public:
+	virtual Size2 get_minimum_size() const override;
+
 	void set_texture_normal(const Ref<Texture2D> &p_normal);
 	void set_texture_pressed(const Ref<Texture2D> &p_pressed);
 	void set_texture_hover(const Ref<Texture2D> &p_hover);


### PR DESCRIPTION
## What problem(s) does this PR solve?

`get_minimum_size()` is a public method of `Control`, that's exposed, but in `TextureButton` it's a protected method, preventing `texture_button->get_minimum_size()`. The current workaround is `texture_button->call(SNAME("get_minimum_size"))`, but it's clearly a mistake that should be fixed.

Related to https://github.com/godotengine/godot/pull/122290
Keeping these separate for easier reviewing.