### PR TITLE
[Android editor] Add support for drag & drop from other applications 

### DIFF
--- a/platform/android/editor/editor_utils_jni.cpp
+++ b/platform/android/editor/editor_utils_jni.cpp
@@ -37,6 +37,7 @@
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/script_editor_debugger.h"
 #include "editor/editor_node.h"
+#include "editor/file_system/editor_file_system.h"
 #include "editor/gui/editor_title_bar.h"
 #include "editor/run/editor_run_bar.h"
 #include "editor/script/script_editor_plugin.h"
@@ -116,6 +117,28 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_EditorUtils_orien
 				}
 			}
 		}
+	}
+#endif
+}
+
+JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_EditorUtils_onDragDropCompleted(JNIEnv *p_env, jclass, jobjectArray p_added_files) {
+#ifdef TOOLS_ENABLED
+	if (EditorFileSystem *efs = EditorFileSystem::get_singleton()) {
+		if (efs->is_scanning()) {
+			return;
+		}
+
+		Vector<String> added_files_paths;
+		jint length = p_env->GetArrayLength(p_added_files);
+		for (jint i = 0; i < length; i++) {
+			jstring j_path = (jstring)p_env->GetObjectArrayElement(p_added_files, i);
+			String path = jstring_to_string(j_path, p_env);
+			added_files_paths.push_back(path);
+			p_env->DeleteLocalRef(j_path);
+		}
+
+		efs->update_files(added_files_paths);
+		efs->reimport_files(added_files_paths);
 	}
 #endif
 }

--- a/platform/android/editor/editor_utils_jni.h
+++ b/platform/android/editor/editor_utils_jni.h
@@ -35,4 +35,5 @@
 extern "C" {
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_EditorUtils_runScene(JNIEnv *p_env, jclass, jstring p_scene, jobjectArray p_scene_args);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_EditorUtils_orientationChanged(JNIEnv *p_env, jclass, jboolean p_portrait);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_editor_utils_EditorUtils_onDragDropCompleted(JNIEnv *p_env, jclass, jobjectArray p_added_files);
 }

--- a/platform/android/java/editor/build.gradle
+++ b/platform/android/java/editor/build.gradle
@@ -209,6 +209,9 @@ dependencies {
     implementation "androidx.constraintlayout:constraintlayout:2.2.1"
     implementation "org.bouncycastle:bcprov-jdk15to18:1.78"
 
+    // Drag and drop support
+    implementation "androidx.draganddrop:draganddrop:1.0.0"
+
     implementation "org.khronos.openxr:openxr_loader_for_android:$versions.openxrLoaderVersion"
 
     // Android XR dependencies

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -40,12 +40,14 @@ import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.content.pm.PackageManager
 import android.content.res.Configuration
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.os.Debug
 import android.os.Environment
 import android.os.Process
 import android.preference.PreferenceManager
+import android.provider.DocumentsContract
 import android.util.Log
 import android.view.View
 import android.widget.TextView
@@ -54,7 +56,9 @@ import androidx.activity.enableEdgeToEdge
 import androidx.annotation.CallSuper
 import androidx.core.content.edit
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.core.view.ContentInfoCompat
 import androidx.core.view.isVisible
+import androidx.draganddrop.DropHelper
 import androidx.window.layout.WindowMetricsCalculator
 import org.godotengine.editor.buildprovider.GradleBuildProvider
 import org.godotengine.editor.embed.EmbeddedGodotGame
@@ -75,6 +79,7 @@ import org.godotengine.godot.utils.PermissionsUtil
 import org.godotengine.godot.utils.ProcessPhoenix
 import org.godotengine.openxr.vendors.utils.*
 import java.io.File
+import java.io.FileOutputStream
 import kotlin.math.min
 import kotlin.text.indexOf
 
@@ -165,6 +170,14 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 
 		private const val PREF_KEY_DONT_SHOW_GAME_RESUME_HINT = "pref_key_dont_show_game_resume_hint"
 
+		private val DRAG_DROP_SUPPORTED_MIME_TYPES = arrayOf(
+			"application/octet-stream",
+			"audio/*",
+			"image/*",
+			"video/*",
+			"text/*",
+		)
+
 		@JvmStatic
 		fun isRunningInInstrumentation(): Boolean {
 			if (BuildConfig.BUILD_TYPE == "release") {
@@ -176,6 +189,36 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 				true
 			} catch (_: ClassNotFoundException) {
 				false
+			}
+		}
+
+		private fun copyFileFromUri(context: Context, srcUri: Uri, destFile: File): Boolean {
+			return try {
+				context.contentResolver.openInputStream(srcUri)?.use { inputStream ->
+					FileOutputStream(destFile).use { outputStream ->
+						inputStream.copyTo(outputStream)
+					}
+				}
+				true
+			} catch (e: Exception) {
+				Log.e(TAG, "Error copying from uri $srcUri to $destFile.", e)
+				false
+			}
+		}
+
+		private fun isMimeTypeValid(resolvedMime: String?, allowedTypes: Array<String>): Boolean {
+			if (resolvedMime == null) {
+				return false
+			}
+
+			return allowedTypes.any { allowed ->
+				if (allowed.endsWith("/*")) {
+					// Match wildcards like "image/*".
+					resolvedMime.startsWith(allowed.removeSuffix("*"))
+				} else {
+					// Match exact types like "application/pdf".
+					resolvedMime.equals(allowed, ignoreCase = true)
+				}
 			}
 		}
 	}
