### PR TITLE
Fix variable name typo in `EditorProperty` for "separation"

### DIFF
--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -192,7 +192,7 @@ private:
 
 	void _update_popup();
 	void _focusable_focused(int p_index);
-	int _get_v_separation() const { return bottom_editor && bottom_editor_seperation ? theme_cache.vertical_separation : 0; }
+	int _get_v_separation() const { return bottom_editor && bottom_editor_separation ? theme_cache.vertical_separation : 0; }
 	Dictionary _get_context_data();
 
 	bool selectable = true;
@@ -220,7 +220,7 @@ private:
 protected:
 	bool has_borders = false;
 	bool can_override = false;
-	bool bottom_editor_seperation = false;
+	bool bottom_editor_separation = false;
 
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/editor/settings/editor_settings_dialog.cpp
+++ b/editor/settings/editor_settings_dialog.cpp
@@ -1127,7 +1127,7 @@ EditorSettingsDialog::~EditorSettingsDialog() {
 }
 
 void EditorSettingsPropertyWrapper::_setup_override_info() {
-	bottom_editor_seperation = true;
+	bottom_editor_separation = true;
 
 	override_container = memnew(HBoxContainer);
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

In https://github.com/godotengine/godot/pull/121550 I misspelled "separation" in "bottom_editor_separation", which I fixed in the PR title but probably forgot to fix it in code...

- `bottom_editor_seperation` --> `bottom_editor_separation`

Opening this PR based on the discussion https://chat.godotengine.org/channel/editor?msg=RmvjzKuxL25eJQ4Lf