### PR TITLE
Fix missing "Open in Editor" context menu button in unsaved inherited scene root

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4062,32 +4062,38 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 
 		// Group "make_local" etc. with "save_branch_as_scene", if it is available.
 		bool is_external = selection.front()->get()->is_instance();
-		if (is_external) {
-			bool is_inherited = selection.front()->get()->get_scene_inherited_state().is_valid();
-			bool is_top_level = selection.front()->get()->get_owner() == nullptr;
-			if (is_inherited && is_top_level) {
-				if (profile_allow_editing) {
-					BEGIN_SECTION()
-					menu->add_item(TTRC("Clear Inheritance"), TOOL_SCENE_CLEAR_INHERITANCE);
-				}
+		bool is_inherited = selection.front()->get()->get_scene_inherited_state().is_valid();
+		bool is_top_level = selection.front()->get()->get_owner() == nullptr;
+		if (is_inherited && is_top_level) {
+			// "clear_inheritance" should be available even when the scene is unsaved (is_external == false).
+			if (profile_allow_editing) {
+				BEGIN_SECTION()
+				menu->add_item(TTRC("Clear Inheritance"), TOOL_SCENE_CLEAR_INHERITANCE);
+			}
+
+			// TODO: This condition incorrectly hides "open_in_editor" for unsaved inherited scene root.
+			if (is_external) {
 				is_tool_scene_open_inherited_available = true;
-			} else if (!is_top_level) {
-				bool editable = EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(selection.front()->get());
-				bool placeholder = selection.front()->get()->get_scene_instance_load_placeholder();
-				if (profile_allow_editing) {
-					BEGIN_SECTION()
-					menu->add_item(TTRC("Make Local"), TOOL_SCENE_MAKE_LOCAL);
-
-					menu->add_check_item(TTRC("Editable Children"), TOOL_SCENE_EDITABLE_CHILDREN);
-					menu->set_item_shortcut(-1, ED_GET_SHORTCUT("scene_tree/toggle_editable_children"));
-					menu->set_item_checked(-1, editable);
-
-					menu->add_check_item(TTRC("Load as Placeholder"), TOOL_SCENE_USE_PLACEHOLDER);
-					menu->set_item_checked(-1, placeholder);
-				}
-				is_tool_scene_open_available = true;
 			}
 		}
+
+		if (is_external && !is_top_level) {
+			bool editable = EditorNode::get_singleton()->get_edited_scene()->is_editable_instance(selection.front()->get());
+			bool placeholder = selection.front()->get()->get_scene_instance_load_placeholder();
+			if (profile_allow_editing) {
+				BEGIN_SECTION()
+				menu->add_item(TTRC("Make Local"), TOOL_SCENE_MAKE_LOCAL);
+
+				menu->add_check_item(TTRC("Editable Children"), TOOL_SCENE_EDITABLE_CHILDREN);
+				menu->set_item_shortcut(-1, ED_GET_SHORTCUT("scene_tree/toggle_editable_children"));
+				menu->set_item_checked(-1, editable);
+
+				menu->add_check_item(TTRC("Load as Placeholder"), TOOL_SCENE_USE_PLACEHOLDER);
+				menu->set_item_checked(-1, placeholder);
+			}
+			is_tool_scene_open_available = true;
+		}
+
 		END_SECTION()
 	}
 

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -4070,11 +4070,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 				BEGIN_SECTION()
 				menu->add_item(TTRC("Clear Inheritance"), TOOL_SCENE_CLEAR_INHERITANCE);
 			}
-
-			// TODO: This condition incorrectly hides "open_in_editor" for unsaved inherited scene root.
-			if (is_external) {
-				is_tool_scene_open_inherited_available = true;
-			}
+			is_tool_scene_open_inherited_available = true;
 		}
 
 		if (is_external && !is_top_level) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

Closes https://github.com/godotengine/godot/issues/122303
Requires https://github.com/godotengine/godot/pull/119638

## Additional information

Changes:
- "Open in Editor" now appears when right-clicking the root node of an `[unsaved](*)` inherited scene.

Screenshot:
<img width="343" height="397" alt="Image 2026-08-11_22-45-03" src="https://github.com/user-attachments/assets/995cc9be-8d1d-4b81-b57f-ae1a850b9a5f" />

## Author disclosure

I wrote this PR by myself.