### PR TITLE
Move `ScriptLanguage::auto_indent_code` to `EditorLanguage::format_code`

### DIFF
--- a/core/object/editor_language.h
+++ b/core/object/editor_language.h
@@ -119,6 +119,17 @@ public:
 	 */
 	virtual int32_t find_function(const String &p_function, const String &p_code) const { return -1; }
 
+	/**
+	 * Called by the editor to reformat a section of code.
+	 *
+	 * In the case of GDScript the only supported kind of formatting is auto-indentation.
+	 *
+	 * @param r_code The current content of the source fragment. Implementations should also use this to return the formatted code. Either by formatting in place or through assignment.
+	 * @param p_from_line First line to be formatted (inclusive).
+	 * @param p_to_line Last line to be formatted (inclusive).
+	 */
+	virtual void format_code(String &r_code, uint32_t p_from_line, uint32_t p_to_line) const {}
+
 	virtual ~EditorLanguage() = default;
 };
 

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -373,7 +373,6 @@ public:
 		TypedArray<int> charac;
 	};
 
-	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const = 0;
 	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value) = 0;
 	virtual void add_named_global_constant(const StringName &p_name, const Variant &p_value) {}
 	virtual void remove_named_global_constant(const StringName &p_name) {}

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -283,6 +283,10 @@ private:
 			return script_language->find_function(p_function, p_code);
 		}
 
+		virtual void format_code(String &r_code, uint32_t p_from_line, uint32_t p_to_line) const override {
+			return script_language->auto_indent_code(r_code, p_from_line, p_to_line);
+		}
+
 		EditorAdapter(ScriptLanguageExtension *p_script_language) {
 			script_language = p_script_language;
 		}
@@ -547,11 +551,15 @@ public:
 #endif // TOOLS_ENABLED
 
 	GDVIRTUAL3RC_REQUIRED(String, _auto_indent_code, const String &, int, int)
