### PR TITLE
Exclude `EngineDebugger` and related code from release builds

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -41,6 +41,7 @@
 #include "core/math/geometry_2d.h"
 #include "core/math/geometry_3d.h"
 #include "core/object/class_db.h"
+#include "core/object/script_language.h"
 #include "core/os/keyboard.h"
 #include "core/os/main_loop.h"
 #include "core/os/os.h"
@@ -2178,76 +2179,123 @@ void Engine::_bind_methods() {
 
 ////// EngineDebugger //////
 
+#if defined(DEBUG_ENABLED) || !defined(DISABLE_DEPRECATED)
+
 bool EngineDebugger::is_active() {
+#ifdef DEBUG_ENABLED
 	return ::EngineDebugger::is_active();
+#else
+	return false;
+#endif
 }
 
 void EngineDebugger::register_profiler(const StringName &p_name, Ref<EngineProfiler> p_profiler) {
 	ERR_FAIL_COND(p_profiler.is_null());
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(p_profiler->is_bound(), "Profiler already registered.");
+#endif
 	ERR_FAIL_COND_MSG(profilers.has(p_name) || has_profiler(p_name), vformat("Profiler name already in use: '%s'.", p_name));
+#ifdef DEBUG_ENABLED
 	Error err = p_profiler->bind(p_name);
 	ERR_FAIL_COND_MSG(err != OK, vformat("Profiler failed to register with error: %d.", err));
+#endif
 	profilers.insert(p_name, p_profiler);
 }
 
 void EngineDebugger::unregister_profiler(const StringName &p_name) {
 	ERR_FAIL_COND_MSG(!profilers.has(p_name), vformat("Profiler not registered: '%s'.", p_name));
+#ifdef DEBUG_ENABLED
 	profilers[p_name]->unbind();
+#endif
 	profilers.erase(p_name);
 }
 
 bool EngineDebugger::is_profiling(const StringName &p_name) {
+#ifdef DEBUG_ENABLED
 	return ::EngineDebugger::is_profiling(p_name);
+#else
+	return false;
+#endif
 }
 
 bool EngineDebugger::has_profiler(const StringName &p_name) {
+#ifdef DEBUG_ENABLED
 	return ::EngineDebugger::has_profiler(p_name);
+#else
+	return profilers.has(p_name);
+#endif
 }
 
 void EngineDebugger::profiler_add_frame_data(const StringName &p_name, const Array &p_data) {
+#ifdef DEBUG_ENABLED
 	::EngineDebugger::profiler_add_frame_data(p_name, p_data);
+#else
+	ERR_FAIL_COND_MSG(!profilers.has(p_name), vformat("Can't add frame data, no profiler: '%s'.", p_name));
+#endif
 }
 
 void EngineDebugger::profiler_enable(const StringName &p_name, bool p_enabled, const Array &p_opts) {
+#ifdef DEBUG_ENABLED
 	if (::EngineDebugger::get_singleton()) {
 		::EngineDebugger::get_singleton()->profiler_enable(p_name, p_enabled, p_opts);
 	}
+#endif
 }
 
 void EngineDebugger::register_message_capture(const StringName &p_name, const Callable &p_callable) {
 	ERR_FAIL_COND_MSG(captures.has(p_name) || has_capture(p_name), vformat("Capture already registered: '%s'.", p_name));
 	captures.insert(p_name, p_callable);
+#ifdef DEBUG_ENABLED
 	Callable &c = captures[p_name];
 	::EngineDebugger::Capture capture(&c, &EngineDebugger::call_capture);
 	::EngineDebugger::register_message_capture(p_name, capture);
+#endif
 }
 
 void EngineDebugger::unregister_message_capture(const StringName &p_name) {
 	ERR_FAIL_COND_MSG(!captures.has(p_name), vformat("Capture not registered: '%s'.", p_name));
+#ifdef DEBUG_ENABLED
 	::EngineDebugger::unregister_message_capture(p_name);
+#endif
 	captures.erase(p_name);
 }
 
 bool EngineDebugger::has_capture(const StringName &p_name) {
+#ifdef DEBUG_ENABLED
 	return ::EngineDebugger::has_capture(p_name);
+#else
+	return captures.has(p_name);
+#endif
 }
 
 void EngineDebugger::send_message(const String &p_msg, const Array &p_data) {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(!::EngineDebugger::is_active(), "Can't send message. No active debugger");
 	::EngineDebugger::get_singleton()->send_message(p_msg, p_data);
+#else
+	ERR_FAIL_MSG("Can't send message. No active debugger");
+#endif
 }
 
 void EngineDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(!::EngineDebugger::is_active(), "Can't send debug. No active debugger");
 	::EngineDebugger::get_singleton()->debug(p_can_continue, p_is_error_breakpoint);
+#else
+	ERR_FAIL_MSG("Can't send debug. No active debugger");
+#endif
 }
 
 void EngineDebugger::script_debug(ScriptLanguage *p_lang, bool p_can_continue, bool p_is_error_breakpoint) {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(!::EngineDebugger::get_script_debugger(), "Can't send debug. No active debugger");
 	::EngineDebugger::get_script_debugger()->debug(p_lang, p_can_continue, p_is_error_breakpoint);
+#else
+	ERR_FAIL_MSG("Can't send debug. No active debugger");
+#endif
 }
 
