### PR TITLE
Fix alert dialog crash on Android

### DIFF
--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
@@ -903,24 +903,33 @@ class Godot private constructor(val context: Context) {
 
 	@JvmOverloads
 	fun alert(message: String, title: String, okCallback: Runnable? = null) {
-		val activity = getActivity() ?: return
-
 		val renderLatch = CountDownLatch(1)
 		runOnHostThread {
-			val builder = AlertDialog.Builder(activity)
-			builder.setMessage(message).setTitle(title)
-			builder.setPositiveButton(
-				R.string.dialog_ok
-			) { dialog: DialogInterface, _: Int ->
-				okCallback?.run()
-				dialog.cancel()
+			val activity = getActivity()
+			if (activity == null) {
+				renderLatch.countDown()
+				return@runOnHostThread
+			}
+
+			try {
+				val builder = AlertDialog.Builder(activity)
+				builder.setMessage(message).setTitle(title)
+				builder.setPositiveButton(
+					R.string.dialog_ok
+				) { dialog: DialogInterface, _: Int ->
+					okCallback?.run()
+					dialog.cancel()
+					renderLatch.countDown()
+				}
+				builder.setOnCancelListener {
+					renderLatch.countDown()
+				}
+				val dialog = builder.create()
+				dialog.show()
+			} catch (e: WindowManager.BadTokenException) {
+				// fallback in case the activity state changes before show().
 				renderLatch.countDown()
 			}
-			builder.setOnCancelListener {
-				renderLatch.countDown()
-			}
-			val dialog = builder.create()
-			dialog.show()
 		}
 
 		// We only block the render thread.


### PR DESCRIPTION
Adds defensive checks to prevent this crash: https://play.google.com/console/u/0/developers/5310120689138741555/app/4972363226496209566/vitals/crashes/b367348c8134ffc70010fc0f2ae8939c/details?isUserPerceived=true&versionCode=40702401
```
Exception android.view.WindowManager$BadTokenException:
  at android.view.ViewRootImpl.setView (ViewRootImpl.java:2053)
  at android.view.WindowManagerGlobal.addView (WindowManagerGlobal.java:606)
  at android.view.WindowManagerImpl.addView (WindowManagerImpl.java:167)
  at android.app.Dialog.show (Dialog.java:544)
  at org.godotengine.godot.Godot.alert$lambda$24 (Godot.kt:895)
  at org.godotengine.godot.Godot.$r8$lambda$JCTWNqH5NmSniJH-bC-2yaS9gxk (Godot.kt)
  at org.godotengine.godot.Godot$$ExternalSyntheticLambda9.run (D8$$SyntheticClass)
  at android.os.Handler.handleCallback (Handler.java:1070)
  at android.os.Handler.dispatchMessage (Handler.java:125)
  at android.os.Looper.dispatchMessage (Looper.java:358)
  at android.os.Looper.loopOnce (Looper.java:288)
  at android.os.Looper.loop (Looper.java:392)
  at android.app.ActivityThread.main (ActivityThread.java:10346)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:638)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:972)
```
