### PR TITLE
Delete `operator=(const m_class &p_rval)` on `Object` subclasses

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -248,7 +248,7 @@ private:
 #define GDCLASS(m_class, m_inherits) \
 	GDSOFTCLASS(m_class, m_inherits) \
 private: \
-	void operator=(const m_class &p_rval) {} \
+	void operator=(const m_class &p_rval) = delete; \
 	friend class ::ClassDB; \
 \
 	static GDType &get_gdtype_static_mutable() { \


### PR DESCRIPTION
This started on godot-cpp in https://github.com/godotengine/godot-cpp/pull/2027 and this is bringing the same change to upstream Godot

Right now `operator=(const m_class &p_rval)` has an empty implementation - this goes one step further by deleting the method entirely

I think this should be fine, because we don't want to copy `Object`'s by value, they should always be pointers. This is only changing a silent no-op for something that shouldn't happen into a loud compilation error :-)