### PR TITLE
Document that preloaded resources are only freed on exit.

### DIFF
--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -193,6 +193,7 @@
 			<description>
 				Returns a [Resource] from the filesystem located at [param path]. During run-time, the resource is loaded when the script is being parsed. This function effectively acts as a reference to that resource. Note that this function requires [param path] to be a constant [String]. If you want to load a resource from a dynamic/variable path, use [method load].
 				[b]Note:[/b] Resource paths can be obtained by right-clicking on a resource in the Assets Panel and choosing "Copy Path", or by dragging the file from the FileSystem dock into the current script.
+				[b]Warning:[/b] Preloaded resources will only be freed when Godot closes. This behavior may change in the near future and should not be taken into consideration while making your project.
 				[codeblock]
 				# Create instance of a scene.
 				var diamond = preload("res://diamond.tscn").instantiate()


### PR DESCRIPTION
This issue happens since version v4.0.3~v4.0.4

Related issues:
- #77513
- #118528

PR that added similar warning in for `@static_unload`:
- #89484

My other PR that adds this warning in the documentation for Resources:
- https://github.com/godotengine/godot-docs/pull/12270