@@ -247,6 +290,80 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 	@CallSuper
 	protected open fun getXRRuntimePermissions(): MutableSet<String> {
 		return mutableSetOf()
+	}
+
+	/**
+	 * Configure drag & drop support for the main editor window.
+	 *
+	 * This should be invoked after the engine has been set up in [onGodotSetupCompleted].
+	 */
+	private fun setupDragAndDrop() {
+		if (getEditorWindowInfo() != EDITOR_MAIN_INFO || godot?.isEditorHint() != true) {
+			// Drag and drop is only enabled for the main editor window.
+			return
+		}
+
+		val godotView = godot?.renderView?.view ?: return
+
+		Log.v(TAG, "Configuring main editor window for drag and drop support.")
+		DropHelper.configureView(this, godotView, DRAG_DROP_SUPPORTED_MIME_TYPES) { _, payload: ContentInfoCompat ->
+			val split = payload.partition { item -> item.uri != null }
+			val uriContent = split.first
+			val remaining = split.second
+			if (uriContent != null) {
+				val addedFiles = mutableListOf<String>()
+
+				val clipData = uriContent.clip
+				for (index in 0 until clipData.itemCount) {
+					val clipItem = clipData.getItemAt(index)
+					val clipUri = clipItem.uri ?: continue
+
+					val mimeType = contentResolver.getType(clipUri)
+					if (!isMimeTypeValid(mimeType, DRAG_DROP_SUPPORTED_MIME_TYPES)) {
+						Log.w(TAG, "Unsupported mime type $mimeType for drag&drop.")
+						continue
+					}
+
+					val displayName = contentResolver.query(clipUri, arrayOf(DocumentsContract.Document.COLUMN_DISPLAY_NAME), null, null, null)?.use { cursor ->
+						if (cursor.moveToFirst()) {
+							val colIndex = cursor.getColumnIndex(DocumentsContract.Document.COLUMN_DISPLAY_NAME)
+							if (colIndex != -1 && !cursor.isNull(colIndex)) {
+								return@use cursor.getString(colIndex)
+							}
+						}
+						return@use clipUri.lastPathSegment
+					}
+
+					if (displayName.isNullOrBlank()) {
+						continue
+					}
+
+					val currentPath = getProjectPathFromCommandLine()
+					if (currentPath.isBlank()) {
+						Log.w(TAG, "Missing project path. Unable to store dropped content from $clipUri.")
+						continue
+					}
+
+					val destFile = File(currentPath, displayName)
+					val result = copyFileFromUri(this, clipUri, destFile)
+					if (result) {
+						Log.v(TAG, "Copied uri $clipUri to $destFile")
+						addedFiles.add(destFile.absolutePath)
+					} else {
+						Log.e(TAG, "Failed to copy uri $clipUri to $destFile")
+					}
+				}
+
+				if (addedFiles.isNotEmpty()) {
+					godot?.runOnRenderThread {
+						EditorUtils.onDragDropCompleted(addedFiles.toTypedArray())
+					}
+				}
+			}
+
+			// Return the rest for the platform to handle.
+			remaining
+		}
 	}
 
 	override fun onCreate(savedInstanceState: Bundle?) {
@@ -411,21 +528,8 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 							updatedCommandLineParams.addAll(loadProjectArgs)
 						} else {
 							// Check if we are already editing the specified directory.
-							var isEditor = false
-							var nextIsPath = false
-							var currentPath = ""
-							for (arg in commandLine) {
-								if (nextIsPath) {
-									currentPath = arg
-									nextIsPath = false
-								}
-
-								if (arg == EDITOR_ARG || arg == EDITOR_ARG_SHORT) {
-									isEditor = true
-								} else if (arg == PATH_ARG) {
-									nextIsPath = true
-								}
-							}
+							val isEditor = commandLine.contains(EDITOR_ARG) || commandLine.contains(EDITOR_ARG_SHORT)
+							val currentPath = getProjectPathFromCommandLine()
 							if (!isEditor || currentPath != dataDir.absolutePath) {
 								onNewGodotInstanceRequested(loadProjectArgs)
 							}
@@ -436,6 +540,26 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 		}
 
 		super.handleStartIntent(intent, newLaunch)
+	}
+
+	/**
+	 * Retrieve the project path from the command line arguments.
+	 */
+	private fun getProjectPathFromCommandLine(): String {
+		var nextIsPath = false
+		var currentPath = ""
+		for (arg in commandLine) {
+			if (nextIsPath) {
+				currentPath = arg
+				nextIsPath = false
+			}
+
+			if (arg == PATH_ARG) {
+				nextIsPath = true
+			}
+		}
+
+		return currentPath
 	}
 
 	protected open fun shouldShowGameMenuBar() = gameMenuContainer != null
@@ -474,6 +598,9 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 				setOverrideVolumeButtons(overrideVolumeButtonsEnabled)
 				enableHapticFeedback(hapticEnabled)
 			}
+
+			// Enable drag and drop for the main editor window.
+			setupDragAndDrop()
 		}
 	}
 

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/editor/utils/EditorUtils.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/editor/utils/EditorUtils.kt
@@ -41,4 +41,12 @@ object EditorUtils {
 
 	@JvmStatic
 	external fun orientationChanged(isPortrait: Boolean)
+
+	/**
+	 * Invoked when a drag&drop operation completes successfully.
+	 *
+	 * @param addedFiles List of paths for the added files.
+	 */
+	@JvmStatic
+	external fun onDragDropCompleted(addedFiles: Array<String>)
 }


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

Enables users to add files / images/ assets to their projects by dragging and dropping them onto the Android editor. 


https://github.com/user-attachments/assets/0271d16e-e77a-4f1b-80d5-19a17f9f65f2


Note: This can be used as reference to add support for `drag&drop` for template builds using the `files_dropped` signal as suggested in https://github.com/godotengine/godot-proposals/issues/6168.
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
