### PR TITLE
Fix XMLParser::seek() not updating current_line

### DIFF
--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -341,7 +341,17 @@ Error XMLParser::seek(uint64_t p_pos) {
 	ERR_FAIL_NULL_V(data, ERR_FILE_EOF);
 	ERR_FAIL_COND_V(p_pos >= length, ERR_FILE_EOF);
 
+	if (line_offsets.is_empty() && length > 0) {
+		line_offsets.push_back(0);
+		for (uint64_t i = 0; i < length; i++) {
+			if (data[i] == '\n') {
+				line_offsets.push_back(i + 1);
+			}
+		}
+	}
+
 	P = data + p_pos;
+	current_line = line_offsets.bsearch(p_pos, false) - 1;
 
 	return read();
 }
@@ -463,6 +473,7 @@ Error XMLParser::open_buffer(const Vector<uint8_t> &p_buffer) {
 		data_copy = nullptr;
 	}
 
+	line_offsets.clear();
 	length = p_buffer.size();
 	data_copy = memnew_arr(char, length + 1);
 	memcpy(data_copy, p_buffer.ptr(), length);
@@ -483,6 +494,7 @@ Error XMLParser::_open_buffer(const uint8_t *p_buffer, size_t p_size) {
 		data_copy = nullptr;
 	}
 
+	line_offsets.clear();
 	length = p_size;
 	data = (const char *)p_buffer;
 	P = data;
@@ -505,6 +517,7 @@ Error XMLParser::open(const String &p_path) {
 		data_copy = nullptr;
 	}
 
+	line_offsets.clear();
 	data_copy = memnew_arr(char, length + 1);
 	file->get_buffer((uint8_t *)data_copy, length);
 	data_copy[length] = 0;
@@ -545,6 +558,7 @@ void XMLParser::close() {
 	node_empty = false;
 	node_type = NODE_NONE;
 	node_offset = 0;
+	line_offsets.clear();
 }
 
 int XMLParser::get_current_line() const {

--- a/core/io/xml_parser.h
+++ b/core/io/xml_parser.h
@@ -69,6 +69,7 @@ private:
 	const char *P = nullptr;
 	uint64_t length = 0;
 	uint64_t current_line = 0;
+	Vector<uint64_t> line_offsets;
 	String node_name;
 	bool node_empty = false;
 	NodeType node_type = NODE_NONE;

--- a/tests/core/io/test_xml_parser.cpp
+++ b/tests/core/io/test_xml_parser.cpp
@@ -231,4 +231,23 @@ TEST_CASE("[XMLParser] CDATA") {
 	CHECK_EQ(parser.get_node_name(), "a");
 }
 
+TEST_CASE("[XMLParser] Seek and current line") {
+	XMLParser parser;
+	const String input = "<a>\n<b>\r\n</a>";
+	REQUIRE_EQ(parser.open_buffer(input.to_utf8_buffer()), OK);
+
+	REQUIRE_EQ(parser.read(), OK); // <a>, line 0
+	CHECK_EQ(parser.get_current_line(), 0);
+
+	REQUIRE_EQ(parser.read(), OK); // <b>, line 1
+	CHECK_EQ(parser.get_current_line(), 1);
+	uint64_t offset = parser.get_node_offset();
+
+	REQUIRE_EQ(parser.read(), OK); // </a>, line 2
+	CHECK_EQ(parser.get_current_line(), 2);
+
+	REQUIRE_EQ(parser.seek(offset), OK); // Seek back to <b>
+	CHECK_EQ(parser.get_current_line(), 1);
+}
+
 } // namespace TestXMLParser


### PR DESCRIPTION
While going through XMLParser::seek(), I saw that after moving the internal pointer P it never updates current_line, so any later call to get_current_line() returns a stale value. 

I fixed this by lazily building a line-offset index on the first seek and then using a binary search to set the correct line in O(log n) time. The cache is cleared when a new buffer is opened, so there’s zero overhead for the common non-seeking path.

