### PR TITLE
Make `get_minimum_size()` public in some GUI Nodes

### DIFF
--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -79,7 +79,6 @@ private:
 
 protected:
 	virtual void pressed() override;
-	virtual Size2 get_minimum_size() const override;
 
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -87,6 +86,9 @@ protected:
 	virtual String _get_accessibility_name() const override;
 
 public:
+	virtual Size2 get_minimum_size() const override;
+	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
+
 	void set_text(const String &p_text);
 	String get_text() const;
 	void set_uri(const String &p_uri);
@@ -115,8 +117,6 @@ public:
 
 	Ref<Font> get_button_font() const;
 	int get_button_font_size() const;
-
-	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 
 	LinkButton(const String &p_text = String());
 };

--- a/scene/gui/nine_patch_rect.h
+++ b/scene/gui/nine_patch_rect.h
@@ -54,10 +54,11 @@ public:
 
 protected:
 	void _notification(int p_what);
-	virtual Size2 get_minimum_size() const override;
 	static void _bind_methods();
 
 public:
+	virtual Size2 get_minimum_size() const override;
+
 	void set_texture(const Ref<Texture2D> &p_tex);
 	Ref<Texture2D> get_texture() const;
 

--- a/scene/gui/texture_button.h
+++ b/scene/gui/texture_button.h
@@ -67,12 +67,13 @@ private:
 	void _texture_changed();
 
 protected:
-	virtual Size2 get_minimum_size() const override;
 	virtual bool has_point(const Point2 &p_point) const override;
 	void _notification(int p_what);
 	static void _bind_methods();
 
 public:
+	virtual Size2 get_minimum_size() const override;
+
 	void set_texture_normal(const Ref<Texture2D> &p_normal);
 	void set_texture_pressed(const Ref<Texture2D> &p_pressed);
 	void set_texture_hover(const Ref<Texture2D> &p_hover);

--- a/scene/gui/texture_rect.h
+++ b/scene/gui/texture_rect.h
@@ -66,13 +66,14 @@ private:
 
 protected:
 	void _notification(int p_what);
-	virtual Size2 get_minimum_size() const override;
 	static void _bind_methods();
 #ifndef DISABLE_DEPRECATED
 	bool _set(const StringName &p_name, const Variant &p_value);
 #endif
 
 public:
+	virtual Size2 get_minimum_size() const override;
+
 	void set_texture(const Ref<Texture2D> &p_tex);
 	Ref<Texture2D> get_texture() const;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

`get_minimum_size()` is a public method of `Control`, that's exposed, but in some GUI Nodes the override is incorrectly put in the `protected` section, preventing calling `node->get_minimum_size()` (note that a workaround is `node->call("get_minimum_size")`, which works). This PR makes them `public`.

## Additional information

Includes: https://github.com/godotengine/godot/pull/122293, https://github.com/godotengine/godot/pull/122292, https://github.com/godotengine/godot/pull/122290