### PR TITLE
Skeleton3D: Fix invalid bone name error formatting

### DIFF
--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -605,7 +605,7 @@ uint64_t Skeleton3D::get_version() const {
 }
 
 int Skeleton3D::add_bone(const String &p_name) {
-	ERR_FAIL_COND_V_MSG(p_name.is_empty() || p_name.contains_char(':') || p_name.contains_char('/'), -1, vformat("Bone name cannot be empty or contain ':' or '/'.", p_name));
+	ERR_FAIL_COND_V_MSG(p_name.is_empty() || p_name.contains_char(':') || p_name.contains_char('/'), -1, vformat("Bone name \"%s\" cannot be empty or contain ':' or '/'.", p_name));
 	ERR_FAIL_COND_V_MSG(name_to_bone_index.has(p_name), -1, vformat("Skeleton3D \"%s\" already has a bone with name \"%s\".", to_string(), p_name));
 
 	Bone b;


### PR DESCRIPTION
﻿## Summary

`Skeleton3D::add_bone()` rejected invalid bone names with:

```cpp
vformat("Bone name cannot be empty or contain ':' or '/'.", p_name)
```

`p_name` was passed to `vformat()` without a `%s` placeholder, so formatting failed and the intended validation message was lost.

This change adds the missing `%s` so the invalid bone name is included in the error message.

## Notes

- No runtime tests were run locally because a compiled Godot binary is not available in this environment.
- The change only affects error-message formatting; bone validation behavior is unchanged.

## Test plan

- [ ] Call `Skeleton3D.add_bone("")` and confirm the error mentions the bone name constraint (no `vformat` formatting error).
- [ ] Call `Skeleton3D.add_bone("foo:bar")` and `add_bone("foo/bar")` and confirm both return `-1` with a clear error that includes the invalid name.
- [ ] Call `Skeleton3D.add_bone("valid")` and confirm it still succeeds.
