### PR TITLE
Vulkan: request VK_KHR_external_memory_win32 and VK_KHR_external_semaphore_win32 as optional device extensions

### DIFF
--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -592,6 +592,18 @@ Error RenderingDeviceDriverVulkan::_initialize_device_extensions() {
 	// can and will fill the validation layers with useless info otherwise if not enabled.
 	_register_requested_device_extension(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME, false);
 
+#if defined(VK_USE_PLATFORM_WIN32_KHR)
+	// WALKUP (h0tz0mbie/WALKUP#264): let a GDExtension import a D3D11
+	// video decoder's surface as a Vulkan image (zero-copy video decode),
+	// and the decoder's fence as a semaphore so the cross-API handoff can
+	// be synchronized GPU-side. Optional on purpose: enabling them changes
+	// nothing until an extension asks the device for an import, so
+	// hardware or drivers without them behave exactly as stock. The
+	// Windows siblings of the FD extension registered above.
+	_register_requested_device_extension(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME, false);
+	_register_requested_device_extension(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME, false);
+#endif
+
 	if (Engine::get_singleton()->is_generate_spirv_debug_info_enabled()) {
 		_register_requested_device_extension(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME, true);
 	}


### PR DESCRIPTION
Registers `VK_KHR_external_memory_win32` and `VK_KHR_external_semaphore_win32` as optional device extensions on Windows, next to the existing `VK_KHR_external_memory_fd` registration they mirror.

**What feature this enables**

GDExtensions can already wrap an existing `VkImage` with `RenderingDevice.texture_create_from_extension()`. On Windows, however, there is no way to get D3D11 content into such an image without a round trip through system memory: importing a shared D3D11 texture requires `VK_KHR_external_memory_win32`, and Godot creates its device without it, so `vkGetMemoryWin32HandlePropertiesKHR` never resolves.

With the extension enabled, a GDExtension can import a shared D3D11 texture as a `VkImage` and wrap it as an RD texture. The concrete use case is zero-copy hardware video decode: a D3D11VA decoded frame reaches the screen without ever touching the CPU. On my test machine this removes about 5 ms of per-frame copying at 1080p60. The semaphore extension is included so the same interop can share a D3D11 fence for cross-API synchronization.

**Why optional**

Enabling these changes nothing by itself. They only have an effect once an application asks the device for an import, and code using them is expected to check that the extension functions actually resolve. That check is also the natural fallback path on hardware or drivers without support.

**Testing**

Built on Windows 11 with MSVC. Verified the extensions appear on the created device, a shared D3D11 texture import binds and wraps as an RD texture on NVIDIA hardware, and rendering is unchanged when the interop is not used.