+#ifdef DEBUG_ENABLED
 Error EngineDebugger::call_capture(void *p_user, const String &p_cmd, const Array &p_data, bool &r_captured) {
 	Callable &capture = *(Callable *)p_user;
 	if (!capture.is_valid()) {
@@ -2263,61 +2311,104 @@ Error EngineDebugger::call_capture(void *p_user, const String &p_cmd, const Arra
 	r_captured = retval;
 	return OK;
 }
+#endif
 
 void EngineDebugger::line_poll() {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(!::EngineDebugger::is_active(), "Can't poll. No active debugger");
 	::EngineDebugger::get_singleton()->line_poll();
+#else
+	ERR_FAIL_MSG("Can't poll. No active debugger");
+#endif
 }
 
 void EngineDebugger::set_lines_left(int p_lines) {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(!::EngineDebugger::get_script_debugger(), "Can't set lines left. No active debugger");
 	::EngineDebugger::get_script_debugger()->set_lines_left(p_lines);
+#else
+	ERR_FAIL_MSG("Can't set lines left. No active debugger");
+#endif
 }
 
 int EngineDebugger::get_lines_left() const {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_V_MSG(!::EngineDebugger::get_script_debugger(), 0, "Can't get lines left. No active debugger");
 	return ::EngineDebugger::get_script_debugger()->get_lines_left();
+#else
+	ERR_FAIL_V_MSG(0, "Can't get lines left. No active debugger");
+#endif
 }
 
 void EngineDebugger::set_depth(int p_depth) {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(!::EngineDebugger::get_script_debugger(), "Can't set depth. No active debugger");
 	::EngineDebugger::get_script_debugger()->set_depth(p_depth);
+#else
+	ERR_FAIL_MSG("Can't set depth. No active debugger");
+#endif
 }
 
 int EngineDebugger::get_depth() const {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_V_MSG(!::EngineDebugger::get_script_debugger(), 0, "Can't get depth. No active debugger");
 	return ::EngineDebugger::get_script_debugger()->get_depth();
+#else
+	ERR_FAIL_V_MSG(0, "Can't get depth. No active debugger");
+#endif
 }
 
 bool EngineDebugger::is_breakpoint(int p_line, const StringName &p_source) const {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_V_MSG(!::EngineDebugger::get_script_debugger(), false, "Can't check breakpoint. No active debugger");
 	return ::EngineDebugger::get_script_debugger()->is_breakpoint(p_line, p_source);
+#else
+	ERR_FAIL_V_MSG(false, "Can't check breakpoint. No active debugger");
+#endif
 }
 
 bool EngineDebugger::is_skipping_breakpoints() const {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_V_MSG(!::EngineDebugger::get_script_debugger(), false, "Can't check skipping breakpoint. No active debugger");
 	return ::EngineDebugger::get_script_debugger()->is_skipping_breakpoints();
+#else
+	ERR_FAIL_V_MSG(false, "Can't check skipping breakpoint. No active debugger");
+#endif
 }
 
 void EngineDebugger::insert_breakpoint(int p_line, const StringName &p_source) {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(!::EngineDebugger::get_script_debugger(), "Can't insert breakpoint. No active debugger");
 	::EngineDebugger::get_script_debugger()->insert_breakpoint(p_line, p_source);
+#else
+	ERR_FAIL_MSG("Can't insert breakpoint. No active debugger");
+#endif
 }
 
 void EngineDebugger::remove_breakpoint(int p_line, const StringName &p_source) {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(!::EngineDebugger::get_script_debugger(), "Can't remove breakpoint. No active debugger");
 	::EngineDebugger::get_script_debugger()->remove_breakpoint(p_line, p_source);
+#else
+	ERR_FAIL_MSG("Can't remove breakpoint. No active debugger");
+#endif
 }
 
 void EngineDebugger::clear_breakpoints() {
+#ifdef DEBUG_ENABLED
 	ERR_FAIL_COND_MSG(!::EngineDebugger::get_script_debugger(), "Can't clear breakpoints. No active debugger");
 	::EngineDebugger::get_script_debugger()->clear_breakpoints();
+#else
+	ERR_FAIL_MSG("Can't clear breakpoints. No active debugger");
+#endif
 }
 
 EngineDebugger::~EngineDebugger() {
+#ifdef DEBUG_ENABLED
 	for (const KeyValue<StringName, Callable> &E : captures) {
 		::EngineDebugger::unregister_message_capture(E.key);
 	}
+#endif
 	captures.clear();
 }
 
@@ -2355,6 +2446,8 @@ void EngineDebugger::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_breakpoint", "line", "source"), &EngineDebugger::remove_breakpoint);
 	ClassDB::bind_method(D_METHOD("clear_breakpoints"), &EngineDebugger::clear_breakpoints);
 }
+
+#endif // defined(DEBUG_ENABLED) || !defined(DISABLE_DEPRECATED)
 
 Variant WeakRef::get_ref() const {
 	if (ref.is_null()) {

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -646,6 +646,7 @@ public:
 	Engine() { singleton = this; }
 };
 
+#if defined(DEBUG_ENABLED) || !defined(DISABLE_DEPRECATED)
 class EngineDebugger : public Object {
 	GDCLASS(EngineDebugger, Object);
 
@@ -676,7 +677,9 @@ public:
 	void debug(bool p_can_continue = true, bool p_is_error_breakpoint = false);
 	void script_debug(ScriptLanguage *p_lang, bool p_can_continue = true, bool p_is_error_breakpoint = false);
 
+#ifdef DEBUG_ENABLED
 	static Error call_capture(void *p_user, const String &p_cmd, const Array &p_data, bool &r_captured);
+#endif
 
 	void line_poll();
 
@@ -695,6 +698,7 @@ public:
 	EngineDebugger() { singleton = this; }
 	~EngineDebugger();
 };
+#endif // defined(DEBUG_ENABLED) || !defined(DISABLE_DEPRECATED)
 
 class WeakRef : public RefCounted {
 	GDCLASS(WeakRef, RefCounted);

--- a/core/debugger/debugger_marshalls.cpp
+++ b/core/debugger/debugger_marshalls.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifdef DEBUG_ENABLED
+
 #include "debugger_marshalls.h"
 
 #include "core/io/marshalls.h"
@@ -205,3 +207,5 @@ String DebuggerMarshalls::parse_type_from_variant(const Variant &p_variant) {
 
 	return name;
 }
+
+#endif // DEBUG_ENABLED

--- a/core/debugger/debugger_marshalls.h
+++ b/core/debugger/debugger_marshalls.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#ifdef DEBUG_ENABLED
+
 #include "core/input/shortcut.h"
 #include "core/object/script_language.h"
 
@@ -74,3 +76,5 @@ struct DebuggerMarshalls {
 
 	static String parse_type_from_variant(const Variant &p_variant);
 };
+
+#endif // DEBUG_ENABLED

--- a/core/debugger/engine_debugger.cpp
+++ b/core/debugger/engine_debugger.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifdef DEBUG_ENABLED
+
 #include "engine_debugger.h"
 
 #include "core/debugger/local_debugger.h"
@@ -195,3 +197,5 @@ EngineDebugger::~EngineDebugger() {
 	script_debugger = nullptr;
 	singleton = nullptr;
 }
+
+#endif // DEBUG_ENABLED

--- a/core/debugger/engine_debugger.h
+++ b/core/debugger/engine_debugger.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#ifdef DEBUG_ENABLED
+
 #include "core/object/ref_counted.h"
 #include "core/string/string_name.h"
 #include "core/string/ustring.h"
@@ -140,3 +142,5 @@ public:
 
 	virtual ~EngineDebugger();
 };
+
+#endif // DEBUG_ENABLED

--- a/core/debugger/engine_profiler.cpp
+++ b/core/debugger/engine_profiler.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#if defined(DEBUG_ENABLED) || !defined(DISABLE_DEPRECATED)
+
 #include "engine_profiler.h"
 
 #include "core/debugger/engine_debugger.h"
@@ -39,6 +41,7 @@ void EngineProfiler::_bind_methods() {
 	GDVIRTUAL_BIND(_tick, "frame_time", "process_time", "physics_time", "physics_frame_time");
 }
 
+#ifdef DEBUG_ENABLED
 void EngineProfiler::toggle(bool p_enable, const Array &p_array) {
 	GDVIRTUAL_CALL(_toggle, p_enable, p_array);
 }
@@ -75,9 +78,14 @@ Error EngineProfiler::unbind() {
 	registration.clear();
 	return OK;
 }
+#endif // DEBUG_ENABLED
 
 EngineProfiler::~EngineProfiler() {
+#ifdef DEBUG_ENABLED
 	if (is_bound()) {
 		unbind();
 	}
+#endif
 }
+
+#endif // defined(DEBUG_ENABLED) || !defined(DISABLE_DEPRECATED)

--- a/core/debugger/engine_profiler.h
+++ b/core/debugger/engine_profiler.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#if defined(DEBUG_ENABLED) || !defined(DISABLE_DEPRECATED)
+
 #include "core/object/gdvirtual.gen.h"
 #include "core/object/ref_counted.h"
 
@@ -37,12 +39,15 @@ class EngineProfiler : public RefCounted {
 	GDCLASS(EngineProfiler, RefCounted);
 
 private:
+#ifdef DEBUG_ENABLED
 	String registration;
+#endif
 
 protected:
 	static void _bind_methods();
 
 public:
+#ifdef DEBUG_ENABLED
 	virtual void toggle(bool p_enable, const Array &p_opts);
 	virtual void add(const Array &p_data);
 	virtual void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time);
@@ -50,6 +55,7 @@ public:
 	Error bind(const String &p_name);
 	Error unbind();
 	bool is_bound() const { return registration.length() > 0; }
+#endif // DEBUG_ENABLED
 
 	GDVIRTUAL2(_toggle, bool, Array);
 	GDVIRTUAL1(_add_frame, Array);
@@ -57,3 +63,5 @@ public:
 
 	virtual ~EngineProfiler();
 };
+
+#endif // defined(DEBUG_ENABLED) || !defined(DISABLE_DEPRECATED)

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifdef DEBUG_ENABLED
+
 #include "local_debugger.h"
 
 #include "core/debugger/script_debugger.h"
@@ -397,3 +399,5 @@ LocalDebugger::~LocalDebugger() {
 	unregister_profiler("scripts");
 	memdelete(scripts_profiler);
 }
+
+#endif // DEBUG_ENABLED

--- a/core/debugger/local_debugger.h
+++ b/core/debugger/local_debugger.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#ifdef DEBUG_ENABLED
+
 #include "core/debugger/engine_debugger.h"
 #include "core/templates/list.h"
 
@@ -53,3 +55,5 @@ public:
 	LocalDebugger();
 	~LocalDebugger();
 };
