### PR TITLE
[4.4] Use explicit public access modifier in C# code

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/IHandshake.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/IHandshake.cs
@@ -4,7 +4,7 @@ namespace GodotTools.IdeMessaging
 {
     public interface IHandshake
     {
-        string GetHandshakeLine(string identity);
-        bool IsValidPeerHandshake(string handshake, [NotNullWhen(true)] out string? identity, ILogger logger);
+        public string GetHandshakeLine(string identity);
+        public bool IsValidPeerHandshake(string handshake, [NotNullWhen(true)] out string? identity, ILogger logger);
     }
 }

--- a/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/ILogger.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/ILogger.cs
@@ -4,10 +4,10 @@ namespace GodotTools.IdeMessaging
 {
     public interface ILogger
     {
-        void LogDebug(string message);
-        void LogInfo(string message);
-        void LogWarning(string message);
-        void LogError(string message);
-        void LogError(string message, Exception e);
+        public void LogDebug(string message);
+        public void LogInfo(string message);
+        public void LogWarning(string message);
+        public void LogError(string message);
+        public void LogError(string message, Exception e);
     }
 }

--- a/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/IMessageHandler.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.IdeMessaging/IMessageHandler.cs
@@ -4,6 +4,6 @@ namespace GodotTools.IdeMessaging
 {
     public interface IMessageHandler
     {
-        Task<MessageContent> HandleRequest(Peer peer, string id, MessageContent content, ILogger logger);
+        public Task<MessageContent> HandleRequest(Peer peer, string id, MessageContent content, ILogger logger);
     }
 }

--- a/modules/mono/editor/GodotTools/GodotTools.OpenVisualStudio/Program.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.OpenVisualStudio/Program.cs
@@ -281,13 +281,13 @@ namespace GodotTools.OpenVisualStudio
         private interface IOleMessageFilter
         {
             [PreserveSig]
-            int HandleInComingCall(int dwCallType, IntPtr hTaskCaller, int dwTickCount, IntPtr lpInterfaceInfo);
+            public int HandleInComingCall(int dwCallType, IntPtr hTaskCaller, int dwTickCount, IntPtr lpInterfaceInfo);
 
             [PreserveSig]
-            int RetryRejectedCall(IntPtr hTaskCallee, int dwTickCount, int dwRejectType);
+            public int RetryRejectedCall(IntPtr hTaskCallee, int dwTickCount, int dwRejectType);
 
             [PreserveSig]
-            int MessagePending(IntPtr hTaskCallee, int dwTickCount, int dwPendingType);
+            public int MessagePending(IntPtr hTaskCallee, int dwTickCount, int dwPendingType);
         }
 
         #endregion

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaitable.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaitable.cs
@@ -5,7 +5,11 @@ namespace Godot
     /// </summary>
     public interface IAwaitable
     {
-        IAwaiter GetAwaiter();
+        /// <summary>
+        /// Gets an Awaiter for this <see cref="IAwaitable"/>.
+        /// </summary>
+        /// <returns>An Awaiter.</returns>
+        public IAwaiter GetAwaiter();
     }
 
     /// <summary>
@@ -14,6 +18,10 @@ namespace Godot
     /// <typeparam name="TResult">A reference to the result to be passed out.</typeparam>
     public interface IAwaitable<out TResult>
     {
-        IAwaiter<TResult> GetAwaiter();
+        /// <summary>
+        /// Gets an Awaiter for this <see cref="IAwaitable{TResult}"/>.
+        /// </summary>
+        /// <returns>An Awaiter.</returns>
+        public IAwaiter<TResult> GetAwaiter();
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaiter.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaiter.cs
@@ -7,9 +7,15 @@ namespace Godot
     /// </summary>
     public interface IAwaiter : INotifyCompletion
     {
-        bool IsCompleted { get; }
+        /// <summary>
+        /// The completion status of this <see cref="IAwaiter"/>.
+        /// </summary>
+        public bool IsCompleted { get; }
 
-        void GetResult();
+        /// <summary>
+        /// Gets the result of completion for this <see cref="IAwaiter"/>.
+        /// </summary>
+        public void GetResult();
     }
 
     /// <summary>
@@ -18,8 +24,14 @@ namespace Godot
     /// <typeparam name="TResult">A reference to the result to be passed out.</typeparam>
     public interface IAwaiter<out TResult> : INotifyCompletion
     {
-        bool IsCompleted { get; }
+        /// <summary>
+        /// The completion status of this <see cref="IAwaiter{TResult}"/>.
+        /// </summary>
+        public bool IsCompleted { get; }
 
-        TResult GetResult();
+        /// <summary>
+        /// Gets the result of completion for this <see cref="IAwaiter{TResult}"/>.
+        /// </summary>
+        public TResult GetResult();
     }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/ISerializationListener.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/ISerializationListener.cs
@@ -10,12 +10,12 @@ namespace Godot
         /// Executed before serializing this instance's state when reloading assemblies.
         /// Clear any data that should not be serialized.
         /// </summary>
-        void OnBeforeSerialize();
+        public void OnBeforeSerialize();
 
         /// <summary>
         /// Executed after deserializing this instance's state after reloading assemblies.
         /// Restore any state that has been lost.
         /// </summary>
-        void OnAfterDeserialize();
+        public void OnAfterDeserialize();
     }
 }


### PR DESCRIPTION
This is a manual cherry-pick of PR https://github.com/godotengine/godot/pull/108885 to the 4.4 branch due to conflicts.

Why? This is required to fix diffs when running the `dotnet format` step in `pre-commit run --all-files`.

I also included the doc comments that exist in newer Godot versions, since it's a harmless addition.