### PR TITLE
[4.4] Fix indentation in Dictionary.xml code blocks

### DIFF
--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -139,30 +139,30 @@
 		# Creates a typed dictionary with String keys and int values.
 		# Attempting to use any other type for keys or values will result in an error.
 		var typed_dict: Dictionary[String, int] = {
-			"some_key": 1,
-			"some_other_key": 2,
+		    "some_key": 1,
+		    "some_other_key": 2,
 		}
 
 		# Creates a typed dictionary with String keys and values of any type.
 		# Attempting to use any other type for keys will result in an error.
 		var typed_dict_key_only: Dictionary[String, Variant] = {
-			"some_key": 12.34,
-			"some_other_key": "string",
+		    "some_key": 12.34,
+		    "some_other_key": "string",
 		}
 		[/gdscript]
 		[csharp]
 		// Creates a typed dictionary with String keys and int values.
 		// Attempting to use any other type for keys or values will result in an error.
 		var typedDict = new Godot.Collections.Dictionary&lt;String, int&gt; {
-			{"some_key", 1},
-			{"some_other_key", 2},
+		    {"some_key", 1},
+		    {"some_other_key", 2},
 		};
 
 		// Creates a typed dictionary with String keys and values of any type.
 		// Attempting to use any other type for keys will result in an error.
 		var typedDictKeyOnly = new Godot.Collections.Dictionary&lt;String, Variant&gt; {
-			{"some_key", 12.34},
-			{"some_other_key", "string"},
+		    {"some_key", 12.34},
+		    {"some_other_key", "string"},
 		};
 		[/csharp]
 		[/codeblocks]


### PR DESCRIPTION
The 4.4 branch (and only the 4.4 branch) was failing CI due to `make_rst.py` erroring on `Dictionary.xml`:

```
  ERROR: Dictionary.xml: Four spaces should be used for indentation within [gdscript].
  ERROR: Dictionary.xml: Four spaces should be used for indentation within [csharp].
```

This is because PR #107071 was cherry-picked for Godot 4.4 [here](https://github.com/godotengine/godot/pull/107071#issuecomment-3319082491), but the 4.4 branch does not have the ability to use tabs in code blocks. That ability was introduced in PR #89819 for Godot 4.5.

CC @Repiteo, this should be a very fast approval, it's a trivial fix.