-	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const override {
+
+#ifdef TOOLS_ENABLED
+	void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const {
 		String ret;
 		GDVIRTUAL_CALL(_auto_indent_code, p_code, p_from_line, p_to_line, ret);
 		p_code = ret;
 	}
+#endif
+
 	EXBIND2(add_global_constant, const StringName &, const Variant &)
 	EXBIND2(add_named_global_constant, const StringName &, const Variant &)
 	EXBIND1(remove_named_global_constant, const StringName &)

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1789,7 +1789,7 @@ bool ScriptTextEditor::_edit_option(int p_op) {
 				// Auto indent all lines that have a caret or selection on it.
 				Vector<Point2i> line_ranges = tx->get_line_ranges_from_carets();
 				for (Point2i line_range : line_ranges) {
-					scr->get_language()->auto_indent_code(text, line_range.x, line_range.y);
+					scr->get_language()->get_editor_language()->format_code(text, line_range.x, line_range.y);
 					if (line_range.x < begin) {
 						begin = line_range.x;
 					}
@@ -1801,7 +1801,7 @@ bool ScriptTextEditor::_edit_option(int p_op) {
 				// Auto indent entire text.
 				begin = 0;
 				end = tx->get_line_count() - 1;
-				scr->get_language()->auto_indent_code(text, begin, end);
+				scr->get_language()->get_editor_language()->format_code(text, begin, end);
 			}
 
 			// Apply auto indented code.

--- a/modules/gdscript/editor/gdscript_editor_language.h
+++ b/modules/gdscript/editor/gdscript_editor_language.h
@@ -44,6 +44,8 @@ public:
 
 	virtual int32_t find_function(const String &p_function, const String &p_code) const override;
 
+	virtual void format_code(String &r_code, uint32_t p_from_line, uint32_t p_to_line) const override;
+
 	GDScriptEditorLanguage() {
 		ERR_FAIL_COND(singleton != nullptr);
 		singleton = this;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -601,8 +601,6 @@ public:
 	virtual bool supports_documentation() const override;
 	virtual bool can_inherit_from_file() const override { return true; }
 	virtual String make_function(const String &p_class, const String &p_name, const PackedStringArray &p_args) const override;
-	virtual String _get_indentation() const;
-	virtual void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const override;
 	virtual void add_global_constant(const StringName &p_variable, const Variant &p_value) override;
 	virtual void add_named_global_constant(const StringName &p_name, const Variant &p_value) override;
 	virtual void remove_named_global_constant(const StringName &p_name) override;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -64,6 +64,20 @@ EditorLanguage *GDScriptLanguage::get_editor_language() {
 }
 #endif // TOOLS_ENABLED
 
+static String _get_indentation() {
+#ifdef TOOLS_ENABLED
+	if (Engine::get_singleton()->is_editor_hint()) {
+		bool use_space_indentation = EDITOR_GET("text_editor/behavior/indent/type");
+
+		if (use_space_indentation) {
+			int indent_size = EDITOR_GET("text_editor/behavior/indent/size");
+			return String(" ").repeat(indent_size);
+		}
+	}
+#endif
+	return "\t";
+}
+
 Vector<String> GDScriptLanguage::get_comment_delimiters() const {
 	static const Vector<String> delimiters = { "#" };
 	return delimiters;
@@ -3870,27 +3884,15 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 
 //////// END COMPLETION //////////
 
-String GDScriptLanguage::_get_indentation() const {
 #ifdef TOOLS_ENABLED
-	if (Engine::get_singleton()->is_editor_hint()) {
-		bool use_space_indentation = EDITOR_GET("text_editor/behavior/indent/type");
 
-		if (use_space_indentation) {
-			int indent_size = EDITOR_GET("text_editor/behavior/indent/size");
-			return String(" ").repeat(indent_size);
-		}
-	}
-#endif
-	return "\t";
-}
-
-void GDScriptLanguage::auto_indent_code(String &p_code, int p_from_line, int p_to_line) const {
+void GDScriptEditorLanguage::format_code(String &r_code, uint32_t p_from_line, uint32_t p_to_line) const {
 	String indent = _get_indentation();
 
-	Vector<String> lines = p_code.split("\n");
+	Vector<String> lines = r_code.split("\n");
 	List<int> indent_stack;
 
-	for (int i = 0; i < lines.size(); i++) {
+	for (uint32_t i = 0; i < lines.size(); i++) {
 		String l = lines[i];
 		int tc = 0;
 		for (int j = 0; j < l.length(); j++) {
@@ -3932,16 +3934,14 @@ void GDScriptLanguage::auto_indent_code(String &p_code, int p_from_line, int p_t
 		lines.write[i] = l;
 	}
 
-	p_code = "";
+	r_code = String();
 	for (int i = 0; i < lines.size(); i++) {
 		if (i > 0) {
-			p_code += "\n";
+			r_code += "\n";
 		}
-		p_code += lines[i];
+		r_code += lines[i];
 	}
 }
-
-#ifdef TOOLS_ENABLED
 
 static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, const String &p_symbol, EditorLanguage::LookupResult &r_result) {
 	GDScriptParser::DataType base_type = p_base;

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -519,8 +519,7 @@ public:
 	bool supports_builtin_mode() const override;
 	String make_function(const String &p_class, const String &p_name, const PackedStringArray &p_args) const override;
 	virtual bool can_make_function() const override { return false; }
-	virtual String _get_indentation() const;
-	/* TODO? */ void auto_indent_code(String &p_code, int p_from_line, int p_to_line) const override {}
+	String _get_indentation() const;
 	/* TODO */ void add_global_constant(const StringName &p_variable, const Variant &p_value) override {}
 	virtual ScriptNameCasing preferred_file_name_casing() const override;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Part of https://github.com/godotengine/godot-proposals/issues/14566

## Additional information

I decided to not only move this method but also rename it to `format_code`, since an indentation only API doesn't really translate to other languages, since formatting capabilities are usually bundled as one feature.
