### PR TITLE
Update reference to Control offset properties in SubViewportContainer documentation

### DIFF
--- a/doc/classes/SubViewportContainer.xml
+++ b/doc/classes/SubViewportContainer.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		A container that displays the contents of underlying [SubViewport] child nodes. It uses the combined size of the [SubViewport]s as minimum size, unless [member stretch] is enabled.
-		[b]Note:[/b] Changing a [SubViewportContainer]'s [member Control.scale] will cause its contents to appear distorted. To change its visual size without causing distortion, adjust the node's margins instead (if it's not already in a container).
+		[b]Note:[/b] Changing a [SubViewportContainer]'s [member Control.scale] will cause its contents to appear distorted. To change its visual size without causing distortion, adjust the node's offset properties instead (if it's not already in a container).
 		[b]Note:[/b] The [SubViewportContainer] forwards mouse-enter and mouse-exit notifications to its sub-viewports.
 	</description>
 	<tutorials>


### PR DESCRIPTION
`margin_*` was the name used in Godot 3 for what's called `offset_*` in Godot 4.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/804#discussioncomment-17870603.