+
+#endif // DEBUG_ENABLED

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifdef DEBUG_ENABLED
+
 #include "remote_debugger.h"
 
 #include "core/config/engine.h"
@@ -805,3 +807,5 @@ RemoteDebugger::~RemoteDebugger() {
 	remove_print_handler(&phl);
 	remove_error_handler(&eh);
 }
+
+#endif // DEBUG_ENABLED

--- a/core/debugger/remote_debugger.h
+++ b/core/debugger/remote_debugger.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#ifdef DEBUG_ENABLED
+
 #include "core/debugger/debugger_marshalls.h"
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/remote_debugger_peer.h"
@@ -117,3 +119,5 @@ public:
 	explicit RemoteDebugger(Ref<RemoteDebuggerPeer> p_peer);
 	~RemoteDebugger();
 };
+
+#endif // DEBUG_ENABLED

--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifdef DEBUG_ENABLED
+
 #include "remote_debugger_peer.h"
 
 #include "core/config/project_settings.h"
@@ -269,3 +271,5 @@ void RemoteDebuggerPeerTCP::_disconnect_with_error(const String &p_reason) {
 	ERR_PRINT(p_reason);
 	tcp_client->disconnect_from_host();
 }
+
+#endif // DEBUG_ENABLED

--- a/core/debugger/remote_debugger_peer.h
+++ b/core/debugger/remote_debugger_peer.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#ifdef DEBUG_ENABLED
+
 #include "core/object/ref_counted.h"
 #include "core/os/mutex.h"
 #include "core/os/thread.h"
@@ -98,3 +100,5 @@ public:
 	RemoteDebuggerPeerTCP();
 	~RemoteDebuggerPeerTCP();
 };
+
+#endif // DEBUG_ENABLED

--- a/core/debugger/script_debugger.cpp
+++ b/core/debugger/script_debugger.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifdef DEBUG_ENABLED
+
 #include "script_debugger.h"
 
 #include "core/debugger/engine_debugger.h"
@@ -105,3 +107,5 @@ Vector<ScriptLanguage::StackInfo> ScriptDebugger::get_error_stack_info() const {
 ScriptLanguage *ScriptDebugger::get_break_language() const {
 	return break_lang;
 }
+
+#endif // DEBUG_ENABLED

--- a/core/debugger/script_debugger.h
+++ b/core/debugger/script_debugger.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#ifdef DEBUG_ENABLED
+
 #include "core/object/script_language.h"
 #include "core/string/string_name.h"
 #include "core/templates/hash_set.h"
@@ -83,3 +85,5 @@ public:
 	void send_error(const String &p_func, const String &p_file, int p_line, const String &p_err, const String &p_descr, bool p_editor_notify, ErrorHandlerType p_type, const Vector<StackInfo> &p_stack_info);
 	Vector<StackInfo> get_error_stack_info() const;
 };
