### PR TITLE
Fix signal connect dialog crashes.

### DIFF
--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -1034,10 +1034,6 @@ void SceneTreeEditor::_update_tree(bool p_scroll_to_selected) {
 		return;
 	}
 
-	if (!update_when_invisible && !is_visible_in_tree()) {
-		return;
-	}
-
 	Node *scene_node = get_scene_node();
 	const ObjectID scene_id = scene_node ? scene_node->get_instance_id() : ObjectID();
 	if (node_cache.current_scene_id != scene_id) {
@@ -1045,6 +1041,10 @@ void SceneTreeEditor::_update_tree(bool p_scroll_to_selected) {
 		marked.clear();
 		node_cache.current_scene_id = scene_id;
 		node_cache.force_update = true;
+	}
+
+	if (!update_when_invisible && !is_visible_in_tree()) {
+		return;
 	}
 
 	if (tree->is_editing()) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #121630 
- Closes #116235


## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

#101145 fixed signal connection crash, and #113789 introduced regression.

When the signal connection is initialized, because it is not yet visible, the cache after scene changes is not cleared during the `_update_tree`, which may lead to access to freed nodes.

The process of reproduction is as follows: 
Open two scenes, A and B. Trigger two connections in scene B. After the tooltip pops up, close scene B using `Ctrl + W`. 
Connecting in scene A will have a high probability of triggering a crash. If no crash occurs, close scenes A and B and try again.
`Ctrl + W` is a custom keyboard shortcut for `ui_close_dialog` and `close_scene`.

I don't know why it requires two connection and tooltips, which causes the cache to not be cleared.

[connect.webm](https://github.com/user-attachments/assets/e90e669f-9f3c-4e97-b0d7-94f839031b78)
