### PR TITLE
Fail when attempting to profile in release exports

### DIFF
--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -80,7 +80,7 @@ void EngineDebugger::profiler_enable(const StringName &p_name, bool p_enabled, c
 void EngineDebugger::profiler_add_frame_data(const StringName &p_name, const Array &p_data) {
 	ERR_FAIL_COND_MSG(!profilers.has(p_name), vformat("Can't add frame data, no profiler: '%s'.", p_name));
 	Profiler &p = profilers[p_name];
-	if (p.add) {
+	if (p.active && p.add) {
 		p.add(p.data, p_data);
 	}
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -261,8 +261,8 @@ static bool force_res = false;
 
 // Debug
 
-static bool use_debug_profiler = false;
 #ifdef DEBUG_ENABLED
+static bool use_debug_profiler = false;
 static bool debug_collisions = false;
 static bool debug_paths = false;
 static bool debug_navigation = false;
@@ -587,12 +587,12 @@ void Main::print_help(const char *p_binary) {
 	print_help_option("--accessibility-driver <driver>", "Select accessibility driver ['accesskit', 'dummy'].\n");
 
 	print_help_title("Debug options");
-#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
+#ifdef DEBUG_ENABLED
 	print_help_option("-d, --debug", "Debug (local stdout debugger).\n");
 	print_help_option("-b, --breakpoints", "Breakpoint list as source:line comma-separated pairs, no spaces (use %%20 instead).\n");
 	print_help_option("--ignore-error-breaks", "If debugger is connected, prevents sending error breakpoints.\n");
-#endif
 	print_help_option("--profiling", "Enable profiling in the script debugger.\n");
+#endif
 	print_help_option("--gpu-profile", "Show a GPU profile of the tasks that took the most time during frame rendering.\n");
 	print_help_option("--gpu-validation", "Enable graphics API validation layers for debugging.\n");
 #ifdef DEBUG_ENABLED
@@ -1461,9 +1461,13 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				goto error;
 			}
 		} else if (arg == "--profiling") { // enable profiling
-
+#ifdef DEBUG_ENABLED
 			use_debug_profiler = true;
-
+#else
+			ERR_PRINT(
+					"`--profiling` was specified on the command line, but this Godot binary was compiled without debug. Aborting.\n"
+					"To be able to use it, use the `target=template_debug` SCons option when compiling Godot.\n");
+#endif
 		} else if (arg == "-l" || arg == "--language") { // language
 
 			if (N) {
@@ -3836,11 +3840,13 @@ Error Main::setup2(bool p_show_boot_logo) {
 	BindingsGenerator::handle_cmdline_args(cmdline_args);
 #endif
 
+#ifdef DEBUG_ENABLED
 	if (use_debug_profiler && EngineDebugger::is_active()) {
 		// Start the "scripts" profiler, used in local debugging.
 		// We could add more, and make the CLI arg require a comma-separated list of profilers.
 		EngineDebugger::get_singleton()->profiler_enable("scripts", true);
 	}
+#endif
 
 	if (!project_manager) {
 		// If not running the project manager, and now that the engine is


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Spiritual successor to https://github.com/godotengine/godot/pull/122213
- While working on https://github.com/godotengine/godot/pull/122210 I got into profiler territory. A lot of this stuff is provably useless in release builds. So we should restrict access to it early as well.

## Additional information

- I decided to adopt `ifdef DEBUG_ENABLED` over `defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)` since tools imply debugging at the moment. And looking at the internals I don't see that changing.
- The main loop changes are not compat breaking, we print an error if users pass `--profiling` but continue. The `ifdef` condition can provably never happen, since `EngineDebugger::is_active` can't be true in release builds.
- This PR includes a second change, which makes `EngineDebugger::profiler_add_frame_data` a no-op if the specified profiler is not actively profiling.
  - Activating a profiler in release builds impossible: https://github.com/HolonProduction/godot/blob/5913cd27514fab93a4bdfb04167e46f36562ea96/core/core_bind.cpp#L2213 (the guard is only in core bind, but the internal version is not called in release builds).
  - However the registration infrastructure for profilers is functional in release builds.
  - Since `profiler_add_frame_data` was not guarded against inactive profilers, one could theoretically abuse this infrastructure as a message broker in release builds. This is obviously not a valid usecase and fine to forbid. However I felt this detail would have gotten lost in https://github.com/godotengine/godot/pull/122210 which focuses on verifiably safe exclusions.