### PR TITLE
Style: Change `RequiredParam` prefixes from `rp_` to `p_`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -24,7 +24,7 @@ CheckOptions:
   modernize-use-default-member-init.IgnoreMacros: false
   modernize-use-default-member-init.UseAssignment: true
   readability-identifier-naming.ParameterCase: lower_case
-  readability-identifier-naming.ParameterIgnoredRegexp: ^rp?_[^A-Z]*
+  readability-identifier-naming.ParameterIgnoredRegexp: ^r_[a-z0-9_]*[a-z0-9]$
   readability-identifier-naming.ParameterPrefix: p_
   readability-operators-representation.BinaryOperators: "&&;&=;&;|;~;!;!=;||;|=;^;^="
   readability-operators-representation.OverloadedOperators: "&&;&=;&;|;~;!;!=;||;|=;^;^="

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -94,14 +94,14 @@ Vector<String> ResourceLoader::get_recognized_extensions_for_type(const String &
 	return ret;
 }
 
-void ResourceLoader::add_resource_format_loader(RequiredParam<ResourceFormatLoader> rp_format_loader, bool p_at_front) {
-	EXTRACT_PARAM_OR_FAIL(p_format_loader, rp_format_loader);
-	::ResourceLoader::add_resource_format_loader(p_format_loader, p_at_front);
+void ResourceLoader::add_resource_format_loader(RequiredParam<ResourceFormatLoader> p_format_loader, bool p_at_front) {
+	EXTRACT_PARAM_OR_FAIL(format_loader, p_format_loader);
+	::ResourceLoader::add_resource_format_loader(format_loader, p_at_front);
 }
 
-void ResourceLoader::remove_resource_format_loader(RequiredParam<ResourceFormatLoader> rp_format_loader) {
-	EXTRACT_PARAM_OR_FAIL(p_format_loader, rp_format_loader);
-	::ResourceLoader::remove_resource_format_loader(p_format_loader);
+void ResourceLoader::remove_resource_format_loader(RequiredParam<ResourceFormatLoader> p_format_loader) {
+	EXTRACT_PARAM_OR_FAIL(format_loader, p_format_loader);
+	::ResourceLoader::remove_resource_format_loader(format_loader);
 }
 
 void ResourceLoader::set_abort_on_missing_resources(bool p_abort) {
@@ -186,10 +186,10 @@ Error ResourceSaver::set_uid(const String &p_path, ResourceUID::ID p_uid) {
 	return ::ResourceSaver::set_uid(p_path, p_uid);
 }
 
-Vector<String> ResourceSaver::get_recognized_extensions(RequiredParam<Resource> rp_resource) {
-	EXTRACT_PARAM_OR_FAIL_V(p_resource, rp_resource, Vector<String>());
+Vector<String> ResourceSaver::get_recognized_extensions(RequiredParam<Resource> p_resource) {
+	EXTRACT_PARAM_OR_FAIL_V(resource, p_resource, Vector<String>());
 	List<String> exts;
-	::ResourceSaver::get_recognized_extensions(p_resource, &exts);
+	::ResourceSaver::get_recognized_extensions(resource, &exts);
 	Vector<String> ret;
 	for (const String &E : exts) {
 		ret.push_back(E);
@@ -197,14 +197,14 @@ Vector<String> ResourceSaver::get_recognized_extensions(RequiredParam<Resource> 
 	return ret;
 }
 
-void ResourceSaver::add_resource_format_saver(RequiredParam<ResourceFormatSaver> rp_format_saver, bool p_at_front) {
-	EXTRACT_PARAM_OR_FAIL(p_format_saver, rp_format_saver);
-	::ResourceSaver::add_resource_format_saver(p_format_saver, p_at_front);
+void ResourceSaver::add_resource_format_saver(RequiredParam<ResourceFormatSaver> p_format_saver, bool p_at_front) {
+	EXTRACT_PARAM_OR_FAIL(format_saver, p_format_saver);
+	::ResourceSaver::add_resource_format_saver(format_saver, p_at_front);
 }
 
-void ResourceSaver::remove_resource_format_saver(RequiredParam<ResourceFormatSaver> rp_format_saver) {
-	EXTRACT_PARAM_OR_FAIL(p_format_saver, rp_format_saver);
-	::ResourceSaver::remove_resource_format_saver(p_format_saver);
+void ResourceSaver::remove_resource_format_saver(RequiredParam<ResourceFormatSaver> p_format_saver) {
+	EXTRACT_PARAM_OR_FAIL(format_saver, p_format_saver);
+	::ResourceSaver::remove_resource_format_saver(format_saver);
 }
 
 ResourceUID::ID ResourceSaver::get_resource_id_for_path(const String &p_path, bool p_generate) {
@@ -722,22 +722,22 @@ String OS::get_unique_id() const {
 	return ::OS::get_singleton()->get_unique_id();
 }
 
-void OS::add_logger(RequiredParam<Logger> rp_logger) {
-	EXTRACT_PARAM_OR_FAIL(p_logger, rp_logger);
+void OS::add_logger(RequiredParam<Logger> p_logger) {
+	EXTRACT_PARAM_OR_FAIL(logger, p_logger);
 
 	if (!logger_bind) {
 		logger_bind = memnew(LoggerBind);
 		::OS::get_singleton()->add_logger(logger_bind);
 	}
 
-	ERR_FAIL_COND_MSG(logger_bind->loggers.find(p_logger) != -1, "Could not add logger, as it has already been added.");
-	logger_bind->loggers.push_back(p_logger);
+	ERR_FAIL_COND_MSG(logger_bind->loggers.find(logger) != -1, "Could not add logger, as it has already been added.");
+	logger_bind->loggers.push_back(logger);
 }
 
-void OS::remove_logger(RequiredParam<Logger> rp_logger) {
-	EXTRACT_PARAM_OR_FAIL(p_logger, rp_logger);
-	ERR_FAIL_COND_MSG(!logger_bind || logger_bind->loggers.find(p_logger) == -1, "Could not remove logger, as it hasn't been added.");
-	logger_bind->loggers.erase(p_logger);
+void OS::remove_logger(RequiredParam<Logger> p_logger) {
+	EXTRACT_PARAM_OR_FAIL(logger, p_logger);
+	ERR_FAIL_COND_MSG(!logger_bind || logger_bind->loggers.find(logger) == -1, "Could not remove logger, as it hasn't been added.");
+	logger_bind->loggers.erase(logger);
 }
 
 void OS::remove_script_loggers(const ScriptLanguage *p_script) {
@@ -1683,17 +1683,17 @@ StringName ClassDB::class_get_property_setter(const StringName &p_class, const S
 	return ::ClassDB::get_property_setter(p_class, p_property);
 }
 
-Variant ClassDB::class_get_property(RequiredParam<Object> rp_object, const StringName &p_property) const {
-	EXTRACT_PARAM_OR_FAIL_V(p_object, rp_object, Variant());
+Variant ClassDB::class_get_property(RequiredParam<Object> p_object, const StringName &p_property) const {
+	EXTRACT_PARAM_OR_FAIL_V(object, p_object, Variant());
 	Variant ret;
-	::ClassDB::get_property(p_object, p_property, ret);
+	::ClassDB::get_property(object, p_property, ret);
 	return ret;
 }
 
-Error ClassDB::class_set_property(RequiredParam<Object> rp_object, const StringName &p_property, const Variant &p_value) const {
-	EXTRACT_PARAM_OR_FAIL_V(p_object, rp_object, ERR_INVALID_PARAMETER);
+Error ClassDB::class_set_property(RequiredParam<Object> p_object, const StringName &p_property, const Variant &p_value) const {
+	EXTRACT_PARAM_OR_FAIL_V(object, p_object, ERR_INVALID_PARAMETER);
 	bool valid;
-	if (!::ClassDB::set_property(p_object, p_property, p_value, &valid)) {
+	if (!::ClassDB::set_property(object, p_property, p_value, &valid)) {
 		return ERR_UNAVAILABLE;
 	} else if (!valid) {
 		return ERR_INVALID_DATA;
@@ -2007,14 +2007,14 @@ Object *Engine::get_singleton_object(const StringName &p_name) const {
 	return ::Engine::get_singleton()->get_singleton_object(p_name);
 }
 
-void Engine::register_singleton(const StringName &p_name, RequiredParam<Object> rp_instance) {
-	EXTRACT_PARAM_OR_FAIL(p_object, rp_instance);
+void Engine::register_singleton(const StringName &p_name, RequiredParam<Object> p_instance) {
+	EXTRACT_PARAM_OR_FAIL(object, p_instance);
 	ERR_FAIL_COND_MSG(has_singleton(p_name), vformat("Singleton already registered: '%s'.", String(p_name)));
 	ERR_FAIL_COND_MSG(!String(p_name).is_valid_ascii_identifier(), vformat("Singleton name is not a valid identifier: '%s'.", p_name));
 	::Engine::Singleton s;
 	s.class_name = p_name;
 	s.name = p_name;
-	s.ptr = p_object;
+	s.ptr = object;
 	s.user_created = true;
 	::Engine::get_singleton()->add_singleton(s);
 }
@@ -2035,14 +2035,14 @@ Vector<String> Engine::get_singleton_list() const {
 	return ret;
 }
 
-Error Engine::register_script_language(RequiredParam<ScriptLanguage> rp_language) {
-	EXTRACT_PARAM_OR_FAIL_V(p_language, rp_language, ERR_INVALID_PARAMETER);
-	return ScriptServer::register_language(p_language);
+Error Engine::register_script_language(RequiredParam<ScriptLanguage> p_language) {
+	EXTRACT_PARAM_OR_FAIL_V(language, p_language, ERR_INVALID_PARAMETER);
+	return ScriptServer::register_language(language);
 }
 
-Error Engine::unregister_script_language(RequiredParam<const ScriptLanguage> rp_language) {
-	EXTRACT_PARAM_OR_FAIL_V(p_language, rp_language, ERR_INVALID_PARAMETER);
-	return ScriptServer::unregister_language(p_language);
+Error Engine::unregister_script_language(RequiredParam<const ScriptLanguage> p_language) {
+	EXTRACT_PARAM_OR_FAIL_V(language, p_language, ERR_INVALID_PARAMETER);
+	return ScriptServer::unregister_language(language);
 }
 
 int Engine::get_script_language_count() {

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -451,9 +451,9 @@ bool Input::is_action_just_pressed(const StringName &p_action, bool p_exact) con
 	}
 }
 
-bool Input::is_action_just_pressed_by_event(const StringName &p_action, RequiredParam<InputEvent> rp_event, bool p_exact) const {
+bool Input::is_action_just_pressed_by_event(const StringName &p_action, RequiredParam<InputEvent> p_event, bool p_exact) const {
 	ERR_FAIL_COND_V_MSG(!InputMap::get_singleton()->has_action(p_action), false, InputMap::get_singleton()->suggest_actions(p_action));
-	EXTRACT_PARAM_OR_FAIL_V(p_event, rp_event, false);
+	EXTRACT_PARAM_OR_FAIL_V(event, p_event, false);
 
 	if (disable_input) {
 		return false;
@@ -468,7 +468,7 @@ bool Input::is_action_just_pressed_by_event(const StringName &p_action, Required
 		return false;
 	}
 
-	if (E->value.pressed_event_id != p_event->get_instance_id()) {
+	if (E->value.pressed_event_id != event->get_instance_id()) {
 		return false;
 	}
 
@@ -508,9 +508,9 @@ bool Input::is_action_just_released(const StringName &p_action, bool p_exact) co
 	}
 }
 
-bool Input::is_action_just_released_by_event(const StringName &p_action, RequiredParam<InputEvent> rp_event, bool p_exact) const {
+bool Input::is_action_just_released_by_event(const StringName &p_action, RequiredParam<InputEvent> p_event, bool p_exact) const {
 	ERR_FAIL_COND_V_MSG(!InputMap::get_singleton()->has_action(p_action), false, InputMap::get_singleton()->suggest_actions(p_action));
-	EXTRACT_PARAM_OR_FAIL_V(p_event, rp_event, false);
+	EXTRACT_PARAM_OR_FAIL_V(event, p_event, false);
 
 	if (disable_input) {
 		return false;
@@ -525,7 +525,7 @@ bool Input::is_action_just_released_by_event(const StringName &p_action, Require
 		return false;
 	}
 
-	if (E->value.released_event_id != p_event->get_instance_id()) {
+	if (E->value.released_event_id != event->get_instance_id()) {
 		return false;
 	}
 
@@ -1600,18 +1600,18 @@ void Input::set_custom_mouse_cursor(const Ref<Resource> &p_cursor, CursorShape p
 	set_custom_mouse_cursor_func(p_cursor, p_shape, p_hotspot);
 }
 
-void Input::parse_input_event(RequiredParam<InputEvent> rp_event) {
+void Input::parse_input_event(RequiredParam<InputEvent> p_event) {
 	_THREAD_SAFE_METHOD_
 
-	EXTRACT_PARAM_OR_FAIL(p_event, rp_event);
+	EXTRACT_PARAM_OR_FAIL(event, p_event);
 
 #ifdef DEBUG_ENABLED
 	uint64_t curr_frame = Engine::get_singleton()->get_process_frames();
 	if (curr_frame != last_parsed_frame) {
 		frame_parsed_events.clear();
 		last_parsed_frame = curr_frame;
-		frame_parsed_events.insert(p_event);
-	} else if (frame_parsed_events.has(p_event)) {
+		frame_parsed_events.insert(event);
+	} else if (frame_parsed_events.has(event)) {
 		// It would be technically safe to send the same event in cases such as:
 		// - After an explicit flush.
 		// - In platforms using buffering when agile flushing is enabled, after one of the mid-frame flushes.
@@ -1626,18 +1626,18 @@ void Input::parse_input_event(RequiredParam<InputEvent> rp_event) {
 				"If you are generating events in a script, you have to instantiate a new event instead of sending the same one more than once, unless the original one was sent on an earlier frame.\n"
 				"You can call duplicate() on the event to get a new instance with identical values.");
 	} else {
-		frame_parsed_events.insert(p_event);
+		frame_parsed_events.insert(event);
 	}
 #endif
 
 	if (use_accumulated_input) {
-		if (buffered_events.is_empty() || !buffered_events.back()->get()->accumulate(p_event)) {
-			buffered_events.push_back(p_event);
+		if (buffered_events.is_empty() || !buffered_events.back()->get()->accumulate(event)) {
+			buffered_events.push_back(event);
 		}
 	} else if (agile_input_event_flushing) {
-		buffered_events.push_back(p_event);
+		buffered_events.push_back(event);
 	} else {
-		_parse_input_event_impl(p_event, false);
+		_parse_input_event_impl(event, false);
 	}
 }
 

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -377,8 +377,8 @@ public:
 	bool is_action_pressed(const StringName &p_action, bool p_exact = false) const;
 	bool is_action_just_pressed(const StringName &p_action, bool p_exact = false) const;
 	bool is_action_just_released(const StringName &p_action, bool p_exact = false) const;
-	bool is_action_just_pressed_by_event(const StringName &p_action, RequiredParam<InputEvent> rp_event, bool p_exact = false) const;
-	bool is_action_just_released_by_event(const StringName &p_action, RequiredParam<InputEvent> rp_event, bool p_exact = false) const;
+	bool is_action_just_pressed_by_event(const StringName &p_action, RequiredParam<InputEvent> p_event, bool p_exact = false) const;
+	bool is_action_just_released_by_event(const StringName &p_action, RequiredParam<InputEvent> p_event, bool p_exact = false) const;
 	float get_action_strength(const StringName &p_action, bool p_exact = false) const;
 	float get_action_raw_strength(const StringName &p_action, bool p_exact = false) const;
 
@@ -411,7 +411,7 @@ public:
 	void warp_mouse(const Vector2 &p_position);
 	Point2 warp_mouse_motion(const Ref<InputEventMouseMotion> &p_motion, const Rect2 &p_rect);
 
-	void parse_input_event(RequiredParam<InputEvent> rp_event);
+	void parse_input_event(RequiredParam<InputEvent> p_event);
 
 	void set_gravity(const Vector3 &p_gravity);
 	void set_accelerometer(const Vector3 &p_accel);

--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -199,43 +199,43 @@ void InputMap::action_set_deadzone(const StringName &p_action, float p_deadzone)
 	input_map[p_action].deadzone = p_deadzone;
 }
 
-void InputMap::action_add_event(const StringName &p_action, RequiredParam<InputEvent> rp_event) {
-	EXTRACT_PARAM_OR_FAIL_MSG(p_event, rp_event, "It's not a reference to a valid InputEvent object.");
+void InputMap::action_add_event(const StringName &p_action, RequiredParam<InputEvent> p_event) {
+	EXTRACT_PARAM_OR_FAIL_MSG(event, p_event, "It's not a reference to a valid InputEvent object.");
 	ERR_FAIL_COND_MSG(!input_map.has(p_action), suggest_actions(p_action));
-	if (_find_event(input_map[p_action], p_event, true)) {
+	if (_find_event(input_map[p_action], event, true)) {
 		return; // Already added.
 	}
 
 	// Normalize legacy device IDs: before the device ID change,
 	// keyboard and mouse events defaulted to device=0.
-	if (p_event->get_device() == 0) {
-		switch (p_event->get_type()) {
+	if (event->get_device() == 0) {
+		switch (event->get_type()) {
 			case InputEventType::KEY:
-				p_event->set_device(InputEvent::DEVICE_ID_KEYBOARD);
+				event->set_device(InputEvent::DEVICE_ID_KEYBOARD);
 				break;
 			case InputEventType::MOUSE_BUTTON:
 			case InputEventType::MOUSE_MOTION:
-				p_event->set_device(InputEvent::DEVICE_ID_MOUSE);
+				event->set_device(InputEvent::DEVICE_ID_MOUSE);
 				break;
 			default:
 				break;
 		}
 	}
 
-	input_map[p_action].inputs.push_back(p_event);
+	input_map[p_action].inputs.push_back(event);
 }
 
-bool InputMap::action_has_event(const StringName &p_action, RequiredParam<InputEvent> rp_event) {
-	EXTRACT_PARAM_OR_FAIL_V(p_event, rp_event, false);
+bool InputMap::action_has_event(const StringName &p_action, RequiredParam<InputEvent> p_event) {
+	EXTRACT_PARAM_OR_FAIL_V(event, p_event, false);
 	ERR_FAIL_COND_V_MSG(!input_map.has(p_action), false, suggest_actions(p_action));
-	return (_find_event(input_map[p_action], p_event, true) != nullptr);
+	return (_find_event(input_map[p_action], event, true) != nullptr);
 }
 
-void InputMap::action_erase_event(const StringName &p_action, RequiredParam<InputEvent> rp_event) {
-	EXTRACT_PARAM_OR_FAIL(p_event, rp_event);
+void InputMap::action_erase_event(const StringName &p_action, RequiredParam<InputEvent> p_event) {
+	EXTRACT_PARAM_OR_FAIL(event, p_event);
 	ERR_FAIL_COND_MSG(!input_map.has(p_action), suggest_actions(p_action));
 
-	List<Ref<InputEvent>>::Element *E = _find_event(input_map[p_action], p_event, true);
+	List<Ref<InputEvent>>::Element *E = _find_event(input_map[p_action], event, true);
 	if (E) {
 		input_map[p_action].inputs.erase(E);
 
@@ -276,9 +276,9 @@ const List<Ref<InputEvent>> *InputMap::action_get_events(const StringName &p_act
 	return &E->value.inputs;
 }
 
-bool InputMap::event_is_action(RequiredParam<InputEvent> rp_event, const StringName &p_action, bool p_exact_match) const {
-	EXTRACT_PARAM_OR_FAIL_V(p_event, rp_event, false);
-	return event_get_action_status(p_event, p_action, p_exact_match);
+bool InputMap::event_is_action(RequiredParam<InputEvent> p_event, const StringName &p_action, bool p_exact_match) const {
+	EXTRACT_PARAM_OR_FAIL_V(event, p_event, false);
+	return event_get_action_status(event, p_action, p_exact_match);
 }
 
 int InputMap::event_get_index(const Ref<InputEvent> &p_event, const StringName &p_action, bool p_exact_match) const {

--- a/core/input/input_map.h
+++ b/core/input/input_map.h
@@ -87,13 +87,13 @@ public:
 
 	float action_get_deadzone(const StringName &p_action);
 	void action_set_deadzone(const StringName &p_action, float p_deadzone);
-	void action_add_event(const StringName &p_action, RequiredParam<InputEvent> rp_event);
-	bool action_has_event(const StringName &p_action, RequiredParam<InputEvent> rp_event);
-	void action_erase_event(const StringName &p_action, RequiredParam<InputEvent> rp_event);
+	void action_add_event(const StringName &p_action, RequiredParam<InputEvent> p_event);
+	bool action_has_event(const StringName &p_action, RequiredParam<InputEvent> p_event);
+	void action_erase_event(const StringName &p_action, RequiredParam<InputEvent> p_event);
 	void action_erase_events(const StringName &p_action);
 
 	const List<Ref<InputEvent>> *action_get_events(const StringName &p_action);
-	bool event_is_action(RequiredParam<InputEvent> rp_event, const StringName &p_action, bool p_exact_match = false) const;
+	bool event_is_action(RequiredParam<InputEvent> p_event, const StringName &p_action, bool p_exact_match = false) const;
 	int event_get_index(const Ref<InputEvent> &p_event, const StringName &p_action, bool p_exact_match = false) const;
 	bool event_get_action_status(const Ref<InputEvent> &p_event, const StringName &p_action, bool p_exact_match = false, bool *r_pressed = nullptr, float *r_strength = nullptr, float *r_raw_strength = nullptr, int *r_event_index = nullptr) const;
 

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -99,52 +99,52 @@ void ResourceFormatSaver::_bind_methods() {
 	GDVIRTUAL_BIND(_recognize_path, "resource", "path");
 }
 
-Error ResourceSaver::save(RequiredParam<Resource> rp_resource, const String &p_path, uint32_t p_flags) {
-	EXTRACT_PARAM_OR_FAIL_V_MSG(p_resource, rp_resource, ERR_INVALID_PARAMETER, vformat("Can't save empty resource to path '%s'.", p_path));
+Error ResourceSaver::save(RequiredParam<Resource> p_resource, const String &p_path, uint32_t p_flags) {
+	EXTRACT_PARAM_OR_FAIL_V_MSG(resource, p_resource, ERR_INVALID_PARAMETER, vformat("Can't save empty resource to path '%s'.", p_path));
 	String path = p_path;
 	if (path.is_empty()) {
-		path = p_resource->get_path();
+		path = resource->get_path();
 	}
 	ERR_FAIL_COND_V_MSG(path.is_empty(), ERR_INVALID_PARAMETER, "Can't save resource to empty path. Provide non-empty path or a Resource with non-empty resource_path.");
 
 	Error err = ERR_FILE_UNRECOGNIZED;
 
 	for (int i = 0; i < saver_count; i++) {
-		if (!saver[i]->recognize(p_resource)) {
+		if (!saver[i]->recognize(resource)) {
 			continue;
 		}
 
-		if (!saver[i]->recognize_path(p_resource, path)) {
+		if (!saver[i]->recognize_path(resource, path)) {
 			continue;
 		}
 
-		String old_path = p_resource->get_path();
+		String old_path = resource->get_path();
 
 		String local_path = ProjectSettings::get_singleton()->localize_path(path);
 
 		if (p_flags & FLAG_CHANGE_PATH) {
-			p_resource->set_path(local_path);
+			resource->set_path(local_path);
 		}
 
-		err = saver[i]->save(p_resource, path, p_flags);
+		err = saver[i]->save(resource, path, p_flags);
 
 		if (err == OK) {
 #ifdef TOOLS_ENABLED
 
-			((Resource *)p_resource.ptr())->set_edited(false);
+			((Resource *)resource.ptr())->set_edited(false);
 			if (timestamp_on_save) {
 				uint64_t mt = FileAccess::get_modified_time(path);
 
-				((Resource *)p_resource.ptr())->set_last_modified_time(mt);
+				((Resource *)resource.ptr())->set_last_modified_time(mt);
 			}
 #endif
 
 			if (p_flags & FLAG_CHANGE_PATH) {
-				p_resource->set_path(old_path);
+				resource->set_path(old_path);
 			}
 
 			if (save_callback && path.begins_with("res://")) {
-				save_callback(p_resource, path);
+				save_callback(resource, path);
 			}
 
 			return OK;

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -83,7 +83,7 @@ public:
 		FLAG_REPLACE_SUBRESOURCE_PATHS = 64,
 	};
 
-	static Error save(RequiredParam<Resource> rp_resource, const String &p_path = "", uint32_t p_flags = (uint32_t)FLAG_NONE);
+	static Error save(RequiredParam<Resource> p_resource, const String &p_path = "", uint32_t p_flags = (uint32_t)FLAG_NONE);
 	static void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions);
 	static void add_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver, bool p_at_front = false);
 	static void remove_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver);

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -976,12 +976,12 @@ RID GodotPhysicsServer3D::soft_body_create() {
 	return rid;
 }
 
-void GodotPhysicsServer3D::soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> rp_rendering_server_handler) {
+void GodotPhysicsServer3D::soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> p_rendering_server_handler) {
 	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(soft_body);
-	EXTRACT_PARAM_OR_FAIL(p_rendering_server_handler, rp_rendering_server_handler);
+	EXTRACT_PARAM_OR_FAIL(rendering_server_handler, p_rendering_server_handler);
 
-	soft_body->update_rendering_server(p_rendering_server_handler);
+	soft_body->update_rendering_server(rendering_server_handler);
 }
 
 void GodotPhysicsServer3D::soft_body_set_space(RID p_body, RID p_space) {

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -263,7 +263,7 @@ public:
 
 	virtual RID soft_body_create() override;
 
-	virtual void soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> rp_rendering_server_handler) override;
+	virtual void soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> p_rendering_server_handler) override;
 
 	virtual void soft_body_set_space(RID p_body, RID p_space) override;
 	virtual RID soft_body_get_space(RID p_body) const override;

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -985,12 +985,12 @@ RID JoltPhysicsServer3D::soft_body_create() {
 	return rid;
 }
 
-void JoltPhysicsServer3D::soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> rp_rendering_server_handler) {
+void JoltPhysicsServer3D::soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> p_rendering_server_handler) {
 	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
-	EXTRACT_PARAM_OR_FAIL(p_rendering_server_handler, rp_rendering_server_handler);
+	EXTRACT_PARAM_OR_FAIL(rendering_server_handler, p_rendering_server_handler);
 
-	return body->update_rendering_server(p_rendering_server_handler);
+	return body->update_rendering_server(rendering_server_handler);
 }
 
 void JoltPhysicsServer3D::soft_body_set_space(RID p_body, RID p_space) {

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -300,7 +300,7 @@ public:
 
 	virtual RID soft_body_create() override;
 
-	virtual void soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> rp_rendering_server_handler) override;
+	virtual void soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> p_rendering_server_handler) override;
 
 	virtual void soft_body_set_space(RID p_body, RID p_space) override;
 	virtual RID soft_body_get_space(RID p_body) const override;

--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -395,20 +395,20 @@ void Node2D::set_global_transform(const Transform2D &p_transform) {
 	}
 }
 
-Transform2D Node2D::get_relative_transform_to_parent(RequiredParam<const Node> rp_parent) const {
-	EXTRACT_PARAM_OR_FAIL_V(p_parent, rp_parent, Transform2D());
+Transform2D Node2D::get_relative_transform_to_parent(RequiredParam<const Node> p_parent) const {
+	EXTRACT_PARAM_OR_FAIL_V(parent, p_parent, Transform2D());
 	ERR_READ_THREAD_GUARD_V(Transform2D());
-	if (p_parent == this) {
+	if (parent == this) {
 		return Transform2D();
 	}
 
 	Node2D *parent_2d = Object::cast_to<Node2D>(get_parent());
 
 	ERR_FAIL_NULL_V(parent_2d, Transform2D());
-	if (p_parent == parent_2d) {
+	if (parent == parent_2d) {
 		return get_transform();
 	} else {
-		return parent_2d->get_relative_transform_to_parent(p_parent) * get_transform();
+		return parent_2d->get_relative_transform_to_parent(parent) * get_transform();
 	}
 }
 

--- a/scene/2d/physics/area_2d.cpp
+++ b/scene/2d/physics/area_2d.cpp
@@ -505,18 +505,18 @@ bool Area2D::has_overlapping_areas() const {
 	return !area_map.is_empty();
 }
 
-bool Area2D::overlaps_area(RequiredParam<Node> rp_area) const {
-	EXTRACT_PARAM_OR_FAIL_V(p_area, rp_area, false);
-	HashMap<ObjectID, AreaState>::ConstIterator E = area_map.find(p_area->get_instance_id());
+bool Area2D::overlaps_area(RequiredParam<Node> p_area) const {
+	EXTRACT_PARAM_OR_FAIL_V(check_area, p_area, false);
+	HashMap<ObjectID, AreaState>::ConstIterator E = area_map.find(check_area->get_instance_id());
 	if (!E) {
 		return false;
 	}
 	return E->value.in_tree;
 }
 
-bool Area2D::overlaps_body(RequiredParam<Node> rp_body) const {
-	EXTRACT_PARAM_OR_FAIL_V(p_body, rp_body, false);
-	HashMap<ObjectID, BodyState>::ConstIterator E = body_map.find(p_body->get_instance_id());
+bool Area2D::overlaps_body(RequiredParam<Node> p_body) const {
+	EXTRACT_PARAM_OR_FAIL_V(body, p_body, false);
+	HashMap<ObjectID, BodyState>::ConstIterator E = body_map.find(body->get_instance_id());
 	if (!E) {
 		return false;
 	}

--- a/scene/2d/physics/area_2d.h
+++ b/scene/2d/physics/area_2d.h
@@ -185,8 +185,8 @@ public:
 	bool has_overlapping_bodies() const;
 	bool has_overlapping_areas() const;
 
-	bool overlaps_area(RequiredParam<Node> rp_area) const;
-	bool overlaps_body(RequiredParam<Node> rp_body) const;
+	bool overlaps_area(RequiredParam<Node> p_area) const;
+	bool overlaps_body(RequiredParam<Node> p_body) const;
 
 	void set_audio_bus_override(bool p_override);
 	bool is_overriding_audio_bus() const;

--- a/scene/2d/physics/collision_object_2d.cpp
+++ b/scene/2d/physics/collision_object_2d.cpp
@@ -440,18 +440,18 @@ Object *CollisionObject2D::shape_owner_get_owner(uint32_t p_owner) const {
 	return ObjectDB::get_instance(shapes[p_owner].owner_id);
 }
 
-void CollisionObject2D::shape_owner_add_shape(uint32_t p_owner, RequiredParam<Shape2D> rp_shape) {
+void CollisionObject2D::shape_owner_add_shape(uint32_t p_owner, RequiredParam<Shape2D> p_shape) {
 	ERR_FAIL_COND(!shapes.has(p_owner));
-	EXTRACT_PARAM_OR_FAIL(p_shape, rp_shape);
+	EXTRACT_PARAM_OR_FAIL(shape, p_shape);
 
 	ShapeData &sd = shapes[p_owner];
 	ShapeData::Shape s;
 	s.index = total_subshapes;
-	s.shape = p_shape;
+	s.shape = shape;
 	if (area) {
-		PhysicsServer2D::get_singleton()->area_add_shape(rid, p_shape->get_rid(), sd.xform, sd.disabled);
+		PhysicsServer2D::get_singleton()->area_add_shape(rid, shape->get_rid(), sd.xform, sd.disabled);
 	} else {
-		PhysicsServer2D::get_singleton()->body_add_shape(rid, p_shape->get_rid(), sd.xform, sd.disabled);
+		PhysicsServer2D::get_singleton()->body_add_shape(rid, shape->get_rid(), sd.xform, sd.disabled);
 	}
 	sd.shapes.push_back(s);
 

--- a/scene/2d/physics/collision_object_2d.h
+++ b/scene/2d/physics/collision_object_2d.h
@@ -159,7 +159,7 @@ public:
 	void shape_owner_set_one_way_collision_direction(uint32_t p_owner, const Vector2 &p_direction);
 	Vector2 get_shape_owner_one_way_collision_direction(uint32_t p_owner) const;
 
-	void shape_owner_add_shape(uint32_t p_owner, RequiredParam<Shape2D> rp_shape);
+	void shape_owner_add_shape(uint32_t p_owner, RequiredParam<Shape2D> p_shape);
 	int shape_owner_get_shape_count(uint32_t p_owner) const;
 	Ref<Shape2D> shape_owner_get_shape(uint32_t p_owner, int p_shape) const;
 	int shape_owner_get_shape_index(uint32_t p_owner, int p_shape) const;

--- a/scene/2d/physics/physics_body_2d.cpp
+++ b/scene/2d/physics/physics_body_2d.cpp
@@ -161,16 +161,16 @@ TypedArray<PhysicsBody2D> PhysicsBody2D::get_collision_exceptions() {
 	return ret;
 }
 
-void PhysicsBody2D::add_collision_exception_with(RequiredParam<Node> rp_node) {
-	EXTRACT_PARAM_OR_FAIL(p_node, rp_node);
-	PhysicsBody2D *physics_body = Object::cast_to<PhysicsBody2D>(p_node);
+void PhysicsBody2D::add_collision_exception_with(RequiredParam<Node> p_node) {
+	EXTRACT_PARAM_OR_FAIL(node, p_node);
+	PhysicsBody2D *physics_body = Object::cast_to<PhysicsBody2D>(node);
 	ERR_FAIL_NULL_MSG(physics_body, "Collision exception only works between two nodes that inherit from PhysicsBody2D.");
 	PhysicsServer2D::get_singleton()->body_add_collision_exception(get_rid(), physics_body->get_rid());
 }
 
-void PhysicsBody2D::remove_collision_exception_with(RequiredParam<Node> rp_node) {
-	EXTRACT_PARAM_OR_FAIL(p_node, rp_node);
-	PhysicsBody2D *physics_body = Object::cast_to<PhysicsBody2D>(p_node);
+void PhysicsBody2D::remove_collision_exception_with(RequiredParam<Node> p_node) {
+	EXTRACT_PARAM_OR_FAIL(node, p_node);
+	PhysicsBody2D *physics_body = Object::cast_to<PhysicsBody2D>(node);
 	ERR_FAIL_NULL_MSG(physics_body, "Collision exception only works between two nodes that inherit from PhysicsBody2D.");
 	PhysicsServer2D::get_singleton()->body_remove_collision_exception(get_rid(), physics_body->get_rid());
 }

--- a/scene/2d/physics/physics_body_2d.h
+++ b/scene/2d/physics/physics_body_2d.h
@@ -52,6 +52,6 @@ public:
 	Vector2 get_gravity() const;
 
 	TypedArray<PhysicsBody2D> get_collision_exceptions();
-	void add_collision_exception_with(RequiredParam<Node> rp_node); //must be physicsbody
-	void remove_collision_exception_with(RequiredParam<Node> rp_node);
+	void add_collision_exception_with(RequiredParam<Node> p_node); //must be physicsbody
+	void remove_collision_exception_with(RequiredParam<Node> p_node);
 };

--- a/scene/2d/physics/ray_cast_2d.cpp
+++ b/scene/2d/physics/ray_cast_2d.cpp
@@ -276,18 +276,18 @@ void RayCast2D::add_exception_rid(const RID &p_rid) {
 	exclude.insert(p_rid);
 }
 
-void RayCast2D::add_exception(RequiredParam<const CollisionObject2D> rp_node) {
-	EXTRACT_PARAM_OR_FAIL_MSG(p_node, rp_node, "The passed Node must be an instance of CollisionObject2D.");
-	add_exception_rid(p_node->get_rid());
+void RayCast2D::add_exception(RequiredParam<const CollisionObject2D> p_node) {
+	EXTRACT_PARAM_OR_FAIL_MSG(node, p_node, "The passed Node must be an instance of CollisionObject2D.");
+	add_exception_rid(node->get_rid());
 }
 
 void RayCast2D::remove_exception_rid(const RID &p_rid) {
 	exclude.erase(p_rid);
 }
 
-void RayCast2D::remove_exception(RequiredParam<const CollisionObject2D> rp_node) {
-	EXTRACT_PARAM_OR_FAIL_MSG(p_node, rp_node, "The passed Node must be an instance of CollisionObject2D.");
-	remove_exception_rid(p_node->get_rid());
+void RayCast2D::remove_exception(RequiredParam<const CollisionObject2D> p_node) {
+	EXTRACT_PARAM_OR_FAIL_MSG(node, p_node, "The passed Node must be an instance of CollisionObject2D.");
+	remove_exception_rid(node->get_rid());
 }
 
 void RayCast2D::clear_exceptions() {

--- a/scene/2d/physics/ray_cast_2d.h
+++ b/scene/2d/physics/ray_cast_2d.h
@@ -97,9 +97,9 @@ public:
 	Vector2 get_collision_normal() const;
 
 	void add_exception_rid(const RID &p_rid);
-	void add_exception(RequiredParam<const CollisionObject2D> rp_node);
+	void add_exception(RequiredParam<const CollisionObject2D> p_node);
 	void remove_exception_rid(const RID &p_rid);
-	void remove_exception(RequiredParam<const CollisionObject2D> rp_node);
+	void remove_exception(RequiredParam<const CollisionObject2D> p_node);
 	void clear_exceptions();
 
 	RayCast2D();

--- a/scene/2d/physics/shape_cast_2d.cpp
+++ b/scene/2d/physics/shape_cast_2d.cpp
@@ -355,18 +355,18 @@ void ShapeCast2D::add_exception_rid(const RID &p_rid) {
 	exclude.insert(p_rid);
 }
 
-void ShapeCast2D::add_exception(RequiredParam<const CollisionObject2D> rp_node) {
-	EXTRACT_PARAM_OR_FAIL_MSG(p_node, rp_node, "The passed Node must be an instance of CollisionObject2D.");
-	add_exception_rid(p_node->get_rid());
+void ShapeCast2D::add_exception(RequiredParam<const CollisionObject2D> p_node) {
+	EXTRACT_PARAM_OR_FAIL_MSG(node, p_node, "The passed Node must be an instance of CollisionObject2D.");
+	add_exception_rid(node->get_rid());
 }
 
 void ShapeCast2D::remove_exception_rid(const RID &p_rid) {
 	exclude.erase(p_rid);
 }
 
-void ShapeCast2D::remove_exception(RequiredParam<const CollisionObject2D> rp_node) {
-	EXTRACT_PARAM_OR_FAIL_MSG(p_node, rp_node, "The passed Node must be an instance of CollisionObject2D.");
-	remove_exception_rid(p_node->get_rid());
+void ShapeCast2D::remove_exception(RequiredParam<const CollisionObject2D> p_node) {
+	EXTRACT_PARAM_OR_FAIL_MSG(node, p_node, "The passed Node must be an instance of CollisionObject2D.");
+	remove_exception_rid(node->get_rid());
 }
 
 void ShapeCast2D::clear_exceptions() {

--- a/scene/2d/physics/shape_cast_2d.h
+++ b/scene/2d/physics/shape_cast_2d.h
@@ -112,9 +112,9 @@ public:
 	real_t get_closest_collision_unsafe_fraction() const;
 
 	void add_exception_rid(const RID &p_rid);
-	void add_exception(RequiredParam<const CollisionObject2D> rp_node);
+	void add_exception(RequiredParam<const CollisionObject2D> p_node);
 	void remove_exception_rid(const RID &p_rid);
-	void remove_exception(RequiredParam<const CollisionObject2D> rp_node);
+	void remove_exception(RequiredParam<const CollisionObject2D> p_node);
 	void clear_exceptions();
 
 	PackedStringArray get_configuration_warnings() const override;

--- a/scene/3d/physics/area_3d.cpp
+++ b/scene/3d/physics/area_3d.cpp
@@ -572,18 +572,18 @@ bool Area3D::has_overlapping_areas() const {
 	return !area_map.is_empty();
 }
 
-bool Area3D::overlaps_area(RequiredParam<Node> rp_area) const {
-	EXTRACT_PARAM_OR_FAIL_V(p_area, rp_area, false);
-	HashMap<ObjectID, AreaState>::ConstIterator E = area_map.find(p_area->get_instance_id());
+bool Area3D::overlaps_area(RequiredParam<Node> p_area) const {
+	EXTRACT_PARAM_OR_FAIL_V(check_area, p_area, false);
+	HashMap<ObjectID, AreaState>::ConstIterator E = area_map.find(check_area->get_instance_id());
 	if (!E) {
 		return false;
 	}
 	return E->value.in_tree;
 }
 
-bool Area3D::overlaps_body(RequiredParam<Node> rp_body) const {
-	EXTRACT_PARAM_OR_FAIL_V(p_body, rp_body, false);
-	HashMap<ObjectID, BodyState>::ConstIterator E = body_map.find(p_body->get_instance_id());
+bool Area3D::overlaps_body(RequiredParam<Node> p_body) const {
+	EXTRACT_PARAM_OR_FAIL_V(body, p_body, false);
+	HashMap<ObjectID, BodyState>::ConstIterator E = body_map.find(body->get_instance_id());
 	if (!E) {
 		return false;
 	}

--- a/scene/3d/physics/area_3d.h
+++ b/scene/3d/physics/area_3d.h
@@ -204,8 +204,8 @@ public:
 	bool has_overlapping_bodies() const;
 	bool has_overlapping_areas() const;
 
-	bool overlaps_area(RequiredParam<Node> rp_area) const;
-	bool overlaps_body(RequiredParam<Node> rp_body) const;
+	bool overlaps_area(RequiredParam<Node> p_area) const;
+	bool overlaps_body(RequiredParam<Node> p_body) const;
 
 	void set_audio_bus_override(bool p_override);
 	bool is_overriding_audio_bus() const;

--- a/scene/3d/physics/collision_object_3d.cpp
+++ b/scene/3d/physics/collision_object_3d.cpp
@@ -625,19 +625,19 @@ Object *CollisionObject3D::shape_owner_get_owner(uint32_t p_owner) const {
 	return ObjectDB::get_instance(shapes[p_owner].owner_id);
 }
 
-void CollisionObject3D::shape_owner_add_shape(uint32_t p_owner, RequiredParam<Shape3D> rp_shape) {
+void CollisionObject3D::shape_owner_add_shape(uint32_t p_owner, RequiredParam<Shape3D> p_shape) {
 	ERR_FAIL_COND(!shapes.has(p_owner));
-	EXTRACT_PARAM_OR_FAIL(p_shape, rp_shape);
+	EXTRACT_PARAM_OR_FAIL(shape, p_shape);
 
 	ShapeData &sd = shapes[p_owner];
 	ShapeData::ShapeBase s;
 	s.index = total_subshapes;
-	s.shape = p_shape;
+	s.shape = shape;
 
 	if (area) {
-		PhysicsServer3D::get_singleton()->area_add_shape(rid, p_shape->get_rid(), sd.xform, sd.disabled);
+		PhysicsServer3D::get_singleton()->area_add_shape(rid, shape->get_rid(), sd.xform, sd.disabled);
 	} else {
-		PhysicsServer3D::get_singleton()->body_add_shape(rid, p_shape->get_rid(), sd.xform, sd.disabled);
+		PhysicsServer3D::get_singleton()->body_add_shape(rid, shape->get_rid(), sd.xform, sd.disabled);
 	}
 	sd.shapes.push_back(s);
 

--- a/scene/3d/physics/collision_object_3d.h
+++ b/scene/3d/physics/collision_object_3d.h
@@ -159,7 +159,7 @@ public:
 	void shape_owner_set_disabled(uint32_t p_owner, bool p_disabled);
 	bool is_shape_owner_disabled(uint32_t p_owner) const;
 
-	void shape_owner_add_shape(uint32_t p_owner, RequiredParam<Shape3D> rp_shape);
+	void shape_owner_add_shape(uint32_t p_owner, RequiredParam<Shape3D> p_shape);
 	int shape_owner_get_shape_count(uint32_t p_owner) const;
 	Ref<Shape3D> shape_owner_get_shape(uint32_t p_owner, int p_shape) const;
 	int shape_owner_get_shape_index(uint32_t p_owner, int p_shape) const;

--- a/scene/3d/physics/physics_body_3d.cpp
+++ b/scene/3d/physics/physics_body_3d.cpp
@@ -73,16 +73,16 @@ TypedArray<PhysicsBody3D> PhysicsBody3D::get_collision_exceptions() {
 	return ret;
 }
 
-void PhysicsBody3D::add_collision_exception_with(RequiredParam<Node> rp_node) {
-	EXTRACT_PARAM_OR_FAIL(p_node, rp_node);
-	CollisionObject3D *collision_object = Object::cast_to<CollisionObject3D>(p_node);
+void PhysicsBody3D::add_collision_exception_with(RequiredParam<Node> p_node) {
+	EXTRACT_PARAM_OR_FAIL(node, p_node);
+	CollisionObject3D *collision_object = Object::cast_to<CollisionObject3D>(node);
 	ERR_FAIL_NULL_MSG(collision_object, "Collision exception only works between two nodes that inherit from CollisionObject3D (such as Area3D or PhysicsBody3D).");
 	PhysicsServer3D::get_singleton()->body_add_collision_exception(get_rid(), collision_object->get_rid());
 }
 
-void PhysicsBody3D::remove_collision_exception_with(RequiredParam<Node> rp_node) {
-	EXTRACT_PARAM_OR_FAIL(p_node, rp_node);
-	CollisionObject3D *collision_object = Object::cast_to<CollisionObject3D>(p_node);
+void PhysicsBody3D::remove_collision_exception_with(RequiredParam<Node> p_node) {
+	EXTRACT_PARAM_OR_FAIL(node, p_node);
+	CollisionObject3D *collision_object = Object::cast_to<CollisionObject3D>(node);
 	ERR_FAIL_NULL_MSG(collision_object, "Collision exception only works between two nodes that inherit from CollisionObject3D (such as Area3D or PhysicsBody3D).");
 	PhysicsServer3D::get_singleton()->body_remove_collision_exception(get_rid(), collision_object->get_rid());
 }

--- a/scene/3d/physics/physics_body_3d.h
+++ b/scene/3d/physics/physics_body_3d.h
@@ -64,6 +64,6 @@ public:
 	virtual real_t get_inverse_mass() const;
 
 	TypedArray<PhysicsBody3D> get_collision_exceptions();
-	void add_collision_exception_with(RequiredParam<Node> rp_node); //must be physicsbody
-	void remove_collision_exception_with(RequiredParam<Node> rp_node);
+	void add_collision_exception_with(RequiredParam<Node> p_node); //must be physicsbody
+	void remove_collision_exception_with(RequiredParam<Node> p_node);
 };

--- a/scene/3d/physics/ray_cast_3d.cpp
+++ b/scene/3d/physics/ray_cast_3d.cpp
@@ -278,18 +278,18 @@ void RayCast3D::add_exception_rid(const RID &p_rid) {
 	exclude.insert(p_rid);
 }
 
-void RayCast3D::add_exception(RequiredParam<const CollisionObject3D> rp_node) {
-	EXTRACT_PARAM_OR_FAIL_MSG(p_node, rp_node, "The passed Node must be an instance of CollisionObject3D.");
-	add_exception_rid(p_node->get_rid());
+void RayCast3D::add_exception(RequiredParam<const CollisionObject3D> p_node) {
+	EXTRACT_PARAM_OR_FAIL_MSG(node, p_node, "The passed Node must be an instance of CollisionObject3D.");
+	add_exception_rid(node->get_rid());
 }
 
 void RayCast3D::remove_exception_rid(const RID &p_rid) {
 	exclude.erase(p_rid);
 }
 
-void RayCast3D::remove_exception(RequiredParam<const CollisionObject3D> rp_node) {
-	EXTRACT_PARAM_OR_FAIL_MSG(p_node, rp_node, "The passed Node must be an instance of CollisionObject3D.");
-	remove_exception_rid(p_node->get_rid());
+void RayCast3D::remove_exception(RequiredParam<const CollisionObject3D> p_node) {
+	EXTRACT_PARAM_OR_FAIL_MSG(node, p_node, "The passed Node must be an instance of CollisionObject3D.");
+	remove_exception_rid(node->get_rid());
 }
 
 void RayCast3D::clear_exceptions() {

--- a/scene/3d/physics/ray_cast_3d.h
+++ b/scene/3d/physics/ray_cast_3d.h
@@ -129,9 +129,9 @@ public:
 	int get_collision_face_index() const;
 
 	void add_exception_rid(const RID &p_rid);
-	void add_exception(RequiredParam<const CollisionObject3D> rp_node);
+	void add_exception(RequiredParam<const CollisionObject3D> p_node);
 	void remove_exception_rid(const RID &p_rid);
-	void remove_exception(RequiredParam<const CollisionObject3D> rp_node);
+	void remove_exception(RequiredParam<const CollisionObject3D> p_node);
 	void clear_exceptions();
 
 	RayCast3D();

--- a/scene/3d/physics/shape_cast_3d.cpp
+++ b/scene/3d/physics/shape_cast_3d.cpp
@@ -455,18 +455,18 @@ void ShapeCast3D::add_exception_rid(const RID &p_rid) {
 	exclude.insert(p_rid);
 }
 
-void ShapeCast3D::add_exception(RequiredParam<const CollisionObject3D> rp_node) {
-	EXTRACT_PARAM_OR_FAIL_MSG(p_node, rp_node, "The passed Node must be an instance of CollisionObject3D.");
-	add_exception_rid(p_node->get_rid());
+void ShapeCast3D::add_exception(RequiredParam<const CollisionObject3D> p_node) {
+	EXTRACT_PARAM_OR_FAIL_MSG(node, p_node, "The passed Node must be an instance of CollisionObject3D.");
+	add_exception_rid(node->get_rid());
 }
 
 void ShapeCast3D::remove_exception_rid(const RID &p_rid) {
 	exclude.erase(p_rid);
 }
 
-void ShapeCast3D::remove_exception(RequiredParam<const CollisionObject3D> rp_node) {
-	EXTRACT_PARAM_OR_FAIL_MSG(p_node, rp_node, "The passed Node must be an instance of CollisionObject3D.");
-	remove_exception_rid(p_node->get_rid());
+void ShapeCast3D::remove_exception(RequiredParam<const CollisionObject3D> p_node) {
+	EXTRACT_PARAM_OR_FAIL_MSG(node, p_node, "The passed Node must be an instance of CollisionObject3D.");
+	remove_exception_rid(node->get_rid());
 }
 
 void ShapeCast3D::clear_exceptions() {

--- a/scene/3d/physics/shape_cast_3d.h
+++ b/scene/3d/physics/shape_cast_3d.h
@@ -137,9 +137,9 @@ public:
 	bool is_colliding() const;
 
 	void add_exception_rid(const RID &p_rid);
-	void add_exception(RequiredParam<const CollisionObject3D> rp_node);
+	void add_exception(RequiredParam<const CollisionObject3D> p_node);
 	void remove_exception_rid(const RID &p_rid);
-	void remove_exception(RequiredParam<const CollisionObject3D> rp_node);
+	void remove_exception(RequiredParam<const CollisionObject3D> p_node);
 	void clear_exceptions();
 
 	virtual PackedStringArray get_configuration_warnings() const override;

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -622,16 +622,16 @@ TypedArray<PhysicsBody3D> SoftBody3D::get_collision_exceptions() {
 	return ret;
 }
 
-void SoftBody3D::add_collision_exception_with(RequiredParam<Node> rp_node) {
-	EXTRACT_PARAM_OR_FAIL(p_node, rp_node);
-	CollisionObject3D *collision_object = Object::cast_to<CollisionObject3D>(p_node);
+void SoftBody3D::add_collision_exception_with(RequiredParam<Node> p_node) {
+	EXTRACT_PARAM_OR_FAIL(node, p_node);
+	CollisionObject3D *collision_object = Object::cast_to<CollisionObject3D>(node);
 	ERR_FAIL_NULL_MSG(collision_object, "Collision exception only works between two nodes that inherit from CollisionObject3D (such as Area3D or PhysicsBody3D).");
 	PhysicsServer3D::get_singleton()->soft_body_add_collision_exception(physics_rid, collision_object->get_rid());
 }
 
-void SoftBody3D::remove_collision_exception_with(RequiredParam<Node> rp_node) {
-	EXTRACT_PARAM_OR_FAIL(p_node, rp_node);
-	CollisionObject3D *collision_object = Object::cast_to<CollisionObject3D>(p_node);
+void SoftBody3D::remove_collision_exception_with(RequiredParam<Node> p_node) {
+	EXTRACT_PARAM_OR_FAIL(node, p_node);
+	CollisionObject3D *collision_object = Object::cast_to<CollisionObject3D>(node);
 	ERR_FAIL_NULL_MSG(collision_object, "Collision exception only works between two nodes that inherit from CollisionObject3D (such as Area3D or PhysicsBody3D).");
 	PhysicsServer3D::get_singleton()->soft_body_remove_collision_exception(physics_rid, collision_object->get_rid());
 }

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -178,8 +178,8 @@ public:
 	real_t get_drag_coefficient();
 
 	TypedArray<PhysicsBody3D> get_collision_exceptions();
-	void add_collision_exception_with(RequiredParam<Node> rp_node);
-	void remove_collision_exception_with(RequiredParam<Node> rp_node);
+	void add_collision_exception_with(RequiredParam<Node> p_node);
+	void remove_collision_exception_with(RequiredParam<Node> p_node);
 
 	Vector3 get_point_transform(int p_point_index);
 

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -97,17 +97,17 @@ void Tween::_stop_internal(bool p_reset) {
 	}
 }
 
-RequiredResult<PropertyTweener> Tween::tween_property(RequiredParam<const Object> rp_target, const NodePath &p_property, Variant p_to, double p_duration) {
-	EXTRACT_PARAM_OR_FAIL_V(p_target, rp_target, nullptr);
+RequiredResult<PropertyTweener> Tween::tween_property(RequiredParam<const Object> p_target, const NodePath &p_property, Variant p_to, double p_duration) {
+	EXTRACT_PARAM_OR_FAIL_V(target, p_target, nullptr);
 	CHECK_VALID();
 
 	Vector<StringName> property_subnames = p_property.get_as_property_path().get_subnames();
 #ifdef DEBUG_ENABLED
 	bool prop_valid;
-	const Variant &prop_value = p_target->get_indexed(property_subnames, &prop_valid);
-	ERR_FAIL_COND_V_MSG(!prop_valid, nullptr, vformat("The tweened property \"%s\" does not exist in object \"%s\".", p_property, p_target));
+	const Variant &prop_value = target->get_indexed(property_subnames, &prop_valid);
+	ERR_FAIL_COND_V_MSG(!prop_valid, nullptr, vformat("The tweened property \"%s\" does not exist in object \"%s\".", p_property, target));
 #else
-	const Variant &prop_value = p_target->get_indexed(property_subnames);
+	const Variant &prop_value = target->get_indexed(property_subnames);
 #endif
 
 	if (!Animation::validate_type_match(prop_value, p_to)) {
@@ -115,7 +115,7 @@ RequiredResult<PropertyTweener> Tween::tween_property(RequiredParam<const Object
 	}
 
 	Ref<PropertyTweener> tweener;
-	tweener.instantiate(p_target, property_subnames, p_to, p_duration);
+	tweener.instantiate(target, property_subnames, p_to, p_duration);
 	append(tweener);
 	return tweener;
 }
@@ -151,14 +151,14 @@ RequiredResult<MethodTweener> Tween::tween_method(const Callable &p_callback, co
 	return tweener;
 }
 
-RequiredResult<SubtweenTweener> Tween::tween_subtween(RequiredParam<Tween> rp_subtween) {
+RequiredResult<SubtweenTweener> Tween::tween_subtween(RequiredParam<Tween> p_subtween) {
 	CHECK_VALID();
 
 	// Ensure that the subtween being added is not null.
-	EXTRACT_PARAM_OR_FAIL_V(p_subtween, rp_subtween, nullptr);
+	EXTRACT_PARAM_OR_FAIL_V(subtween, p_subtween, nullptr);
 
 	Ref<SubtweenTweener> tweener;
-	tweener.instantiate(p_subtween);
+	tweener.instantiate(subtween);
 
 	// Remove the tween from its parent tree, if it has one.
 	// If the user created this tween without a parent tree attached,
@@ -166,7 +166,7 @@ RequiredResult<SubtweenTweener> Tween::tween_subtween(RequiredParam<Tween> rp_su
 	if (tweener->subtween->parent_tree != nullptr) {
 		tweener->subtween->parent_tree->remove_tween(tweener->subtween);
 	}
-	subtweens.push_back(p_subtween);
+	subtweens.push_back(subtween);
 	append(tweener);
 	return tweener;
 }
@@ -235,10 +235,10 @@ void Tween::clear() {
 	tweeners.clear();
 }
 
-RequiredResult<Tween> Tween::bind_node(RequiredParam<const Node> rp_node) {
-	EXTRACT_PARAM_OR_FAIL_V(p_node, rp_node, this);
+RequiredResult<Tween> Tween::bind_node(RequiredParam<const Node> p_node) {
+	EXTRACT_PARAM_OR_FAIL_V(node, p_node, this);
 
-	bound_node = p_node->get_instance_id();
+	bound_node = node->get_instance_id();
 	is_bound = true;
 	return this;
 }

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -145,11 +145,11 @@ protected:
 	virtual String _to_string() override;
 
 public:
-	RequiredResult<PropertyTweener> tween_property(RequiredParam<const Object> rp_target, const NodePath &p_property, Variant p_to, double p_duration);
+	RequiredResult<PropertyTweener> tween_property(RequiredParam<const Object> p_target, const NodePath &p_property, Variant p_to, double p_duration);
 	RequiredResult<IntervalTweener> tween_interval(double p_time);
 	RequiredResult<CallbackTweener> tween_callback(const Callable &p_callback);
 	RequiredResult<MethodTweener> tween_method(const Callable &p_callback, const Variant p_from, Variant p_to, double p_duration);
-	RequiredResult<SubtweenTweener> tween_subtween(RequiredParam<Tween> rp_subtween);
+	RequiredResult<SubtweenTweener> tween_subtween(RequiredParam<Tween> p_subtween);
 	RequiredResult<AwaitTweener> tween_await(const Signal &p_signal);
 	void append(Ref<Tweener> p_tweener);
 
@@ -164,7 +164,7 @@ public:
 	bool is_valid();
 	void clear();
 
-	RequiredResult<Tween> bind_node(RequiredParam<const Node> rp_node);
+	RequiredResult<Tween> bind_node(RequiredParam<const Node> p_node);
 	RequiredResult<Tween> set_process_mode(TweenProcessMode p_mode);
 	TweenProcessMode get_process_mode() const;
 	RequiredResult<Tween> set_pause_mode(TweenPauseMode p_mode);

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -108,17 +108,17 @@ void Container::_sort_children() {
 	layout_pending_finish();
 }
 
-void Container::fit_child_in_rect(RequiredParam<Control> rp_child, const Rect2 &p_rect) {
-	EXTRACT_PARAM_OR_FAIL(p_child, rp_child);
-	ERR_FAIL_COND(p_child->get_parent() != this);
+void Container::fit_child_in_rect(RequiredParam<Control> p_child, const Rect2 &p_rect) {
+	EXTRACT_PARAM_OR_FAIL(child, p_child);
+	ERR_FAIL_COND(child->get_parent() != this);
 
 	bool rtl = is_layout_rtl();
-	Size2 minsize = p_child->get_combined_minimum_size();
-	Size2 desired_size = p_child->get_bound_desired_size();
-	Size2 maxsize = p_child->get_combined_maximum_size();
+	Size2 minsize = child->get_combined_minimum_size();
+	Size2 desired_size = child->get_bound_desired_size();
+	Size2 maxsize = child->get_combined_maximum_size();
 	Rect2 r = p_rect;
-	BitField<SizeFlags> h_size_flags = p_child->get_h_size_flags();
-	BitField<SizeFlags> v_size_flags = p_child->get_v_size_flags();
+	BitField<SizeFlags> h_size_flags = child->get_h_size_flags();
+	BitField<SizeFlags> v_size_flags = child->get_v_size_flags();
 
 	if (!h_size_flags.has_flag(SIZE_FILL)) {
 		float final_width = minsize.width;
@@ -150,9 +150,9 @@ void Container::fit_child_in_rect(RequiredParam<Control> rp_child, const Rect2 &
 		}
 	}
 
-	p_child->set_rect(r);
-	p_child->set_rotation(0);
-	p_child->set_scale(Vector2(1, 1));
+	child->set_rect(r);
+	child->set_rotation(0);
+	child->set_scale(Vector2(1, 1));
 }
 
 void Container::queue_sort() {

--- a/scene/gui/container.h
+++ b/scene/gui/container.h
@@ -67,7 +67,7 @@ public:
 		NOTIFICATION_SORT_CHILDREN = 51,
 	};
 
-	void fit_child_in_rect(RequiredParam<Control> rp_child, const Rect2 &p_rect);
+	void fit_child_in_rect(RequiredParam<Control> p_child, const Rect2 &p_rect);
 
 	virtual Vector<int> get_allowed_size_flags_horizontal() const;
 	virtual Vector<int> get_allowed_size_flags_vertical() const;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -4036,41 +4036,41 @@ bool Control::has_theme_constant(const StringName &p_name, const StringName &p_t
 
 /// Local property overrides.
 
-void Control::add_theme_icon_override(const StringName &p_name, RequiredParam<Texture2D> rp_icon) {
+void Control::add_theme_icon_override(const StringName &p_name, RequiredParam<Texture2D> p_icon) {
 	ERR_MAIN_THREAD_GUARD;
-	EXTRACT_PARAM_OR_FAIL(p_icon, rp_icon);
+	EXTRACT_PARAM_OR_FAIL(icon, p_icon);
 
 	if (data.theme_icon_override.has(p_name)) {
 		data.theme_icon_override[p_name]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
 	}
 
-	data.theme_icon_override[p_name] = p_icon;
+	data.theme_icon_override[p_name] = icon;
 	data.theme_icon_override[p_name]->connect_changed(callable_mp(this, &Control::_notify_theme_override_changed), CONNECT_REFERENCE_COUNTED);
 	_notify_theme_override_changed();
 }
 
-void Control::add_theme_style_override(const StringName &p_name, RequiredParam<StyleBox> rp_style) {
+void Control::add_theme_style_override(const StringName &p_name, RequiredParam<StyleBox> p_style) {
 	ERR_MAIN_THREAD_GUARD;
-	EXTRACT_PARAM_OR_FAIL(p_style, rp_style);
+	EXTRACT_PARAM_OR_FAIL(style, p_style);
 
 	if (data.theme_style_override.has(p_name)) {
 		data.theme_style_override[p_name]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
 	}
 
-	data.theme_style_override[p_name] = p_style;
+	data.theme_style_override[p_name] = style;
 	data.theme_style_override[p_name]->connect_changed(callable_mp(this, &Control::_notify_theme_override_changed), CONNECT_REFERENCE_COUNTED);
 	_notify_theme_override_changed();
 }
 
-void Control::add_theme_font_override(const StringName &p_name, RequiredParam<Font> rp_font) {
+void Control::add_theme_font_override(const StringName &p_name, RequiredParam<Font> p_font) {
 	ERR_MAIN_THREAD_GUARD;
-	EXTRACT_PARAM_OR_FAIL(p_font, rp_font);
+	EXTRACT_PARAM_OR_FAIL(font, p_font);
 
 	if (data.theme_font_override.has(p_name)) {
 		data.theme_font_override[p_name]->disconnect_changed(callable_mp(this, &Control::_notify_theme_override_changed));
 	}
 
-	data.theme_font_override[p_name] = p_font;
+	data.theme_font_override[p_name] = font;
 	data.theme_font_override[p_name]->connect_changed(callable_mp(this, &Control::_notify_theme_override_changed), CONNECT_REFERENCE_COUNTED);
 	_notify_theme_override_changed();
 }

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -796,9 +796,9 @@ public:
 	void begin_bulk_theme_override();
 	void end_bulk_theme_override();
 
-	void add_theme_icon_override(const StringName &p_name, RequiredParam<Texture2D> rp_icon);
-	void add_theme_style_override(const StringName &p_name, RequiredParam<StyleBox> rp_style);
-	void add_theme_font_override(const StringName &p_name, RequiredParam<Font> rp_font);
+	void add_theme_icon_override(const StringName &p_name, RequiredParam<Texture2D> p_icon);
+	void add_theme_style_override(const StringName &p_name, RequiredParam<StyleBox> p_style);
+	void add_theme_font_override(const StringName &p_name, RequiredParam<Font> p_font);
 	void add_theme_font_size_override(const StringName &p_name, int p_font_size);
 	void add_theme_color_override(const StringName &p_name, const Color &p_color);
 	void add_theme_constant_override(const StringName &p_name, int p_constant);

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -973,51 +973,51 @@ void CanvasItem::draw_circle(const Point2 &p_pos, real_t p_radius, const Color &
 	draw_ellipse(p_pos, p_radius, p_radius, p_color, p_filled, p_width, p_antialiased);
 }
 
-void CanvasItem::draw_texture(RequiredParam<Texture2D> rp_texture, const Point2 &p_pos, const Color &p_modulate) {
+void CanvasItem::draw_texture(RequiredParam<Texture2D> p_texture, const Point2 &p_pos, const Color &p_modulate) {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
 
-	EXTRACT_PARAM_OR_FAIL(p_texture, rp_texture);
+	EXTRACT_PARAM_OR_FAIL(texture, p_texture);
 
-	p_texture->draw(canvas_item, p_pos, p_modulate, false);
+	texture->draw(canvas_item, p_pos, p_modulate, false);
 }
 
-void CanvasItem::draw_texture_rect(RequiredParam<Texture2D> rp_texture, const Rect2 &p_rect, bool p_tile, const Color &p_modulate, bool p_transpose) {
+void CanvasItem::draw_texture_rect(RequiredParam<Texture2D> p_texture, const Rect2 &p_rect, bool p_tile, const Color &p_modulate, bool p_transpose) {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
 
-	EXTRACT_PARAM_OR_FAIL(p_texture, rp_texture);
-	p_texture->draw_rect(canvas_item, p_rect, p_tile, p_modulate, p_transpose);
+	EXTRACT_PARAM_OR_FAIL(texture, p_texture);
+	texture->draw_rect(canvas_item, p_rect, p_tile, p_modulate, p_transpose);
 }
 
-void CanvasItem::draw_texture_rect_region(RequiredParam<Texture2D> rp_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate, bool p_transpose, bool p_clip_uv) {
+void CanvasItem::draw_texture_rect_region(RequiredParam<Texture2D> p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate, bool p_transpose, bool p_clip_uv) {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
-	EXTRACT_PARAM_OR_FAIL(p_texture, rp_texture);
-	p_texture->draw_rect_region(canvas_item, p_rect, p_src_rect, p_modulate, p_transpose, p_clip_uv);
+	EXTRACT_PARAM_OR_FAIL(texture, p_texture);
+	texture->draw_rect_region(canvas_item, p_rect, p_src_rect, p_modulate, p_transpose, p_clip_uv);
 }
 
-void CanvasItem::draw_msdf_texture_rect_region(RequiredParam<Texture2D> rp_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate, double p_outline, double p_pixel_range, double p_scale) {
+void CanvasItem::draw_msdf_texture_rect_region(RequiredParam<Texture2D> p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate, double p_outline, double p_pixel_range, double p_scale) {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
-	EXTRACT_PARAM_OR_FAIL(p_texture, rp_texture);
-	RenderingServer::get_singleton()->canvas_item_add_msdf_texture_rect_region(canvas_item, p_rect, p_texture->get_rid(), p_src_rect, p_modulate, p_outline, p_pixel_range, p_scale);
+	EXTRACT_PARAM_OR_FAIL(texture, p_texture);
+	RenderingServer::get_singleton()->canvas_item_add_msdf_texture_rect_region(canvas_item, p_rect, texture->get_rid(), p_src_rect, p_modulate, p_outline, p_pixel_range, p_scale);
 }
 
-void CanvasItem::draw_lcd_texture_rect_region(RequiredParam<Texture2D> rp_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate) {
+void CanvasItem::draw_lcd_texture_rect_region(RequiredParam<Texture2D> p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate) {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
-	EXTRACT_PARAM_OR_FAIL(p_texture, rp_texture);
-	RenderingServer::get_singleton()->canvas_item_add_lcd_texture_rect_region(canvas_item, p_rect, p_texture->get_rid(), p_src_rect, p_modulate);
+	EXTRACT_PARAM_OR_FAIL(texture, p_texture);
+	RenderingServer::get_singleton()->canvas_item_add_lcd_texture_rect_region(canvas_item, p_rect, texture->get_rid(), p_src_rect, p_modulate);
 }
 
-void CanvasItem::draw_style_box(RequiredParam<StyleBox> rp_style_box, const Rect2 &p_rect) {
+void CanvasItem::draw_style_box(RequiredParam<StyleBox> p_style_box, const Rect2 &p_rect) {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
 
-	EXTRACT_PARAM_OR_FAIL(p_style_box, rp_style_box);
+	EXTRACT_PARAM_OR_FAIL(style_box, p_style_box);
 
-	p_style_box->draw(canvas_item, p_rect);
+	style_box->draw(canvas_item, p_rect);
 }
 
 void CanvasItem::draw_primitive(const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs, Ref<Texture2D> p_texture) {
@@ -1084,69 +1084,69 @@ void CanvasItem::draw_colored_polygon(const Vector<Point2> &p_points, const Colo
 	draw_polygon(p_points, { p_color }, p_uvs, p_texture);
 }
 
-void CanvasItem::draw_mesh(RequiredParam<Mesh> rp_mesh, const Ref<Texture2D> &p_texture, const Transform2D &p_transform, const Color &p_modulate) {
+void CanvasItem::draw_mesh(RequiredParam<Mesh> p_mesh, const Ref<Texture2D> &p_texture, const Transform2D &p_transform, const Color &p_modulate) {
 	ERR_THREAD_GUARD;
-	EXTRACT_PARAM_OR_FAIL(p_mesh, rp_mesh);
+	EXTRACT_PARAM_OR_FAIL(mesh, p_mesh);
 	RID texture_rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
 
-	RenderingServer::get_singleton()->canvas_item_add_mesh(canvas_item, p_mesh->get_rid(), p_transform, p_modulate, texture_rid);
+	RenderingServer::get_singleton()->canvas_item_add_mesh(canvas_item, mesh->get_rid(), p_transform, p_modulate, texture_rid);
 }
 
-void CanvasItem::draw_multimesh(RequiredParam<MultiMesh> rp_multimesh, const Ref<Texture2D> &p_texture) {
+void CanvasItem::draw_multimesh(RequiredParam<MultiMesh> p_multimesh, const Ref<Texture2D> &p_texture) {
 	ERR_THREAD_GUARD;
-	EXTRACT_PARAM_OR_FAIL(p_multimesh, rp_multimesh);
+	EXTRACT_PARAM_OR_FAIL(multimesh, p_multimesh);
 	RID texture_rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
-	RenderingServer::get_singleton()->canvas_item_add_multimesh(canvas_item, p_multimesh->get_rid(), texture_rid);
+	RenderingServer::get_singleton()->canvas_item_add_multimesh(canvas_item, multimesh->get_rid(), texture_rid);
 }
 
-void CanvasItem::draw_string(RequiredParam<Font> rp_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment, float p_width, int p_font_size, const Color &p_modulate, BitField<TextServer::JustificationFlag> p_jst_flags, TextServer::Direction p_direction, TextServer::Orientation p_orientation, float p_oversampling) const {
+void CanvasItem::draw_string(RequiredParam<Font> p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment, float p_width, int p_font_size, const Color &p_modulate, BitField<TextServer::JustificationFlag> p_jst_flags, TextServer::Direction p_direction, TextServer::Orientation p_orientation, float p_oversampling) const {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
-	EXTRACT_PARAM_OR_FAIL(p_font, rp_font);
+	EXTRACT_PARAM_OR_FAIL(font, p_font);
 
-	p_font->draw_string(canvas_item, p_pos, p_text, p_alignment, p_width, p_font_size, p_modulate, p_jst_flags, p_direction, p_orientation, p_oversampling);
+	font->draw_string(canvas_item, p_pos, p_text, p_alignment, p_width, p_font_size, p_modulate, p_jst_flags, p_direction, p_orientation, p_oversampling);
 }
 
-void CanvasItem::draw_multiline_string(RequiredParam<Font> rp_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment, float p_width, int p_font_size, int p_max_lines, const Color &p_modulate, BitField<TextServer::LineBreakFlag> p_brk_flags, BitField<TextServer::JustificationFlag> p_jst_flags, TextServer::Direction p_direction, TextServer::Orientation p_orientation, float p_oversampling) const {
+void CanvasItem::draw_multiline_string(RequiredParam<Font> p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment, float p_width, int p_font_size, int p_max_lines, const Color &p_modulate, BitField<TextServer::LineBreakFlag> p_brk_flags, BitField<TextServer::JustificationFlag> p_jst_flags, TextServer::Direction p_direction, TextServer::Orientation p_orientation, float p_oversampling) const {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
-	EXTRACT_PARAM_OR_FAIL(p_font, rp_font);
+	EXTRACT_PARAM_OR_FAIL(font, p_font);
 
-	p_font->draw_multiline_string(canvas_item, p_pos, p_text, p_alignment, p_width, p_font_size, p_max_lines, p_modulate, p_brk_flags, p_jst_flags, p_direction, p_orientation, p_oversampling);
+	font->draw_multiline_string(canvas_item, p_pos, p_text, p_alignment, p_width, p_font_size, p_max_lines, p_modulate, p_brk_flags, p_jst_flags, p_direction, p_orientation, p_oversampling);
 }
 
-void CanvasItem::draw_string_outline(RequiredParam<Font> rp_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment, float p_width, int p_font_size, int p_size, const Color &p_modulate, BitField<TextServer::JustificationFlag> p_jst_flags, TextServer::Direction p_direction, TextServer::Orientation p_orientation, float p_oversampling) const {
+void CanvasItem::draw_string_outline(RequiredParam<Font> p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment, float p_width, int p_font_size, int p_size, const Color &p_modulate, BitField<TextServer::JustificationFlag> p_jst_flags, TextServer::Direction p_direction, TextServer::Orientation p_orientation, float p_oversampling) const {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
-	EXTRACT_PARAM_OR_FAIL(p_font, rp_font);
+	EXTRACT_PARAM_OR_FAIL(font, p_font);
 
-	p_font->draw_string_outline(canvas_item, p_pos, p_text, p_alignment, p_width, p_font_size, p_size, p_modulate, p_jst_flags, p_direction, p_orientation, p_oversampling);
+	font->draw_string_outline(canvas_item, p_pos, p_text, p_alignment, p_width, p_font_size, p_size, p_modulate, p_jst_flags, p_direction, p_orientation, p_oversampling);
 }
 
-void CanvasItem::draw_multiline_string_outline(RequiredParam<Font> rp_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment, float p_width, int p_font_size, int p_max_lines, int p_size, const Color &p_modulate, BitField<TextServer::LineBreakFlag> p_brk_flags, BitField<TextServer::JustificationFlag> p_jst_flags, TextServer::Direction p_direction, TextServer::Orientation p_orientation, float p_oversampling) const {
+void CanvasItem::draw_multiline_string_outline(RequiredParam<Font> p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment, float p_width, int p_font_size, int p_max_lines, int p_size, const Color &p_modulate, BitField<TextServer::LineBreakFlag> p_brk_flags, BitField<TextServer::JustificationFlag> p_jst_flags, TextServer::Direction p_direction, TextServer::Orientation p_orientation, float p_oversampling) const {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
-	EXTRACT_PARAM_OR_FAIL(p_font, rp_font);
+	EXTRACT_PARAM_OR_FAIL(font, p_font);
 
-	p_font->draw_multiline_string_outline(canvas_item, p_pos, p_text, p_alignment, p_width, p_font_size, p_max_lines, p_size, p_modulate, p_brk_flags, p_jst_flags, p_direction, p_orientation, p_oversampling);
+	font->draw_multiline_string_outline(canvas_item, p_pos, p_text, p_alignment, p_width, p_font_size, p_max_lines, p_size, p_modulate, p_brk_flags, p_jst_flags, p_direction, p_orientation, p_oversampling);
 }
 
-void CanvasItem::draw_char(RequiredParam<Font> rp_font, const Point2 &p_pos, const String &p_char, int p_font_size, const Color &p_modulate, float p_oversampling) const {
+void CanvasItem::draw_char(RequiredParam<Font> p_font, const Point2 &p_pos, const String &p_char, int p_font_size, const Color &p_modulate, float p_oversampling) const {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
 	ERR_FAIL_COND(p_char.length() != 1);
-	EXTRACT_PARAM_OR_FAIL(p_font, rp_font);
+	EXTRACT_PARAM_OR_FAIL(font, p_font);
 
-	p_font->draw_char(canvas_item, p_pos, p_char[0], p_font_size, p_modulate, p_oversampling);
+	font->draw_char(canvas_item, p_pos, p_char[0], p_font_size, p_modulate, p_oversampling);
 }
 
-void CanvasItem::draw_char_outline(RequiredParam<Font> rp_font, const Point2 &p_pos, const String &p_char, int p_font_size, int p_size, const Color &p_modulate, float p_oversampling) const {
+void CanvasItem::draw_char_outline(RequiredParam<Font> p_font, const Point2 &p_pos, const String &p_char, int p_font_size, int p_size, const Color &p_modulate, float p_oversampling) const {
 	ERR_THREAD_GUARD;
 	ERR_DRAW_GUARD;
 	ERR_FAIL_COND(p_char.length() != 1);
-	EXTRACT_PARAM_OR_FAIL(p_font, rp_font);
+	EXTRACT_PARAM_OR_FAIL(font, p_font);
 
-	p_font->draw_char_outline(canvas_item, p_pos, p_char[0], p_font_size, p_size, p_modulate, p_oversampling);
+	font->draw_char_outline(canvas_item, p_pos, p_char[0], p_font_size, p_size, p_modulate, p_oversampling);
 }
 
 void CanvasItem::_notify_transform_deferred() {
@@ -1348,12 +1348,12 @@ Vector2 CanvasItem::make_canvas_position_local(const Vector2 &screen_point) cons
 	return local_matrix.xform(screen_point);
 }
 
-RequiredResult<InputEvent> CanvasItem::make_input_local(RequiredParam<InputEvent> rp_event) const {
+RequiredResult<InputEvent> CanvasItem::make_input_local(RequiredParam<InputEvent> p_event) const {
 	ERR_READ_THREAD_GUARD_V(Ref<InputEvent>());
-	EXTRACT_PARAM_OR_FAIL_V(p_event, rp_event, Ref<InputEvent>());
-	ERR_FAIL_COND_V(!is_inside_tree(), p_event);
+	EXTRACT_PARAM_OR_FAIL_V(event, p_event, Ref<InputEvent>());
+	ERR_FAIL_COND_V(!is_inside_tree(), event);
 
-	return p_event->xformed_by((get_canvas_transform() * get_global_transform()).affine_inverse());
+	return event->xformed_by((get_canvas_transform() * get_global_transform()).affine_inverse());
 }
 
 Vector2 CanvasItem::get_global_mouse_position() const {

--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -341,27 +341,27 @@ public:
 	void draw_rect(const Rect2 &p_rect, const Color &p_color, bool p_filled = true, real_t p_width = -1.0, bool p_antialiased = false);
 	void draw_ellipse(const Point2 &p_pos, real_t p_major, real_t p_minor, const Color &p_color, bool p_filled = true, real_t p_width = -1.0, bool p_antialiased = false);
 	void draw_circle(const Point2 &p_pos, real_t p_radius, const Color &p_color, bool p_filled = true, real_t p_width = -1.0, bool p_antialiased = false);
-	void draw_texture(RequiredParam<Texture2D> rp_texture, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1, 1));
-	void draw_texture_rect(RequiredParam<Texture2D> rp_texture, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false);
-	void draw_texture_rect_region(RequiredParam<Texture2D> rp_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = false);
-	void draw_msdf_texture_rect_region(RequiredParam<Texture2D> rp_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), double p_outline = 0.0, double p_pixel_range = 4.0, double p_scale = 1.0);
-	void draw_lcd_texture_rect_region(RequiredParam<Texture2D> rp_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1));
-	void draw_style_box(RequiredParam<StyleBox> rp_style_box, const Rect2 &p_rect);
+	void draw_texture(RequiredParam<Texture2D> p_texture, const Point2 &p_pos, const Color &p_modulate = Color(1, 1, 1, 1));
+	void draw_texture_rect(RequiredParam<Texture2D> p_texture, const Rect2 &p_rect, bool p_tile = false, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false);
+	void draw_texture_rect_region(RequiredParam<Texture2D> p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), bool p_transpose = false, bool p_clip_uv = false);
+	void draw_msdf_texture_rect_region(RequiredParam<Texture2D> p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1), double p_outline = 0.0, double p_pixel_range = 4.0, double p_scale = 1.0);
+	void draw_lcd_texture_rect_region(RequiredParam<Texture2D> p_texture, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate = Color(1, 1, 1));
+	void draw_style_box(RequiredParam<StyleBox> p_style_box, const Rect2 &p_rect);
 	void draw_primitive(const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs, Ref<Texture2D> p_texture = Ref<Texture2D>());
 	void draw_polygon(const Vector<Point2> &p_points, const Vector<Color> &p_colors, const Vector<Point2> &p_uvs = Vector<Point2>(), Ref<Texture2D> p_texture = Ref<Texture2D>());
 	void draw_colored_polygon(const Vector<Point2> &p_points, const Color &p_color, const Vector<Point2> &p_uvs = Vector<Point2>(), Ref<Texture2D> p_texture = Ref<Texture2D>());
 
-	void draw_mesh(RequiredParam<Mesh> rp_mesh, const Ref<Texture2D> &p_texture, const Transform2D &p_transform = Transform2D(), const Color &p_modulate = Color(1, 1, 1));
-	void draw_multimesh(RequiredParam<MultiMesh> rp_multimesh, const Ref<Texture2D> &p_texture);
+	void draw_mesh(RequiredParam<Mesh> p_mesh, const Ref<Texture2D> &p_texture, const Transform2D &p_transform = Transform2D(), const Color &p_modulate = Color(1, 1, 1));
+	void draw_multimesh(RequiredParam<MultiMesh> p_multimesh, const Ref<Texture2D> &p_texture);
 
-	void draw_string(RequiredParam<Font> rp_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_font_size = DEFAULT_FONT_SIZE, const Color &p_modulate = Color(1.0, 1.0, 1.0), BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL, float p_oversampling = 0.0) const;
-	void draw_multiline_string(RequiredParam<Font> rp_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_font_size = DEFAULT_FONT_SIZE, int p_max_lines = -1, const Color &p_modulate = Color(1.0, 1.0, 1.0), BitField<TextServer::LineBreakFlag> p_brk_flags = TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND, BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL, float p_oversampling = 0.0) const;
+	void draw_string(RequiredParam<Font> p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_font_size = DEFAULT_FONT_SIZE, const Color &p_modulate = Color(1.0, 1.0, 1.0), BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL, float p_oversampling = 0.0) const;
+	void draw_multiline_string(RequiredParam<Font> p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_font_size = DEFAULT_FONT_SIZE, int p_max_lines = -1, const Color &p_modulate = Color(1.0, 1.0, 1.0), BitField<TextServer::LineBreakFlag> p_brk_flags = TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND, BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL, float p_oversampling = 0.0) const;
 
-	void draw_string_outline(RequiredParam<Font> rp_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_font_size = DEFAULT_FONT_SIZE, int p_size = 1, const Color &p_modulate = Color(1.0, 1.0, 1.0), BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL, float p_oversampling = 0.0) const;
-	void draw_multiline_string_outline(RequiredParam<Font> rp_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_font_size = DEFAULT_FONT_SIZE, int p_max_lines = -1, int p_size = 1, const Color &p_modulate = Color(1.0, 1.0, 1.0), BitField<TextServer::LineBreakFlag> p_brk_flags = TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND, BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL, float p_oversampling = 0.0) const;
+	void draw_string_outline(RequiredParam<Font> p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_font_size = DEFAULT_FONT_SIZE, int p_size = 1, const Color &p_modulate = Color(1.0, 1.0, 1.0), BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL, float p_oversampling = 0.0) const;
+	void draw_multiline_string_outline(RequiredParam<Font> p_font, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_font_size = DEFAULT_FONT_SIZE, int p_max_lines = -1, int p_size = 1, const Color &p_modulate = Color(1.0, 1.0, 1.0), BitField<TextServer::LineBreakFlag> p_brk_flags = TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND, BitField<TextServer::JustificationFlag> p_jst_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND, TextServer::Direction p_direction = TextServer::DIRECTION_AUTO, TextServer::Orientation p_orientation = TextServer::ORIENTATION_HORIZONTAL, float p_oversampling = 0.0) const;
 
-	void draw_char(RequiredParam<Font> rp_font, const Point2 &p_pos, const String &p_char, int p_font_size = DEFAULT_FONT_SIZE, const Color &p_modulate = Color(1.0, 1.0, 1.0), float p_oversampling = 0.0) const;
-	void draw_char_outline(RequiredParam<Font> rp_font, const Point2 &p_pos, const String &p_char, int p_font_size = DEFAULT_FONT_SIZE, int p_size = 1, const Color &p_modulate = Color(1.0, 1.0, 1.0), float p_oversampling = 0.0) const;
+	void draw_char(RequiredParam<Font> p_font, const Point2 &p_pos, const String &p_char, int p_font_size = DEFAULT_FONT_SIZE, const Color &p_modulate = Color(1.0, 1.0, 1.0), float p_oversampling = 0.0) const;
+	void draw_char_outline(RequiredParam<Font> p_font, const Point2 &p_pos, const String &p_char, int p_font_size = DEFAULT_FONT_SIZE, int p_size = 1, const Color &p_modulate = Color(1.0, 1.0, 1.0), float p_oversampling = 0.0) const;
 
 	void draw_set_transform(const Point2 &p_offset, real_t p_rot = 0.0, const Size2 &p_scale = Size2(1.0, 1.0));
 	void draw_set_transform_matrix(const Transform2D &p_matrix);
@@ -412,7 +412,7 @@ public:
 	virtual void set_use_parent_material(bool p_use_parent_material);
 	bool get_use_parent_material() const;
 
-	RequiredResult<InputEvent> make_input_local(RequiredParam<InputEvent> rp_event) const;
+	RequiredResult<InputEvent> make_input_local(RequiredParam<InputEvent> p_event) const;
 	Vector2 make_canvas_position_local(const Vector2 &screen_point) const;
 
 	Vector2 get_global_mouse_position() const;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -500,31 +500,31 @@ void Node::_propagate_physics_interpolation_reset_requested(bool p_requested) {
 	data.blocked--;
 }
 
-void Node::move_child(RequiredParam<Node> rp_child, int p_index) {
+void Node::move_child(RequiredParam<Node> p_child, int p_index) {
 	ERR_FAIL_COND_MSG(data.tree && !Thread::is_main_thread(), "Moving child node positions inside the SceneTree is only allowed from the main thread. Use call_deferred(\"move_child\",child,index).");
-	EXTRACT_PARAM_OR_FAIL(p_child, rp_child);
-	ERR_FAIL_COND_MSG(p_child->data.parent != this, "Child is not a child of this node.");
+	EXTRACT_PARAM_OR_FAIL(child, p_child);
+	ERR_FAIL_COND_MSG(child->data.parent != this, "Child is not a child of this node.");
 
 	_update_children_cache();
 	// We need to check whether node is internal and move it only in the relevant node range.
-	if (p_child->data.internal_mode == INTERNAL_MODE_FRONT) {
+	if (child->data.internal_mode == INTERNAL_MODE_FRONT) {
 		if (p_index < 0) {
 			p_index += data.internal_children_front_count_cache;
 		}
 		ERR_FAIL_INDEX_MSG(p_index, data.internal_children_front_count_cache, vformat("Invalid new child index: %d. Child is internal.", p_index));
-		_move_child(p_child, p_index);
-	} else if (p_child->data.internal_mode == INTERNAL_MODE_BACK) {
+		_move_child(child, p_index);
+	} else if (child->data.internal_mode == INTERNAL_MODE_BACK) {
 		if (p_index < 0) {
 			p_index += data.internal_children_back_count_cache;
 		}
 		ERR_FAIL_INDEX_MSG(p_index, data.internal_children_back_count_cache, vformat("Invalid new child index: %d. Child is internal.", p_index));
-		_move_child(p_child, (int)data.children_cache.size() - data.internal_children_back_count_cache + p_index);
+		_move_child(child, (int)data.children_cache.size() - data.internal_children_back_count_cache + p_index);
 	} else {
 		if (p_index < 0) {
 			p_index += get_child_count(false);
 		}
 		ERR_FAIL_INDEX_MSG(p_index, (int)data.children_cache.size() + 1 - data.internal_children_front_count_cache - data.internal_children_back_count_cache, vformat("Invalid new child index: %d.", p_index));
-		_move_child(p_child, p_index + data.internal_children_front_count_cache);
+		_move_child(child, p_index + data.internal_children_front_count_cache);
 	}
 }
 
@@ -1708,47 +1708,47 @@ void Node::_add_child_nocheck(Node *p_child, const StringName &p_name, InternalM
 	emit_signal(SNAME("child_order_changed"));
 }
 
-void Node::add_child(RequiredParam<Node> rp_child, bool p_force_readable_name, InternalMode p_internal) {
+void Node::add_child(RequiredParam<Node> p_child, bool p_force_readable_name, InternalMode p_internal) {
 	ERR_FAIL_COND_MSG(data.tree && !Thread::is_main_thread(), "Adding children to a node inside the SceneTree is only allowed from the main thread. Use call_deferred(\"add_child\",node).");
 
 	ERR_THREAD_GUARD
-	EXTRACT_PARAM_OR_FAIL(p_child, rp_child);
-	ERR_FAIL_COND_MSG(p_child == this, vformat("Can't add child '%s' to itself.", p_child->get_name())); // adding to itself!
-	ERR_FAIL_COND_MSG(p_child->data.parent, vformat("Can't add child '%s' to '%s', already has a parent '%s'.", p_child->get_name(), get_name(), p_child->data.parent->get_name())); //Fail if node has a parent
+	EXTRACT_PARAM_OR_FAIL(child, p_child);
+	ERR_FAIL_COND_MSG(child == this, vformat("Can't add child '%s' to itself.", child->get_name())); // adding to itself!
+	ERR_FAIL_COND_MSG(child->data.parent, vformat("Can't add child '%s' to '%s', already has a parent '%s'.", child->get_name(), get_name(), child->data.parent->get_name())); //Fail if node has a parent
 #ifdef DEBUG_ENABLED
-	ERR_FAIL_COND_MSG(p_child->is_ancestor_of(this), vformat("Can't add child '%s' to '%s' as it would result in a cyclic dependency since '%s' is already a parent of '%s'.", p_child->get_name(), get_name(), p_child->get_name(), get_name()));
+	ERR_FAIL_COND_MSG(child->is_ancestor_of(this), vformat("Can't add child '%s' to '%s' as it would result in a cyclic dependency since '%s' is already a parent of '%s'.", child->get_name(), get_name(), child->get_name(), get_name()));
 #endif
 	ERR_FAIL_COND_MSG(data.blocked > 0, "Parent node is busy setting up children, `add_child()` failed. Consider using `add_child.call_deferred(child)` instead.");
 
-	_validate_child_name(p_child, p_force_readable_name);
+	_validate_child_name(child, p_force_readable_name);
 
 #ifdef DEBUG_ENABLED
-	if (p_child->data.owner && !p_child->data.owner->is_ancestor_of(p_child)) {
+	if (child->data.owner && !child->data.owner->is_ancestor_of(child)) {
 		// Owner of p_child should be ancestor of p_child.
-		WARN_PRINT(vformat("Adding '%s' as child to '%s' will make owner '%s' inconsistent. Consider unsetting the owner beforehand.", p_child->get_name(), get_name(), p_child->data.owner->get_name()));
+		WARN_PRINT(vformat("Adding '%s' as child to '%s' will make owner '%s' inconsistent. Consider unsetting the owner beforehand.", child->get_name(), get_name(), child->data.owner->get_name()));
 	}
 #endif // DEBUG_ENABLED
 
-	_add_child_nocheck(p_child, p_child->data.name, p_internal);
+	_add_child_nocheck(child, child->data.name, p_internal);
 }
 
-void Node::add_sibling(RequiredParam<Node> rp_sibling, bool p_force_readable_name) {
+void Node::add_sibling(RequiredParam<Node> p_sibling, bool p_force_readable_name) {
 	ERR_FAIL_COND_MSG(data.tree && !Thread::is_main_thread(), "Adding a sibling to a node inside the SceneTree is only allowed from the main thread. Use call_deferred(\"add_sibling\",node).");
-	EXTRACT_PARAM_OR_FAIL(p_sibling, rp_sibling);
-	ERR_FAIL_COND_MSG(p_sibling == this, vformat("Can't add sibling '%s' to itself.", p_sibling->get_name())); // adding to itself!
+	EXTRACT_PARAM_OR_FAIL(sibling, p_sibling);
+	ERR_FAIL_COND_MSG(sibling == this, vformat("Can't add sibling '%s' to itself.", sibling->get_name())); // adding to itself!
 	ERR_FAIL_NULL(data.parent);
 	ERR_FAIL_COND_MSG(data.parent->data.blocked > 0, "Parent node is busy setting up children, `add_sibling()` failed. Consider using `add_sibling.call_deferred(sibling)` instead.");
 
-	data.parent->add_child(p_sibling, p_force_readable_name, data.internal_mode);
+	data.parent->add_child(sibling, p_force_readable_name, data.internal_mode);
 	data.parent->_update_children_cache();
-	data.parent->_move_child(p_sibling, get_index() + 1);
+	data.parent->_move_child(sibling, get_index() + 1);
 }
 
-void Node::remove_child(RequiredParam<Node> rp_child) {
+void Node::remove_child(RequiredParam<Node> p_child) {
 	ERR_FAIL_COND_MSG(data.tree && !Thread::is_main_thread(), "Removing children from a node inside the SceneTree is only allowed from the main thread. Use call_deferred(\"remove_child\",node).");
-	EXTRACT_PARAM_OR_FAIL(p_child, rp_child);
+	EXTRACT_PARAM_OR_FAIL(child, p_child);
 	ERR_FAIL_COND_MSG(data.blocked > 0, "Parent node is busy adding/removing children, `remove_child()` can't be called at this time. Consider using `remove_child.call_deferred(child)` instead.");
-	ERR_FAIL_COND(p_child->data.parent != this);
+	ERR_FAIL_COND(child->data.parent != this);
 
 	/**
 	 *  Do not change the data.internal_children*cache counters here.
@@ -1761,19 +1761,19 @@ void Node::remove_child(RequiredParam<Node> rp_child) {
 	 */
 
 	data.blocked++;
-	p_child->_set_tree(nullptr);
+	child->_set_tree(nullptr);
 
-	remove_child_notify(p_child);
-	p_child->notification(NOTIFICATION_UNPARENTED);
+	remove_child_notify(child);
+	child->notification(NOTIFICATION_UNPARENTED);
 
 	data.blocked--;
 
-	if (!data.children_cache_dirty && !data.children_cache.is_empty() && data.children_cache[data.children_cache.size() - 1] == p_child) {
+	if (!data.children_cache_dirty && !data.children_cache.is_empty() && data.children_cache[data.children_cache.size() - 1] == child) {
 		// Removing the last child keeps the cache and the counters valid, so pop it
 		// instead of dirtying the cache. This keeps interleaving removals with reads
 		// (like get_child()) linear, as long as children are removed back to front.
 		data.children_cache.resize(data.children_cache.size() - 1);
-		switch (p_child->data.internal_mode) {
+		switch (child->data.internal_mode) {
 			case INTERNAL_MODE_DISABLED: {
 				data.external_children_count_cache--;
 			} break;
@@ -1787,17 +1787,17 @@ void Node::remove_child(RequiredParam<Node> rp_child) {
 	} else {
 		data.children_cache_dirty = true;
 	}
-	bool success = data.children.erase(p_child->data.name);
+	bool success = data.children.erase(child->data.name);
 	ERR_FAIL_COND_MSG(!success, "Children name does not match parent name in hashtable, this is a bug.");
 
-	p_child->data.parent = nullptr;
-	p_child->data.index = -1;
+	child->data.parent = nullptr;
+	child->data.index = -1;
 
 	notification(NOTIFICATION_CHILD_ORDER_CHANGED);
 	emit_signal(SNAME("child_order_changed"));
 
 	if (data.tree) {
-		p_child->_propagate_after_exit_tree();
+		child->_propagate_after_exit_tree();
 	}
 }
 
@@ -2069,17 +2069,17 @@ TypedArray<Node> Node::find_children(const String &p_pattern, const String &p_ty
 	return ret;
 }
 
-void Node::reparent(RequiredParam<Node> rp_parent, bool p_keep_global_transform) {
+void Node::reparent(RequiredParam<Node> p_parent, bool p_keep_global_transform) {
 	ERR_THREAD_GUARD
-	EXTRACT_PARAM_OR_FAIL(p_parent, rp_parent);
+	EXTRACT_PARAM_OR_FAIL(parent, p_parent);
 	ERR_FAIL_NULL_MSG(data.parent, "Node needs a parent to be reparented.");
-	ERR_FAIL_COND_MSG(p_parent == this, vformat("Can't reparent '%s' to itself.", p_parent->get_name()));
+	ERR_FAIL_COND_MSG(parent == this, vformat("Can't reparent '%s' to itself.", parent->get_name()));
 
-	if (p_parent == data.parent) {
+	if (parent == data.parent) {
 		return;
 	}
 
-	bool preserve_owner = data.owner && (data.owner == p_parent || data.owner->is_ancestor_of(p_parent));
+	bool preserve_owner = data.owner && (data.owner == parent || data.owner->is_ancestor_of(parent));
 	Node *owner_temp = data.owner;
 	LocalVector<Node *> common_parents;
 
@@ -2105,7 +2105,7 @@ void Node::reparent(RequiredParam<Node> rp_parent, bool p_keep_global_transform)
 	}
 
 	data.parent->remove_child(this);
-	p_parent->add_child(this);
+	parent->add_child(this);
 
 	// Reassign the old owner to those found nodes.
 	if (preserve_owner) {
@@ -2166,12 +2166,12 @@ Window *Node::get_last_exclusive_window() const {
 	return w;
 }
 
-bool Node::is_ancestor_of(RequiredParam<const Node> rp_node) const {
-	EXTRACT_PARAM_OR_FAIL_V(p_node, rp_node, false);
+bool Node::is_ancestor_of(RequiredParam<const Node> p_node) const {
+	EXTRACT_PARAM_OR_FAIL_V(node, p_node, false);
 
-	const Node *n = p_node;
+	const Node *n = node;
 
-	if (is_inside_tree() && p_node->data.tree == data.tree) {
+	if (is_inside_tree() && node->data.tree == data.tree) {
 		const int depth = data.depth;
 		while (n->data.depth > depth) {
 			n = n->data.parent;
@@ -2179,7 +2179,7 @@ bool Node::is_ancestor_of(RequiredParam<const Node> rp_node) const {
 		return n == this;
 	}
 
-	n = p_node->data.parent;
+	n = node->data.parent;
 	while (n) {
 		if (n == this) {
 			return true;
@@ -2190,24 +2190,24 @@ bool Node::is_ancestor_of(RequiredParam<const Node> rp_node) const {
 	return false;
 }
 
-bool Node::is_greater_than(RequiredParam<const Node> rp_node) const {
+bool Node::is_greater_than(RequiredParam<const Node> p_node) const {
 	// parent->get_child(1) > parent->get_child(0) > parent
 
-	EXTRACT_PARAM_OR_FAIL_V(p_node, rp_node, false);
+	EXTRACT_PARAM_OR_FAIL_V(node, p_node, false);
 	ERR_FAIL_COND_V(!data.tree, false);
-	ERR_FAIL_COND_V(p_node->data.tree != data.tree, false);
+	ERR_FAIL_COND_V(node->data.tree != data.tree, false);
 
 	ERR_FAIL_COND_V(data.depth < 0, false);
-	ERR_FAIL_COND_V(p_node->data.depth < 0, false);
+	ERR_FAIL_COND_V(node->data.depth < 0, false);
 
 	_update_children_cache();
 
-	bool this_is_deeper = this->data.depth > p_node->data.depth;
+	bool this_is_deeper = this->data.depth > node->data.depth;
 
 	const Node *deep = this;
-	const Node *shallow = p_node;
+	const Node *shallow = node;
 	if (!this_is_deeper) {
-		deep = p_node;
+		deep = node;
 		shallow = this;
 	}
 
@@ -2367,10 +2367,10 @@ Node *Node::find_common_parent_with(const Node *p_node) const {
 	return const_cast<Node *>(common_parent);
 }
 
-NodePath Node::get_path_to(RequiredParam<const Node> rp_node, bool p_use_unique_path) const {
-	EXTRACT_PARAM_OR_FAIL_V(p_node, rp_node, NodePath());
+NodePath Node::get_path_to(RequiredParam<const Node> p_node, bool p_use_unique_path) const {
+	EXTRACT_PARAM_OR_FAIL_V(node, p_node, NodePath());
 
-	if (this == p_node) {
+	if (this == node) {
 		return NodePath(".");
 	}
 
@@ -2383,7 +2383,7 @@ NodePath Node::get_path_to(RequiredParam<const Node> rp_node, bool p_use_unique_
 		n = n->data.parent;
 	}
 
-	const Node *common_parent = p_node;
+	const Node *common_parent = node;
 
 	while (common_parent) {
 		if (visited.has(common_parent)) {
@@ -2392,7 +2392,7 @@ NodePath Node::get_path_to(RequiredParam<const Node> rp_node, bool p_use_unique_
 		common_parent = common_parent->data.parent;
 	}
 
-	ERR_FAIL_NULL_V_MSG(common_parent, NodePath(), vformat("No path can be resolved between the nodes %s and %s as they share no common ancestor.", get_description(true), p_node->get_description(true)));
+	ERR_FAIL_NULL_V_MSG(common_parent, NodePath(), vformat("No path can be resolved between the nodes %s and %s as they share no common ancestor.", get_description(true), node->get_description(true)));
 
 	visited.clear();
 
@@ -2400,7 +2400,7 @@ NodePath Node::get_path_to(RequiredParam<const Node> rp_node, bool p_use_unique_
 	StringName up = String("..");
 
 	if (p_use_unique_path) {
-		n = p_node;
+		n = node;
 
 		bool is_detected = false;
 		while (n != common_parent) {
@@ -2436,7 +2436,7 @@ NodePath Node::get_path_to(RequiredParam<const Node> rp_node, bool p_use_unique_
 			}
 		}
 	} else {
-		n = p_node;
+		n = node;
 
 		while (n != common_parent) {
 			path.push_back(n->get_name());
@@ -2683,20 +2683,20 @@ String Node::get_editor_description() const {
 	return data.editor_description;
 }
 
-void Node::set_editable_instance(RequiredParam<Node> rp_node, bool p_editable) {
+void Node::set_editable_instance(RequiredParam<Node> p_node, bool p_editable) {
 	ERR_THREAD_GUARD
-	EXTRACT_PARAM_OR_FAIL(p_node, rp_node);
-	ERR_FAIL_COND(!is_ancestor_of(p_node));
+	EXTRACT_PARAM_OR_FAIL(node, p_node);
+	ERR_FAIL_COND(!is_ancestor_of(node));
 	if (!p_editable) {
-		p_node->data.editable_instance = false;
+		node->data.editable_instance = false;
 		// Avoid this flag being needlessly saved;
 		// also give more visual feedback if editable children are re-enabled
 		set_display_folded(false);
 	} else {
-		p_node->data.editable_instance = true;
+		node->data.editable_instance = true;
 	}
 
-	p_node->_emit_editor_state_changed();
+	node->_emit_editor_state_changed();
 }
 
 bool Node::is_editable_instance(const Node *p_node) const {
@@ -3230,25 +3230,25 @@ static void find_owned_by(Node *p_by, Node *p_node, List<Node *> *p_owned) {
 	}
 }
 
-void Node::replace_by(RequiredParam<Node> rp_node, bool p_keep_groups) {
+void Node::replace_by(RequiredParam<Node> p_node, bool p_keep_groups) {
 	ERR_THREAD_GUARD
-	EXTRACT_PARAM_OR_FAIL(p_node, rp_node);
-	ERR_FAIL_COND(p_node->data.parent);
+	EXTRACT_PARAM_OR_FAIL(node, p_node);
+	ERR_FAIL_COND(node->data.parent);
 
 	List<Node *> owned(data.owned);
 	List<Node *> owned_by_owner;
-	Node *owner = (data.owner == this) ? p_node : data.owner;
+	Node *owner = (data.owner == this) ? node : data.owner;
 
 	if (p_keep_groups) {
 		List<GroupInfo> groups;
 		get_groups(&groups);
 
 		for (const GroupInfo &E : groups) {
-			p_node->add_to_group(E.name, E.persistent);
+			node->add_to_group(E.name, E.persistent);
 		}
 	}
 
-	_replace_connections_target(p_node);
+	_replace_connections_target(node);
 
 	if (data.owner) {
 		for (int i = 0; i < get_child_count(); i++) {
@@ -3263,26 +3263,26 @@ void Node::replace_by(RequiredParam<Node> rp_node, bool p_keep_groups) {
 
 	if (data.parent) {
 		parent->remove_child(this);
-		parent->add_child(p_node);
-		parent->move_child(p_node, index_in_parent);
+		parent->add_child(node);
+		parent->move_child(node, index_in_parent);
 	}
 
-	emit_signal(SNAME("replacing_by"), p_node);
+	emit_signal(SNAME("replacing_by"), node);
 
 	// Move non-internal children to `p_node`.
 	while (get_child_count(false)) {
 		Node *child = get_child(0, false);
 		remove_child(child);
-		Node *child_owner = child->get_owner() == this ? p_node : child->get_owner();
+		Node *child_owner = child->get_owner() == this ? node : child->get_owner();
 		child->set_owner(nullptr);
-		p_node->add_child(child);
+		node->add_child(child);
 		child->set_owner(child_owner);
 	}
 
-	p_node->set_owner(owner);
+	node->set_owner(owner);
 	for (Node *E : owned) {
-		if (E->data.owner != p_node) {
-			E->set_owner(p_node);
+		if (E->data.owner != node) {
+			E->set_owner(node);
 		}
 	}
 
@@ -3292,7 +3292,7 @@ void Node::replace_by(RequiredParam<Node> rp_node, bool p_keep_groups) {
 		}
 	}
 
-	p_node->set_scene_file_path(get_scene_file_path());
+	node->set_scene_file_path(get_scene_file_path());
 }
 
 void Node::_replace_connections_target(Node *p_new_target) {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -525,9 +525,9 @@ public:
 
 	InternalMode get_internal_mode() const;
 
-	void add_child(RequiredParam<Node> rp_child, bool p_force_readable_name = false, InternalMode p_internal = INTERNAL_MODE_DISABLED);
-	void add_sibling(RequiredParam<Node> rp_sibling, bool p_force_readable_name = false);
-	void remove_child(RequiredParam<Node> rp_child);
+	void add_child(RequiredParam<Node> p_child, bool p_force_readable_name = false, InternalMode p_internal = INTERNAL_MODE_DISABLED);
+	void add_sibling(RequiredParam<Node> p_sibling, bool p_force_readable_name = false);
+	void remove_child(RequiredParam<Node> p_child);
 
 	/// Optimal way to iterate the children of this node.
 	/// The caller is responsible to ensure:
@@ -547,7 +547,7 @@ public:
 	bool has_node_and_resource(const NodePath &p_path) const;
 	Node *get_node_and_resource(const NodePath &p_path, Ref<Resource> &r_res, Vector<StringName> &r_leftover_subpath, bool p_last_is_property = true) const;
 
-	virtual void reparent(RequiredParam<Node> rp_parent, bool p_keep_global_transform = true);
+	virtual void reparent(RequiredParam<Node> p_parent, bool p_keep_global_transform = true);
 	Node *get_parent() const;
 	Node *find_parent(const String &p_pattern) const;
 
@@ -566,11 +566,11 @@ public:
 	_FORCE_INLINE_ bool is_inside_tree() const { return data.tree; }
 	bool is_internal() const { return data.internal_mode != INTERNAL_MODE_DISABLED; }
 
-	bool is_ancestor_of(RequiredParam<const Node> rp_node) const;
-	bool is_greater_than(RequiredParam<const Node> rp_node) const;
+	bool is_ancestor_of(RequiredParam<const Node> p_node) const;
+	bool is_greater_than(RequiredParam<const Node> p_node) const;
 
 	NodePath get_path() const;
-	NodePath get_path_to(RequiredParam<const Node> rp_node, bool p_use_unique_path = false) const;
+	NodePath get_path_to(RequiredParam<const Node> p_node, bool p_use_unique_path = false) const;
 	Node *find_common_parent_with(const Node *p_node) const;
 
 	void add_to_group(const StringName &p_identifier, bool p_persistent = false);
@@ -585,7 +585,7 @@ public:
 	void get_groups(List<GroupInfo> *p_groups) const;
 	int get_persistent_group_count() const;
 
-	void move_child(RequiredParam<Node> rp_child, int p_index);
+	void move_child(RequiredParam<Node> p_child, int p_index);
 	void _move_child(Node *p_child, int p_index, bool p_ignore_end = false);
 
 	void set_owner(Node *p_owner);
@@ -634,7 +634,7 @@ public:
 	void set_editor_description(const String &p_editor_description);
 	String get_editor_description() const;
 
-	void set_editable_instance(RequiredParam<Node> rp_node, bool p_editable);
+	void set_editable_instance(RequiredParam<Node> p_node, bool p_editable);
 	bool is_editable_instance(const Node *p_node) const;
 	Node *get_deepest_editable_node(Node *p_start_node) const;
 
@@ -756,7 +756,7 @@ public:
 		return binds;
 	}
 
-	void replace_by(RequiredParam<Node> rp_node, bool p_keep_groups = false);
+	void replace_by(RequiredParam<Node> p_node, bool p_keep_groups = false);
 
 	void set_process_mode(ProcessMode p_mode);
 	ProcessMode get_process_mode() const;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1639,11 +1639,11 @@ void SceneTree::_flush_delete_queue() {
 	}
 }
 
-void SceneTree::queue_delete(RequiredParam<Object> rp_object) {
+void SceneTree::queue_delete(RequiredParam<Object> p_object) {
 	_THREAD_SAFE_METHOD_
-	EXTRACT_PARAM_OR_FAIL(p_object, rp_object);
-	p_object->_is_queued_for_deletion = true;
-	delete_queue.push_back(p_object->get_instance_id());
+	EXTRACT_PARAM_OR_FAIL(object, p_object);
+	object->_is_queued_for_deletion = true;
+	delete_queue.push_back(object->get_instance_id());
 }
 
 int SceneTree::get_node_count() const {
@@ -1712,18 +1712,18 @@ Error SceneTree::change_scene_to_file(const String &p_path) {
 	return change_scene_to_packed(new_scene);
 }
 
-Error SceneTree::change_scene_to_packed(RequiredParam<PackedScene> rp_scene) {
-	EXTRACT_PARAM_OR_FAIL_V_MSG(p_scene, rp_scene, ERR_INVALID_PARAMETER, "Can't change to a null scene. Use unload_current_scene() if you wish to unload it.");
+Error SceneTree::change_scene_to_packed(RequiredParam<PackedScene> p_scene) {
+	EXTRACT_PARAM_OR_FAIL_V_MSG(scene, p_scene, ERR_INVALID_PARAMETER, "Can't change to a null scene. Use unload_current_scene() if you wish to unload it.");
 
-	Node *new_scene = p_scene->instantiate();
+	Node *new_scene = scene->instantiate();
 	ERR_FAIL_NULL_V(new_scene, ERR_CANT_CREATE);
 
 	return change_scene_to_node(new_scene);
 }
 
-Error SceneTree::change_scene_to_node(RequiredParam<Node> rp_node) {
-	EXTRACT_PARAM_OR_FAIL_V_MSG(p_node, rp_node, ERR_INVALID_PARAMETER, "Can't change to a null node. Use unload_current_scene() if you wish to unload it.");
-	ERR_FAIL_COND_V_MSG(p_node->is_inside_tree(), ERR_UNCONFIGURED, "The new scene node can't already be inside scene tree.");
+Error SceneTree::change_scene_to_node(RequiredParam<Node> p_node) {
+	EXTRACT_PARAM_OR_FAIL_V_MSG(node, p_node, ERR_INVALID_PARAMETER, "Can't change to a null node. Use unload_current_scene() if you wish to unload it.");
+	ERR_FAIL_COND_V_MSG(node->is_inside_tree(), ERR_UNCONFIGURED, "The new scene node can't already be inside scene tree.");
 
 	// If called again while a change is pending.
 	if (pending_new_scene_id.is_valid()) {
@@ -1742,7 +1742,7 @@ Error SceneTree::change_scene_to_node(RequiredParam<Node> rp_node) {
 	}
 	DEV_ASSERT(!current_scene);
 
-	pending_new_scene_id = p_node->get_instance_id();
+	pending_new_scene_id = node->get_instance_id();
 	return OK;
 }
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -409,7 +409,7 @@ public:
 
 	int get_node_count() const;
 
-	void queue_delete(RequiredParam<Object> rp_object);
+	void queue_delete(RequiredParam<Object> p_object);
 
 	Vector<Node *> get_nodes_in_group(const StringName &p_group);
 	Node *get_first_node_in_group(const StringName &p_group);
@@ -425,8 +425,8 @@ public:
 	void set_current_scene(Node *p_scene);
 	Node *get_current_scene() const;
 	Error change_scene_to_file(const String &p_path);
-	Error change_scene_to_packed(RequiredParam<PackedScene> rp_scene);
-	Error change_scene_to_node(RequiredParam<Node> rp_node);
+	Error change_scene_to_packed(RequiredParam<PackedScene> p_scene);
+	Error change_scene_to_node(RequiredParam<Node> p_node);
 	Error reload_current_scene();
 	void unload_current_scene();
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3495,10 +3495,10 @@ void Viewport::_drop_mouse_over(Control *p_until_control) {
 	gui.sending_mouse_enter_exit_notifications = false;
 }
 
-void Viewport::push_input(RequiredParam<InputEvent> rp_event, bool p_local_coords) {
+void Viewport::push_input(RequiredParam<InputEvent> p_event, bool p_local_coords) {
 	ERR_MAIN_THREAD_GUARD;
 	ERR_FAIL_COND(!is_inside_tree());
-	EXTRACT_PARAM_OR_FAIL(p_event, rp_event);
+	EXTRACT_PARAM_OR_FAIL(event, p_event);
 
 	if (disable_input || disable_input_override) {
 		return;
@@ -3522,9 +3522,9 @@ void Viewport::push_input(RequiredParam<InputEvent> rp_event, bool p_local_coord
 
 	Ref<InputEvent> ev;
 	if (!p_local_coords) {
-		ev = _make_input_local(p_event);
+		ev = _make_input_local(event);
 	} else {
-		ev = p_event;
+		ev = event;
 	}
 
 	Ref<InputEventMouse> me = ev;
@@ -3562,11 +3562,11 @@ void Viewport::push_input(RequiredParam<InputEvent> rp_event, bool p_local_coord
 }
 
 #ifndef DISABLE_DEPRECATED
-void Viewport::push_unhandled_input(RequiredParam<InputEvent> rp_event, bool p_local_coords) {
+void Viewport::push_unhandled_input(RequiredParam<InputEvent> p_event, bool p_local_coords) {
 	ERR_MAIN_THREAD_GUARD;
 	WARN_DEPRECATED_MSG(R"*(The "push_unhandled_input()" method is deprecated, use "push_input()" instead.)*");
 	ERR_FAIL_COND(!is_inside_tree());
-	EXTRACT_PARAM_OR_FAIL(p_event, rp_event);
+	EXTRACT_PARAM_OR_FAIL(event, p_event);
 
 	local_input_handled = false;
 
@@ -3580,9 +3580,9 @@ void Viewport::push_unhandled_input(RequiredParam<InputEvent> rp_event, bool p_l
 
 	Ref<InputEvent> ev;
 	if (!p_local_coords) {
-		ev = _make_input_local(p_event);
+		ev = _make_input_local(event);
 	} else {
-		ev = p_event;
+		ev = event;
 	}
 
 	_push_unhandled_input_internal(ev);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -630,9 +630,9 @@ public:
 
 	void _push_text_input(const String &p_text, bool p_emit_text_changed_signal = false);
 	void push_text_input(const String &p_text);
-	void push_input(RequiredParam<InputEvent> rp_event, bool p_local_coords = false);
+	void push_input(RequiredParam<InputEvent> p_event, bool p_local_coords = false);
 #ifndef DISABLE_DEPRECATED
-	void push_unhandled_input(RequiredParam<InputEvent> rp_event, bool p_local_coords = false);
+	void push_unhandled_input(RequiredParam<InputEvent> p_event, bool p_local_coords = false);
 #endif // DISABLE_DEPRECATED
 	void notify_mouse_entered();
 	void notify_mouse_exited();

--- a/scene/resources/2d/shape_2d.cpp
+++ b/scene/resources/2d/shape_2d.cpp
@@ -47,25 +47,25 @@ real_t Shape2D::get_custom_solver_bias() const {
 	return custom_bias;
 }
 
-bool Shape2D::collide_with_motion(const Transform2D &p_local_xform, const Vector2 &p_local_motion, RequiredParam<Shape2D> rp_shape, const Transform2D &p_shape_xform, const Vector2 &p_shape_motion) {
-	EXTRACT_PARAM_OR_FAIL_V(p_shape, rp_shape, false);
+bool Shape2D::collide_with_motion(const Transform2D &p_local_xform, const Vector2 &p_local_motion, RequiredParam<Shape2D> p_shape, const Transform2D &p_shape_xform, const Vector2 &p_shape_motion) {
+	EXTRACT_PARAM_OR_FAIL_V(check_shape, p_shape, false);
 	int r;
-	return PhysicsServer2D::get_singleton()->shape_collide(get_rid(), p_local_xform, p_local_motion, p_shape->get_rid(), p_shape_xform, p_shape_motion, nullptr, 0, r);
+	return PhysicsServer2D::get_singleton()->shape_collide(get_rid(), p_local_xform, p_local_motion, check_shape->get_rid(), p_shape_xform, p_shape_motion, nullptr, 0, r);
 }
 
-bool Shape2D::collide(const Transform2D &p_local_xform, RequiredParam<Shape2D> rp_shape, const Transform2D &p_shape_xform) {
-	EXTRACT_PARAM_OR_FAIL_V(p_shape, rp_shape, false);
+bool Shape2D::collide(const Transform2D &p_local_xform, RequiredParam<Shape2D> p_shape, const Transform2D &p_shape_xform) {
+	EXTRACT_PARAM_OR_FAIL_V(check_shape, p_shape, false);
 	int r;
-	return PhysicsServer2D::get_singleton()->shape_collide(get_rid(), p_local_xform, Vector2(), p_shape->get_rid(), p_shape_xform, Vector2(), nullptr, 0, r);
+	return PhysicsServer2D::get_singleton()->shape_collide(get_rid(), p_local_xform, Vector2(), check_shape->get_rid(), p_shape_xform, Vector2(), nullptr, 0, r);
 }
 
-PackedVector2Array Shape2D::collide_with_motion_and_get_contacts(const Transform2D &p_local_xform, const Vector2 &p_local_motion, RequiredParam<Shape2D> rp_shape, const Transform2D &p_shape_xform, const Vector2 &p_shape_motion) {
-	EXTRACT_PARAM_OR_FAIL_V(p_shape, rp_shape, PackedVector2Array());
+PackedVector2Array Shape2D::collide_with_motion_and_get_contacts(const Transform2D &p_local_xform, const Vector2 &p_local_motion, RequiredParam<Shape2D> p_shape, const Transform2D &p_shape_xform, const Vector2 &p_shape_motion) {
+	EXTRACT_PARAM_OR_FAIL_V(check_shape, p_shape, PackedVector2Array());
 	const int max_contacts = 16;
 	Vector2 result[max_contacts * 2];
 	int contacts = 0;
 
-	if (!PhysicsServer2D::get_singleton()->shape_collide(get_rid(), p_local_xform, p_local_motion, p_shape->get_rid(), p_shape_xform, p_shape_motion, result, max_contacts, contacts)) {
+	if (!PhysicsServer2D::get_singleton()->shape_collide(get_rid(), p_local_xform, p_local_motion, check_shape->get_rid(), p_shape_xform, p_shape_motion, result, max_contacts, contacts)) {
 		return PackedVector2Array();
 	}
 
@@ -78,13 +78,13 @@ PackedVector2Array Shape2D::collide_with_motion_and_get_contacts(const Transform
 	return results;
 }
 
-PackedVector2Array Shape2D::collide_and_get_contacts(const Transform2D &p_local_xform, RequiredParam<Shape2D> rp_shape, const Transform2D &p_shape_xform) {
-	EXTRACT_PARAM_OR_FAIL_V(p_shape, rp_shape, PackedVector2Array());
+PackedVector2Array Shape2D::collide_and_get_contacts(const Transform2D &p_local_xform, RequiredParam<Shape2D> p_shape, const Transform2D &p_shape_xform) {
+	EXTRACT_PARAM_OR_FAIL_V(check_shape, p_shape, PackedVector2Array());
 	const int max_contacts = 16;
 	Vector2 result[max_contacts * 2];
 	int contacts = 0;
 
-	if (!PhysicsServer2D::get_singleton()->shape_collide(get_rid(), p_local_xform, Vector2(), p_shape->get_rid(), p_shape_xform, Vector2(), result, max_contacts, contacts)) {
+	if (!PhysicsServer2D::get_singleton()->shape_collide(get_rid(), p_local_xform, Vector2(), check_shape->get_rid(), p_shape_xform, Vector2(), result, max_contacts, contacts)) {
 		return PackedVector2Array();
 	}
 

--- a/scene/resources/2d/shape_2d.h
+++ b/scene/resources/2d/shape_2d.h
@@ -49,11 +49,11 @@ public:
 	void set_custom_solver_bias(real_t p_bias);
 	real_t get_custom_solver_bias() const;
 
-	bool collide_with_motion(const Transform2D &p_local_xform, const Vector2 &p_local_motion, RequiredParam<Shape2D> rp_shape, const Transform2D &p_shape_xform, const Vector2 &p_shape_motion);
-	bool collide(const Transform2D &p_local_xform, RequiredParam<Shape2D> rp_shape, const Transform2D &p_shape_xform);
+	bool collide_with_motion(const Transform2D &p_local_xform, const Vector2 &p_local_motion, RequiredParam<Shape2D> p_shape, const Transform2D &p_shape_xform, const Vector2 &p_shape_motion);
+	bool collide(const Transform2D &p_local_xform, RequiredParam<Shape2D> p_shape, const Transform2D &p_shape_xform);
 
-	PackedVector2Array collide_with_motion_and_get_contacts(const Transform2D &p_local_xform, const Vector2 &p_local_motion, RequiredParam<Shape2D> rp_shape, const Transform2D &p_shape_xform, const Vector2 &p_shape_motion);
-	PackedVector2Array collide_and_get_contacts(const Transform2D &p_local_xform, RequiredParam<Shape2D> rp_shape, const Transform2D &p_shape_xform);
+	PackedVector2Array collide_with_motion_and_get_contacts(const Transform2D &p_local_xform, const Vector2 &p_local_motion, RequiredParam<Shape2D> p_shape, const Transform2D &p_shape_xform, const Vector2 &p_shape_motion);
+	PackedVector2Array collide_and_get_contacts(const Transform2D &p_local_xform, RequiredParam<Shape2D> p_shape, const Transform2D &p_shape_xform);
 
 	virtual void draw(const RID &p_to_rid, const Color &p_color) {}
 	virtual Rect2 get_rect() const { return Rect2(); }

--- a/servers/physics_2d/direct_states/physics_direct_space_state_2d.cpp
+++ b/servers/physics_2d/direct_states/physics_direct_space_state_2d.cpp
@@ -33,11 +33,11 @@
 #include "core/object/class_db.h"
 #include "core/variant/typed_array.h"
 
-Dictionary PhysicsDirectSpaceState2D::_intersect_ray(RequiredParam<PhysicsRayQueryParameters2D> rp_ray_query) {
-	EXTRACT_PARAM_OR_FAIL_V(p_ray_query, rp_ray_query, Dictionary());
+Dictionary PhysicsDirectSpaceState2D::_intersect_ray(RequiredParam<PhysicsRayQueryParameters2D> p_ray_query) {
+	EXTRACT_PARAM_OR_FAIL_V(ray_query, p_ray_query, Dictionary());
 
 	PS2DT::RayResult result;
-	bool res = intersect_ray(p_ray_query->get_parameters(), result);
+	bool res = intersect_ray(ray_query->get_parameters(), result);
 
 	if (!res) {
 		return Dictionary();
@@ -54,13 +54,13 @@ Dictionary PhysicsDirectSpaceState2D::_intersect_ray(RequiredParam<PhysicsRayQue
 	return d;
 }
 
-TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_point(RequiredParam<PhysicsPointQueryParameters2D> rp_point_query, int p_max_results) {
-	EXTRACT_PARAM_OR_FAIL_V(p_point_query, rp_point_query, TypedArray<Dictionary>());
+TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_point(RequiredParam<PhysicsPointQueryParameters2D> p_point_query, int p_max_results) {
+	EXTRACT_PARAM_OR_FAIL_V(point_query, p_point_query, TypedArray<Dictionary>());
 
 	Vector<PS2DT::ShapeResult> ret;
 	ret.resize(p_max_results);
 
-	int rc = intersect_point(p_point_query->get_parameters(), ret.ptrw(), ret.size());
+	int rc = intersect_point(point_query->get_parameters(), ret.ptrw(), ret.size());
 
 	if (rc == 0) {
 		return TypedArray<Dictionary>();
@@ -79,12 +79,12 @@ TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_point(RequiredParam
 	return r;
 }
 
-TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_shape(RequiredParam<PhysicsShapeQueryParameters2D> rp_shape_query, int p_max_results) {
-	EXTRACT_PARAM_OR_FAIL_V(p_shape_query, rp_shape_query, TypedArray<Dictionary>());
+TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_shape(RequiredParam<PhysicsShapeQueryParameters2D> p_shape_query, int p_max_results) {
+	EXTRACT_PARAM_OR_FAIL_V(shape_query, p_shape_query, TypedArray<Dictionary>());
 
 	Vector<PS2DT::ShapeResult> sr;
 	sr.resize(p_max_results);
-	int rc = intersect_shape(p_shape_query->get_parameters(), sr.ptrw(), sr.size());
+	int rc = intersect_shape(shape_query->get_parameters(), sr.ptrw(), sr.size());
 	TypedArray<Dictionary> ret;
 	ret.resize(rc);
 	for (int i = 0; i < rc; i++) {
@@ -99,11 +99,11 @@ TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_shape(RequiredParam
 	return ret;
 }
 
-Vector<real_t> PhysicsDirectSpaceState2D::_cast_motion(RequiredParam<PhysicsShapeQueryParameters2D> rp_shape_query) {
-	EXTRACT_PARAM_OR_FAIL_V(p_shape_query, rp_shape_query, Vector<real_t>());
+Vector<real_t> PhysicsDirectSpaceState2D::_cast_motion(RequiredParam<PhysicsShapeQueryParameters2D> p_shape_query) {
+	EXTRACT_PARAM_OR_FAIL_V(shape_query, p_shape_query, Vector<real_t>());
 
 	real_t closest_safe, closest_unsafe;
-	bool res = cast_motion(p_shape_query->get_parameters(), closest_safe, closest_unsafe);
+	bool res = cast_motion(shape_query->get_parameters(), closest_safe, closest_unsafe);
 	if (!res) {
 		return Vector<real_t>();
 	}
@@ -114,13 +114,13 @@ Vector<real_t> PhysicsDirectSpaceState2D::_cast_motion(RequiredParam<PhysicsShap
 	return ret;
 }
 
-TypedArray<Vector2> PhysicsDirectSpaceState2D::_collide_shape(RequiredParam<PhysicsShapeQueryParameters2D> rp_shape_query, int p_max_results) {
-	EXTRACT_PARAM_OR_FAIL_V(p_shape_query, rp_shape_query, TypedArray<Vector2>());
+TypedArray<Vector2> PhysicsDirectSpaceState2D::_collide_shape(RequiredParam<PhysicsShapeQueryParameters2D> p_shape_query, int p_max_results) {
+	EXTRACT_PARAM_OR_FAIL_V(shape_query, p_shape_query, TypedArray<Vector2>());
 
 	Vector<Vector2> ret;
 	ret.resize(p_max_results * 2);
 	int rc = 0;
-	bool res = collide_shape(p_shape_query->get_parameters(), ret.ptrw(), p_max_results, rc);
+	bool res = collide_shape(shape_query->get_parameters(), ret.ptrw(), p_max_results, rc);
 	if (!res) {
 		return TypedArray<Vector2>();
 	}
@@ -132,12 +132,12 @@ TypedArray<Vector2> PhysicsDirectSpaceState2D::_collide_shape(RequiredParam<Phys
 	return r;
 }
 
-Dictionary PhysicsDirectSpaceState2D::_get_rest_info(RequiredParam<PhysicsShapeQueryParameters2D> rp_shape_query) {
-	EXTRACT_PARAM_OR_FAIL_V(p_shape_query, rp_shape_query, Dictionary());
+Dictionary PhysicsDirectSpaceState2D::_get_rest_info(RequiredParam<PhysicsShapeQueryParameters2D> p_shape_query) {
+	EXTRACT_PARAM_OR_FAIL_V(shape_query, p_shape_query, Dictionary());
 
 	PS2DT::ShapeRestInfo sri;
 
-	bool res = rest_info(p_shape_query->get_parameters(), &sri);
+	bool res = rest_info(shape_query->get_parameters(), &sri);
 	Dictionary r;
 	if (!res) {
 		return r;

--- a/servers/physics_2d/direct_states/physics_direct_space_state_2d.h
+++ b/servers/physics_2d/direct_states/physics_direct_space_state_2d.h
@@ -39,12 +39,12 @@
 class PhysicsDirectSpaceState2D : public Object {
 	GDCLASS(PhysicsDirectSpaceState2D, Object);
 
-	Dictionary _intersect_ray(RequiredParam<PhysicsRayQueryParameters2D> rp_ray_query);
-	TypedArray<Dictionary> _intersect_point(RequiredParam<PhysicsPointQueryParameters2D> rp_point_query, int p_max_results = 32);
-	TypedArray<Dictionary> _intersect_shape(RequiredParam<PhysicsShapeQueryParameters2D> rp_shape_query, int p_max_results = 32);
-	Vector<real_t> _cast_motion(RequiredParam<PhysicsShapeQueryParameters2D> rp_shape_query);
-	TypedArray<Vector2> _collide_shape(RequiredParam<PhysicsShapeQueryParameters2D> rp_shape_query, int p_max_results = 32);
-	Dictionary _get_rest_info(RequiredParam<PhysicsShapeQueryParameters2D> rp_shape_query);
+	Dictionary _intersect_ray(RequiredParam<PhysicsRayQueryParameters2D> p_ray_query);
+	TypedArray<Dictionary> _intersect_point(RequiredParam<PhysicsPointQueryParameters2D> p_point_query, int p_max_results = 32);
+	TypedArray<Dictionary> _intersect_shape(RequiredParam<PhysicsShapeQueryParameters2D> p_shape_query, int p_max_results = 32);
+	Vector<real_t> _cast_motion(RequiredParam<PhysicsShapeQueryParameters2D> p_shape_query);
+	TypedArray<Vector2> _collide_shape(RequiredParam<PhysicsShapeQueryParameters2D> p_shape_query, int p_max_results = 32);
+	Dictionary _get_rest_info(RequiredParam<PhysicsShapeQueryParameters2D> p_shape_query);
 
 protected:
 	static void _bind_methods();

--- a/servers/physics_2d/physics_server_2d.cpp
+++ b/servers/physics_2d/physics_server_2d.cpp
@@ -40,15 +40,15 @@ PhysicsServer2D *PhysicsServer2D::get_singleton() {
 	return singleton;
 }
 
-bool PhysicsServer2D::_body_test_motion(RID p_body, RequiredParam<PhysicsTestMotionParameters2D> rp_parameters, const Ref<PhysicsTestMotionResult2D> &p_result) {
-	EXTRACT_PARAM_OR_FAIL_V(p_parameters, rp_parameters, false);
+bool PhysicsServer2D::_body_test_motion(RID p_body, RequiredParam<PhysicsTestMotionParameters2D> p_parameters, const Ref<PhysicsTestMotionResult2D> &p_result) {
+	EXTRACT_PARAM_OR_FAIL_V(parameters, p_parameters, false);
 
 	PS2DT::MotionResult *result_ptr = nullptr;
 	if (p_result.is_valid()) {
 		result_ptr = p_result->get_result_ptr();
 	}
 
-	return body_test_motion(p_body, p_parameters->get_parameters(), result_ptr);
+	return body_test_motion(p_body, parameters->get_parameters(), result_ptr);
 }
 
 void PhysicsServer2D::_bind_methods() {

--- a/servers/physics_2d/physics_server_2d.h
+++ b/servers/physics_2d/physics_server_2d.h
@@ -44,7 +44,7 @@ class PhysicsServer2D : public Object {
 
 	static PhysicsServer2D *singleton;
 
-	virtual bool _body_test_motion(RID p_body, RequiredParam<PhysicsTestMotionParameters2D> rp_parameters, const Ref<PhysicsTestMotionResult2D> &p_result = Ref<PhysicsTestMotionResult2D>());
+	virtual bool _body_test_motion(RID p_body, RequiredParam<PhysicsTestMotionParameters2D> p_parameters, const Ref<PhysicsTestMotionResult2D> &p_result = Ref<PhysicsTestMotionResult2D>());
 
 protected:
 	static void _bind_methods();

--- a/servers/physics_3d/direct_states/physics_direct_space_state_3d.cpp
+++ b/servers/physics_3d/direct_states/physics_direct_space_state_3d.cpp
@@ -33,11 +33,11 @@
 #include "core/object/class_db.h"
 #include "core/variant/typed_array.h"
 
-Dictionary PhysicsDirectSpaceState3D::_intersect_ray(RequiredParam<PhysicsRayQueryParameters3D> rp_ray_query) {
-	EXTRACT_PARAM_OR_FAIL_V(p_ray_query, rp_ray_query, Dictionary());
+Dictionary PhysicsDirectSpaceState3D::_intersect_ray(RequiredParam<PhysicsRayQueryParameters3D> p_ray_query) {
+	EXTRACT_PARAM_OR_FAIL_V(ray_query, p_ray_query, Dictionary());
 
 	PS3DT::RayResult result;
-	bool res = intersect_ray(p_ray_query->get_parameters(), result);
+	bool res = intersect_ray(ray_query->get_parameters(), result);
 
 	if (!res) {
 		return Dictionary();
@@ -55,13 +55,13 @@ Dictionary PhysicsDirectSpaceState3D::_intersect_ray(RequiredParam<PhysicsRayQue
 	return d;
 }
 
-TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_point(RequiredParam<PhysicsPointQueryParameters3D> rp_point_query, int p_max_results) {
-	EXTRACT_PARAM_OR_FAIL_V(p_point_query, rp_point_query, TypedArray<Dictionary>());
+TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_point(RequiredParam<PhysicsPointQueryParameters3D> p_point_query, int p_max_results) {
+	EXTRACT_PARAM_OR_FAIL_V(point_query, p_point_query, TypedArray<Dictionary>());
 
 	Vector<PS3DT::ShapeResult> ret;
 	ret.resize(p_max_results);
 
-	int rc = intersect_point(p_point_query->get_parameters(), ret.ptrw(), ret.size());
+	int rc = intersect_point(point_query->get_parameters(), ret.ptrw(), ret.size());
 
 	if (rc == 0) {
 		return TypedArray<Dictionary>();
@@ -80,12 +80,12 @@ TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_point(RequiredParam
 	return r;
 }
 
-TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_shape(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query, int p_max_results) {
-	EXTRACT_PARAM_OR_FAIL_V(p_shape_query, rp_shape_query, TypedArray<Dictionary>());
+TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_shape(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query, int p_max_results) {
+	EXTRACT_PARAM_OR_FAIL_V(shape_query, p_shape_query, TypedArray<Dictionary>());
 
 	Vector<PS3DT::ShapeResult> sr;
 	sr.resize(p_max_results);
-	int rc = intersect_shape(p_shape_query->get_parameters(), sr.ptrw(), sr.size());
+	int rc = intersect_shape(shape_query->get_parameters(), sr.ptrw(), sr.size());
 	TypedArray<Dictionary> ret;
 	ret.resize(rc);
 	for (int i = 0; i < rc; i++) {
@@ -100,11 +100,11 @@ TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_shape(RequiredParam
 	return ret;
 }
 
-Vector<real_t> PhysicsDirectSpaceState3D::_cast_motion(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query) {
-	EXTRACT_PARAM_OR_FAIL_V(p_shape_query, rp_shape_query, Vector<real_t>());
+Vector<real_t> PhysicsDirectSpaceState3D::_cast_motion(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query) {
+	EXTRACT_PARAM_OR_FAIL_V(shape_query, p_shape_query, Vector<real_t>());
 
 	real_t closest_safe = 1.0f, closest_unsafe = 1.0f;
-	bool res = cast_motion(p_shape_query->get_parameters(), closest_safe, closest_unsafe);
+	bool res = cast_motion(shape_query->get_parameters(), closest_safe, closest_unsafe);
 	if (!res) {
 		return Vector<real_t>();
 	}
@@ -115,13 +115,13 @@ Vector<real_t> PhysicsDirectSpaceState3D::_cast_motion(RequiredParam<PhysicsShap
 	return ret;
 }
 
-TypedArray<Vector3> PhysicsDirectSpaceState3D::_collide_shape(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query, int p_max_results) {
-	EXTRACT_PARAM_OR_FAIL_V(p_shape_query, rp_shape_query, TypedArray<Vector3>());
+TypedArray<Vector3> PhysicsDirectSpaceState3D::_collide_shape(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query, int p_max_results) {
+	EXTRACT_PARAM_OR_FAIL_V(shape_query, p_shape_query, TypedArray<Vector3>());
 
 	Vector<Vector3> ret;
 	ret.resize(p_max_results * 2);
 	int rc = 0;
-	bool res = collide_shape(p_shape_query->get_parameters(), ret.ptrw(), p_max_results, rc);
+	bool res = collide_shape(shape_query->get_parameters(), ret.ptrw(), p_max_results, rc);
 	if (!res) {
 		return TypedArray<Vector3>();
 	}
@@ -133,12 +133,12 @@ TypedArray<Vector3> PhysicsDirectSpaceState3D::_collide_shape(RequiredParam<Phys
 	return r;
 }
 
-Dictionary PhysicsDirectSpaceState3D::_get_rest_info(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query) {
-	EXTRACT_PARAM_OR_FAIL_V(p_shape_query, rp_shape_query, Dictionary());
+Dictionary PhysicsDirectSpaceState3D::_get_rest_info(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query) {
+	EXTRACT_PARAM_OR_FAIL_V(shape_query, p_shape_query, Dictionary());
 
 	PS3DT::ShapeRestInfo sri;
 
-	bool res = rest_info(p_shape_query->get_parameters(), &sri);
+	bool res = rest_info(shape_query->get_parameters(), &sri);
 	Dictionary r;
 	if (!res) {
 		return r;

--- a/servers/physics_3d/direct_states/physics_direct_space_state_3d.h
+++ b/servers/physics_3d/direct_states/physics_direct_space_state_3d.h
@@ -40,12 +40,12 @@ class PhysicsDirectSpaceState3D : public Object {
 	GDCLASS(PhysicsDirectSpaceState3D, Object);
 
 private:
-	Dictionary _intersect_ray(RequiredParam<PhysicsRayQueryParameters3D> rp_ray_query);
-	TypedArray<Dictionary> _intersect_point(RequiredParam<PhysicsPointQueryParameters3D> rp_point_query, int p_max_results = 32);
-	TypedArray<Dictionary> _intersect_shape(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query, int p_max_results = 32);
-	Vector<real_t> _cast_motion(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query);
-	TypedArray<Vector3> _collide_shape(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query, int p_max_results = 32);
-	Dictionary _get_rest_info(RequiredParam<PhysicsShapeQueryParameters3D> rp_shape_query);
+	Dictionary _intersect_ray(RequiredParam<PhysicsRayQueryParameters3D> p_ray_query);
+	TypedArray<Dictionary> _intersect_point(RequiredParam<PhysicsPointQueryParameters3D> p_point_query, int p_max_results = 32);
+	TypedArray<Dictionary> _intersect_shape(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query, int p_max_results = 32);
+	Vector<real_t> _cast_motion(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query);
+	TypedArray<Vector3> _collide_shape(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query, int p_max_results = 32);
+	Dictionary _get_rest_info(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query);
 
 protected:
 	static void _bind_methods();

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -40,15 +40,15 @@ PhysicsServer3D *PhysicsServer3D::get_singleton() {
 	return singleton;
 }
 
-bool PhysicsServer3D::_body_test_motion(RID p_body, RequiredParam<PhysicsTestMotionParameters3D> rp_parameters, const Ref<PhysicsTestMotionResult3D> &p_result) {
-	EXTRACT_PARAM_OR_FAIL_V(p_parameters, rp_parameters, false);
+bool PhysicsServer3D::_body_test_motion(RID p_body, RequiredParam<PhysicsTestMotionParameters3D> p_parameters, const Ref<PhysicsTestMotionResult3D> &p_result) {
+	EXTRACT_PARAM_OR_FAIL_V(parameters, p_parameters, false);
 
 	PS3DT::MotionResult *result_ptr = nullptr;
 	if (p_result.is_valid()) {
 		result_ptr = p_result->get_result_ptr();
 	}
 
-	return body_test_motion(p_body, p_parameters->get_parameters(), result_ptr);
+	return body_test_motion(p_body, parameters->get_parameters(), result_ptr);
 }
 
 RID PhysicsServer3D::shape_create(PS3DE::ShapeType p_shape) {

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -53,7 +53,7 @@ class PhysicsServer3D : public Object {
 
 	static PhysicsServer3D *singleton;
 
-	virtual bool _body_test_motion(RID p_body, RequiredParam<PhysicsTestMotionParameters3D> rp_parameters, const Ref<PhysicsTestMotionResult3D> &p_result = Ref<PhysicsTestMotionResult3D>());
+	virtual bool _body_test_motion(RID p_body, RequiredParam<PhysicsTestMotionParameters3D> p_parameters, const Ref<PhysicsTestMotionResult3D> &p_result = Ref<PhysicsTestMotionResult3D>());
 
 protected:
 	static void _bind_methods();
@@ -254,7 +254,7 @@ public:
 
 	virtual RID soft_body_create() = 0;
 
-	virtual void soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> rp_rendering_server_handler) = 0;
+	virtual void soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> p_rendering_server_handler) = 0;
 
 	virtual void soft_body_set_space(RID p_body, RID p_space) = 0;
 	virtual RID soft_body_get_space(RID p_body) const = 0;

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -312,7 +312,7 @@ public:
 
 	virtual RID soft_body_create() override { return RID(); }
 
-	virtual void soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> rp_rendering_server_handler) override {}
+	virtual void soft_body_update_rendering_server(RID p_body, RequiredParam<PhysicsServer3DRenderingServerHandler> p_rendering_server_handler) override {}
 
 	virtual void soft_body_set_space(RID p_body, RID p_space) override {}
 	virtual RID soft_body_get_space(RID p_body) const override { return RID(); }

--- a/tests/core/object/test_object.cpp
+++ b/tests/core/object/test_object.cpp
@@ -653,9 +653,9 @@ TEST_CASE("[Object] Destruction at the end of the call chain is safe") {
 			"Object was tail-deleted without crashes.");
 }
 
-int required_param_compare(const Ref<RefCounted> &p_ref, const RequiredParam<RefCounted> &rp_required) {
-	EXTRACT_PARAM_OR_FAIL_V(p_required, rp_required, false);
-	ERR_FAIL_COND_V(p_ref->get_reference_count() != p_required->get_reference_count(), -1);
+int required_param_compare(const Ref<RefCounted> &p_ref, const RequiredParam<RefCounted> &p_required) {
+	EXTRACT_PARAM_OR_FAIL_V(required, p_required, false);
+	ERR_FAIL_COND_V(p_ref->get_reference_count() != required->get_reference_count(), -1);
 	return p_ref->get_reference_count();
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

While the original intent of the `rp_` prefix was to keep diffs minimal where introduced, this breaks convention in a few confusing ways. Most pertinently: it means that we're utilizing local variables with a `p_` prefix, which makes parsing local variables vs arguments much trickier at a glance.

That alone was more of an annoyance than an actual blocker, but [this comment](https://github.com/godotengine/godot/pull/122301#discussion_r3759490871) made me realize two things:
1. We entirely lack formal documentation for `rp_`, so maintainers risk being confused at their inclusion.
2. We have no `inout` signifier, which `rp_` could be a useful way of signifying. However, we can't utilize it if `rp_` is currently reserved for `RequiredParam`, which does not imply `inout` whatsoever.

With all of the above in mind, I believe the best course of action is changing all instances of `RequiredParam` prefixes from `rp_` to `p_`. This matches existing conventions and expectations, and wound up not causing *nearly* as much noise as we originally thought.

## Additional information

This removes `rp_` from the valid list of argument prefixes. If we ever want to integrate the `inout` convention via prefix, we can revisit the prefix at that time; however, that's out-of-scope for this PR.

Wherever possible, all local variables with a `p_` prefix simply had said prefix stripped. The only exceptions were if said prefix shadowed a class variable, in which case they were prefixed with `check_` instead.