### PR TITLE
[3.x] [iOS] Bump min. version to 15.0, remove 32-bit code, add min. target export option.

### DIFF
--- a/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
+++ b/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
@@ -254,7 +254,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				$os_deployment_target
 				"LD_CLASSIC_1500" = "-ld_classic";
 				"LD_CLASSIC_1501" = "-ld_classic";
 				"LD_CLASSIC_1510" = "-ld_classic";
@@ -296,7 +296,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				$os_deployment_target
 				"LD_CLASSIC_1500" = "-ld_classic";
 				"LD_CLASSIC_1501" = "-ld_classic";
 				"LD_CLASSIC_1510" = "-ld_classic";
@@ -319,7 +319,7 @@
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				DEVELOPMENT_TEAM = $team_id;
 				INFOPLIST_FILE = "$binary/$binary-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				$os_deployment_target
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -350,7 +350,7 @@
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				DEVELOPMENT_TEAM = $team_id;
 				INFOPLIST_FILE = "$binary/$binary-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				$os_deployment_target
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/platform/iphone/app_delegate.mm
+++ b/platform/iphone/app_delegate.mm
@@ -109,15 +109,6 @@ static AppDelegate *delegate_singleton = nil;
 		return FALSE;
 	}
 
-	if (@available(iOS 13, tvOS 13, *)) {
-		// NOP
-	} else {
-		// Create a full-screen window
-		CGRect windowBounds = [[UIScreen mainScreen] bounds];
-		self.window = [[UIWindow alloc] initWithFrame:windowBounds];
-		[self createViewController];
-	}
-
 	[[NSNotificationCenter defaultCenter]
 			addObserver:self
 			   selector:@selector(onAudioInterruption:)

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -76,16 +76,16 @@ def configure(env):
             env.Append(LINKFLAGS=["-flto"])
 
     # Architecture
-    if env["arch"] == "x86":  # i386
-        env["bits"] = "32"
-    elif env["arch"] == "x86_64":
-        env["bits"] = "64"
-    elif env["arch"] == "arm" or env["arch"] == "arm32" or env["arch"] == "armv7" or env["bits"] == "32":  # arm
-        env["arch"] = "arm"
-        env["bits"] = "32"
-    else:  # armv64
+
+    # iOS no longer runs on 32-bit since 11.0 which is unsupported since 2018
+    # As such, we only support 64-bit
+    env["bits"] = "64"
+
+    if env["arch"] == "x86_64":
+        print("Building for iOS 15.0+, platform x86-64.")
+    else:
         env["arch"] = "arm64"
-        env["bits"] = "64"
+        print("Building for iOS 15.0+, platform arm64.")
 
     ## Compiler configuration
 
@@ -116,38 +116,29 @@ def configure(env):
 
     if env["ios_simulator"]:
         detect_darwin_sdk_path("iphonesimulator", env)
-        env.Append(ASFLAGS=["-mios-simulator-version-min=12.0"])
-        env.Append(CCFLAGS=["-mios-simulator-version-min=12.0"])
-        env.Append(LINKFLAGS=["-mios-simulator-version-min=12.0"])
+        env.Append(ASFLAGS=["-mios-simulator-version-min=15.0"])
+        env.Append(CCFLAGS=["-mios-simulator-version-min=15.0"])
+        env.Append(LINKFLAGS=["-mios-simulator-version-min=15.0"])
         env.extra_suffix = ".simulator" + env.extra_suffix
     else:
         detect_darwin_sdk_path("iphone", env)
-        env.Append(ASFLAGS=["-miphoneos-version-min=12.0"])
-        env.Append(CCFLAGS=["-miphoneos-version-min=12.0"])
-        env.Append(LINKFLAGS=["-miphoneos-version-min=12.0"])
+        env.Append(ASFLAGS=["-miphoneos-version-min=15.0"])
+        env.Append(CCFLAGS=["-miphoneos-version-min=15.0"])
+        env.Append(LINKFLAGS=["-miphoneos-version-min=15.0"])
 
-    if env["arch"] == "x86" or env["arch"] == "x86_64":
+    if env["arch"] == "x86_64":
         if not env["ios_simulator"]:
-            print("ERROR: Building for iOS with 'arch=x86_64' or 'arch=x86' requires 'ios_simulator=yes'.")
+            print("ERROR: Building for iOS with 'arch=x86_64' requires 'ios_simulator=yes'.")
             sys.exit(255)
 
-        env["ENV"]["MACOSX_DEPLOYMENT_TARGET"] = "10.9"
-        arch_flag = "i386" if env["arch"] == "x86" else env["arch"]
+        env["ENV"]["MACOSX_DEPLOYMENT_TARGET"] = "11.0"
         env.Append(
             CCFLAGS=(
-                "-arch "
-                + arch_flag
-                + " -fobjc-arc -fobjc-abi-version=2 -fobjc-legacy-dispatch -fmessage-length=0 -fpascal-strings -fblocks -fasm-blocks -isysroot $IPHONESDK"
+                "-arch x86_64 -fobjc-arc -fobjc-abi-version=2 -fobjc-legacy-dispatch -fmessage-length=0 -fpascal-strings -fblocks -fasm-blocks -isysroot $IPHONESDK"
             ).split()
         )
-        env.Append(ASFLAGS=["-arch", arch_flag])
-    elif env["arch"] == "arm":
-        detect_darwin_sdk_path("iphone", env)
-        env.Append(
-            CCFLAGS='-fobjc-arc -arch armv7 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fblocks -isysroot $IPHONESDK -fvisibility=hidden -mthumb "-DIBOutlet=__attribute__((iboutlet))" "-DIBOutletCollection(ClassName)=__attribute__((iboutletcollection(ClassName)))" "-DIBAction=void)__attribute__((ibaction)" -MMD -MT dependencies'.split()
-        )
-        env.Append(ASFLAGS=["-arch", "armv7"])
-    elif env["arch"] == "arm64":
+        env.Append(ASFLAGS=["-arch x86_64"])
+    else:
         detect_darwin_sdk_path("iphone", env)
         env.Append(
             CCFLAGS="-fobjc-arc -arch arm64 -fmessage-length=0 -fno-strict-aliasing -fdiagnostics-print-source-range-info -fdiagnostics-show-category=id -fdiagnostics-parseable-fixits -fpascal-strings -fblocks -fvisibility=hidden -MMD -MT dependencies -isysroot $IPHONESDK".split()
@@ -161,12 +152,11 @@ def configure(env):
 
     ## Link flags
 
-    if env["arch"] == "x86" or env["arch"] == "x86_64":
-        arch_flag = "i386" if env["arch"] == "x86" else env["arch"]
+    if env["arch"] == "x86_64":
         env.Append(
             LINKFLAGS=[
                 "-arch",
-                arch_flag,
+                "x86_64",
                 "-isysroot",
                 "$IPHONESDK",
                 "-Xlinker",
@@ -176,9 +166,7 @@ def configure(env):
                 "-F$IPHONESDK",
             ]
         )
-    elif env["arch"] == "arm":
-        env.Append(LINKFLAGS=["-arch", "armv7", "-Wl,-dead_strip"])
-    if env["arch"] == "arm64":
+    else:
         env.Append(LINKFLAGS=["-arch", "arm64", "-Wl,-dead_strip"])
 
     env.Append(

--- a/platform/iphone/export/export.cpp
+++ b/platform/iphone/export/export.cpp
@@ -83,20 +83,6 @@ class EditorExportPlatformIOS : public EditorExportPlatform {
 		Vector<String> capabilities;
 		bool use_swift_runtime;
 	};
-	struct ExportArchitecture {
-		String name;
-		bool is_default;
-
-		ExportArchitecture() :
-				name(""),
-				is_default(false) {
-		}
-
-		ExportArchitecture(String p_name, bool p_is_default) {
-			name = p_name;
-			is_default = p_is_default;
-		}
-	};
 
 	struct IOSExportAsset {
 		String exported_path;
@@ -110,9 +96,6 @@ class EditorExportPlatformIOS : public EditorExportPlatform {
 	void _fix_config_file(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &pfile, const IOSConfigData &p_config, bool p_debug);
 	Error _export_loading_screen_file(const Ref<EditorExportPreset> &p_preset, const String &p_dest_dir);
 	Error _export_icons(const Ref<EditorExportPreset> &p_preset, const String &p_iconset_dir);
-
-	Vector<ExportArchitecture> _get_supported_architectures();
-	Vector<String> _get_preset_architectures(const Ref<EditorExportPreset> &p_preset);
 
 	void _add_assets_to_project(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &p_project_data, const Vector<IOSExportAsset> &p_additional_assets);
 	Error _copy_asset(const String &p_out_dir, const String &p_asset, const String *p_custom_file_name, bool p_is_framework, bool p_should_embed, Vector<IOSExportAsset> &r_exported_assets);
@@ -308,17 +291,7 @@ void EditorExportPlatformIOS::get_preset_features(const Ref<EditorExportPreset> 
 		r_features->push_back("etc2");
 	}
 
-	Vector<String> architectures = _get_preset_architectures(p_preset);
-	for (int i = 0; i < architectures.size(); ++i) {
-		r_features->push_back(architectures[i]);
-	}
-}
-
-Vector<EditorExportPlatformIOS::ExportArchitecture> EditorExportPlatformIOS::_get_supported_architectures() {
-	Vector<ExportArchitecture> archs;
-	archs.push_back(ExportArchitecture("armv7", false)); // Disabled by default, not included in official templates.
-	archs.push_back(ExportArchitecture("arm64", true));
-	return archs;
+	r_features->push_back("arm64");
 }
 
 struct APIAccessInfo {
@@ -413,11 +386,6 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/debug", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/release", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
 
-	Vector<ExportArchitecture> architectures = _get_supported_architectures();
-	for (int i = 0; i < architectures.size(); ++i) {
-		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, vformat("%s/%s", PNAME("architectures"), architectures[i].name)), architectures[i].is_default));
-	}
-
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/app_store_team_id"), ""));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/provisioning_profile_uuid_debug"), ""));
@@ -428,6 +396,7 @@ void EditorExportPlatformIOS::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/export_method_release", PROPERTY_HINT_ENUM, "App Store,Development,Ad-Hoc,Enterprise"), 0));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/targeted_device_family", PROPERTY_HINT_ENUM, "iPhone,iPad,iPhone & iPad"), 2));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/min_ios_version"), "15.0"));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/name", PROPERTY_HINT_PLACEHOLDER_TEXT, "Game Name"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/info"), "Made with Godot Engine"));
@@ -610,7 +579,7 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 		} else if (lines[i].find("$additional_plist_content") != -1) {
 			strnew += lines[i].replace("$additional_plist_content", p_config.plist_content) + "\n";
 		} else if (lines[i].find("$godot_archs") != -1) {
-			strnew += lines[i].replace("$godot_archs", p_config.architectures) + "\n";
+			strnew += lines[i].replace("$godot_archs", "arm64") + "\n";
 		} else if (lines[i].find("$linker_flags") != -1) {
 			strnew += lines[i].replace("$linker_flags", p_config.linker_flags) + "\n";
 		} else if (lines[i].find("$targeted_device_family") != -1) {
@@ -627,6 +596,10 @@ void EditorExportPlatformIOS::_fix_config_file(const Ref<EditorExportPreset> &p_
 					break;
 			}
 			strnew += lines[i].replace("$targeted_device_family", xcode_value) + "\n";
+		} else if (lines[i].find("$os_deployment_target") != -1) {
+			String min_version = p_preset->get("application/min_ios_version");
+			String value = "IPHONEOS_DEPLOYMENT_TARGET = " + min_version + ";";
+			strnew += lines[i].replace("$os_deployment_target", value) + "\n";
 		} else if (lines[i].find("$cpp_code") != -1) {
 			strnew += lines[i].replace("$cpp_code", p_config.cpp_code) + "\n";
 		} else if (lines[i].find("$docs_in_place") != -1) {
@@ -1582,18 +1555,6 @@ Error EditorExportPlatformIOS::_export_additional_assets(const String &p_out_dir
 	return OK;
 }
 
-Vector<String> EditorExportPlatformIOS::_get_preset_architectures(const Ref<EditorExportPreset> &p_preset) {
-	Vector<ExportArchitecture> all_archs = _get_supported_architectures();
-	Vector<String> enabled_archs;
-	for (int i = 0; i < all_archs.size(); ++i) {
-		bool is_enabled = p_preset->get("architectures/" + all_archs[i].name);
-		if (is_enabled) {
-			enabled_archs.push_back(all_archs[i].name);
-		}
-	}
-	return enabled_archs;
-}
-
 Error EditorExportPlatformIOS::_export_ios_plugins(const Ref<EditorExportPreset> &p_preset, IOSConfigData &p_config_data, const String &dest_dir, Vector<IOSExportAsset> &r_exported_assets, bool p_debug) {
 	String plugin_definition_cpp_code;
 	String plugin_initialization_cpp_code;
@@ -1907,7 +1868,7 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 		pkg_name,
 		binary_name,
 		_get_additional_plist_content(),
-		String(" ").join(_get_preset_architectures(p_preset)),
+		"arm64",
 		_get_linker_flags(),
 		_get_cpp_code(),
 		"",

--- a/platform/iphone/godot_app_delegate.m
+++ b/platform/iphone/godot_app_delegate.m
@@ -64,29 +64,15 @@ static NSMutableArray<ApplicationDelegateService *> *services = nil;
 - (UIWindow *)window {
 	UIWindow *result = nil;
 
-	if (@available(iOS 13, tvOS 13, *)) {
-		for (SceneDelegateService *service in [SceneDelegate services]) {
-			if (![service respondsToSelector:_cmd]) {
-				continue;
-			}
-
-			UIWindow *value = [service window];
-
-			if (value) {
-				result = value;
-			}
+	for (SceneDelegateService *service in [SceneDelegate services]) {
+		if (![service respondsToSelector:_cmd]) {
+			continue;
 		}
-	} else {
-		for (ApplicationDelegateService *service in services) {
-			if (![service respondsToSelector:_cmd]) {
-				continue;
-			}
 
-			UIWindow *value = [service window];
+		UIWindow *value = [service window];
 
-			if (value) {
-				result = value;
-			}
+		if (value) {
+			result = value;
 		}
 	}
 

--- a/platform/iphone/godot_scene_delegate.m
+++ b/platform/iphone/godot_scene_delegate.m
@@ -42,10 +42,8 @@ static NSMutableArray<SceneDelegateService *> *services = nil;
 }
 
 + (void)load {
-	if (@available(iOS 13, tvOS 13, *)) {
-		services = [NSMutableArray new];
-		[services addObject:[AppDelegate getSingleton]];
-	}
+	services = [NSMutableArray new];
+	[services addObject:[AppDelegate getSingleton]];
 }
 
 + (void)addService:(SceneDelegateService *)service API_AVAILABLE(ios(13.0), tvos(13.0)) {

--- a/platform/iphone/godot_view.mm
+++ b/platform/iphone/godot_view.mm
@@ -420,11 +420,7 @@ static const int max_touches = 32;
 
 	UIInterfaceOrientation interfaceOrientation = UIInterfaceOrientationUnknown;
 
-	if (@available(iOS 13, *)) {
-		interfaceOrientation = [UIApplication sharedApplication].delegate.window.windowScene.interfaceOrientation;
-	} else {
-		interfaceOrientation = [[UIApplication sharedApplication] statusBarOrientation];
-	}
+	interfaceOrientation = [UIApplication sharedApplication].delegate.window.windowScene.interfaceOrientation;
 
 	switch (interfaceOrientation) {
 		case UIInterfaceOrientationLandscapeLeft: {

--- a/platform/iphone/ios.mm
+++ b/platform/iphone/ios.mm
@@ -45,10 +45,8 @@ void iOS::_bind_methods() {
 };
 
 bool iOS::supports_haptic_engine() {
-	if (@available(iOS 13, *)) {
-		id<CHHapticDeviceCapability> capabilities = [CHHapticEngine capabilitiesForHardware];
-		return capabilities.supportsHaptics;
-	}
+	id<CHHapticDeviceCapability> capabilities = [CHHapticEngine capabilitiesForHardware];
+	return capabilities.supportsHaptics;
 
 	return false;
 }
@@ -70,69 +68,63 @@ CHHapticEngine *iOS::get_haptic_engine_instance() API_AVAILABLE(ios(13)) {
 }
 
 void iOS::vibrate_haptic_engine(float p_duration_seconds) API_AVAILABLE(ios(13)) {
-	if (@available(iOS 13, *)) { // We need the @available check every time to make the compiler happy...
-		if (supports_haptic_engine()) {
-			CHHapticEngine *haptic_engine = get_haptic_engine_instance();
-			if (haptic_engine) {
-				NSDictionary *hapticDict = @{
-					CHHapticPatternKeyPattern : @[
-						@{CHHapticPatternKeyEvent : @{
-							CHHapticPatternKeyEventType : CHHapticEventTypeHapticContinuous,
-							CHHapticPatternKeyTime : @(CHHapticTimeImmediate),
-							CHHapticPatternKeyEventDuration : @(p_duration_seconds)
-						},
-						},
-					],
-				};
+	if (supports_haptic_engine()) {
+		CHHapticEngine *haptic_engine = get_haptic_engine_instance();
+		if (haptic_engine) {
+			NSDictionary *hapticDict = @{
+				CHHapticPatternKeyPattern : @[
+					@{CHHapticPatternKeyEvent : @{
+						CHHapticPatternKeyEventType : CHHapticEventTypeHapticContinuous,
+						CHHapticPatternKeyTime : @(CHHapticTimeImmediate),
+						CHHapticPatternKeyEventDuration : @(p_duration_seconds)
+					},
+					},
+				],
+			};
 
-				NSError *error;
-				CHHapticPattern *pattern = [[CHHapticPattern alloc] initWithDictionary:hapticDict error:&error];
+			NSError *error;
+			CHHapticPattern *pattern = [[CHHapticPattern alloc] initWithDictionary:hapticDict error:&error];
 
-				[[haptic_engine createPlayerWithPattern:pattern error:&error] startAtTime:0 error:&error];
+			[[haptic_engine createPlayerWithPattern:pattern error:&error] startAtTime:0 error:&error];
 
-				NSLog(@"Could not vibrate using haptic engine: %@", error);
-			}
-
-			return;
+			NSLog(@"Could not vibrate using haptic engine: %@", error);
 		}
+
+		return;
 	}
 
 	NSLog(@"Haptic engine is not supported in this version of iOS");
 }
 
 void iOS::start_haptic_engine() {
-	if (@available(iOS 13, *)) {
-		if (supports_haptic_engine()) {
-			CHHapticEngine *haptic_engine = get_haptic_engine_instance();
-			if (haptic_engine) {
-				[haptic_engine startWithCompletionHandler:^(NSError *returnedError) {
-					if (returnedError) {
-						NSLog(@"Could not start haptic engine: %@", returnedError);
-					}
-				}];
-			}
-
-			return;
+	if (supports_haptic_engine()) {
+		CHHapticEngine *haptic_engine = get_haptic_engine_instance();
+		if (haptic_engine) {
+			[haptic_engine startWithCompletionHandler:^(NSError *returnedError) {
+				if (returnedError) {
+					NSLog(@"Could not start haptic engine: %@", returnedError);
+				}
+			}];
 		}
+
+		return;
 	}
 
 	NSLog(@"Haptic engine is not supported in this version of iOS");
 }
 
 void iOS::stop_haptic_engine() {
-	if (@available(iOS 13, *)) {
-		if (supports_haptic_engine()) {
-			CHHapticEngine *haptic_engine = get_haptic_engine_instance();
-			if (haptic_engine) {
-				[haptic_engine stopWithCompletionHandler:^(NSError *returnedError) {
-					if (returnedError) {
-						NSLog(@"Could not stop haptic engine: %@", returnedError);
-					}
-				}];
-			}
-
-			return;
+	if (supports_haptic_engine()) {
+		CHHapticEngine *haptic_engine = get_haptic_engine_instance();
+		if (haptic_engine) {
+			[haptic_engine stopWithCompletionHandler:^(NSError *returnedError) {
+				if (returnedError) {
+					NSLog(@"Could not stop haptic engine: %@", returnedError);
+				}
+			}];
 		}
+
+		return;
 	}
 
 	NSLog(@"Haptic engine is not supported in this version of iOS");

--- a/platform/iphone/joypad_iphone.mm
+++ b/platform/iphone/joypad_iphone.mm
@@ -310,21 +310,17 @@ void JoypadIPhone::start_processing() {
 				OSIPhone::get_singleton()->joy_axis(joy_id, JOY_ANALOG_R2, value);
 			}
 
-			if (@available(iOS 13, *)) {
-				if (element == gamepad.buttonOptions) {
-					OSIPhone::get_singleton()->joy_button(joy_id, JOY_BUTTON_10,
-							gamepad.buttonOptions.isPressed);
-				} else if (element == gamepad.buttonMenu) {
-					OSIPhone::get_singleton()->joy_button(joy_id, JOY_BUTTON_11,
-							gamepad.buttonMenu.isPressed);
-				}
+			if (element == gamepad.buttonOptions) {
+				OSIPhone::get_singleton()->joy_button(joy_id, JOY_BUTTON_10,
+						gamepad.buttonOptions.isPressed);
+			} else if (element == gamepad.buttonMenu) {
+				OSIPhone::get_singleton()->joy_button(joy_id, JOY_BUTTON_11,
+						gamepad.buttonMenu.isPressed);
 			}
 
-			if (@available(iOS 14, *)) {
-				if (element == gamepad.buttonHome) {
-					OSIPhone::get_singleton()->joy_button(joy_id, JOY_GUIDE,
-							gamepad.buttonHome.isPressed);
-				}
+			if (element == gamepad.buttonHome) {
+				OSIPhone::get_singleton()->joy_button(joy_id, JOY_GUIDE,
+						gamepad.buttonHome.isPressed);
 			}
 		};
 	} else if (controller.microGamepad != nil) {

--- a/platform/iphone/os_iphone.mm
+++ b/platform/iphone/os_iphone.mm
@@ -537,9 +537,7 @@ void OSIPhone::show_virtual_keyboard(const String &p_existing_text, const Rect2 
 		} break;
 		case KEYBOARD_TYPE_PASSWORD: {
 			AppDelegate.viewController.keyboardView.keyboardType = UIKeyboardTypeDefault;
-			if (@available(iOS 11.0, *)) {
-				AppDelegate.viewController.keyboardView.textContentType = UITextContentTypePassword;
-			}
+			AppDelegate.viewController.keyboardView.textContentType = UITextContentTypePassword;
 		} break;
 		case KEYBOARD_TYPE_URL: {
 			AppDelegate.viewController.keyboardView.keyboardType = UIKeyboardTypeWebSearch;
@@ -666,22 +664,18 @@ float OSIPhone::get_screen_refresh_rate(int p_screen) const {
 }
 
 Rect2 OSIPhone::get_window_safe_area() const {
-	if (@available(iOS 11, *)) {
-		UIEdgeInsets insets = UIEdgeInsetsZero;
-		UIView *view = AppDelegate.viewController.godotView;
+	UIEdgeInsets insets = UIEdgeInsetsZero;
+	UIView *view = AppDelegate.viewController.godotView;
 
-		if ([view respondsToSelector:@selector(safeAreaInsets)]) {
-			insets = [view safeAreaInsets];
-		}
-
-		float scale = [UIScreen mainScreen].nativeScale;
-		Size2i insets_position = Size2i(insets.left, insets.top) * scale;
-		Size2i insets_size = Size2i(insets.left + insets.right, insets.top + insets.bottom) * scale;
-
-		return Rect2i(insets_position, get_window_size() - insets_size);
-	} else {
-		return Rect2i(Size2i(0, 0), get_window_size());
+	if ([view respondsToSelector:@selector(safeAreaInsets)]) {
+		insets = [view safeAreaInsets];
 	}
+
+	float scale = [UIScreen mainScreen].nativeScale;
+	Size2i insets_position = Size2i(insets.left, insets.top) * scale;
+	Size2i insets_size = Size2i(insets.left + insets.right, insets.top + insets.bottom) * scale;
+
+	return Rect2i(insets_position, get_window_size() - insets_size);
 }
 
 bool OSIPhone::has_touchscreen_ui_hint() const {

--- a/platform/iphone/view_controller.mm
+++ b/platform/iphone/view_controller.mm
@@ -101,9 +101,7 @@
 	[self observeKeyboard];
 	[self displayLoadingOverlay];
 
-	if (@available(iOS 11.0, *)) {
-		[self setNeedsUpdateOfScreenEdgesDeferringSystemGestures];
-	}
+	[self setNeedsUpdateOfScreenEdgesDeferringSystemGestures];
 }
 
 - (void)observeKeyboard {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/68720

## Additional information

- Bumps min. version to 15.0 (min supported by Xcode 27).
- Adds min. target export option.
- Removes dead code for older versions.
- Removes 32-bit build configs/export code (not support since iOS 11).