### PR TITLE
[Core]: Improve `ObjectDB` multi-threading performance and safety

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -38,6 +38,7 @@
 #include "core/object/message_queue.h"
 #include "core/object/script_language.h"
 #include "core/os/os.h"
+#include "core/os/spin_lock.h"
 #include "core/string/print_string.h"
 #include "core/string/translation_server.h"
 #include "core/variant/typed_array.h"
@@ -136,9 +137,15 @@ Object::Connection::Connection(const Variant &p_variant) {
 }
 
 bool Object::_predelete() {
+	ObjectDB::ObjectSlot *object_slot = nullptr;
+	if (_instance_id != ObjectID()) {
+		object_slot = ObjectDB::predelete_instance(this);
+	}
+
 	_predelete_ok = true;
 	notification(NOTIFICATION_PREDELETE, true);
 	if (!_predelete_ok) {
+		ObjectDB::cancel_predelete(object_slot);
 		return false;
 	}
 
@@ -2435,15 +2442,35 @@ void postinitialize_handler(Object *p_object) {
 }
 
 void ObjectDB::debug_objects(DebugFunc p_func, void *p_user_data) {
-	spin_lock.lock();
+	mutex.lock();
+	is_blocked.set();
 
-	for (uint32_t i = 0, count = slot_count; i < slot_max && count != 0; i++) {
-		if (object_slots[i].validator) {
-			p_func(object_slots[i].object, p_user_data);
-			count--;
+	// Give time for all writers to exit.
+	OS::get_singleton()->delay_usec(1000);
+
+	uint32_t count = get_object_count();
+	if (count == 0) {
+		is_blocked.clear();
+		mutex.unlock();
+		return;
+	}
+	for (uint32_t block_idx = 0; block_idx < block_max.get(); block_idx++) {
+		for (uint32_t slot_idx = 0; slot_idx < OBJECTDB_BLOCK_SIZE; slot_idx++) {
+			const ObjectSlot &slot = object_blocks[block_idx][slot_idx];
+			if (!slot.get_data().is_active()) {
+				// Not active, skip.
+				continue;
+			}
+			p_func(slot.object, p_user_data);
+			if (--count == 0) {
+				block_idx = block_max.get();
+				slot_idx = OBJECTDB_BLOCK_SIZE;
+				continue;
+			}
 		}
 	}
-	spin_lock.unlock();
+	is_blocked.clear();
+	mutex.unlock();
 }
 
 #ifdef TOOLS_ENABLED
@@ -2492,102 +2519,222 @@ void Object::get_argument_options(const StringName &p_function, int p_idx, List<
 }
 #endif
 
-SpinLock ObjectDB::spin_lock;
-uint32_t ObjectDB::slot_count = 0;
-uint32_t ObjectDB::slot_max = 0;
-ObjectDB::ObjectSlot *ObjectDB::object_slots = nullptr;
-uint64_t ObjectDB::validator_counter = 0;
+void ObjectDB::push_free_slot(ObjectSlot *p_slot, SlotData p_slot_data) {
+	// This lock-free stack uses the tagged index to prevent the ABA problem.
+	// Every change in the top is accompanied with a unique version, so
+	// `compare_exchange` will expect the same version when trying to change it,
+	// and will fail if any other thread modified the top first.
+	// We don't need to worry about memory reclamation, because we don't allocate
+	// physical memory when we store slots, the free slots stack is purely virtual.
+
+	TaggedIndex current_top{ free_slots_top.get() };
+	while (true) {
+		// Store the current top in the new free slot's data.
+		p_slot->set_data(p_slot_data.with_index(current_top.index()));
+
+		// Try to store the new free slot as top.
+		TaggedIndex new_top = TaggedIndex::create(p_slot_data.index(), current_top.new_version());
+
+		if (free_slots_top.compare_exchange<false>(current_top.raw, new_top)) {
+			// Successfully changed top.
+			return;
+		}
+	}
+}
+
+bool ObjectDB::try_pop_free_slot(ObjectSlot *&r_slot, SlotData &r_slot_data) {
+	// See `ObjectDB::push_free_slot` for overview on how this lock-free stack works.
+
+	TaggedIndex current_top{ free_slots_top.get() };
+	while (true) {
+		SlotIndex top_index = current_top.index();
+		if (unlikely(top_index.is_null())) {
+			// The stack is empty.
+			return false;
+		}
+
+		ObjectSlot *top_slot = &object_blocks[top_index.block][top_index.slot];
+		// Get the previous top from the current top's data.
+		SlotData top_data = top_slot->get_data();
+		SlotIndex prev_top = top_data.index();
+
+		// Try to store the previous top as a new top.
+		TaggedIndex new_top = TaggedIndex::create(prev_top, current_top.new_version());
+
+		if (free_slots_top.compare_exchange<false>(current_top.raw, new_top)) {
+			// Successfully changed top.
+			r_slot = top_slot;
+			// Return top's ( block | slot | validator ) together.
+			r_slot_data = top_data.with_index(top_index);
+			return true;
+		}
+	}
+}
 
 int ObjectDB::get_object_count() {
-	return slot_count;
+	return slot_count.get();
+}
+
+ObjectDB::ObjectSlot *ObjectDB::get_free_slot(SlotData &r_slot_data) {
+	ObjectSlot *free_slot = nullptr;
+
+	// Because we push all allocated slots to a free slots stack
+	// try pop can only fail if there is no more free slots left.
+	while (unlikely(!try_pop_free_slot(free_slot, r_slot_data))) {
+		// Only 1 thread is allowed to allocate a new block at a time,
+		// but we can allocate and pop slots from the stack at the same time.
+		static SafeFlag is_allocating{ false };
+		if (!is_allocating.set_if_clear()) {
+			Thread::yield();
+			continue;
+		}
+
+		uint32_t new_block_idx = block_max.get();
+		CRASH_COND(new_block_idx >= OBJECTDB_BLOCK_MAX_COUNT);
+		object_blocks[new_block_idx] = (ObjectSlot *)memalloc(sizeof(ObjectSlot) * OBJECTDB_BLOCK_SIZE);
+		block_max.add(1);
+
+		// We don't need any special logic to handle the "null" slot (0, 0).
+		// Even if we try to store it in the stack, the stack only stores the
+		// top's index, so it will be stored as a "null" index.
+		for (uint32_t i = 0; i < SLOTS_IN_CACHE_LINE; i++) {
+			for (uint32_t j = i; j < OBJECTDB_BLOCK_SIZE; j += SLOTS_IN_CACHE_LINE) {
+				ObjectSlot *new_slot = memnew_placement(&object_blocks[new_block_idx][j], ObjectSlot);
+				SlotData new_data = SlotData::create(SlotIndex(new_block_idx, j), 0, false, false, false);
+				push_free_slot(new_slot, new_data);
+			}
+		}
+		is_allocating.clear();
+	}
+
+	return free_slot;
 }
 
 ObjectID ObjectDB::add_instance(Object *p_object) {
-	spin_lock.lock();
-	if (unlikely(slot_count == slot_max)) {
-		CRASH_COND(slot_count == (1 << OBJECTDB_SLOT_MAX_COUNT_BITS));
+	if (unlikely(is_blocked.is_set())) {
+		MutexLock lock(mutex);
+	}
+	SlotData stored_data;
+	ObjectSlot *slot = get_free_slot(stored_data);
 
-		uint32_t new_slot_max = slot_max > 0 ? slot_max * 2 : 1;
-		object_slots = (ObjectSlot *)memrealloc(object_slots, sizeof(ObjectSlot) * new_slot_max);
-		for (uint32_t i = slot_max; i < new_slot_max; i++) {
-			object_slots[i].object = nullptr;
-			object_slots[i].is_ref_counted = false;
-			object_slots[i].next_free = i;
-			object_slots[i].validator = 0;
+	ERR_FAIL_COND_V(slot->object != nullptr, ObjectID());
+	slot->object = p_object;
+
+	SlotData slot_data = SlotData::create(
+			SlotIndex{},
+			stored_data.new_validator(),
+			false,
+			true,
+			p_object->is_ref_counted());
+	slot->set_data(slot_data);
+
+	slot_count.add(1);
+
+	return ObjectID(slot_data.with_index(stored_data.index()));
+}
+
+ObjectDB::ObjectSlot *ObjectDB::predelete_instance(Object *p_object) {
+	if (unlikely(is_blocked.is_set())) {
+		MutexLock lock(mutex);
+	}
+	SlotData instance_data{ p_object->get_instance_id() };
+	// Slot index is always valid on a valid object.
+	SlotIndex slot_index = instance_data.index();
+	ObjectSlot *slot = &object_blocks[slot_index.block][slot_index.slot];
+	SlotData slot_data = slot->get_data();
+
+	ERR_FAIL_COND_V(slot_data.validator_with<OBJECTDB_PREDELETE_BIT>() != instance_data.validator_with<OBJECTDB_PREDELETE_BIT>(), nullptr);
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND_V(slot->object != p_object, nullptr);
+#endif
+	// Mark the slot as being in predelete.
+	slot_data = SlotData{ slot->safe_data.bit_or(OBJECTDB_PREDELETE_BIT) };
+	if (unlikely(slot_data.has_locked_readers())) {
+		// Wait for all locked readers to exit. It will wait until all instances
+		// gotten from `ObjectDB::get_locked_instance` are unlocked.
+		while (SlotData{ SafeNumericInternal::relaxed_get(&slot->safe_data) }.has_locked_readers()) {
+			_cpu_pause(); // Spin.
 		}
-		slot_max = new_slot_max;
 	}
+	return slot;
+}
 
-	uint32_t slot = object_slots[slot_count].next_free;
-	if (object_slots[slot].object != nullptr) {
-		spin_lock.unlock();
-		ERR_FAIL_COND_V(object_slots[slot].object != nullptr, ObjectID());
+void ObjectDB::cancel_predelete(ObjectSlot *p_object_slot) {
+	if (p_object_slot) {
+		p_object_slot->safe_data.bit_and(~OBJECTDB_PREDELETE_BIT);
 	}
-	object_slots[slot].object = p_object;
-	object_slots[slot].is_ref_counted = p_object->is_ref_counted();
-	validator_counter = (validator_counter + 1) & OBJECTDB_VALIDATOR_MASK;
-	if (unlikely(validator_counter == 0)) {
-		validator_counter = 1;
-	}
-	object_slots[slot].validator = validator_counter;
-
-	uint64_t id = validator_counter;
-	id <<= OBJECTDB_SLOT_MAX_COUNT_BITS;
-	id |= uint64_t(slot);
-
-	if (p_object->is_ref_counted()) {
-		id |= OBJECTDB_REFERENCE_BIT;
-	}
-
-	slot_count++;
-
-	spin_lock.unlock();
-
-	return ObjectID(id);
 }
 
 void ObjectDB::remove_instance(Object *p_object) {
-	uint64_t t = p_object->get_instance_id();
-	uint32_t slot = t & OBJECTDB_SLOT_MAX_COUNT_MASK; //slot is always valid on valid object
+	SlotData instance_data{ p_object->get_instance_id() };
+	// Slot index is always valid on a valid object.
+	SlotIndex slot_index = instance_data.index();
+	ObjectSlot *slot = &object_blocks[slot_index.block][slot_index.slot];
+	SlotData slot_data = slot->get_data();
 
-	spin_lock.lock();
-
+	ERR_FAIL_COND(slot_data.validator_with<OBJECTDB_ACTIVE_BIT>() != instance_data.validator_with<OBJECTDB_ACTIVE_BIT>());
 #ifdef DEBUG_ENABLED
+	ERR_FAIL_COND(slot->object != p_object);
+#endif
+	// Mark the slot as inactive.
+	slot_data = SlotData{ slot->safe_data.bit_and(~OBJECTDB_ACTIVE_BIT) };
+	// Decrease the slot count, we only track active slots.
+	slot_count.sub(1);
 
-	if (object_slots[slot].object != p_object) {
-		spin_lock.unlock();
-		ERR_FAIL_COND(object_slots[slot].object != p_object);
-	}
-	{
-		uint64_t validator = (t >> OBJECTDB_SLOT_MAX_COUNT_BITS) & OBJECTDB_VALIDATOR_MASK;
-		if (object_slots[slot].validator != validator) {
-			spin_lock.unlock();
-			ERR_FAIL_COND(object_slots[slot].validator != validator);
+	if (unlikely(slot_data.has_readers())) {
+		// Wait for all readers to exit. The section being guarded is very short
+		// because we stop all new readers from entering, so it shouldn't be too long.
+		while (SlotData{ SafeNumericInternal::relaxed_get(&slot->safe_data) }.has_readers()) {
+			_cpu_pause(); // Spin.
 		}
 	}
+	// No readers left, safe to change.
+	slot->object = nullptr;
+	// Add to the free slots stack.
+	push_free_slot(slot, SlotData::create(slot_index, slot_data.validator(), true, false, false));
+}
 
+void ObjectDB::unlock_instance(Object *p_object) {
+	if (!p_object) {
+		return;
+	}
+	SlotData instance_data{ p_object->get_instance_id() };
+	SlotIndex slot_index = instance_data.index();
+	ObjectSlot *slot = &object_blocks[slot_index.block][slot_index.slot];
+	// `get_data` is needed for correct sync.
+	SlotData slot_data = slot->get_data();
+
+	ERR_FAIL_COND(slot_data.validator_with<OBJECTDB_ACTIVE_BIT>() != instance_data.validator_with<OBJECTDB_ACTIVE_BIT>());
+#ifdef DEBUG_ENABLED
+	ERR_FAIL_COND(slot->object != p_object);
+	ERR_FAIL_COND(!slot_data.has_locked_readers());
 #endif
-	//decrease slot count
-	slot_count--;
-	//set the free slot properly
-	object_slots[slot_count].next_free = slot;
-	//invalidate, so checks against it fail
-	object_slots[slot].validator = 0;
-	object_slots[slot].is_ref_counted = false;
-	object_slots[slot].object = nullptr;
-
-	spin_lock.unlock();
+	// Decrement the bit after the inner readers count.
+	slot->safe_data.sub(1 << OBJECTDB_INNER_READERS_BITS);
 }
 
 void ObjectDB::setup() {
-	//nothing to do now
+	mutex.lock();
+	is_blocked.set();
+
+	free_slots_top.set(0);
+
+	object_blocks = (ObjectSlot **)memalloc_zeroed(sizeof(ObjectSlot *) * OBJECTDB_BLOCK_MAX_COUNT);
+	block_max.set(0);
+
+	is_blocked.clear();
+	mutex.unlock();
 }
 
 void ObjectDB::cleanup() {
-	spin_lock.lock();
+	mutex.lock();
+	is_blocked.set();
 
-	if (slot_count > 0) {
-		WARN_PRINT(vformat("%d ObjectDB %s leaked at exit (run with `--verbose` for details).", slot_count, slot_count == 1 ? "instance was" : "instances were"));
+	OS::get_singleton()->delay_usec(1000);
+
+	uint32_t count = get_object_count();
+	if (count > 0) {
+		WARN_PRINT(vformat("%d ObjectDB %s leaked at exit (run with `--verbose` for details).", count, count == 1 ? "instance was" : "instances were"));
 		if (OS::get_singleton()->is_stdout_verbose()) {
 			// Ensure calling the native classes because if a leaked instance has a script
 			// that overrides any of those methods, it'd not be OK to call them at this point,
@@ -2596,35 +2743,53 @@ void ObjectDB::cleanup() {
 			const MethodBind *resource_get_path = ClassDB::get_method("Resource", "get_path");
 			Callable::CallError call_error;
 
-			for (uint32_t i = 0, count = slot_count; i < slot_max && count != 0; i++) {
-				if (object_slots[i].validator) {
-					Object *obj = object_slots[i].object;
+			for (uint32_t block_idx = 0; block_idx < block_max.get(); block_idx++) {
+				for (uint32_t slot_idx = 0; slot_idx < OBJECTDB_BLOCK_SIZE; slot_idx++) {
+					const ObjectSlot &slot = object_blocks[block_idx][slot_idx];
+					SlotData slot_data = slot.get_data();
+					if (slot_data.is_active()) {
+						Object *obj = slot.object;
 
-					String extra_info;
-					if (obj->is_class("Node")) {
-						extra_info = " - Node path: " + String(node_get_path->call(obj, nullptr, 0, call_error));
-					}
-					if (obj->is_class("Resource")) {
-						extra_info = " - Resource path: " + String(resource_get_path->call(obj, nullptr, 0, call_error));
-					}
-					if (obj->is_class("RefCounted")) {
-						extra_info = " - Reference count: " + itos((static_cast<RefCounted *>(obj))->get_reference_count());
-					}
+						String extra_info;
+						if (obj->is_class("Node")) {
+							extra_info = " - Node path: " + String(node_get_path->call(obj, nullptr, 0, call_error));
+						}
+						if (obj->is_class("Resource")) {
+							extra_info = " - Resource path: " + String(resource_get_path->call(obj, nullptr, 0, call_error));
+						}
+						if (obj->is_class("RefCounted")) {
+							extra_info = " - Reference count: " + itos((static_cast<RefCounted *>(obj))->get_reference_count());
+						}
 
-					uint64_t id = uint64_t(i) | (uint64_t(object_slots[i].validator) << OBJECTDB_SLOT_MAX_COUNT_BITS) | (object_slots[i].is_ref_counted ? OBJECTDB_REFERENCE_BIT : 0);
-					DEV_ASSERT(id == (uint64_t)obj->get_instance_id()); // We could just use the id from the object, but this check may help catching memory corruption catastrophes.
-					print_line("Leaked instance: " + String(obj->get_class()) + ":" + uitos(id) + extra_info);
+						uint64_t id = slot_data.with_index(SlotIndex(block_idx, slot_idx));
+						id &= ~OBJECTDB_PREDELETE_BIT; // Check the id without the predelete bit, everything else must match.
+						DEV_ASSERT(id == (uint64_t)obj->get_instance_id()); // We could just use the id from the object, but this check may help catching memory corruption catastrophes.
+						print_line("Leaked instance: " + String(obj->get_class()) + ":" + uitos(id) + extra_info);
 
-					count--;
+						if (--count == 0) {
+							block_idx = block_max.get();
+							slot_idx = OBJECTDB_BLOCK_SIZE;
+							continue;
+						}
+					}
 				}
 			}
 			print_line("Hint: Leaked instances typically happen when nodes are removed from the scene tree (with `remove_child()`) but not freed (with `free()` or `queue_free()`).");
 		}
 	}
 
-	if (object_slots) {
-		memfree(object_slots);
+	for (uint32_t i = 0; i < block_max.get(); i++) {
+		memfree(object_blocks[i]);
+	}
+	block_max.set(0);
+
+	if (object_blocks) {
+		memfree(object_blocks);
+		object_blocks = nullptr;
 	}
 
-	spin_lock.unlock();
+	free_slots_top.set(0);
+
+	is_blocked.clear();
+	mutex.unlock();
 }

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -36,7 +36,8 @@
 #include "core/object/object_id.h"
 #include "core/object/property_info.h"
 #include "core/os/mutex.h"
-#include "core/os/spin_lock.h"
+#include "core/os/spin_lock.h" // IWYU pragma: keep. FIXME: It's being used in other places, remove it after fixing the includes.
+#include "core/os/thread.h"
 #include "core/templates/hash_map.h"
 #include "core/templates/hash_set.h"
 #include "core/templates/list.h"
@@ -878,68 +879,212 @@ bool Object::derives_from() const {
 }
 
 class ObjectDB {
-// This needs to add up to 63, 1 bit is for reference.
-#define OBJECTDB_VALIDATOR_BITS 39
+#define OBJECTDB_VALIDATOR_BITS 37
 #define OBJECTDB_VALIDATOR_MASK ((uint64_t(1) << OBJECTDB_VALIDATOR_BITS) - 1)
-#define OBJECTDB_SLOT_MAX_COUNT_BITS 24
-#define OBJECTDB_SLOT_MAX_COUNT_MASK ((uint64_t(1) << OBJECTDB_SLOT_MAX_COUNT_BITS) - 1)
-#define OBJECTDB_REFERENCE_BIT (uint64_t(1) << (OBJECTDB_SLOT_MAX_COUNT_BITS + OBJECTDB_VALIDATOR_BITS))
+#define OBJECTDB_PREDELETE_BIT (uint64_t(1) << 61)
+#define OBJECTDB_ACTIVE_BIT (uint64_t(1) << 62)
+#define OBJECTDB_REFERENCE_BIT (uint64_t(1) << 63)
 
-	struct ObjectSlot { // 128 bits per slot.
-		uint64_t validator : OBJECTDB_VALIDATOR_BITS;
-		uint64_t next_free : OBJECTDB_SLOT_MAX_COUNT_BITS;
-		uint64_t is_ref_counted : 1;
-		Object *object = nullptr;
+#define OBJECTDB_BLOCK_BITS 10
+#define OBJECTDB_BLOCK_MASK ((uint64_t(1) << OBJECTDB_BLOCK_BITS) - 1)
+#define OBJECTDB_SLOT_BITS 14
+#define OBJECTDB_SLOT_MASK ((uint64_t(1) << OBJECTDB_SLOT_BITS) - 1)
+#define OBJECTDB_INDEX_BITS (OBJECTDB_BLOCK_BITS + OBJECTDB_SLOT_BITS)
+#define OBJECTDB_INDEX_MASK ((uint64_t(1) << OBJECTDB_INDEX_BITS) - 1)
+
+#define OBJECTDB_INNER_READERS_BITS 11
+#define OBJECTDB_INNER_READERS_MASK ((uint64_t(1) << OBJECTDB_INNER_READERS_BITS) - 1)
+#define OBJECTDB_LOCKED_READERS_BITS 13
+#define OBJECTDB_LOCKED_READERS_MASK ((uint64_t(1) << OBJECTDB_LOCKED_READERS_BITS) - 1)
+#define OBJECTDB_READERS_BITS (OBJECTDB_INNER_READERS_BITS + OBJECTDB_LOCKED_READERS_BITS)
+#define OBJECTDB_READERS_MASK ((uint64_t(1) << OBJECTDB_READERS_BITS) - 1)
+
+// The number of bits used in a lock-free stack to prevent the ABA problem.
+#define OBJECTDB_STACK_VERSION_BITS (64 - OBJECTDB_INDEX_BITS)
+#define OBJECTDB_STACK_VERSION_MASK ((uint64_t(1) << OBJECTDB_INDEX_BITS) - 1)
+
+#define OBJECTDB_BLOCK_MAX_COUNT (uint64_t(1) << OBJECTDB_BLOCK_BITS)
+#define OBJECTDB_BLOCK_SIZE (uint64_t(1) << OBJECTDB_SLOT_BITS)
+
+	static_assert(OBJECTDB_INDEX_BITS == OBJECTDB_READERS_BITS, "Occupy the same bits.");
+	static_assert((OBJECTDB_BLOCK_BITS + OBJECTDB_SLOT_BITS + OBJECTDB_VALIDATOR_BITS) == 61,
+			"This needs to add up to 61, 2 bits is for state, and 1 bit is for reference.");
+
+	struct SlotIndex {
+		uint16_t block = 0;
+		uint16_t slot = 0;
+
+		SlotIndex() = default;
+		_ALWAYS_INLINE_ SlotIndex(uint16_t p_block, uint16_t p_slot) :
+				block(p_block & OBJECTDB_BLOCK_MASK),
+				slot(p_slot & OBJECTDB_SLOT_MASK) {}
+		_ALWAYS_INLINE_ explicit SlotIndex(uint64_t p_num) :
+				SlotIndex(static_cast<uint32_t>(p_num)) {}
+		_ALWAYS_INLINE_ explicit SlotIndex(uint32_t p_num) :
+				block(p_num & OBJECTDB_BLOCK_MASK),
+				slot((p_num >> OBJECTDB_BLOCK_BITS) & OBJECTDB_SLOT_MASK) {}
+
+		_ALWAYS_INLINE_ bool is_valid() const { return block != 0 || slot != 0; }
+		_ALWAYS_INLINE_ bool is_null() const { return block == 0 && slot == 0; }
+		_ALWAYS_INLINE_ operator uint32_t() const { return block | (slot << OBJECTDB_BLOCK_BITS); }
 	};
 
-	static SpinLock spin_lock;
-	static uint32_t slot_count;
-	static uint32_t slot_max;
-	static ObjectSlot *object_slots;
-	static uint64_t validator_counter;
+	struct TaggedIndex {
+		uint64_t raw = 0;
+
+		TaggedIndex() = default;
+		_ALWAYS_INLINE_ explicit TaggedIndex(uint64_t p_num) : raw(p_num) {}
+		_ALWAYS_INLINE_ SlotIndex index() const { return SlotIndex{ raw }; }
+		_ALWAYS_INLINE_ uint64_t version() const { return (raw >> OBJECTDB_INDEX_BITS) & OBJECTDB_STACK_VERSION_MASK; }
+		_ALWAYS_INLINE_ uint64_t new_version() const { return ((raw >> OBJECTDB_INDEX_BITS) + 1) & OBJECTDB_STACK_VERSION_MASK; }
+
+		_ALWAYS_INLINE_ static TaggedIndex create(SlotIndex p_index, uint64_t p_version) {
+			return TaggedIndex{ p_index | (p_version << OBJECTDB_INDEX_BITS) };
+		}
+		_ALWAYS_INLINE_ operator uint64_t() const { return raw; }
+	};
+
+	// The slots have 2 states: inactive and active. They use the lower 24 bits
+	// for different purposes.
+	//
+	// Inactive slot shares the memory layout with `ObjectID`, but stores the next free slot index.
+	// ┌───────────┬────────────┬───────────────┬────────────────────┬──────────────┬───────────────────┐
+	// │ block: 10 │ slot: 14   │ validator: 37 │ is_in_predelete: 1 | is_active: 1 │ is_ref_counted: 1 │
+	// └───────────┴────────────┴───────────────┴────────────────────┴──────────────┴───────────────────┘
+	// Active slot stores the number of active readers.
+	//   inner - inner readers, locked - locked readers
+	// ┌───────────┬────────────┬───────────────┬────────────────────┬──────────────┬───────────────────┐
+	// │ inner: 11 | locked: 13 │ validator: 37 │ is_in_predelete: 1 | is_active: 1 │ is_ref_counted: 1 │
+	// └───────────┴────────────┴───────────────┴────────────────────┴──────────────┴───────────────────┘
+	struct SlotData {
+		uint64_t raw = 0;
+
+		SlotData() = default;
+		_ALWAYS_INLINE_ explicit SlotData(uint64_t p_num) : raw(p_num) {}
+		_ALWAYS_INLINE_ SlotIndex index() const { return SlotIndex{ raw }; }
+		_ALWAYS_INLINE_ uint32_t inner_readers() const { return raw & OBJECTDB_INNER_READERS_BITS; }
+		_ALWAYS_INLINE_ bool has_inner_readers() const { return inner_readers(); }
+		_ALWAYS_INLINE_ uint32_t locked_readers() const { return (raw >> OBJECTDB_INNER_READERS_BITS) & OBJECTDB_LOCKED_READERS_MASK; }
+		_ALWAYS_INLINE_ bool has_locked_readers() const { return raw & (OBJECTDB_LOCKED_READERS_MASK << OBJECTDB_INNER_READERS_BITS); }
+		_ALWAYS_INLINE_ bool has_readers() const { return raw & OBJECTDB_READERS_MASK; }
+		_ALWAYS_INLINE_ uint64_t validator() const { return (raw >> OBJECTDB_INDEX_BITS) & OBJECTDB_VALIDATOR_MASK; }
+		_ALWAYS_INLINE_ uint64_t new_validator() const { return ((raw >> OBJECTDB_INDEX_BITS) + 1) & OBJECTDB_VALIDATOR_MASK; }
+		template <uint64_t p_additional_bits>
+		_ALWAYS_INLINE_ uint64_t validator_with() const { return raw & ((OBJECTDB_VALIDATOR_MASK << OBJECTDB_INDEX_BITS) | p_additional_bits); }
+		_ALWAYS_INLINE_ bool is_in_predelete() const { return raw & OBJECTDB_PREDELETE_BIT; }
+		_ALWAYS_INLINE_ bool is_active() const { return raw & OBJECTDB_ACTIVE_BIT; }
+		_ALWAYS_INLINE_ bool is_ref_counted() const { return raw & OBJECTDB_REFERENCE_BIT; }
+
+		_ALWAYS_INLINE_ SlotData with_index(SlotIndex p_index) const {
+			return SlotData{ p_index | (raw & ~OBJECTDB_INDEX_MASK) };
+		}
+		_ALWAYS_INLINE_ static SlotData create(SlotIndex p_index, uint64_t p_validator, bool p_is_in_predelete, bool p_is_active, bool p_is_ref_counted) {
+			return SlotData{ p_index |
+				(p_validator << OBJECTDB_INDEX_BITS) |
+				(p_is_in_predelete * OBJECTDB_PREDELETE_BIT) |
+				(p_is_active * OBJECTDB_ACTIVE_BIT) |
+				(p_is_ref_counted * OBJECTDB_REFERENCE_BIT) };
+		}
+		_ALWAYS_INLINE_ operator uint64_t() const { return raw; }
+	};
+
+	struct ObjectSlot { // 128 bits per slot.
+		SafeNumeric<uint64_t> safe_data{ 0 };
+		Object *object = nullptr;
+
+		_ALWAYS_INLINE_ SlotData get_data() const { return SlotData{ safe_data.get() }; }
+		_ALWAYS_INLINE_ void set_data(SlotData p_data) { safe_data.set(p_data); }
+	};
+
+	static constexpr size_t SAFE_NUMERIC_ALIGNMENT = Thread::CACHE_LINE_BYTES > alignof(SafeNumeric<uint64_t>) ? Thread::CACHE_LINE_BYTES : alignof(SafeNumeric<uint64_t>);
+	static constexpr uint32_t SLOTS_IN_CACHE_LINE = Math::division_round_up((uint64_t)Thread::CACHE_LINE_BYTES, (uint64_t)sizeof(ObjectDB::ObjectSlot));
+
+	alignas(SAFE_NUMERIC_ALIGNMENT) inline static SafeNumeric<uint64_t> free_slots_top{ 0 };
+	alignas(SAFE_NUMERIC_ALIGNMENT) inline static SafeNumeric<uint64_t> slot_count{ 0 };
+
+	inline static BinaryMutex mutex;
+	inline static SafeFlag is_blocked{ false };
+	inline static SafeNumeric<uint32_t> block_max{ 0 };
+	inline static ObjectSlot **object_blocks = nullptr;
 
 	friend class Object;
 	friend void unregister_core_types();
 	static void cleanup();
 
+	static void push_free_slot(ObjectSlot *p_slot, SlotData p_slot_data);
+	static bool try_pop_free_slot(ObjectSlot *&r_slot, SlotData &r_slot_data);
+	static ObjectSlot *get_free_slot(SlotData &r_slot_data);
+
 	static ObjectID add_instance(Object *p_object);
+	static ObjectSlot *predelete_instance(Object *p_object);
+	static void cancel_predelete(ObjectSlot *p_object_slot);
 	static void remove_instance(Object *p_object);
 
 	friend void register_core_types();
 	static void setup();
 
+	template <uint64_t p_checked_bits, uint64_t p_counter_shift>
+	_ALWAYS_INLINE_ static ObjectSlot *_get_locked_slot(ObjectID p_instance_id) {
+		SlotData instance_data{ p_instance_id };
+		SlotIndex slot_index = instance_data.index();
+
+		// This should never happen unless RID is corrupted.
+		uint32_t block_count = SafeNumericInternal::relaxed_get(&block_max);
+		ERR_FAIL_COND_V(slot_index.block >= block_count, nullptr);
+
+		ObjectSlot &slot = object_blocks[slot_index.block][slot_index.slot];
+
+		SlotData slot_data = instance_data.with_index(SlotIndex{});
+		// Optimistically try to add the first reader, `compare_exchange` will also compare instance data with
+		// stored validator and state. On failure will update `slot_data` with the current data from the slot.
+		if (!slot.safe_data.compare_exchange<false>(slot_data.raw, slot_data + (1 << p_counter_shift))) {
+			do {
+				// Check the validator and the bits together.
+				// Because ObjectID always has the same state stored in bits, it is
+				// here to check if the slot's state is different from initial.
+				if (unlikely(slot_data.validator_with<p_checked_bits>() != instance_data.validator_with<p_checked_bits>())) {
+					return nullptr;
+				}
+				// In the active slot 11 bits (2048 max) is used for readers that don't exit `ObjectDB`,
+				// and 13 bits (8192 max) is used for locked readers, so overflow shouldn't happen.
+			} while (!slot.safe_data.compare_exchange<false>(slot_data.raw, slot_data + (1 << p_counter_shift)));
+		}
+
+		// A valid Object is always present in the slot with active readers.
+		return &slot;
+	}
+
 public:
 	typedef void (*DebugFunc)(Object *p_obj, void *p_user_data);
 
-	_ALWAYS_INLINE_ static Object *get_instance(ObjectID p_instance_id) {
-		uint64_t id = p_instance_id;
-		uint32_t slot = id & OBJECTDB_SLOT_MAX_COUNT_MASK;
-
-		ERR_FAIL_COND_V(slot >= slot_max, nullptr); // This should never happen unless RID is corrupted.
-
-		spin_lock.lock();
-
-		uint64_t validator = (id >> OBJECTDB_SLOT_MAX_COUNT_BITS) & OBJECTDB_VALIDATOR_MASK;
-
-		if (unlikely(object_slots[slot].validator != validator)) {
-			spin_lock.unlock();
-			return nullptr;
+	static Object *get_instance(ObjectID p_instance_id) {
+		ObjectSlot *slot = ObjectDB::_get_locked_slot<OBJECTDB_ACTIVE_BIT, 0>(p_instance_id);
+		Object *object = nullptr;
+		if (slot) {
+			object = slot->object;
+			slot->safe_data.sub(1);
 		}
-
-		Object *object = object_slots[slot].object;
-
-		spin_lock.unlock();
-
 		return object;
 	}
-
 	template <typename T>
 	_ALWAYS_INLINE_ static T *get_instance(ObjectID p_instance_id) {
 		return Object::cast_to<T>(get_instance(p_instance_id));
 	}
 
+	static Object *get_locked_instance(ObjectID p_instance_id) {
+		// Only return locked instances outside of predelete.
+		// Increment the bit after inner get readers count.
+		ObjectSlot *slot = ObjectDB::_get_locked_slot<OBJECTDB_PREDELETE_BIT | OBJECTDB_ACTIVE_BIT, OBJECTDB_INNER_READERS_BITS>(p_instance_id);
+		return slot ? slot->object : nullptr;
+	}
 	template <typename T>
-	_ALWAYS_INLINE_ static Ref<T> get_ref(ObjectID p_instance_id); // Defined in ref_counted.h
+	_ALWAYS_INLINE_ static T *get_locked_instance(ObjectID p_instance_id) {
+		return Object::cast_to<T>(get_locked_instance(p_instance_id));
+	}
+	static void unlock_instance(Object *p_object);
+
+	template <typename T, std::enable_if_t<std::is_base_of_v<RefCounted, T>, int> = 0>
+	static Ref<T> get_ref(ObjectID p_instance_id); // Defined in ref_counted.h
 
 	static void debug_objects(DebugFunc p_func, void *p_user_data);
 	static int get_object_count();

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -242,7 +242,13 @@ void postinitialize_handler(Ref<T> &p_object) {
 template <typename T>
 struct is_zero_constructible<Ref<T>> : std::true_type {};
 
-template <typename T>
+template <typename T, std::enable_if_t<std::is_base_of_v<RefCounted, T>, int>>
 Ref<T> ObjectDB::get_ref(ObjectID p_instance_id) {
-	return Ref<T>(get_instance(p_instance_id));
+	ObjectSlot *slot = ObjectDB::_get_locked_slot<OBJECTDB_PREDELETE_BIT | OBJECTDB_ACTIVE_BIT, 0>(p_instance_id);
+	Ref<T> ref{};
+	if (slot) {
+		ref.reference_ptr(slot->object);
+		slot->safe_data.sub(1);
+	}
+	return ref;
 }

--- a/core/os/spin_lock.h
+++ b/core/os/spin_lock.h
@@ -43,6 +43,28 @@
 #include <intrin.h>
 #endif
 
+_ALWAYS_INLINE_ static void _cpu_pause() {
+#if defined(_MSC_VER)
+// ----- MSVC.
+#if defined(_M_ARM) || defined(_M_ARM64) // ARM.
+	__yield();
+#elif defined(_M_IX86) || defined(_M_X64) // x86.
+	_mm_pause();
+#endif
+#elif defined(__GNUC__) || defined(__clang__)
+// ----- GCC/Clang.
+#if defined(__i386__) || defined(__x86_64__) // x86.
+	__builtin_ia32_pause();
+#elif defined(__arm__) || defined(__aarch64__) // ARM.
+	asm volatile("yield");
+#elif defined(__powerpc__) // PowerPC.
+	asm volatile("or 27,27,27");
+#elif defined(__riscv) // RISC-V.
+	asm volatile(".insn i 0x0F, 0, x0, x0, 0x010");
+#endif
+#endif
+}
+
 #if defined(__APPLE__)
 
 #include <os/lock.h>
@@ -66,28 +88,6 @@ public:
 #else // __APPLE__
 
 #include <atomic>
-
-_ALWAYS_INLINE_ static void _cpu_pause() {
-#if defined(_MSC_VER)
-// ----- MSVC.
-#if defined(_M_ARM) || defined(_M_ARM64) // ARM.
-	__yield();
-#elif defined(_M_IX86) || defined(_M_X64) // x86.
-	_mm_pause();
-#endif
-#elif defined(__GNUC__) || defined(__clang__)
-// ----- GCC/Clang.
-#if defined(__i386__) || defined(__x86_64__) // x86.
-	__builtin_ia32_pause();
-#elif defined(__arm__) || defined(__aarch64__) // ARM.
-	asm volatile("yield");
-#elif defined(__powerpc__) // PowerPC.
-	asm volatile("or 27,27,27");
-#elif defined(__riscv) // RISC-V.
-	asm volatile(".insn i 0x0F, 0, x0, x0, 0x010");
-#endif
-#endif
-}
 
 static_assert(std::atomic_bool::is_always_lock_free);
 
@@ -122,6 +122,8 @@ public:
 #endif // __APPLE__
 
 #else // THREADS_ENABLED
+
+_ALWAYS_INLINE_ static void _cpu_pause() {}
 
 class SpinLock {
 public:

--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -185,6 +185,8 @@ private:
 public:
 	static void _set_platform_functions(const PlatformFunctions &p_functions);
 
+	_FORCE_INLINE_ static void yield() {}
+
 	_FORCE_INLINE_ ID get_id() const { return 0; }
 	_FORCE_INLINE_ static ID get_caller_id() { return MAIN_ID; }
 	_FORCE_INLINE_ static ID get_main_id() { return MAIN_ID; }

--- a/core/templates/safe_refcount.h
+++ b/core/templates/safe_refcount.h
@@ -60,6 +60,8 @@
 
 template <typename T>
 class SafeNumeric {
+	friend class SafeNumericInternal;
+
 	std::atomic<T> value;
 
 	static_assert(std::atomic<T>::is_always_lock_free);
@@ -118,6 +120,19 @@ public:
 	// Returns the original value instead of the new one
 	_ALWAYS_INLINE_ T postsub(T p_value) {
 		return value.fetch_sub(p_value, std::memory_order_acq_rel);
+	}
+
+	_FORCE_INLINE_ bool compare_exchange(T &p_expected, T p_new_value) {
+		return compare_exchange<true>(p_expected, p_new_value);
+	}
+
+	template <bool p_strong>
+	_FORCE_INLINE_ bool compare_exchange(T &p_expected, T p_new_value) {
+		if constexpr (p_strong) {
+			return value.compare_exchange_strong(p_expected, p_new_value, std::memory_order_acq_rel);
+		} else {
+			return value.compare_exchange_weak(p_expected, p_new_value, std::memory_order_acq_rel);
+		}
 	}
 
 	_ALWAYS_INLINE_ T exchange_if_greater(T p_value) {
@@ -227,5 +242,17 @@ public:
 
 	_ALWAYS_INLINE_ void init(uint32_t p_value = 1) {
 		count.set(p_value);
+	}
+};
+
+// For use when you want to perform relaxed operations with `SafeNumeric`.
+// Use with caution. You need to be sure that relaxed memory order is
+// appropriate for your use case.
+
+class SafeNumericInternal {
+public:
+	template <typename T>
+	_ALWAYS_INLINE_ static T relaxed_get(const SafeNumeric<T> *p_numeric) {
+		return p_numeric->value.load(std::memory_order_relaxed);
 	}
 };

--- a/tests/core/object/test_object.cpp
+++ b/tests/core/object/test_object.cpp
@@ -37,6 +37,10 @@ TEST_FORCE_LINK(test_object)
 #include "core/object/object.h"
 #include "core/object/script_language.h"
 #include "tests/signal_watcher.h"
+#ifdef THREADS_ENABLED
+#include "core/os/os.h"
+#include "core/os/thread.h"
+#endif
 
 namespace TestObject {
 
@@ -691,4 +695,41 @@ TEST_CASE("[Object] RequiredResult") {
 	CHECK_EQ(ref, var);
 }
 
+#ifdef THREADS_ENABLED
+
+static void locked_instance_delete(void *p_void_obj) {
+	memdelete(static_cast<Object *>(p_void_obj));
+}
+
+TEST_CASE("[Object] Locked instance") {
+	Thread thread{};
+
+	Object *obj = memnew(Object);
+	ObjectID obj_id = obj->get_instance_id();
+
+	Object *p_db = ObjectDB::get_locked_instance(obj_id);
+	CHECK_MESSAGE(
+			p_db == obj,
+			"The database pointer returned by the object id should reference same object.");
+
+	thread.start(&locked_instance_delete, obj);
+
+	OS::get_singleton()->delay_usec(1000);
+	CHECK_MESSAGE(
+			ObjectDB::get_locked_instance(obj_id) == nullptr,
+			"Can't return more locked instances after `memdelete`.");
+
+	OS::get_singleton()->delay_usec(1000);
+	CHECK_MESSAGE(
+			ObjectDB::get_instance(obj_id) == obj,
+			"The other thread is forced to wait in `memdelete` until the instance is unlocked.");
+
+	ObjectDB::unlock_instance(obj);
+	thread.wait_to_finish();
+
+	CHECK_MESSAGE(
+			ObjectDB::get_instance(obj_id) == nullptr,
+			"Object is deleted after unlocking.");
+}
+#endif
 } // namespace TestObject


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Supersedes: https://github.com/godotengine/godot/pull/118803
- Closes: https://github.com/godotengine/godot-proposals/issues/15362
- Fixes: https://github.com/godotengine/godot/issues/65404
- Makes `ObjectDB::get_ref` fully thread-safe by removing the short window when the pointer could be freed
- Removes a possible UB in `ObjectDB::debug_objects`. While we are inside the spin lock other threads can try to delete objects, which will make them wait in `ObjectDB::remove_instance`. The problem is that `ObjectDB::remove_instance` is inside the base `Object` destructor, so objects that wait here can only access `Object` members (see `Node::print_orphan_nodes` accessing `Node`). The wait is now when predelete begins, so all members from descended classes are still valid.

Small issues this PR also happens to fix:
- Fixes: https://github.com/godotengine/godot/issues/109178
- Fixes: https://github.com/godotengine/godot/issues/111173

Related issue: https://github.com/godotengine/godot/issues/58279 , I think it is already fixed in master in the release template

## Additional information

Overview of changes:
- Lock-free `add_instance`.
- Each active slot now is a pseudo RWLock for itself.
- `get_instance` is now counts as a reader for that slot, stops being a reader when exiting it.
- `remove_instance` is a writer for that slot and it also marks that slot as invalid which prevents new readers from entering.
- Adds `ObjectDB::get_locked_instance` that will return pointer and prevent it from being deleted until it's unlocked. Returned pointer also counts as an active slot reader until unlocked.

The main speed benefits come from moving from a global lock to a slot local one. Basically less lock contentions.

<details>
<summary>ObjectDB::get_instance affects in VM:</summary>

Debug:
- `OPCODE_TYPE_TEST_NATIVE`
- `OPCODE_TYPE_TEST_SCRIPT`
- `OPCODE_GET_NAMED` leads to `Variant::get_named` with Object
- `OPCODE_SET_NAMED` leads to `Variant::set_named` with Object
- `OPCODE_GET_KEYED` leads to `VariantKeyedSetGetObject::get` (validated getter) with Object
- `OPCODE_SET_KEYED` leads to `VariantKeyedSetGetObject::set` (validated setter) with Object
- `OPCODE_ASSIGN_TYPED_NATIVE`
- `OPCODE_ASSIGN_TYPED_SCRIPT`
- `OPCODE_CAST_TO_BUILTIN` with Object
- `OPCODE_CAST_TO_NATIVE`
- `OPCODE_CAST_TO_SCRIPT`
- `OPCODE_CALL_ASYNC`
- `OPCODE_CALL_RETURN`
- `OPCODE_CALL`
- `OPCODE_CALL_METHOD_BIND`
- `OPCODE_CALL_METHOD_BIND_RET`
- `OPCODE_CALL_METHOD_BIND_VALIDATED_RETURN`
- `OPCODE_CALL_METHOD_BIND_VALIDATED_NO_RETURN`
- `OPCODE_RETURN_TYPED_NATIVE`
- `OPCODE_RETURN_TYPED_SCRIPT`
- `OPCODE_ITERATE_BEGIN_OBJECT`

Release:
- `OPCODE_TYPE_TEST_NATIVE`
- `OPCODE_TYPE_TEST_SCRIPT`
- `OPCODE_GET_NAMED` leads to `Variant::get_named` with Object
- `OPCODE_SET_NAMED` leads to `Variant::set_named` with Object
- `OPCODE_GET_KEYED` leads to `VariantKeyedSetGetObject::get` (validated getter) with Object
- `OPCODE_SET_KEYED` leads to `VariantKeyedSetGetObject::set` (validated setter) with Object
</details>

### Design decisions

- The slots are stored in the array of blocks and we never deallocate already allocated blocks as long as `ObjectDB` works. Thanks to that we can safely access slots from multiple threads without data race or use-after-free, and for accessing the data inside them safely `SafeNumeric<uint64_t>` was used.
<details>
<summary>Why not bit-fields?</summary>

  - After looking at bit-fields I found that almost everything about them is implementation defined, so they aren't cross-platform usable when we want to store it as a specific size, for example for atomics. And because the lower 24 bits can be used for different purposes it was easier to store it as a number and decode it when needed.
</details>

---
- Slot reuse works through the virtual lock-free stack and we push all new slots that we allocate to it, so we can focus on only using free slots stack when adding instances.
<details>
<summary>More info</summary>

 - We store the index with version as the top and for inactive slots we use the same memory layout as `ObjectID` so we treat the lower 24 bits in the top's slot data as the index to the next free slot. Each change is accompanied by increase in the top's version to prevent the ABA problem. It is basically the most basic lock-free stack using tagged pointer, only it uses index to top instead of a pointer to top. And because the stack is virtual we don't need to worry about memory reclamation.
</details>

---
- When the slot is active we use the lower 24 bits as 2 counters to count how many readers are reading this slot inside the `ObjectDB` and how many readers exist outside of `ObjectDB`, we can use it to delay the object's deletion.
<details>
<summary>More info</summary>

 - The first wait point is at the beginning of `_predelete`, here we reject all new outside readers and wait until the existing ones unlock all locked instances.
The second one is in the `Object` destructor, here we wait until all inner readers left `ObjectDB`, then we free the slot.
I tried to move `ObjectDB::remove_instance` to predelete at first, but the existing code relies on the objects being able to call `ObjectDB::get_instance` on itself in its own destructor, like `callable_mp(this, &PrimitiveMesh::_on_settings_changed)`, even with `RefCounted` classes. 
With the help of the first wait point we can force wait until locked instances are unlocked and keep them valid and not partially destructed. We can also use it to detect that we can't create `Ref<T>` from the pointer anymore and don't touch it in the `ObjectDB::get_ref`.
The embedded counters basically make each slot into 2 partial rw spin locks, only we begin to reject new readers when the writer enters, so we can't starve writers.
</details>

---
- `ObjectDB::get_locked_instance` was added after reading in https://redirect.github.com/godotengine/godot/pull/121936 that we don't have any way to provide thread safety for returned non-refcounted objects. More specifically after I fixed `ObjectDB::get_ref` by adding a slot's state change in predelete I realized I can force a wait here. And because it forces wait on deletion, the locked sections should be as small as possible.
- This PR doesn't change how `ObjectDB::get_instance` works from outside of the `ObjectDB`. It is as safe as the current version, which is to say it's not really that safe, but it's also not that unsafe.

### Considerations
- Because of a virtual lock-free stack it has 1 less usable slot (I needed to treat 1 usable index as null).
- If more than 8192 locked pointers returned from `ObjectDB::get_locked_instance` for the same `ObjectID` exists at the same time without unlocking them the slot's internal counter will overflow (so the locked sections should be short and locked pointers must not be stored).
- If more than 2048 threads are inside `ObjectDB::get_instance` or `ObjectDB::get_ref` for the same `ObjectID` at the same time the slot's other internal counter will overflow (I can't imagine this happening).
- Validator is now 37 bits, I needed to dedicate 2 other bits to track the slot's current state. And because we embed the slot's index into `ObjectID` itself we don't need to use a global validator counter, we can keep how many times the slot was used as a validator instead. It helps with accessing 1 less global variable, which would have been turned to `SafeNumeric` if it was used.
- Single-threaded performance is slightly slower as `ObjectDB` now needs to do more things to support multi-threading, except when it creates and frees a large number of objects at the same time (see `func_new_groups`). In majority of other cases even 2 threads nets you a large increase in speed compared to before, except when creating `GDScriptInstance` (every new one locks a global mutex).
- `ObjectDB::debug_objects` can be inaccurate now, to mitigate it I block all new object additions and removals and wait for a short time, but it doesn't provide the absolute guarantee for accuracy.
- Tbh `ObjectDB::get_locked_instance` can be removed, it was just something that seemed nice to have, but the underlying system that made it possible will still be left, we still need some marker in predelete for the correct `ObjectDB::get_ref`, and inside `ObjectDB::remove_instance` we still need to wait until all readers left to safely null the pointer.

## Benchmark

The results are in tables with numbers measuring ns/op. The columns indicate how many threads were used for that run. Each run had the same workload that was split between running threads. 

Project: [test-threads.zip](https://github.com/user-attachments/files/30945631/test-threads.zip)

<details>
<summary>Tested on</summary>

Compile commands:
```
scons target=editor optimize=speed accesskit=no use_llvm=yes linker=lld debug_symbols=yes production=yes tests=yes
scons target=template_release optimize=speed accesskit=no use_llvm=yes linker=lld production=yes
```
System info:
> Godot v4.8.dev (5af048daf) - EndeavourOS `#1` SMP PREEMPT_DYNAMIC Tue, 28 Jul 2026 13:49:51 +0000 on X11 - X11 display driver, Multi-window, 2 monitors - Vulkan (Forward+) - dedicated NVIDIA GeForce GTX 1650 (nvidia; 610.43.03) - Intel(R) Core(TM) i5-9300H CPU @ 2.40GHz (8 threads) - 15.49 GiB memory - PulseAudio (44100 Hz, Stereo/mono)

</details>

<details>
<summary>Results</summary>

Types:
- `debug` - tested it in launched from Godot project
- `tool` - tested it inside tool script in editor
- `release` - tested it in export release

<details>
<summary>func_base</summary>

```gdscript
signal finished(time_spend: float)
var sem: Semaphore

func func_base(count: int) -> int:
    var sum := 0
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        sum += 1
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum
```
| Name   | Type     |      0 |      1 |      2 |      3 |      4 |      5 |      6 |      7 |      8 |
| ------ | -------- | -----: | -----: | -----: | -----: | -----: | -----: | -----: | -----: | -----: |
| master | debug    |   31.9 |   36.0 |   33.5 |   31.2 |   29.3 |   23.9 |   23.3 |   20.1 |   19.4 |
| PR     | debug    |   32.9 |   40.5 |   37.8 |   36.0 |   32.1 |   25.7 |   20.9 |   21.4 |   20.2 |
| master | tool     |   30.2 |   30.1 |   15.4 |   11.5 |    9.1 |   10.3 |    8.8 |    8.4 |    8.1 |
| PR     | tool     |   29.3 |   32.2 |   15.8 |   11.6 |    9.1 |   10.4 |    9.2 |    8.4 |    8.1 |
| master | release  |   20.6 |   22.6 |   12.6 |    9.0 |    7.3 |    6.6 |    5.8 |    5.0 |    4.7 |
| PR     | release  |   20.5 |   23.6 |   14.4 |    9.3 |    7.6 |    7.1 |    6.5 |    5.5 |    5.4 |
</details>
<details>
<summary>func_set</summary>

If you want to know why current master is so slow see what affects the release build in "ObjectDB::get_instance affects in VM:" in the beginning.

```gdscript
signal finished(time_spend: float)
var sem: Semaphore

func func_set(count: int) -> int:
    var obj := HelperObj.new()
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        obj.value = i
    var value := obj.value
    var time_end := Time.get_ticks_usec()
    obj.free()
    finished.emit.call_deferred(time_end - time_start)
    return value
```
| Name   | Type     |      0 |      1 |      2 |      3 |      4 |      5 |      6 |      7 |      8 |
| ------ | -------- | -----: | -----: | -----: | -----: | -----: | -----: | -----: | -----: | -----: |
| master | debug    |   64.8 |   72.1 |   94.9 |  116.8 |  140.4 |  127.7 |  134.8 |  148.5 |  169.2 |
| PR     | debug    |   66.9 |   77.0 |   70.1 |   60.4 |   53.3 |   45.5 |   40.5 |   36.7 |   35.1 |
| master | tool     |   60.2 |   62.3 |   95.2 |  142.5 |  156.6 |  138.7 |  139.8 |  149.0 |  165.9 |
| PR     | tool     |   62.3 |   65.8 |   36.4 |   25.6 |   18.6 |   20.6 |   17.5 |   17.3 |   16.1 |
| master | release  |   48.9 |   54.7 |  109.0 |  138.3 |  176.5 |  154.1 |  160.3 |  164.8 |  172.6 |
| PR     | release  |   54.1 |   61.2 |   33.8 |   24.1 |   19.0 |   18.9 |   17.2 |   15.2 |   14.6 |
</details>
<details>
<summary>call_base</summary>

```gdscript
signal finished(time_spend: float)
var sem: Semaphore

func call_base(count: int) -> int:
    var sum := 0
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        sum += get_instance_increment()
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum

func get_instance_increment() -> int:
    return 1
```
| Name   | Type     |      0 |      1 |      2 |      3 |      4 |      5 |      6 |      7 |      8 |
| ------ | -------- | -----: | -----: | -----: | -----: | -----: | -----: | -----: | -----: | -----: |
| master | debug    |  162.0 |  173.3 |  240.0 |  259.0 |  297.1 |  280.0 |  300.0 |  330.4 |  370.5 |
| PR     | debug    |  176.8 |  205.1 |  165.4 |  130.5 |  115.3 |   98.6 |   85.9 |   77.9 |   72.0 |
| master | tool     |  144.7 |  153.6 |  130.7 |  147.0 |  163.5 |  160.3 |  157.8 |  173.2 |  192.6 |
| PR     | tool     |  145.4 |  156.4 |   81.3 |   57.0 |   44.7 |   50.1 |   44.2 |   45.2 |   43.1 |
| master | release  |  101.4 |  109.7 |   58.2 |   41.9 |   33.3 |   35.2 |   30.3 |   28.4 |   27.7 |
| PR     | release  |  100.8 |  116.5 |   61.6 |   43.8 |   35.8 |   35.6 |   32.0 |   29.1 |   27.8 |
</details>
<details>
<summary>func_new_script</summary>

Global mutex in `GDScript::_create_instance`

```gdscript
signal finished(time_spend: float)
var sem: Semaphore

func func_new_script(count: int) -> int:
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        var obj := HelperObj.new()
        obj.free()
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return count
```
| Name   | Type     |      0 |      1 |      2 |      3 |      4 |      5 |      6 |      7 |      8 |
| ------ | -------- | -----: | -----: | -----: | -----: | -----: | -----: | -----: | -----: | -----: |
| master | debug    |  881.3 |  985.9 | 1326.5 | 1271.7 | 1202.9 | 1131.5 | 1112.6 | 1097.7 | 1202.0 |
| PR     | debug    |  923.1 | 1011.2 | 1534.0 | 1448.7 | 1345.4 | 1277.6 | 1249.8 | 1231.3 | 1222.8 |
| master | tool     |  843.3 |  961.6 | 1260.6 | 1229.8 | 1209.9 | 1164.5 | 1118.0 | 1097.6 | 1104.5 |
| PR     | tool     |  880.5 |  905.2 | 1371.5 | 1353.6 | 1354.0 | 1263.7 | 1185.7 | 1158.0 | 1120.2 |
| master | release  |  470.2 |  532.1 |  719.2 |  690.1 |  752.0 |  798.3 |  811.8 |  815.8 |  952.7 |
| PR     | release  |  478.0 |  528.6 |  699.6 |  687.2 |  750.2 |  804.6 |  815.7 |  821.3 |  830.8 |
</details>
<details>
<summary>func_new_obj</summary>

```gdscript
signal finished(time_spend: float)
var sem: Semaphore

func func_new_obj(count: int) -> int:
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        var obj := Object.new()
        obj.free()
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return count
```
| Name   | Type     |      0 |      1 |      2 |      3 |      4 |      5 |      6 |      7 |      8 |
| ------ | -------- | -----: | -----: | -----: | -----: | -----: | -----: | -----: | -----: | -----: |
| master | debug    |  398.3 |  460.9 |  718.9 |  888.3 | 1030.7 |  989.5 | 1023.1 | 1084.8 | 1198.0 |
| PR     | debug    |  453.8 |  518.0 |  584.1 |  543.3 |  501.2 |  444.0 |  426.5 |  416.3 |  415.1 |
| master | tool     |  371.1 |  392.0 |  656.9 |  796.3 |  917.9 |  867.4 |  879.0 |  932.7 | 1018.6 |
| PR     | tool     |  408.2 |  459.8 |  508.2 |  491.4 |  468.3 |  429.6 |  418.0 |  399.8 |  395.9 |
| master | release  |  273.2 |  317.9 |  398.5 |  511.0 |  616.3 |  584.5 |  581.6 |  617.9 |  656.7 |
| PR     | release  |  290.3 |  353.2 |  368.8 |  365.0 |  356.1 |  341.2 |  333.8 |  334.5 |  337.8 |
</details>
<details>
<summary>func_new_groups</summary>

```gdscript
signal finished(time_spend: float)
var sem: Semaphore

func func_new_groups(count: int) -> int:
    var groups_count: int = 10
    @warning_ignore("integer_division")
    var obj_count: int = count / groups_count
    var holder: Array[Object]
    holder.resize(obj_count)
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for _group in groups_count:
        for i in obj_count:
            holder[i] = Object.new()
        for i in obj_count:
            holder[i].free()
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return obj_count
```
| Name   | Type     |      0 |      1 |      2 |      3 |      4 |      5 |      6 |      7 |      8 |
| ------ | -------- | -----: | -----: | -----: | -----: | -----: | -----: | -----: | -----: | -----: |
| master | debug    |  893.2 | 1172.9 | 1001.8 | 1108.1 | 1250.4 | 1244.9 | 1309.8 | 1390.0 | 1533.5 |
| PR     | debug    |  726.8 | 1264.8 |  932.4 |  841.6 |  757.3 |  680.8 |  626.5 |  592.5 |  586.8 |
| master | tool     |  818.3 | 1000.5 |  805.8 |  892.9 | 1083.7 | 1080.8 | 1103.7 | 1143.7 | 1251.5 |
| PR     | tool     |  666.9 |  711.4 |  815.3 |  679.8 |  577.0 |  544.8 |  490.5 |  496.7 |  464.7 |
| master | release  |  639.6 |  910.4 |  704.4 |  702.8 |  791.7 |  754.9 |  769.7 |  795.3 |  842.5 |
| PR     | release  |  521.9 |  920.7 |  659.2 |  555.1 |  536.1 |  467.8 |  456.0 |  468.4 |  454.7 |
</details>

</details>

No AI used