### PR TITLE
TextureRect: Make `get_minimum_size()` a public method

### DIFF
--- a/scene/gui/texture_rect.h
+++ b/scene/gui/texture_rect.h
@@ -66,13 +66,14 @@ private:
 
 protected:
 	void _notification(int p_what);
-	virtual Size2 get_minimum_size() const override;
 	static void _bind_methods();
 #ifndef DISABLE_DEPRECATED
 	bool _set(const StringName &p_name, const Variant &p_value);
 #endif
 
 public:
+	virtual Size2 get_minimum_size() const override;
+
 	void set_texture(const Ref<Texture2D> &p_tex);
 	Ref<Texture2D> get_texture() const;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

`get_minimum_size()` is a public method of `Control`, that's exposed, but in `TextureRect` it's a protected method, preventing `texture_rect->get_minimum_size()`. The current workaround is `texture_rect->call(SNAME("get_minimum_size"))`, but it's clearly a mistake that should be fixed.

Related to https://github.com/godotengine/godot/pull/122292
Keeping these separate for easier reviewing.

(Sorry for creating many pull requests at once, I don't mean it as "farming" PRs, this is the last one)