### PR TITLE
Don't template shared parts of `register_builtin_method`

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1350,21 +1350,25 @@ static void _populate_variant_builtin_method_info(VariantBuiltInMethodInfo &r_im
 	r_imi.get_argument_type = T::get_argument_type;
 }
 
-template <typename T>
-static void register_builtin_method(const Vector<String> &p_argnames, const Vector<Variant> &p_def_args) {
-	StringName name = T::get_name();
+// Don't use outside of `register_builtin_method`, the returned pointer might become invalid. Splitting the implementation like this reduces template bloat.
+static VariantBuiltInMethodInfo *insert_builtin_method(const StringName &p_name, Variant::Type p_base_type, const Vector<String> &p_argnames, const Vector<Variant> &p_def_args) {
+	ERR_FAIL_COND_V(builtin_method_info[p_base_type].has(p_name), nullptr);
 
-	ERR_FAIL_COND(builtin_method_info[T::get_base_type()].has(name));
-
+	GODOT_GCC_WARNING_IGNORE("-Wmaybe-uninitialized"); // The things we do for a smaller binary. This is guaranteed to be initialized by `_populate_variant_builtin_method_info` later.
 	VariantBuiltInMethodInfo imi;
-	_populate_variant_builtin_method_info<T>(imi, p_argnames, p_def_args);
 
 #ifdef DEBUG_ENABLED
-	ERR_FAIL_COND(!imi.is_vararg && imi.argument_count != imi.argument_names.size());
+	ERR_FAIL_COND_V(!imi.is_vararg && imi.argument_count != imi.argument_names.size(), nullptr);
 #endif // DEBUG_ENABLED
 
-	builtin_method_info[T::get_base_type()].insert(name, imi);
-	builtin_method_names[T::get_base_type()].push_back(name);
+	builtin_method_names[p_base_type].push_back(p_name);
+	return &builtin_method_info[p_base_type].insert(p_name, imi)->value;
+}
+
+template <typename T>
+_FORCE_INLINE_ static void register_builtin_method(const Vector<String> &p_argnames, const Vector<Variant> &p_def_args) {
+	VariantBuiltInMethodInfo *ptr = insert_builtin_method(T::get_name(), T::get_base_type(), p_argnames, p_def_args);
+	_populate_variant_builtin_method_info<T>(*ptr, p_argnames, p_def_args);
 }
 
 #ifndef DISABLE_DEPRECATED


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Reduces binary size at the time of writing (Fedora 44):
  - `scons target=template_release production=yes` -> Roughly 280kb

## Additional information

To explain why this reduces size by this much let's take a look at the inlines in this template using [bloaty](https://github.com/google/bloaty):

```
bloaty --debug-file=dbg.x86_64 godot.linuxbsd.template_release.x86_64 -d shortsymbols,inlines --source-filter="^register_builtin_method"

   FILE SIZE        VM SIZE    
 --------------  -------------- 
 100.0%   696Ki 100.0%   696Ki    register_builtin_method<>()
    39.7%   276Ki  39.7%   276Ki    [809 Others]
     6.3%  43.7Ki   6.3%  43.7Ki    [section .eh_frame]
     4.7%  32.8Ki   4.7%  32.8Ki    ./core/templates/a_hash_map.h:83
     4.6%  32.0Ki   4.6%  32.0Ki    ./core/string/string_name.h:191
     4.2%  29.4Ki   4.2%  29.4Ki    core/variant/variant_call.cpp:1357
     4.1%  28.3Ki   4.1%  28.3Ki    core/variant/variant_call.cpp:1366
     3.7%  26.1Ki   3.7%  26.1Ki    core/variant/variant_call.cpp:1253
     3.3%  22.7Ki   3.3%  22.7Ki    ./core/templates/a_hash_map.h:113
     3.0%  21.0Ki   3.0%  21.0Ki    ./core/templates/a_hash_map.h:107
     3.0%  21.0Ki   3.0%  21.0Ki    core/variant/variant_call.cpp:1337
     2.8%  19.3Ki   2.8%  19.3Ki    ./core/os/memory.h:103
     2.4%  16.8Ki   2.4%  16.8Ki    ./core/templates/cowdata.h:155
     2.4%  16.8Ki   2.4%  16.8Ki    ./core/templates/cowdata.h:225
     2.2%  15.5Ki   2.2%  15.5Ki    ./core/templates/list.h:290
     2.2%  15.1Ki   2.2%  15.1Ki    ./core/templates/cowdata.h:224
     2.1%  14.3Ki   2.1%  14.3Ki    core/variant/variant_call.cpp:1354
     2.1%  14.3Ki   2.1%  14.3Ki    core/variant/variant_call.cpp:1368
     1.9%  13.1Ki   1.9%  13.1Ki    ./core/templates/a_hash_map.h:100
     1.8%  12.6Ki   1.8%  12.6Ki    ./core/string/string_name.h:192
     1.8%  12.6Ki   1.8%  12.6Ki    core/string/string_name.cpp:189
     1.8%  12.3Ki   1.8%  12.3Ki    ./core/templates/a_hash_map.h:112
```

This shows that a lot of the size of this template originates from inlined core container methods. So by putting the interaction with the container into a not templated method, we prevent them from getting excessively inlined.

The additional call shouldn't be performance critical. As this is part of setting up the engine and not some hot path.
