### PR TITLE
Improve selected item contrast for ItemList in the Modern editor theme

### DIFF
--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -762,14 +762,22 @@ void ThemeModern::populate_standard_styles(const Ref<EditorTheme> &p_theme, Edit
 			Ref<StyleBoxFlat> style_itemlist_cursor = p_config.base_style->duplicate();
 			style_itemlist_cursor->set_bg_color(p_config.mono_color * Color(1, 1, 1, 0.04));
 
+			// Use the accent-tinted highlight color instead of the neutral pressed color so the
+			// selected item remains clearly distinguishable from a merely hovered item.
+			const Color itemlist_selected_color = p_config.highlight_color * Color(1, 1, 1, 0.65);
+			Ref<StyleBoxFlat> style_itemlist_selected = p_config.flat_button_pressed->duplicate();
+			style_itemlist_selected->set_bg_color(itemlist_selected_color);
+			Ref<StyleBoxFlat> style_itemlist_hover_selected = p_config.flat_button_hover_pressed->duplicate();
+			style_itemlist_hover_selected->set_bg_color(itemlist_selected_color);
+
 			p_theme->set_stylebox(SceneStringName(panel), "ItemList", style_itemlist_bg);
 			p_theme->set_stylebox("focus", "ItemList", p_config.focus_style);
 			p_theme->set_stylebox("cursor", "ItemList", style_itemlist_cursor);
 			p_theme->set_stylebox("cursor_unfocused", "ItemList", style_itemlist_cursor);
 			p_theme->set_stylebox("selected_focus", "ItemList", p_config.focus_style);
-			p_theme->set_stylebox("selected", "ItemList", p_config.flat_button_pressed);
+			p_theme->set_stylebox("selected", "ItemList", style_itemlist_selected);
 			p_theme->set_stylebox("hovered", "ItemList", p_config.flat_button_hover);
-			p_theme->set_stylebox("hovered_selected", "ItemList", p_config.flat_button_hover_pressed);
+			p_theme->set_stylebox("hovered_selected", "ItemList", style_itemlist_hover_selected);
 			p_theme->set_stylebox("hovered_selected_focus", "ItemList", p_config.focus_style);
 			p_theme->set_color(SceneStringName(font_color), "ItemList", p_config.font_color);
 			p_theme->set_color("font_hovered_color", "ItemList", p_config.font_hover_color);


### PR DESCRIPTION
## Summary
- In the Modern editor theme, `ItemList`'s `selected` / `hovered_selected` styleboxes reused the neutral `flat_button_pressed` color, which is only a slightly darker shade of the base background.
- This makes it hard to tell which item is currently selected vs. merely hovered — most noticeable in the Script editor's script list on the left, where it's difficult to see which script is currently open.
- The Classic theme already highlights selection with an accent-tinted `highlight_color`; this brings the same idea to the Modern theme's `ItemList`, at a reduced opacity so it isn't overly strong against Modern's flatter look.

## Test plan
- [x] Built the editor locally (`scons platform=windows target=editor`) with the Modern theme.
- [x] Opened multiple scripts in the Script editor and confirmed the currently selected script in the file list is now clearly distinguishable from hovered/unselected items.
- [x] Checked Classic theme is unaffected (change is scoped to `theme_modern.cpp`).