+
+#endif // DEBUG_ENABLED

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -58,6 +58,7 @@ struct ProgramExitGuard {
 static ProgramExitGuard program_exit_guard;
 
 void Script::_notification(int p_what) {
+#ifdef DEBUG_ENABLED
 	switch (p_what) {
 		case NOTIFICATION_POSTINITIALIZE: {
 			if (EngineDebugger::is_active()) {
@@ -65,6 +66,7 @@ void Script::_notification(int p_what) {
 			}
 		} break;
 	}
+#endif // DEBUG_ENABLED
 }
 
 Variant Script::_get_property_default_value(const StringName &p_property) {
@@ -113,11 +115,13 @@ Dictionary Script::_get_script_constant_map() {
 	return ret;
 }
 
+#ifdef DEBUG_ENABLED
 void Script::_set_debugger_break_language() {
 	if (EngineDebugger::is_active()) {
 		EngineDebugger::get_script_debugger()->set_break_language(get_language());
 	}
 }
+#endif // DEBUG_ENABLED
 
 int Script::get_script_method_argument_count(const StringName &p_method, bool *r_is_valid) const {
 	MethodInfo mi = get_method_info(p_method);

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -135,7 +135,9 @@ protected:
 	TypedArray<Dictionary> _get_script_signal_list();
 	Dictionary _get_script_constant_map();
 
+#ifdef DEBUG_ENABLED
 	void _set_debugger_break_language();
+#endif
 
 	Variant _get_rpc_config_bind() const {
 		return get_rpc_config().duplicate(true);

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -299,7 +299,9 @@ public:
 
 	virtual void disable_crash_handler() {}
 	virtual bool is_disable_crash_handler() const { return false; }
+#ifdef DEBUG_ENABLED
 	virtual void initialize_debugging() {}
+#endif
 
 	virtual uint64_t get_static_memory_usage() const;
 	virtual uint64_t get_static_memory_peak_usage() const;

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -111,7 +111,9 @@ static CoreBind::OS *_os = nullptr;
 static CoreBind::Engine *_engine = nullptr;
 static CoreBind::Special::ClassDB *_classdb = nullptr;
 static CoreBind::Marshalls *_marshalls = nullptr;
+#if defined(DEBUG_ENABLED) || !defined(DISABLE_DEPRECATED)
 static CoreBind::EngineDebugger *_engine_debugger = nullptr;
+#endif
 
 static IP *ip = nullptr;
 static Time *_time = nullptr;
@@ -305,7 +307,9 @@ void register_core_types() {
 
 	GDREGISTER_ABSTRACT_CLASS(ResourceUID);
 
+#if defined(DEBUG_ENABLED) || !defined(DISABLE_DEPRECATED)
 	GDREGISTER_CLASS(EngineProfiler);
+#endif
 
 	GDREGISTER_CLASS(FuzzySearch);
 	GDREGISTER_CLASS(FuzzySearchMatch);
@@ -328,7 +332,9 @@ void register_core_types() {
 	GDREGISTER_CLASS(CoreBind::Engine);
 	GDREGISTER_CLASS(CoreBind::Special::ClassDB);
 	GDREGISTER_CLASS(CoreBind::Marshalls);
+#if defined(DEBUG_ENABLED) || !defined(DISABLE_DEPRECATED)
 	GDREGISTER_CLASS(CoreBind::EngineDebugger);
+#endif
 
 	GDREGISTER_CLASS(TranslationServer);
 	GDREGISTER_ABSTRACT_CLASS(Input);
@@ -347,7 +353,9 @@ void register_core_types() {
 	_engine = memnew(CoreBind::Engine);
 	_classdb = memnew(CoreBind::Special::ClassDB);
 	_marshalls = memnew(CoreBind::Marshalls);
+#if defined(DEBUG_ENABLED) || !defined(DISABLE_DEPRECATED)
 	_engine_debugger = memnew(CoreBind::EngineDebugger);
+#endif
 
 	GDREGISTER_NATIVE_STRUCT(ObjectID, "uint64_t id = 0");
 	GDREGISTER_NATIVE_STRUCT(ScriptLanguageExtensionProfilingInfo, "StringName signature;uint64_t call_count;uint64_t total_time;uint64_t self_time");
@@ -388,7 +396,9 @@ void register_core_singletons() {
 	Engine::get_singleton()->add_singleton(Engine::Singleton("TranslationServer", TranslationServer::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("Input", Input::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("InputMap", InputMap::get_singleton()));
+#if defined(DEBUG_ENABLED) || !defined(DISABLE_DEPRECATED)
 	Engine::get_singleton()->add_singleton(Engine::Singleton("EngineDebugger", CoreBind::EngineDebugger::get_singleton()));
+#endif
 	Engine::get_singleton()->add_singleton(Engine::Singleton("GDExtensionManager", GDExtensionManager::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("ResourceUID", ResourceUID::get_singleton()));
 	Engine::get_singleton()->add_singleton(Engine::Singleton("WorkerThreadPool", worker_thread_pool));
@@ -426,7 +436,9 @@ void unregister_core_types() {
 
 	memdelete(worker_thread_pool);
 
+#if defined(DEBUG_ENABLED) || !defined(DISABLE_DEPRECATED)
 	memdelete(_engine_debugger);
+#endif
 	memdelete(_marshalls);
 	memdelete(_classdb);
 	memdelete(_engine);

--- a/doc/classes/EngineDebugger.xml
+++ b/doc/classes/EngineDebugger.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		[EngineDebugger] handles the communication between the editor and the running game. It is active in the running game. Messages can be sent/received through it. It also manages the profilers.
+		[b]Note:[/b] Using this class outside of debug or editor builds is deprecated.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/EngineProfiler.xml
+++ b/doc/classes/EngineProfiler.xml
@@ -6,6 +6,7 @@
 	<description>
 		This class can be used to implement custom profilers that are able to interact with the engine and editor debugger.
 		See [EngineDebugger] and [EditorDebuggerPlugin] for more information.
+		[b]Note:[/b] Using this class outside of debug or editor builds is deprecated.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/drivers/unix/os_unix.cpp
+++ b/drivers/unix/os_unix.cpp
@@ -34,6 +34,7 @@
 
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
+#include "core/object/script_backtrace.h"
 #include "core/string/char_utils.h"
 #include "drivers/unix/dir_access_unix.h"
 #include "drivers/unix/file_access_unix.h"
@@ -122,6 +123,7 @@ static void _setup_clock() {
 
 struct sigaction old_action;
 
+#ifdef DEBUG_ENABLED
 static void handle_interrupt(int sig) {
 	if (!EngineDebugger::is_active()) {
 		return;
@@ -144,6 +146,7 @@ void OS_Unix::initialize_debugging() {
 		sigaction(SIGINT, &action, &old_action);
 	}
 }
+#endif
 
 int OS_Unix::unix_initialize_audio(int p_audio_driver) {
 	return 0;

--- a/drivers/unix/os_unix.h
+++ b/drivers/unix/os_unix.h
@@ -134,7 +134,9 @@ public:
 
 	virtual String get_locale() const override;
 
+#ifdef DEBUG_ENABLED
 	virtual void initialize_debugging() override;
+#endif
 
 	virtual String get_executable_path() const override;
 	virtual String get_user_data_dir(const String &p_user_dir) const override;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -879,7 +879,9 @@ void Main::test_cleanup() {
 	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
 	unregister_server_types();
 
+#ifdef DEBUG_ENABLED
 	EngineDebugger::deinitialize();
+#endif
 	OS::get_singleton()->finalize();
 
 	memdelete(packed_data);
@@ -1041,7 +1043,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	String audio_driver = "";
 	String project_path = ".";
 
-#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
+#ifdef DEBUG_ENABLED
 	String debug_uri = "";
 	bool skip_breakpoints = false;
 	bool ignore_error_breaks = false;
@@ -1838,7 +1840,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 #endif // defined(OVERRIDE_PATH_ENABLED) || defined(WEB_ENABLED) || defined(ANDROID_ENABLED)
 
 		} else if (arg == "-d" || arg == "--debug") {
-#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
+#ifdef DEBUG_ENABLED
 			debug_uri = "local://";
 			OS::get_singleton()->_debug_stdout = true;
 #else
@@ -1870,7 +1872,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			test_rd_creation = true;
 #endif // defined(TOOLS_ENABLED) && (defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED))
 		} else if (arg == "--remote-debug") {
-#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
+#ifdef DEBUG_ENABLED
 			if (N) {
 				debug_uri = N->get();
 				if (!debug_uri.contains("://")) { // wrong address
@@ -2255,7 +2257,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "network/limits/debugger/max_errors_per_second", PROPERTY_HINT_RANGE, "1,200,1,or_greater"), 400);
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "network/limits/debugger/max_warnings_per_second", PROPERTY_HINT_RANGE, "1,200,1,or_greater"), 400);
 
-#if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
+#ifdef DEBUG_ENABLED
 	EngineDebugger::initialize(debug_uri, skip_breakpoints, ignore_error_breaks, breakpoints, []() {
 		if (editor_pid) {
 			DisplayServer::get_singleton()->enable_for_stealing_focus(editor_pid);
@@ -2942,7 +2944,9 @@ error:
 		OS::get_singleton()->remove_lock_file();
 	}
 
+#ifdef DEBUG_ENABLED
 	EngineDebugger::deinitialize();
+#endif
 
 	memdelete(performance);
 	memdelete(input_map);
@@ -5049,7 +5053,9 @@ bool Main::iteration() {
 
 	process_ticks = OS::get_singleton()->get_ticks_usec() - process_begin;
 	process_max = MAX(process_ticks, process_max);
+#ifdef DEBUG_ENABLED
 	uint64_t frame_time = OS::get_singleton()->get_ticks_usec() - ticks;
+#endif
 
 	GodotProfileZoneGrouped(_profile_zone, "GDExtensionManager::frame");
 	GDExtensionManager::get_singleton()->frame();
@@ -5062,9 +5068,11 @@ bool Main::iteration() {
 	GodotProfileZoneGrouped(_profile_zone, "AudioServer::update");
 	AudioServer::get_singleton()->update();
 
+#ifdef DEBUG_ENABLED
 	if (EngineDebugger::is_active()) {
 		EngineDebugger::get_singleton()->iteration(frame_time, process_ticks, physics_process_ticks, physics_step);
 	}
+#endif
 
 	frames++;
 	Engine::get_singleton()->_process_frames++;
@@ -5273,7 +5281,9 @@ void Main::cleanup(bool p_force) {
 	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
 	unregister_server_types();
 
+#ifdef DEBUG_ENABLED
 	EngineDebugger::deinitialize();
+#endif
 
 #ifndef XR_DISABLED
 	memdelete(xr_server);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -425,9 +425,11 @@ ScriptInstance *GDScript::instance_create(Object *p_this) {
 
 	if (top->native.is_valid()) {
 		if (!p_this->is_class(top->native->get_name())) {
+#ifdef DEBUG_ENABLED
 			if (EngineDebugger::is_active()) {
 				GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), 1, "Script inherits from native type '" + String(top->native->get_name()) + "', so it can't be assigned to an object of type: '" + p_this->get_class() + "'");
 			}
+#endif
 			ERR_FAIL_V_MSG(nullptr, "Script inherits from native type '" + String(top->native->get_name()) + "', so it can't be assigned to an object of type '" + p_this->get_class() + "'" + ".");
 		}
 	}
@@ -829,9 +831,11 @@ Error GDScript::reload(bool p_keep_state) {
 		err = parser.parse(source, path, false);
 	}
 	if (err) {
+#ifdef DEBUG_ENABLED
 		if (EngineDebugger::is_active()) {
 			GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), parser.get_errors().front()->get().start_line, "Parser Error: " + parser.get_errors().front()->get().message);
 		}
+#endif
 		// TODO: Show all error messages.
 		_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), parser.get_errors().front()->get().start_line, ("Parse Error: " + parser.get_errors().front()->get().message).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
 		reloading = false;
@@ -842,9 +846,11 @@ Error GDScript::reload(bool p_keep_state) {
 	err = analyzer.analyze();
 
 	if (err) {
+#ifdef DEBUG_ENABLED
 		if (EngineDebugger::is_active()) {
 			GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), parser.get_errors().front()->get().start_line, "Parser Error: " + parser.get_errors().front()->get().message);
 		}
+#endif
 
 		const List<GDScriptParser::ParserError>::Element *e = parser.get_errors().front();
 		while (e != nullptr) {
@@ -864,9 +870,11 @@ Error GDScript::reload(bool p_keep_state) {
 		// TODO: Provide the script function as the first argument.
 		_err_print_error("GDScript::reload", path.is_empty() ? "built-in" : (const char *)path.utf8().get_data(), compiler.get_error_line(), ("Compile Error: " + compiler.get_error()).utf8().get_data(), false, ERR_HANDLER_SCRIPT);
 		if (can_run) {
+#ifdef DEBUG_ENABLED
 			if (EngineDebugger::is_active()) {
 				GDScriptLanguage::get_singleton()->debug_break_parse(_get_debug_path(), compiler.get_error_line(), "Parser Error: " + compiler.get_error());
 			}
+#endif
 			reloading = false;
 			return ERR_COMPILATION_FAILED;
 		} else {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -465,8 +465,10 @@ class GDScriptLanguage : public ScriptLanguage {
 #endif
 
 public:
+#ifdef DEBUG_ENABLED
 	bool debug_break(const String &p_error, bool p_allow_continue = true);
 	bool debug_break_parse(const String &p_file, int p_line, const String &p_error);
+#endif
 
 	_FORCE_INLINE_ void enter_function(CallLevel *call_level, GDScriptInstance *p_instance, GDScriptFunction *p_function, Variant *p_stack, int *p_ip, int *p_line) {
 		if (!track_call_stack) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -284,6 +284,7 @@ thread_local int GDScriptLanguage::_debug_parse_err_line = -1;
 thread_local String GDScriptLanguage::_debug_parse_err_file;
 thread_local String GDScriptLanguage::_debug_error;
 
+#ifdef DEBUG_ENABLED
 bool GDScriptLanguage::debug_break_parse(const String &p_file, int p_line, const String &p_error) {
 	// break because of parse error
 
@@ -316,6 +317,7 @@ bool GDScriptLanguage::debug_break(const String &p_error, bool p_allow_continue)
 		return false;
 	}
 }
+#endif // DEBUG_ENABLED
 
 String GDScriptLanguage::debug_get_error() const {
 	return _debug_error;

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -3924,6 +3924,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				line = _code_ptr[ip + 1];
 				ip += 2;
 
+#ifdef DEBUG_ENABLED
 				if (EngineDebugger::is_active()) {
 					// line
 					bool do_break = false;
@@ -3947,6 +3948,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 					EngineDebugger::get_singleton()->line_poll();
 				}
+#endif
 			}
 			DISPATCH_OPCODE;
 

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -1315,7 +1315,9 @@ void GodotPhysicsServer2D::flush_queries() {
 
 	flushing_queries = true;
 
+#ifdef DEBUG_ENABLED
 	uint64_t time_beg = OS::get_singleton()->get_ticks_usec();
+#endif
 
 	for (GodotSpace2D *E : active_spaces) {
 		E->call_queries();
@@ -1323,6 +1325,7 @@ void GodotPhysicsServer2D::flush_queries() {
 
 	flushing_queries = false;
 
+#ifdef DEBUG_ENABLED
 	if (EngineDebugger::is_profiling("servers")) {
 		uint64_t total_time[GodotSpace2D::ELAPSED_TIME_MAX];
 		static const char *time_name[GodotSpace2D::ELAPSED_TIME_MAX] = {
@@ -1355,6 +1358,7 @@ void GodotPhysicsServer2D::flush_queries() {
 		values.push_front("physics_2d");
 		EngineDebugger::profiler_add_frame_data("servers", values);
 	}
+#endif
 }
 
 void GodotPhysicsServer2D::end_sync() {

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -1719,7 +1719,9 @@ void GodotPhysicsServer3D::flush_queries() {
 
 	flushing_queries = true;
 
+#ifdef DEBUG_ENABLED
 	uint64_t time_beg = OS::get_singleton()->get_ticks_usec();
+#endif
 
 	for (GodotSpace3D *E : active_spaces) {
 		GodotSpace3D *space = E;
@@ -1728,6 +1730,7 @@ void GodotPhysicsServer3D::flush_queries() {
 
 	flushing_queries = false;
 
+#ifdef DEBUG_ENABLED
 	if (EngineDebugger::is_profiling("servers")) {
 		uint64_t total_time[GodotSpace3D::ELAPSED_TIME_MAX];
 		static const char *time_name[GodotSpace3D::ELAPSED_TIME_MAX] = {
@@ -1760,6 +1763,7 @@ void GodotPhysicsServer3D::flush_queries() {
 		values.push_front("physics_3d");
 		EngineDebugger::profiler_add_frame_data("servers", values);
 	}
+#endif
 }
 
 void GodotPhysicsServer3D::end_sync() {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1042,27 +1042,29 @@ bool CSharpLanguage::overrides_external_editor() {
 
 bool CSharpLanguage::debug_break_parse(const String &p_file, int p_line, const String &p_error) {
 	// Not a parser error in our case, but it's still used for other type of errors
+#ifdef DEBUG_ENABLED
 	if (EngineDebugger::is_active() && Thread::get_caller_id() == Thread::get_main_id()) {
 		_debug_parse_err_line = p_line;
 		_debug_parse_err_file = p_file;
 		_debug_error = p_error;
 		EngineDebugger::get_script_debugger()->debug(this, false, true);
 		return true;
-	} else {
-		return false;
 	}
+#endif
+	return false;
 }
 
 bool CSharpLanguage::debug_break(const String &p_error, bool p_allow_continue) {
+#ifdef DEBUG_ENABLED
 	if (EngineDebugger::is_active() && Thread::get_caller_id() == Thread::get_main_id()) {
 		_debug_parse_err_line = -1;
 		_debug_parse_err_file = "";
 		_debug_error = p_error;
 		EngineDebugger::get_script_debugger()->debug(this, p_allow_continue);
 		return true;
-	} else {
-		return false;
 	}
+#endif
+	return false;
 }
 
 #ifdef TOOLS_ENABLED
@@ -2461,11 +2463,13 @@ ScriptInstance *CSharpScript::instance_create(Object *p_this) {
 	ERR_FAIL_COND_V(native_name == StringName(), nullptr);
 
 	if (!p_this->is_class(native_name)) {
+#ifdef DEBUG_ENABLED
 		if (EngineDebugger::is_active()) {
 			CSharpLanguage::get_singleton()->debug_break_parse(get_path(), 0,
 					"Script inherits from native type '" + String(native_name) +
 							"', so it can't be assigned to an object of type: '" + p_this->get_class() + "'");
 		}
+#endif
 		ERR_FAIL_V_MSG(nullptr, "Script inherits from native type '" + String(native_name) + "', so it can't be assigned to an object of type: '" + p_this->get_class() + "'.");
 	}
 

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -100,13 +100,19 @@ void godotsharp_stack_info_vector_destroy(
 void godotsharp_internal_script_debugger_send_error(const String *p_func,
 		const String *p_file, int32_t p_line, const String *p_err, const String *p_descr,
 		ErrorHandlerType p_type, const Vector<ScriptLanguage::StackInfo> *p_stack_info_vector) {
+#ifdef DEBUG_ENABLED
 	const String file = ProjectSettings::get_singleton()->localize_path(p_file->simplify_path());
 	EngineDebugger::get_script_debugger()->send_error(*p_func, file, p_line, *p_err, *p_descr,
 			true, p_type, *p_stack_info_vector);
+#endif
 }
 
 bool godotsharp_internal_script_debugger_is_active() {
+#ifdef DEBUG_ENABLED
 	return EngineDebugger::is_active();
+#else
+	return false;
+#endif
 }
 
 GCHandleIntPtr godotsharp_internal_object_get_associated_gchandle(Object *p_ptr) {

--- a/modules/multiplayer/multiplayer_debugger.cpp
+++ b/modules/multiplayer/multiplayer_debugger.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifdef DEBUG_ENABLED
+
 #include "multiplayer_debugger.h"
 
 #include "multiplayer_synchronizer.h"
@@ -328,3 +330,5 @@ void MultiplayerDebugger::ReplicationProfiler::tick(double p_frame_time, double 
 		EngineDebugger::get_singleton()->send_message("multiplayer:syncs", frame.serialize());
 	}
 }
+
+#endif // DEBUG_ENABLED

--- a/modules/multiplayer/multiplayer_debugger.h
+++ b/modules/multiplayer/multiplayer_debugger.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#ifdef DEBUG_ENABLED
+
 #include "core/debugger/engine_profiler.h"
 
 class MultiplayerSynchronizer;
@@ -133,3 +135,5 @@ public:
 	static void initialize();
 	static void deinitialize();
 };
+
+#endif // DEBUG_ENABLED

--- a/modules/multiplayer/register_types.cpp
+++ b/modules/multiplayer/register_types.cpp
@@ -52,7 +52,9 @@ void initialize_multiplayer_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(SceneMultiplayer);
 		if constexpr (GD_IS_CLASS_ENABLED(MultiplayerAPI)) {
 			MultiplayerAPI::set_default_interface("SceneMultiplayer");
+#ifdef DEBUG_ENABLED
 			MultiplayerDebugger::initialize();
+#endif
 		}
 	}
 #ifdef TOOLS_ENABLED
@@ -63,7 +65,9 @@ void initialize_multiplayer_module(ModuleInitializationLevel p_level) {
 }
 
 void uninitialize_multiplayer_module(ModuleInitializationLevel p_level) {
+#ifdef DEBUG_ENABLED
 	if constexpr (GD_IS_CLASS_ENABLED(MultiplayerAPI)) {
 		MultiplayerDebugger::deinitialize();
 	}
+#endif
 }

--- a/modules/websocket/register_types.cpp
+++ b/modules/websocket/register_types.cpp
@@ -70,8 +70,10 @@ void initialize_websocket_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(WebSocketMultiplayerPeer);
 		ClassDB::register_custom_instance_class<WebSocketPeer>();
 
+#ifdef DEBUG_ENABLED
 		EngineDebugger::register_uri_handler("ws://", RemoteDebuggerPeerWebSocket::create);
 		EngineDebugger::register_uri_handler("wss://", RemoteDebuggerPeerWebSocket::create);
+#endif
 	}
 
 #ifdef TOOLS_ENABLED

--- a/modules/websocket/remote_debugger_peer_websocket.cpp
+++ b/modules/websocket/remote_debugger_peer_websocket.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifdef DEBUG_ENABLED
+
 #include "remote_debugger_peer_websocket.h"
 
 #include "core/config/project_settings.h"
@@ -139,3 +141,5 @@ Ref<RemoteDebuggerPeer> RemoteDebuggerPeerWebSocket::create(const String &p_uri)
 	}
 	return peer;
 }
+
+#endif // DEBUG_ENABLED

--- a/modules/websocket/remote_debugger_peer_websocket.h
+++ b/modules/websocket/remote_debugger_peer_websocket.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#ifdef DEBUG_ENABLED
+
 #include "websocket_peer.h"
 
 #include "core/debugger/remote_debugger_peer.h"
@@ -59,3 +61,5 @@ public:
 
 	RemoteDebuggerPeerWebSocket(const Ref<WebSocketPeer> &p_peer = Ref<WebSocketPeer>());
 };
+
+#endif // DEBUG_ENABLED

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -231,6 +231,7 @@ bool OS_Windows::is_using_con_wrapper() const {
 	return found_conwrap_exe;
 }
 
+#ifdef DEBUG_ENABLED
 BOOL WINAPI HandlerRoutine(_In_ DWORD dwCtrlType) {
 	if (!EngineDebugger::is_active()) {
 		return FALSE;
@@ -245,14 +246,17 @@ BOOL WINAPI HandlerRoutine(_In_ DWORD dwCtrlType) {
 			return FALSE;
 	}
 }
+#endif
 
 void OS_Windows::alert(const String &p_alert, const String &p_title) {
 	MessageBoxW(nullptr, (LPCWSTR)(p_alert.utf16().get_data()), (LPCWSTR)(p_title.utf16().get_data()), MB_OK | MB_ICONEXCLAMATION | MB_TASKMODAL);
 }
 
+#ifdef DEBUG_ENABLED
 void OS_Windows::initialize_debugging() {
 	SetConsoleCtrlHandler(HandlerRoutine, TRUE);
 }
+#endif
 
 #ifdef WINDOWS_DEBUG_OUTPUT_ENABLED
 static void _error_handler(void *p_self, const char *p_func, const char *p_file, int p_line, const char *p_error, const char *p_errorexp, bool p_editor_notify, ErrorHandlerType p_type) {

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -253,7 +253,9 @@ public:
 
 	virtual void disable_crash_handler() override;
 	virtual bool is_disable_crash_handler() const override;
+#ifdef DEBUG_ENABLED
 	virtual void initialize_debugging() override;
+#endif
 
 	virtual Error move_to_trash(const String &p_path) override;
 

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifdef DEBUG_ENABLED
+
 #include "scene_debugger.h"
 
 #include "core/config/engine.h"
@@ -60,23 +62,18 @@
 #include "scene/3d/camera_3d.h"
 #endif
 
-#ifdef DEBUG_ENABLED
 #include "scene/debugger/runtime_node_select.h"
-#endif
 
 SceneDebugger::SceneDebugger() {
 	singleton = this;
 
-#ifdef DEBUG_ENABLED
 	LiveEditor::singleton = memnew(LiveEditor);
 	RuntimeNodeSelect::singleton = memnew(RuntimeNodeSelect);
 
 	EngineDebugger::register_message_capture("scene", EngineDebugger::Capture(nullptr, SceneDebugger::parse_message));
-#endif
 }
 
 SceneDebugger::~SceneDebugger() {
-#ifdef DEBUG_ENABLED
 	if (LiveEditor::singleton) {
 		EngineDebugger::unregister_message_capture("scene");
 		memdelete(LiveEditor::singleton);
@@ -87,16 +84,13 @@ SceneDebugger::~SceneDebugger() {
 		memdelete(RuntimeNodeSelect::singleton);
 		RuntimeNodeSelect::singleton = nullptr;
 	}
-#endif // DEBUG_ENABLED
 
 	singleton = nullptr;
 }
 
 void SceneDebugger::initialize() {
 	if (EngineDebugger::is_active()) {
-#ifdef DEBUG_ENABLED
 		_init_message_handlers();
-#endif
 		memnew(SceneDebugger);
 	}
 }
@@ -104,8 +98,6 @@ void SceneDebugger::initialize() {
 void SceneDebugger::deinitialize() {
 	memdelete(singleton);
 }
-
-#ifdef DEBUG_ENABLED
 
 void SceneDebugger::_handle_input(const Ref<InputEvent> &p_event, const Ref<Shortcut> &p_shortcut) {
 	Ref<InputEventKey> k = p_event;
@@ -1338,4 +1330,5 @@ void LiveEditor::_reparent_node_func(const NodePath &p_at, const NodePath &p_new
 		}
 	}
 }
+
 #endif // DEBUG_ENABLED

--- a/scene/debugger/scene_debugger.h
+++ b/scene/debugger/scene_debugger.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#ifdef DEBUG_ENABLED
+
 #include "core/object/ref_counted.h"
 #include "core/string/ustring.h"
 
@@ -50,7 +52,6 @@ public:
 
 	~SceneDebugger();
 
-#ifdef DEBUG_ENABLED
 private:
 	static void _handle_input(const Ref<InputEvent> &p_event, const Ref<Shortcut> &p_shortcut);
 	static void _handle_embed_input(const Ref<InputEvent> &p_event, const Dictionary &p_settings);
@@ -127,10 +128,8 @@ public:
 	static void add_to_cache(const String &p_filename, Node *p_node);
 	static void remove_from_cache(const String &p_filename, Node *p_node);
 	static void reload_cached_files(const PackedStringArray &p_files);
-#endif
 };
 
-#ifdef DEBUG_ENABLED
 class LiveEditor {
 private:
 	friend class SceneDebugger;
@@ -174,4 +173,5 @@ private:
 public:
 	static LiveEditor *get_singleton();
 };
+
 #endif // DEBUG_ENABLED

--- a/scene/debugger/view_3d_controller.cpp
+++ b/scene/debugger/view_3d_controller.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifdef DEBUG_ENABLED
+
 #ifndef _3D_DISABLED
 
 #include "view_3d_controller.h"
@@ -819,3 +821,5 @@ void View3DController::_bind_methods() {
 }
 
 #endif // _3D_DISABLED
+
+#endif // DEBUG_ENABLED

--- a/scene/debugger/view_3d_controller.h
+++ b/scene/debugger/view_3d_controller.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#ifdef DEBUG_ENABLED
+
 #ifndef _3D_DISABLED
 
 #include "core/object/ref_counted.h"
@@ -343,3 +345,5 @@ public:
 };
 
 #endif // _3D_DISABLED
+
+#endif // DEBUG_ENABLED

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4485,7 +4485,7 @@ void Viewport::_audio_listener_2d_remove(AudioListener2D *p_audio_listener) {
 }
 
 void Viewport::_camera_2d_set(Camera2D *p_camera_2d) {
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 	if (is_camera_2d_override_enabled()) {
 		camera_2d_override.set_overridden_camera(p_camera_2d);
 		return;
@@ -4615,7 +4615,7 @@ void Viewport::assign_next_enabled_camera_2d(const StringName &p_camera_group) {
 	}
 }
 
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 void Viewport::enable_camera_2d_override(bool p_enable) {
 	ERR_MAIN_THREAD_GUARD;
 
@@ -4761,7 +4761,7 @@ void Viewport::_camera_3d_set(Camera3D *p_camera) {
 		return;
 	}
 
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 	if (is_camera_3d_override_enabled()) {
 		camera_3d_override.set_overridden_camera(p_camera);
 		return;
@@ -4816,7 +4816,7 @@ void Viewport::_camera_3d_make_next_current(Camera3D *p_exclude) {
 	}
 }
 
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 void Viewport::enable_camera_3d_override(bool p_enable) {
 	ERR_MAIN_THREAD_GUARD;
 
@@ -5859,7 +5859,7 @@ SubViewport::SubViewport() {
 
 /////////////////////////////////
 
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 template <class T>
 bool Viewport::CameraOverride<T>::is_enabled() const {
 	return enabled;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -764,7 +764,7 @@ public:
 	virtual bool is_sub_viewport() const { return false; }
 
 private:
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 	template <class T>
 	class CameraOverride {
 	private:
@@ -792,7 +792,7 @@ private:
 	friend class Camera2D; // Needs _camera_2d_set
 	Camera2D *camera_2d = nullptr;
 	void _camera_2d_set(Camera2D *p_camera_2d);
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 	CameraOverride<Camera2D> camera_2d_override;
 
 public:
@@ -844,7 +844,7 @@ private:
 
 	friend class Camera3D;
 	Camera3D *camera_3d = nullptr;
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 	CameraOverride<Camera3D> camera_3d_override;
 #endif // DEBUG_ENABLED
 	HashSet<Camera3D *> camera_3d_set;
@@ -867,7 +867,7 @@ public:
 
 	Camera3D *get_camera_3d() const;
 
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 	void enable_camera_3d_override(bool p_enable);
 	bool is_camera_3d_override_enabled() const;
 	Camera3D *get_overridden_camera_3d() const;

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -1308,7 +1308,9 @@ void register_scene_types() {
 		GraphEdit::init_shaders();
 	}
 
+#ifdef DEBUG_ENABLED
 	SceneDebugger::initialize();
+#endif
 
 	OS::get_singleton()->benchmark_end_measure("Scene", "Register Types");
 }
@@ -1316,7 +1318,9 @@ void register_scene_types() {
 void unregister_scene_types() {
 	OS::get_singleton()->benchmark_begin_measure("Scene", "Unregister Types");
 
+#ifdef DEBUG_ENABLED
 	SceneDebugger::deinitialize();
+#endif
 
 	if constexpr (GD_IS_CLASS_ENABLED(TextureLayered)) {
 		ResourceLoader::remove_resource_format_loader(resource_loader_texture_layered);

--- a/servers/debugger/servers_debugger.cpp
+++ b/servers/debugger/servers_debugger.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#ifdef DEBUG_ENABLED
+
 #include "servers_debugger.h"
 
 #include "core/config/engine.h"
@@ -536,3 +538,5 @@ ServersDebugger::~ServersDebugger() {
 	EngineDebugger::unregister_message_capture("servers");
 	singleton = nullptr;
 }
+
+#endif // DEBUG_ENABLED

--- a/servers/debugger/servers_debugger.h
+++ b/servers/debugger/servers_debugger.h
@@ -30,6 +30,8 @@
 
 #pragma once
 
+#ifdef DEBUG_ENABLED
+
 #include "core/error/error_list.h"
 #include "core/object/ref_counted.h"
 #include "core/string/string_name.h"
@@ -135,3 +137,5 @@ public:
 
 	~ServersDebugger();
 };
+
+#endif // DEBUG_ENABLED

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -271,7 +271,9 @@ void register_server_types() {
 
 	GDREGISTER_VIRTUAL_CLASS(MovieWriter);
 
+#ifdef DEBUG_ENABLED
 	ServersDebugger::initialize();
+#endif
 
 #ifndef NAVIGATION_2D_DISABLED
 	GDREGISTER_CLASS(NavigationServer2DManager);
@@ -382,7 +384,9 @@ void register_server_types() {
 void unregister_server_types() {
 	OS::get_singleton()->benchmark_begin_measure("Servers", "Unregister Extensions");
 
+#ifdef DEBUG_ENABLED
 	ServersDebugger::deinitialize();
+#endif
 	memdelete(shader_types);
 	if constexpr (GD_IS_CLASS_ENABLED(MovieWriterPNGWAV)) {
 		memdelete(writer_pngwav);

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -5896,7 +5896,7 @@ void RenderingDevice::draw_list_bind_vertex_buffers_format(DrawListID p_list, Ve
 
 	FixedVector<RDG::ResourceTracker *, 32> draw_trackers;
 
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 	uint32_t max_instances_allowed = 0xFFFFFFFF;
 #endif
 
@@ -5913,7 +5913,7 @@ void RenderingDevice::draw_list_bind_vertex_buffers_format(DrawListID p_list, Ve
 
 		_check_transfer_worker_buffer(buffer);
 
-#if DEBUG_ENABLED
+#ifdef DEBUG_ENABLED
 		uint64_t binding_offset = offsets_span[i];
 		ERR_FAIL_COND_MSG(binding_offset > buffer->size, "Vertex buffer offset for attachment (" + itos(i) + ") exceeds buffer size.");
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Requires and includes https://github.com/godotengine/godot/pull/122317
- Supersedes https://github.com/godotengine/godot/pull/122210
- Removes around 250kb from release templates (Fedora 44 `scons target=template_release production=yes`) Some of the savings of https://github.com/godotengine/godot/pull/122210 are gone since the ifdef from https://github.com/godotengine/godot/pull/122213 already allowed some of the excluded code to be stripped through LTO.

## Additional information

I did not just go in and ifdef all those files. The scope of the exclusions was extended stepwise by excluding stuff that was only used in already excluded code (starting with `EngineDebugger::initialize`). If any particular exclusions seem suspicious, feel free to ask!

Excluding through scons isn't an option since parts (`EngineProfiler`) of the stuff in `/debugger` are exposed and need to be kept around as dummies for compat.

> [!NOTE]
> In case someone is concerned: This does not break call stack tracking via `debug/settings/gdscript/always_track_call_stacks` and `debug/settings/gdscript/always_track_local_variables`.

* *Bugsquad edit, fixes (outdated, fixed by other PR): ~https://github.com/godotengine/godot/issues/122341~*