### PR TITLE
[3.x] `SafeError` - prevent implicit conversions of `Error` to `bool`

### DIFF
--- a/core/error_list.h
+++ b/core/error_list.h
@@ -31,6 +31,8 @@
 #ifndef ERROR_LIST_H
 #define ERROR_LIST_H
 
+#include "typedefs.h"
+
 /** Error List. Please never compare an error against FAILED
  * Either do result != OK , or !result. This way, Error fail
  * values can be more detailed in the future.
@@ -88,6 +90,28 @@ enum Error {
 	ERR_HELP, ///< user requested help!!
 	ERR_BUG, ///< a bug in the software certainly happened, due to a double check failing or unexpected behavior.
 	ERR_PRINTER_ON_FIRE, /// the parallel port printer is engulfed in flames
+};
+
+// Error can unfortunately be implicitly converted to a bool.
+// The problem with this is that polarity is reversed, `OK` is false, and `ERR` is true.
+// This is a massive footgun that we want to prevent at compilation time.
+// The solution provided here is to return `Error` through a wrapper class that prevents
+// implicit conversion to bool.
+
+// This forces the caller to use the pattern `if (my_func() != OK)`
+// instead of `if (my_func())`, which is prone to polarity bugs.
+class SafeError {
+	Error value;
+
+public:
+	// Delete the implicit conversion to bool to trigger a compiler error.
+	operator bool() const = delete;
+
+	// Allow it to still act like a normal Error enum everywhere else.
+	_ALWAYS_INLINE_ operator Error() const { return value; }
+
+	_ALWAYS_INLINE_ SafeError(Error p_value) :
+			value(p_value) {}
 };
 
 #endif // ERROR_LIST_H

--- a/core/os/mutex.h
+++ b/core/os/mutex.h
@@ -52,7 +52,7 @@ public:
 		mutex.unlock();
 	}
 
-	_ALWAYS_INLINE_ Error try_lock() const {
+	_ALWAYS_INLINE_ SafeError try_lock() const {
 		return mutex.try_lock() ? OK : ERR_BUSY;
 	}
 };
@@ -104,7 +104,7 @@ class MutexImpl {
 public:
 	_ALWAYS_INLINE_ void lock() const {}
 	_ALWAYS_INLINE_ void unlock() const {}
-	_ALWAYS_INLINE_ Error try_lock() const { return OK; }
+	_ALWAYS_INLINE_ SafeError try_lock() const { return OK; }
 };
 
 class _NO_DISCARD_CLASS_ MutexLock {


### PR DESCRIPTION
Minimum implementation, featuring the class and example use in the most problematic function so far.

Fixes #122314 (partially)

## Upsides to this approach
* standard c++
* targeted to fix the problem exactly where needed

## Downsides to this approach
* code churn (needs functions that want to use it change their return type to `SafeError`)
* can't be used with bound functions (unless we change the binding glue, and even then that might be compat breaking)

In practice though the problem in the wild tends to be most prominent for functions that are logically _expected_ to return true when they succeed, and false on failure. This is particularly the case with `Mutex::try_lock()`, where the standard `std::recursive_mutex` returns true or false for success, and the Godot version returns the opposite polarity. For this reason I've made this PR minimal and just fixed the one area where it has cropped up as a problem recently.

This means that if we target the approach there isn't much code churn in practice.

## Discussion
Ideally we would use some c++ kung fu to prevent `Error` being implicitly cast to `bool`, but it may turn out to be tricky to achieve (see #122314 and rocket chat for more info, it is under active discussion in `core`).

Some potential ways of doing this:
* global conversion function from `Error` to `bool` - _(not supported by c++ it seems)_
* use an `enum class` instead of an `enum` for `Error` _(unfortunately that would be major compatibility breaking it seems, as the scoped name would likely need to be used throughout)_
* use some MACRO kung fu _(may not work because implicit conversion from enum to bool is given high precedence in c++)_
* change `Error` to be the wrapper class and change the error code enum to `ErrorCode` or somesuch - _(a lot of compilation implications, need to fix binding, might not be backward compatible)_

This PR represents one of the more "recommended" standard c++  way of solving this problem - use a wrapper class for the `enum`, and prevent it being converted to `bool`.

## Future
`Error` is used quite a bit in the engine. It likely doesn't make sense to convert all non-bound functions to `SafeError` due to code churn, but it might be worth considering converting a few container classes to make use of it in a follow up.

Probably also should be addressed in some way in 4.x.