### PR TITLE
Fix resource replace loading type change handling

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -587,10 +587,15 @@ void ResourceLoader::_run_load_task(void *p_userdata) {
 					// Either case, we want to keep the resource that was already there.
 					ResourceCache::lock.unlock();
 					pending_unlock = false;
-					if (replacing) {
-						old_res->copy_from(load_task.resource);
+					if (replacing && old_res->get_class() != load_task.resource->get_class()) {
+						WARN_PRINT(vformat("'%s': Cache mode is replace, but resource type changed from previous '%s' to '%s'. Existing references could not be updated.", load_task.local_path, old_res->get_class(), load_task.resource->get_class()));
+						load_task.resource->set_path(load_task.local_path, true);
+					} else {
+						if (replacing) {
+							old_res->copy_from(load_task.resource);
+						}
+						load_task.resource = old_res;
 					}
-					load_task.resource = old_res;
 				}
 			} else {
 				load_task.resource->set_path(load_task.local_path);


### PR DESCRIPTION

## What problem(s) does this PR solve?

Implements an actual resource cache replacement with the newly loaded resource in case of a type mismatch, as the [Docs](https://docs.godotengine.org/en/latest/classes/class_resourceloader.html#class-resourceloader-constant-cache-mode-replace) claim it should be, instead of a silent fail with no cache update.

- Closes #121884

## Additional information

Does not update existing references to the old resource, as there is no mechanism for that. This mirrors how cache replacements are handled elsewhere for e.g. text or binary loading, which also produce orphan references:

<details>
<summary>Reference code snippets</summary>

https://github.com/godotengine/godot/blob/63b7e027254e6b77b3d1036c89973060fb5be088/core/io/resource_format_binary.cpp#L739-L743

https://github.com/godotengine/godot/blob/63b7e027254e6b77b3d1036c89973060fb5be088/scene/resources/resource_format_text.cpp#L632-L636

</details>

I also added a warning, since this behaviour might be unexpected and annoying to debug.

Verification with log outputs from #121884's [MRP](https://github.com/user-attachments/files/30502276/mrp-cache-replace_2026-07-29_13-06-18.zip):

<details>
<summary>Console output before fix</summary>

```
PCK loaded successfully: true
Reloading UID: uid://buwa5v2jrmgf7 from tex_DebugUVTiles.png.import
  - Type of the PCK image: CompressedTexture2D
  - Type of the currently cached image: CompressedTexture2D
(res://tex_DebugUVTiles.png):<CompressedTexture2D#-9223372002193046058>

PCK loaded successfully: true
Reloading UID: uid://buwa5v2jrmgf7 from tex_DebugUVTiles.png.import
  - Type of the PCK image: ImageTexture
  - Type of the currently cached image: CompressedTexture2D
(res://tex_DebugUVTiles.png):<CompressedTexture2D#-9223372002193046058>
```

-> Notice no change of loaded resources type

</details>

<details>
<summary>Console output after fix</summary>

```
PCK loaded successfully: true
Reloading UID: uid://buwa5v2jrmgf7 from tex_DebugUVTiles.png.import
  - Type of the PCK image: CompressedTexture2D
  - Type of the currently cached image: CompressedTexture2D
(res://tex_DebugUVTiles.png):<CompressedTexture2D#-9223371983956212202>

PCK loaded successfully: true
Reloading UID: uid://buwa5v2jrmgf7 from tex_DebugUVTiles.png.import
  - Type of the PCK image: ImageTexture
  - Type of the currently cached image: ImageTexture
(res://tex_DebugUVTiles.png):<ImageTexture#-9223371967531317721>
```

-> Notice change of loaded resources type

</details>