### PR TITLE
Fix broken early return in GDScript auto indent

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3925,22 +3925,16 @@ void GDScriptEditorLanguage::format_code(String &r_code, uint32_t p_from_line, u
 			}
 		}
 
-		if (i >= p_from_line) {
-			l = indent.repeat(indent_stack.size()) + st;
-		} else if (i > p_to_line) {
+		if (i > p_to_line) {
 			break;
+		} else if (i >= p_from_line) {
+			l = indent.repeat(indent_stack.size()) + st;
 		}
 
 		lines.write[i] = l;
 	}
 
-	r_code = String();
-	for (int i = 0; i < lines.size(); i++) {
-		if (i > 0) {
-			r_code += "\n";
-		}
-		r_code += lines[i];
-	}
+	r_code = String("\n").join(lines);
 }
 
 static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, const String &p_symbol, EditorLanguage::LookupResult &r_result) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Noticed this while working on https://github.com/godotengine/godot/pull/122301:
  - The GDScript implementation of `auto_indent_code` does not respect `p_to_line` and formats everything after `p_from_line` (due to a wrong order when checking the return condition).
  - This is not noticeable by users, since the editor side does only apply the lines in the given range: https://github.com/HolonProduction/godot/blob/d488d11119b4e0c67619b0c720d7c335ad2d0565/editor/script/script_text_editor.cpp#L1732-L1736 we should fix the GDScript side anyway in case new code ends up using this.

## Additional information

Also couldn't resist and simplified some string building using `String::join` for readability.
