### PR TITLE
`ScriptLanguageExtension`: Fix compilation error with `deprecated=no`

### DIFF
--- a/core/object/script_language_extension.cpp
+++ b/core/object/script_language_extension.cpp
@@ -123,6 +123,7 @@ void ScriptLanguageExtension::_bind_methods() {
 #ifndef DISABLE_DEPRECATED
 	GDVIRTUAL_BIND(_create_script);
 	GDVIRTUAL_BIND(_has_named_classes);
+	GDVIRTUAL_BIND(_get_recognized_extensions);
 #endif
 	GDVIRTUAL_BIND(_supports_builtin_mode);
 	GDVIRTUAL_BIND(_supports_documentation);
@@ -162,7 +163,6 @@ void ScriptLanguageExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_reload_scripts, "scripts", "soft_reload");
 	GDVIRTUAL_BIND(_reload_tool_script, "script", "soft_reload");
 
-	GDVIRTUAL_BIND(_get_recognized_extensions);
 	GDVIRTUAL_BIND(_get_public_functions);
 	GDVIRTUAL_BIND(_get_public_constants);
 	GDVIRTUAL_BIND(_get_public_annotations);


### PR DESCRIPTION
It looks like https://github.com/godotengine/godot/pull/122166 broke compilation with `deprecated=no`

Tested command on Ubuntu 26.04: `scons target=editor deprecated=no`

The `script_language_extension.h` header file was adjusted, but the cpp file wasn't, causing a compile error for me on Linux.

<img width="2624" height="629" alt="grafik" src="https://github.com/user-attachments/assets/221c0771-2063-4d4d-be52-4ba909ed970a" />

Adding the deprecated check to the source file fixed it for me.