### PR TITLE
[Android editor] Add support for eye hovers on Android XR

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -64,6 +64,17 @@ jobs:
       - name: Setup Python and SCons
         uses: ./.github/actions/godot-deps
 
+      - name: Download pre-built AccessKit
+        shell: sh
+        id: accesskit-sdk
+        run: |
+          if python ./misc/scripts/install_accesskit.py; then
+            echo "ACCESSKIT_ENABLED=yes" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::AccessKit SDK installation failed, building without AccessKit support."
+            echo "ACCESSKIT_ENABLED=no" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Download Swappy
         run: python ./misc/scripts/install_swappy_android.py
 
@@ -81,7 +92,7 @@ jobs:
       - name: Compilation
         uses: ./.github/actions/godot-build
         with:
-          scons-flags: ${{ env.SCONS_FLAGS }} ${{ matrix.scons-flags }} profiler=${{ steps.perfetto_sdk.outputs.PROFILER_ENABLED }}
+          scons-flags: ${{ env.SCONS_FLAGS }} ${{ matrix.scons-flags }} profiler=${{ steps.perfetto_sdk.outputs.PROFILER_ENABLED }} accesskit=${{ steps.accesskit-sdk.outputs.ACCESSKIT_ENABLED }}
           platform: android
           target: ${{ matrix.target }}
 

--- a/doc/classes/AccessibilityServer.xml
+++ b/doc/classes/AccessibilityServer.xml
@@ -4,6 +4,8 @@
 		A server interface for screen reader support.
 	</brief_description>
 	<description>
+		[AccessibilityServer] handles screen reader support.
+		[b]Note:[/b] [AccessibilityServer] is implemented on Android, Linux, macOS, and Windows.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -80,7 +80,7 @@
 			<return type="int" />
 			<description>
 				Returns [code]1[/code] if a screen reader, Braille display or other assistive app is active, [code]0[/code] otherwise. Returns [code]-1[/code] if status is unknown.
-				[b]Note:[/b] This method is implemented on Linux, macOS, and Windows.
+				[b]Note:[/b] This method is implemented on Android, Linux, macOS, and Windows.
 				[b]Note:[/b] Accessibility debugging tools, such as Accessibility Insights for Windows, Accessibility Inspector (macOS), or AT-SPI Browser (Linux/BSD), do not count as assistive apps and will not affect this value. To test your project with these tools, set [member ProjectSettings.accessibility/general/accessibility_support] to [code]1[/code].
 			</description>
 		</method>
@@ -109,14 +109,14 @@
 			<return type="int" />
 			<description>
 				Returns [code]1[/code] if a high-contrast user interface theme should be used, [code]0[/code] otherwise. Returns [code]-1[/code] if status is unknown.
-				[b]Note:[/b] This method is implemented on Linux (X11/Wayland, GNOME), macOS, and Windows.
+				[b]Note:[/b] This method is implemented on Android, Linux (X11/Wayland, GNOME), macOS, and Windows.
 			</description>
 		</method>
 		<method name="accessibility_should_reduce_animation" qualifiers="const">
 			<return type="int" />
 			<description>
 				Returns [code]1[/code] if flashing, blinking, and other moving content that can cause seizures in users with photosensitive epilepsy should be disabled, [code]0[/code] otherwise. Returns [code]-1[/code] if status is unknown.
-				[b]Note:[/b] This method is implemented on macOS and Windows.
+				[b]Note:[/b] This method is implemented on Android, macOS, and Windows.
 			</description>
 		</method>
 		<method name="accessibility_should_reduce_transparency" qualifiers="const">

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -33,7 +33,7 @@ if env["platform"] in ["ios", "visionos"]:
     SConscript("apple_embedded/SCsub")
 
 # Accessibility
-if env["accesskit"] and env["platform"] in ["macos", "windows", "linuxbsd"]:
+if env["accesskit"] and env["platform"] in ["macos", "windows", "linuxbsd", "android"]:
     SConscript("accesskit/SCsub")
 
 # Midi drivers

--- a/drivers/accesskit/accessibility_server_accesskit.cpp
+++ b/drivers/accesskit/accessibility_server_accesskit.cpp
@@ -34,6 +34,10 @@
 
 #include "servers/text/text_server.h"
 
+#ifdef ANDROID_ENABLED
+#include "platform/android/thread_jandroid.h"
+#endif
+
 _FORCE_INLINE_ accesskit_role AccessibilityServerAccessKit::_accessibility_role(AccessibilityServerEnums::AccessibilityRole p_role) const {
 	if (role_map.has(p_role)) {
 		return role_map[p_role];
@@ -58,6 +62,9 @@ bool AccessibilityServerAccessKit::window_create(DisplayServerEnums::WindowID p_
 	ae->window_id = p_window_id;
 	wd.root_id = rid_owner.make_rid(ae);
 
+#ifdef ANDROID_ENABLED
+	wd.adapter = accesskit_android_adapter_new();
+#endif
 #ifdef WINDOWS_ENABLED
 	wd.adapter = accesskit_windows_subclassing_adapter_new(static_cast<HWND>(p_handle), &_accessibility_initial_tree_update_callback, (void *)(size_t)p_window_id, &_accessibility_action_callback, (void *)(size_t)p_window_id);
 #endif
@@ -80,12 +87,108 @@ bool AccessibilityServerAccessKit::window_create(DisplayServerEnums::WindowID p_
 	}
 }
 
+void *AccessibilityServerAccessKit::native_create_node_info(DisplayServerEnums::WindowID p_window_id, void *p_host, int p_view_id) {
+	WindowData *wd = windows.getptr(p_window_id);
+	ERR_FAIL_NULL_V(wd, nullptr);
+#ifdef ANDROID_ENABLED
+	JNIEnv *env = get_jni_env();
+	ERR_FAIL_NULL_V(env, nullptr);
+
+	if (wd->host == nullptr && p_host != nullptr) {
+		wd->host = env->NewGlobalRef((jobject)p_host);
+	}
+
+	return accesskit_android_adapter_create_accessibility_node_info(wd->adapter, &_accessibility_initial_tree_update_callback, (void *)(size_t)p_window_id, env, (jobject)wd->host, p_view_id);
+#else
+	return nullptr;
+#endif
+}
+
+void *AccessibilityServerAccessKit::native_find_focus(DisplayServerEnums::WindowID p_window_id, void *p_host, int p_focus_type) {
+	WindowData *wd = windows.getptr(p_window_id);
+	ERR_FAIL_NULL_V(wd, nullptr);
+#ifdef ANDROID_ENABLED
+	JNIEnv *env = get_jni_env();
+	ERR_FAIL_NULL_V(env, nullptr);
+
+	if (wd->host == nullptr && p_host != nullptr) {
+		wd->host = env->NewGlobalRef((jobject)p_host);
+	}
+
+	return accesskit_android_adapter_find_focus(wd->adapter, &_accessibility_initial_tree_update_callback, (void *)(size_t)p_window_id, env, (jobject)wd->host, p_focus_type);
+#else
+	return nullptr;
+#endif
+}
+
+bool AccessibilityServerAccessKit::native_perform_action(DisplayServerEnums::WindowID p_window_id, void *p_host, int p_view_id, int p_action, void *p_arguments) {
+	WindowData *wd = windows.getptr(p_window_id);
+	ERR_FAIL_NULL_V(wd, false);
+#ifdef ANDROID_ENABLED
+	JNIEnv *env = get_jni_env();
+	ERR_FAIL_NULL_V(env, false);
+
+	if (wd->host == nullptr && p_host != nullptr) {
+		wd->host = env->NewGlobalRef((jobject)p_host);
+	}
+
+	accesskit_android_platform_action *platform_action = accesskit_android_platform_action_from_java(env, p_action, (jobject)p_arguments);
+	if (!platform_action) {
+		return false;
+	}
+
+	accesskit_android_queued_events *events = accesskit_android_adapter_perform_action(wd->adapter, &_accessibility_action_callback, (void *)(size_t)p_window_id, p_view_id, platform_action);
+	accesskit_android_platform_action_free(platform_action);
+
+	if (events) {
+		accesskit_android_queued_events_raise(events, env, (jobject)wd->host);
+		return true;
+	} else {
+		return false;
+	}
+#else
+	return false;
+#endif
+}
+
+bool AccessibilityServerAccessKit::native_on_hover(DisplayServerEnums::WindowID p_window_id, void *p_host, int p_action, float p_x, float p_y) {
+	WindowData *wd = windows.getptr(p_window_id);
+	ERR_FAIL_NULL_V(wd, false);
+#ifdef ANDROID_ENABLED
+	JNIEnv *env = get_jni_env();
+	ERR_FAIL_NULL_V(env, false);
+
+	if (wd->host == nullptr && p_host != nullptr) {
+		wd->host = env->NewGlobalRef((jobject)p_host);
+	}
+
+	accesskit_android_queued_events *events = accesskit_android_adapter_on_hover_event(wd->adapter, &_accessibility_initial_tree_update_callback, (void *)(size_t)p_window_id, p_action, p_x, p_y);
+
+	if (events) {
+		accesskit_android_queued_events_raise(events, env, (jobject)wd->host);
+		return true;
+	} else {
+		return false;
+	}
+#else
+	return false;
+#endif
+}
+
 void AccessibilityServerAccessKit::window_destroy(DisplayServerEnums::WindowID p_window_id) {
 	WindowData *wd = windows.getptr(p_window_id);
 	ERR_FAIL_NULL(wd);
 
 	print_verbose(vformat("Accessibility: window %d adapter destroyed.", p_window_id));
 
+#ifdef ANDROID_ENABLED
+	JNIEnv *env = get_jni_env();
+	if (env && wd->host) {
+		env->DeleteGlobalRef(wd->host);
+		wd->host = nullptr;
+	}
+	accesskit_android_adapter_free(wd->adapter);
+#endif
 #ifdef WINDOWS_ENABLED
 	accesskit_windows_subclassing_adapter_free(wd->adapter);
 #endif
@@ -98,6 +201,10 @@ void AccessibilityServerAccessKit::window_destroy(DisplayServerEnums::WindowID p
 	free_element(wd->root_id);
 
 	windows.erase(p_window_id);
+}
+
+bool AccessibilityServerAccessKit::has_window(DisplayServerEnums::WindowID p_window_id) {
+	return windows.has(p_window_id);
 }
 
 void AccessibilityServerAccessKit::_accessibility_deactivation_callback(void *p_user_data) {
@@ -679,6 +786,15 @@ void AccessibilityServerAccessKit::update_if_active(const Callable &p_callable) 
 	ERR_FAIL_COND(!p_callable.is_valid());
 	update_cb = p_callable;
 	for (KeyValue<DisplayServerEnums::WindowID, WindowData> &window : windows) {
+#ifdef ANDROID_ENABLED
+		if (window.value.host == nullptr) {
+			continue;
+		}
+		accesskit_android_queued_events *events = accesskit_android_adapter_update_if_active(window.value.adapter, _accessibility_build_tree_update, (void *)(size_t)window.key);
+		if (events) {
+			accesskit_android_queued_events_raise(events, get_jni_env(), window.value.host);
+		}
+#endif
 #ifdef WINDOWS_ENABLED
 		accesskit_windows_queued_events *events = accesskit_windows_subclassing_adapter_update_if_active(window.value.adapter, _accessibility_build_tree_update, (void *)(size_t)window.key);
 		if (events) {

--- a/drivers/accesskit/accessibility_server_accesskit.h
+++ b/drivers/accesskit/accessibility_server_accesskit.h
@@ -71,7 +71,10 @@ class AccessibilityServerAccessKit : public AccessibilityServer {
 #ifdef LINUXBSD_ENABLED
 		accesskit_unix_adapter *adapter = nullptr;
 #endif
-
+#ifdef ANDROID_ENABLED
+		accesskit_android_adapter *adapter = nullptr;
+		jobject host = nullptr;
+#endif
 		RID root_id;
 		bool initial_update_completed = false;
 		HashSet<RID> update;
@@ -106,6 +109,7 @@ public:
 
 	bool window_create(DisplayServerEnums::WindowID p_window_id, void *p_handle) override;
 	void window_destroy(DisplayServerEnums::WindowID p_window_id) override;
+	bool has_window(DisplayServerEnums::WindowID p_window_id) override;
 
 	RID create_element(DisplayServerEnums::WindowID p_window_id, AccessibilityServerEnums::AccessibilityRole p_role) override;
 	RID create_sub_element(const RID &p_parent_rid, AccessibilityServerEnums::AccessibilityRole p_role, int p_insert_pos = -1) override;
@@ -190,6 +194,11 @@ public:
 	void update_set_color_value(const RID &p_id, const Color &p_color) override;
 	void update_set_background_color(const RID &p_id, const Color &p_color) override;
 	void update_set_foreground_color(const RID &p_id, const Color &p_color) override;
+
+	void *native_create_node_info(DisplayServerEnums::WindowID p_window_id, void *p_host, int p_view_id) override;
+	void *native_find_focus(DisplayServerEnums::WindowID p_window_id, void *p_host, int p_focus_type) override;
+	bool native_perform_action(DisplayServerEnums::WindowID p_window_id, void *p_host, int p_view_id, int p_action, void *p_arguments) override;
+	bool native_on_hover(DisplayServerEnums::WindowID p_window_id, void *p_host, int p_action, float p_x, float p_y) override;
 
 	static void register_create_func();
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -200,6 +200,7 @@ String tablet_driver = "";
 String text_driver = "";
 static int text_driver_idx = -1;
 static int audio_driver_idx = -1;
+static int accessibility_driver_idx = -1;
 
 // Engine config/tools
 
@@ -1048,6 +1049,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	Vector<String> breakpoints;
 #endif
 
+	Error err = OK;
 #if defined(TOOLS_ENABLED) && (defined(WINDOWS_ENABLED) || defined(LINUXBSD_ENABLED))
 	bool test_rd_creation = false;
 	bool test_rd_support = false;
@@ -2041,7 +2043,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else {
 			port = 6010;
 		}
-		Error err = OS::get_singleton()->setup_remote_filesystem(remotefs, port, remotefs_pass, project_path);
+		err = OS::get_singleton()->setup_remote_filesystem(remotefs, port, remotefs_pass, project_path);
 
 		if (err) {
 			OS::get_singleton()->printerr("Could not connect to remotefs: %s:%i.\n", remotefs.utf8().get_data(), port);
@@ -2901,6 +2903,55 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	message_queue = memnew(MessageQueue);
 
+	// Init AccessibilityServer.
+	// Note: early setup is required for Android.
+	if (accessibility_driver_name.is_empty()) {
+		if (!editor && !project_manager) {
+			accessibility_driver_name = GLOBAL_GET("accessibility/general/accessibility_driver");
+		} else {
+			accessibility_driver_name = "accesskit";
+		}
+	}
+	if (display_driver == NULL_DISPLAY_DRIVER || display_driver == EMBEDDED_DISPLAY_DRIVER || accessibility_mode == AccessibilityServerEnums::AccessibilityMode::ACCESSIBILITY_DISABLED) {
+		accessibility_driver_name = "dummy";
+	}
+
+	if (accessibility_driver_name.is_empty() || accessibility_driver_name == "default") {
+		accessibility_driver_idx = 0;
+	} else {
+		for (int i = 0; i < AccessibilityServer::get_create_function_count(); i++) {
+			String name = AccessibilityServer::get_create_function_name(i);
+			if (accessibility_driver_name == name) {
+				accessibility_driver_idx = i;
+				break;
+			}
+		}
+
+		if (accessibility_driver_idx < 0) {
+			// If the requested driver wasn't found, pick the first entry.
+			// If all else failed it would be the headless server.
+			accessibility_driver_idx = 0;
+		}
+	}
+
+	accessibility_server = AccessibilityServer::create(accessibility_driver_idx, err);
+	if (err != OK || accessibility_server == nullptr) {
+		String last_name = AccessibilityServer::get_create_function_name(accessibility_driver_idx);
+
+		for (int i = 0; i < AccessibilityServer::get_create_function_count(); i++) {
+			if (i == accessibility_driver_idx) {
+				continue; // Don't try the same twice.
+			}
+			String name = AccessibilityServer::get_create_function_name(i);
+			WARN_VERBOSE(vformat("Accessibility driver %s failed, falling back to %s.", last_name, name));
+
+			accessibility_server = AccessibilityServer::create(i, err);
+			if (err == OK && accessibility_server != nullptr) {
+				break;
+			}
+		}
+	}
+
 #if defined(STEAMAPI_ENABLED)
 	if (editor || project_manager) {
 		steam_tracker = memnew(SteamTracker);
@@ -3275,56 +3326,10 @@ Error Main::setup2(bool p_show_boot_logo) {
 				accessibility_mode = (AccessibilityServerEnums::AccessibilityMode)GLOBAL_GET("accessibility/general/accessibility_support").operator int64_t();
 			}
 		}
-		if (accessibility_driver_name.is_empty()) {
-			if (!editor && !project_manager) {
-				accessibility_driver_name = GLOBAL_GET("accessibility/general/accessibility_driver");
-			} else {
-				accessibility_driver_name = "accesskit";
-			}
-		}
-		if (display_driver == NULL_DISPLAY_DRIVER || display_driver == EMBEDDED_DISPLAY_DRIVER || accessibility_mode == AccessibilityServerEnums::AccessibilityMode::ACCESSIBILITY_DISABLED) {
-			accessibility_driver_name = "dummy";
-		}
-		int accessibility_driver_idx = -1;
 
-		if (accessibility_driver_name.is_empty() || accessibility_driver_name == "default") {
-			accessibility_driver_idx = 0;
-		} else {
-			for (int i = 0; i < AccessibilityServer::get_create_function_count(); i++) {
-				String name = AccessibilityServer::get_create_function_name(i);
-				if (accessibility_driver_name == name) {
-					accessibility_driver_idx = i;
-					break;
-				}
-			}
-
-			if (accessibility_driver_idx < 0) {
-				// If the requested driver wasn't found, pick the first entry.
-				// If all else failed it would be the headless server.
-				accessibility_driver_idx = 0;
-			}
-		}
-
-		Error err;
-		accessibility_server = AccessibilityServer::create(accessibility_driver_idx, err);
-		if (err != OK || accessibility_server == nullptr) {
-			String last_name = AccessibilityServer::get_create_function_name(accessibility_driver_idx);
-
-			for (int i = 0; i < AccessibilityServer::get_create_function_count(); i++) {
-				if (i == accessibility_driver_idx) {
-					continue; // Don't try the same twice.
-				}
-				String name = AccessibilityServer::get_create_function_name(i);
-				WARN_VERBOSE(vformat("Accessibility driver %s failed, falling back to %s.", last_name, name));
-
-				accessibility_server = AccessibilityServer::create(i, err);
-				if (err == OK && accessibility_server != nullptr) {
-					break;
-				}
-			}
-		}
 		accessibility_server->set_mode(accessibility_mode);
 
+		Error err;
 		String rendering_driver = OS::get_singleton()->get_current_rendering_driver_name();
 		display_server = DisplayServer::create(display_driver_idx, rendering_driver, window_mode, window_vsync_mode, window_flags, window_position, window_size, init_screen, context, init_embed_parent_window_id, err);
 		if (err != OK || display_server == nullptr) {

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -26,6 +26,22 @@ def get_tools(env: "SConsEnvironment"):
 def get_opts():
     from SCons.Variables import BoolVariable
 
+    # Dependencies folder.
+    deps_folder = os.getenv("LOCALAPPDATA")
+    if deps_folder:
+        deps_folder = os.path.join(deps_folder, "Godot", "build_deps")
+    else:
+        # Cross-compiling, the deps install script puts things in `bin`.
+        # Getting an absolute path to it is a bit hacky in Python.
+        try:
+            import inspect
+
+            caller_frame = inspect.stack()[1]
+            caller_script_dir = os.path.dirname(os.path.abspath(caller_frame[1]))
+            deps_folder = os.path.join(caller_script_dir, "bin", "build_deps")
+        except Exception:  # Give up.
+            deps_folder = ""
+
     return [
         ("ANDROID_HOME", "Path to the Android SDK", get_env_android_sdk_root()),
         (
@@ -40,6 +56,12 @@ def get_opts():
             False,
         ),
         BoolVariable("swappy", "Use Swappy Frame Pacing library", False),
+        # Screen reader support.
+        (
+            "accesskit_sdk_path",
+            "Path to the AccessKit C SDK",
+            os.path.join(deps_folder, "accesskit"),
+        ),
     ]
 
 
@@ -225,6 +247,29 @@ def configure(env: "SConsEnvironment"):
 
     if get_min_sdk_version(env["ndk_platform"]) >= 24:
         env.Append(CPPDEFINES=[("_FILE_OFFSET_BITS", 64)])
+
+    if env["accesskit"]:
+        if os.path.exists(env["accesskit_sdk_path"]):
+            env.Prepend(CPPPATH=[env["accesskit_sdk_path"] + "/include"])
+            if env["arch"] == "arm64":
+                env.Append(LIBPATH=[env["accesskit_sdk_path"] + "/lib/android/arm64-v8a/static/"])
+            elif env["arch"] == "arm32":
+                env.Append(LIBPATH=[env["accesskit_sdk_path"] + "/lib/android/armeabi-v7a/static/"])
+            elif env["arch"] == "x86_64":
+                env.Append(LIBPATH=[env["accesskit_sdk_path"] + "/lib/android/x86_64/static/"])
+            elif env["arch"] == "x86_32":
+                env.Append(LIBPATH=[env["accesskit_sdk_path"] + "/lib/android/x86/static/"])
+            env.Append(LIBS=["accesskit"])
+            env.Append(CPPDEFINES=["ACCESSKIT_ENABLED"])
+        else:
+            print_warning(
+                "The screen reader support driver requires dependencies to be installed.\n"
+                f"You can install them by running `python {os.path.join('misc', 'scripts', 'install_accesskit.py')}`.\n"
+                "See the documentation for more information:\n"
+                "\thttps://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_linuxbsd.html#compiling-with-accesskit-support\n"
+                "Alternatively, disable this driver by compiling with `accesskit=no` explicitly."
+            )
+            env["accesskit"] = False
 
     if env["arch"] == "x86_32":
         if has_swappy:

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -39,6 +39,7 @@
 #include "core/input/input.h"
 #include "core/input/input_event.h"
 #include "core/os/os.h"
+#include "servers/display/accessibility_server.h"
 #include "servers/display/native_menu.h"
 
 #if defined(RD_ENABLED)
@@ -99,6 +100,8 @@ bool DisplayServerAndroid::has_feature(DisplayServerEnums::Feature p_feature) co
 		case DisplayServerEnums::FEATURE_VIRTUAL_KEYBOARD:
 		case DisplayServerEnums::FEATURE_TEXT_TO_SPEECH:
 			return true;
+		case DisplayServerEnums::FEATURE_ACCESSIBILITY_SCREEN_READER:
+			return AccessibilityServer::get_singleton()->is_supported();
 		default:
 			return false;
 	}
@@ -106,6 +109,24 @@ bool DisplayServerAndroid::has_feature(DisplayServerEnums::Feature p_feature) co
 
 String DisplayServerAndroid::get_name() const {
 	return "Android";
+}
+
+int DisplayServerAndroid::accessibility_should_increase_contrast() const {
+	GodotJavaWrapper *godot_java = OS_Android::get_singleton()->get_godot_java();
+	ERR_FAIL_NULL_V(godot_java, -1);
+	return godot_java->is_high_contrast_active();
+}
+
+int DisplayServerAndroid::accessibility_screen_reader_active() const {
+	GodotJavaWrapper *godot_java = OS_Android::get_singleton()->get_godot_java();
+	ERR_FAIL_NULL_V(godot_java, -1);
+	return godot_java->is_screen_reader_active();
+}
+
+int DisplayServerAndroid::accessibility_should_reduce_animation() const {
+	GodotJavaWrapper *godot_java = OS_Android::get_singleton()->get_godot_java();
+	ERR_FAIL_NULL_V(godot_java, -1);
+	return godot_java->is_animation_disabled();
 }
 
 bool DisplayServerAndroid::tts_is_speaking() const {

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -109,6 +109,10 @@ public:
 	virtual bool has_feature(DisplayServerEnums::Feature p_feature) const override;
 	virtual String get_name() const override;
 
+	virtual int accessibility_should_increase_contrast() const override;
+	virtual int accessibility_screen_reader_active() const override;
+	virtual int accessibility_should_reduce_animation() const override;
+
 	virtual bool tts_is_speaking() const override;
 	virtual bool tts_is_paused() const override;
 	virtual TypedArray<Dictionary> tts_get_voices() const override;

--- a/platform/android/java/editor/src/android/java/org/godotengine/editor/GodotEditor.kt
+++ b/platform/android/java/editor/src/android/java/org/godotengine/editor/GodotEditor.kt
@@ -30,12 +30,18 @@
 
 package org.godotengine.editor
 
+import android.util.Log
+
 /**
  * Primary window of the Godot Editor.
  *
  * This is the implementation of the editor used when running on Android devices.
  */
 open class GodotEditor : BaseGodotEditor() {
+
+	companion object {
+		private val TAG = GodotEditor::class.simpleName
+	}
 
 	override fun getXRRuntimePermissions(): MutableSet<String> {
 		val xrRuntimePermissions = super.getXRRuntimePermissions()
@@ -44,5 +50,17 @@ open class GodotEditor : BaseGodotEditor() {
 		xrRuntimePermissions.add("android.permission.HAND_TRACKING")
 
 		return xrRuntimePermissions
+	}
+
+	override fun getCommandLine(): MutableList<String> {
+		val updatedArgs = super.getCommandLine()
+		if (getEditorWindowInfo() == EDITOR_MAIN_INFO && packageManager.hasSystemFeature("android.hardware.xr.input.eye_tracking")) {
+			if (!updatedArgs.contains("--accessibility ")) {
+				Log.v(TAG, "Enabling accessibility for Android XR to add support for eye hovers.")
+				updatedArgs.add("--accessibility ")
+				updatedArgs.add("always")
+			}
+		}
+		return updatedArgs
 	}
 }

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotGLRenderView.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotGLRenderView.java
@@ -30,6 +30,7 @@
 
 package org.godotengine.godot;
 
+import org.godotengine.godot.GodotLib;
 import org.godotengine.godot.gl.GLSurfaceView;
 import org.godotengine.godot.gl.GodotRenderer;
 import org.godotengine.godot.input.GodotInputHandler;
@@ -46,12 +47,16 @@ import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.PixelFormat;
+import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.SparseArray;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.PointerIcon;
 import android.view.SurfaceView;
+import android.view.View;
+import android.view.accessibility.AccessibilityNodeInfo;
+import android.view.accessibility.AccessibilityNodeProvider;
 
 import androidx.annotation.Keep;
 
@@ -80,15 +85,60 @@ class GodotGLRenderView extends GLSurfaceView implements GodotRenderView {
 	private final GodotInputHandler inputHandler;
 	private final GodotRenderer godotRenderer;
 	private final SparseArray<PointerIcon> customPointerIcons = new SparseArray<>();
+	private final AccessibilityNodeProvider accessibilityNodeProvider;
+	private final long mWindowID = 0; // DisplayServerEnums::MAIN_WINDOW_ID
 
 	public GodotGLRenderView(Godot godot, GodotInputHandler inputHandler, XRMode xrMode, boolean useDebugOpengl, boolean shouldBeTranslucent) {
 		super(godot.getContext());
-
+		if (GodotLib.createAccessKitAdapter(mWindowID)) {
+			accessibilityNodeProvider = new AccessibilityNodeProvider() {
+				@Override
+				public AccessibilityNodeInfo createAccessibilityNodeInfo(int virtualViewId) {
+					return GodotLib.createAccessibilityNodeInfo(mWindowID, getView(), virtualViewId);
+				}
+				@Override
+				public AccessibilityNodeInfo findFocus(int focusType) {
+					return GodotLib.findAccessibilityFocus(mWindowID, getView(), focusType);
+				}
+				@Override
+				public boolean performAction(int virtualViewId, int action, Bundle arguments) {
+					return GodotLib.performAccessibilityAction(mWindowID, getView(), virtualViewId, action, arguments);
+				}
+			};
+			setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_YES);
+		} else {
+			accessibilityNodeProvider = null;
+		}
 		this.godot = godot;
 		this.inputHandler = inputHandler;
 		this.godotRenderer = new GodotRenderer();
 		setPointerIcon(PointerIcon.getSystemIcon(getContext(), PointerIcon.TYPE_DEFAULT));
 		init(xrMode, shouldBeTranslucent, useDebugOpengl);
+	}
+
+	@Override
+	public boolean onHoverEvent(MotionEvent event) {
+		if (accessibilityNodeProvider != null && GodotLib.onAccessibilityHoverEvent(mWindowID, this, event.getAction(), event.getX(), event.getY())) {
+			return true;
+		}
+		return super.onHoverEvent(event);
+	}
+
+	@Override
+	public AccessibilityNodeProvider getAccessibilityNodeProvider() {
+		if (accessibilityNodeProvider == null) {
+			return super.getAccessibilityNodeProvider();
+		}
+		return accessibilityNodeProvider;
+	}
+
+	@Override
+	protected void finalize() throws Throwable {
+		try {
+			GodotLib.freeAccessKitAdapter(mWindowID);
+		} finally {
+			super.finalize();
+		}
 	}
 
 	@Override

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotLib.java
@@ -41,7 +41,11 @@ import org.godotengine.godot.variant.Callable;
 import android.app.Activity;
 import android.content.res.AssetManager;
 import android.hardware.SensorEvent;
+import android.os.Bundle;
 import android.view.Surface;
+import android.view.View;
+import android.view.accessibility.AccessibilityNodeInfo;
+import android.view.accessibility.AccessibilityNodeProvider;
 
 import javax.microedition.khronos.opengles.GL10;
 
@@ -107,6 +111,17 @@ public class GodotLib {
 	 * TTS callback.
 	 */
 	public static native void ttsCallback(int event, long id, int pos);
+
+	/**
+	 * Accesskit.
+	 */
+
+	static native boolean createAccessKitAdapter(long windowID);
+	static native void freeAccessKitAdapter(long windowID);
+	static native AccessibilityNodeInfo createAccessibilityNodeInfo(long windowID, View host, int virtualViewId);
+	static native AccessibilityNodeInfo findAccessibilityFocus(long windowID, View host, int focusType);
+	static native boolean performAccessibilityAction(long windowID, View host, int virtualViewId, int action, Bundle arguments);
+	static native boolean onAccessibilityHoverEvent(long windowID, View host, int action, float x, float y);
 
 	/**
 	 * Forward touch events.

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotVulkanRenderView.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotVulkanRenderView.java
@@ -30,6 +30,7 @@
 
 package org.godotengine.godot;
 
+import org.godotengine.godot.GodotLib;
 import org.godotengine.godot.input.GodotInputHandler;
 import org.godotengine.godot.vulkan.VkRenderer;
 import org.godotengine.godot.vulkan.VkSurfaceView;
@@ -39,12 +40,16 @@ import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.PixelFormat;
+import android.os.Bundle;
 import android.text.TextUtils;
 import android.util.SparseArray;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.PointerIcon;
 import android.view.SurfaceView;
+import android.view.View;
+import android.view.accessibility.AccessibilityNodeInfo;
+import android.view.accessibility.AccessibilityNodeProvider;
 
 import androidx.annotation.Keep;
 
@@ -56,9 +61,30 @@ class GodotVulkanRenderView extends VkSurfaceView implements GodotRenderView {
 	private final VkRenderer mRenderer;
 	private final SparseArray<PointerIcon> customPointerIcons = new SparseArray<>();
 
+	private final AccessibilityNodeProvider accessibilityNodeProvider;
+	private final long mWindowID = 0; // DisplayServerEnums::MAIN_WINDOW_ID
+
 	public GodotVulkanRenderView(Godot godot, GodotInputHandler inputHandler, boolean shouldBeTranslucent) {
 		super(godot.getContext());
-
+		if (GodotLib.createAccessKitAdapter(mWindowID)) {
+			accessibilityNodeProvider = new AccessibilityNodeProvider() {
+				@Override
+				public AccessibilityNodeInfo createAccessibilityNodeInfo(int virtualViewId) {
+					return GodotLib.createAccessibilityNodeInfo(mWindowID, getView(), virtualViewId);
+				}
+				@Override
+				public AccessibilityNodeInfo findFocus(int focusType) {
+					return GodotLib.findAccessibilityFocus(mWindowID, getView(), focusType);
+				}
+				@Override
+				public boolean performAction(int virtualViewId, int action, Bundle arguments) {
+					return GodotLib.performAccessibilityAction(mWindowID, getView(), virtualViewId, action, arguments);
+				}
+			};
+			setImportantForAccessibility(View.IMPORTANT_FOR_ACCESSIBILITY_YES);
+		} else {
+			accessibilityNodeProvider = null;
+		}
 		this.godot = godot;
 		mInputHandler = inputHandler;
 		mRenderer = new VkRenderer();
@@ -68,6 +94,31 @@ class GodotVulkanRenderView extends VkSurfaceView implements GodotRenderView {
 
 		if (shouldBeTranslucent) {
 			this.getHolder().setFormat(PixelFormat.TRANSLUCENT);
+		}
+	}
+
+	@Override
+	public boolean onHoverEvent(MotionEvent event) {
+		if (accessibilityNodeProvider != null && GodotLib.onAccessibilityHoverEvent(mWindowID, this, event.getAction(), event.getX(), event.getY())) {
+			return true;
+		}
+		return super.onHoverEvent(event);
+	}
+
+	@Override
+	public AccessibilityNodeProvider getAccessibilityNodeProvider() {
+		if (accessibilityNodeProvider == null) {
+			return super.getAccessibilityNodeProvider();
+		}
+		return accessibilityNodeProvider;
+	}
+
+	@Override
+	protected void finalize() throws Throwable {
+		try {
+			GodotLib.freeAccessKitAdapter(mWindowID);
+		} finally {
+			super.finalize();
 		}
 	}
 

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/nativeapi/GodotNativeBridge.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/nativeapi/GodotNativeBridge.kt
@@ -30,15 +30,19 @@
 
 package org.godotengine.godot.nativeapi
 
+import android.accessibilityservice.AccessibilityServiceInfo
 import android.annotation.SuppressLint
 import android.app.AlertDialog
+import android.content.ContentResolver
 import android.content.Context
 import android.content.DialogInterface
 import android.content.Intent
 import android.content.res.Configuration
+import android.provider.Settings.Global
 import android.os.Build
 import android.os.VibrationEffect
 import android.os.Vibrator
+import android.view.accessibility.AccessibilityManager
 import android.util.Log
 import android.util.Rational
 import android.util.TypedValue
@@ -114,6 +118,47 @@ internal class GodotNativeBridge(private val godot: Godot) {
 	}
 
 	private fun forceQuit(instanceId: Int) = godot.forceQuit(instanceId)
+
+	/**
+	 * Returns true if screen reader is active, false otherwise.
+	 */
+	@Keep
+	private fun isScreenReaderActive(): Boolean {
+		val am = godot.context.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
+		if (am != null && am.isEnabled()) {
+			val serviceInfoList = am.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_SPOKEN)
+			if (!serviceInfoList.isEmpty()) {
+				return true
+			}
+		}
+		return false
+	}
+
+	/**
+	 * Returns true if high contrast text is enabled, false otherwise.
+	 */
+	@Keep
+	private fun isHighContrastActive(): Boolean {
+		val am = godot.context.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
+		if (am != null && am.isEnabled()) {
+			return am.isHighContrastTextEnabled()
+		}
+		return false
+	}
+
+	/**
+	 * Returns true if animation is disabled, false otherwise.
+	 */
+	@Keep
+	private fun isAnimationDisabled(): Boolean {
+		val am = godot.context.getSystemService(Context.ACCESSIBILITY_SERVICE) as? AccessibilityManager
+		if (am != null && am.isEnabled()) {
+			return (Global.getFloat(godot.context.getContentResolver(), Global.ANIMATOR_DURATION_SCALE, 1.0f) == 0f
+                && Global.getFloat(godot.context.getContentResolver(), Global.TRANSITION_ANIMATION_SCALE, 1.0f) == 0f
+                && Global.getFloat(godot.context.getContentResolver(), Global.WINDOW_ANIMATION_SCALE, 1.0f) == 0f)
+		}
+		return false
+	}
 
 	/**
 	 * Returns true if dark mode is supported, false otherwise.

--- a/platform/android/java/nativeSrcsConfigs/CMakeLists.txt
+++ b/platform/android/java/nativeSrcsConfigs/CMakeLists.txt
@@ -32,4 +32,5 @@ add_definitions(
         -DDEBUG_ENABLED
         -DRD_ENABLED
         -DGODOT_USE_PERFETTO
+        -DACCESSKIT_ENABLED
 )

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -55,6 +55,7 @@
 #include "core/profiling/profiling.h"
 #include "main/main.h"
 #include "servers/camera/camera_server.h"
+#include "servers/display/accessibility_server.h"
 #include "servers/rendering/rendering_server.h"
 
 #ifndef XR_DISABLED
@@ -96,6 +97,11 @@ static void _terminate(JNIEnv *env, bool p_restart = false) {
 	}
 
 	step.set(STEP_TERMINATED); // Ensure no further steps are attempted and no further events are sent
+
+	AccessibilityServer *ac = AccessibilityServer::get_singleton();
+	if (ac && ac->has_window(DisplayServerEnums::MAIN_WINDOW_ID)) {
+		ac->window_destroy(DisplayServerEnums::MAIN_WINDOW_ID);
+	}
 
 	// lets cleanup
 	// Unregister android plugins
@@ -285,6 +291,53 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_back(JNIEnv *env, jcl
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_ttsCallback(JNIEnv *env, jclass clazz, jint event, jlong id, jint pos) {
 	TTS_Android::_java_utterance_callback(event, id, pos);
+}
+
+JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_createAccessKitAdapter(JNIEnv *env, jclass clazz, jlong p_window_id) {
+	AccessibilityServer *ac = AccessibilityServer::get_singleton();
+	if (ac && ac->is_supported()) {
+		return ac->window_create((DisplayServerEnums::WindowID)p_window_id, nullptr);
+	}
+	return false;
+}
+
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_freeAccessKitAdapter(JNIEnv *env, jclass clazz, jlong p_window_id) {
+	AccessibilityServer *ac = AccessibilityServer::get_singleton();
+	if (ac && ac->has_window((DisplayServerEnums::WindowID)p_window_id)) {
+		ac->window_destroy((DisplayServerEnums::WindowID)p_window_id);
+	}
+}
+
+JNIEXPORT jobject JNICALL Java_org_godotengine_godot_GodotLib_createAccessibilityNodeInfo(JNIEnv *env, jclass clazz, jlong p_window_id, jobject p_host, jint p_virtual_view_id) {
+	AccessibilityServer *ac = AccessibilityServer::get_singleton();
+	if (ac) {
+		return (jobject)ac->native_create_node_info((DisplayServerEnums::WindowID)p_window_id, (void *)p_host, p_virtual_view_id);
+	}
+	return nullptr;
+}
+
+JNIEXPORT jobject JNICALL Java_org_godotengine_godot_GodotLib_findAccessibilityFocus(JNIEnv *env, jclass clazz, jlong p_window_id, jobject p_host, jint p_focus_type) {
+	AccessibilityServer *ac = AccessibilityServer::get_singleton();
+	if (ac) {
+		return (jobject)ac->native_find_focus((DisplayServerEnums::WindowID)p_window_id, (void *)p_host, p_focus_type);
+	}
+	return nullptr;
+}
+
+JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_performAccessibilityAction(JNIEnv *env, jclass clazz, jlong p_window_id, jobject p_host, jint p_virtual_view_id, jint p_action, jobject p_arguments) {
+	AccessibilityServer *ac = AccessibilityServer::get_singleton();
+	if (ac) {
+		return ac->native_perform_action((DisplayServerEnums::WindowID)p_window_id, (void *)p_host, p_virtual_view_id, p_action, (void *)p_arguments);
+	}
+	return false;
+}
+
+JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_onAccessibilityHoverEvent(JNIEnv *env, jclass clazz, jlong p_window_id, jobject p_host, jint p_action, jfloat p_x, jfloat p_y) {
+	AccessibilityServer *ac = AccessibilityServer::get_singleton();
+	if (ac) {
+		return ac->native_on_hover((DisplayServerEnums::WindowID)p_window_id, (void *)p_host, p_action, p_x, p_y);
+	}
+	return false;
 }
 
 JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, jclass clazz) {

--- a/platform/android/java_godot_lib_jni.h
+++ b/platform/android/java_godot_lib_jni.h
@@ -43,6 +43,12 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_resize(JNIEnv *env, j
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_newcontext(JNIEnv *env, jclass clazz, jobject p_surface);
 JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, jclass clazz);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_ttsCallback(JNIEnv *env, jclass clazz, jint event, jlong id, jint pos);
+JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_createAccessKitAdapter(JNIEnv *env, jclass clazz, jlong p_window_id);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_freeAccessKitAdapter(JNIEnv *env, jclass clazz, jlong p_window_id);
+JNIEXPORT jobject JNICALL Java_org_godotengine_godot_GodotLib_createAccessibilityNodeInfo(JNIEnv *env, jclass clazz, jlong p_window_id, jobject p_host, jint p_virtual_view_id);
+JNIEXPORT jobject JNICALL Java_org_godotengine_godot_GodotLib_findAccessibilityFocus(JNIEnv *env, jclass clazz, jlong p_window_id, jobject p_host, jint p_focus_type);
+JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_performAccessibilityAction(JNIEnv *env, jclass clazz, jlong p_window_id, jobject p_host, jint p_virtual_view_id, jint p_action, jobject p_arguments);
+JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_onAccessibilityHoverEvent(JNIEnv *env, jclass clazz, jlong p_window_id, jobject p_host, jint p_action, jfloat p_x, jfloat p_y);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_back(JNIEnv *env, jclass clazz);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchMouseEvent(JNIEnv *env, jclass clazz, jint p_event_type, jint p_button_mask, jfloat p_x, jfloat p_y, jfloat p_delta_x, jfloat p_delta_y, jboolean p_double_click, jboolean p_source_mouse_relative, jfloat p_pressure, jfloat p_tilt_x, jfloat p_tilt_y);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchTouchEvent(JNIEnv *env, jclass clazz, jint ev, jint pointer, jint pointer_count, jfloatArray positions, jboolean p_double_tap);

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -96,6 +96,9 @@ GodotJavaWrapper::GodotJavaWrapper(JNIEnv *p_env, jobject p_godot_native_bridge)
 	_build_env_execute = p_env->GetMethodID(godot_native_bridge_class, "nativeBuildEnvExecute", "(Ljava/lang/String;[Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Lorg/godotengine/godot/variant/Callable;Lorg/godotengine/godot/variant/Callable;)I");
 	_build_env_cancel = p_env->GetMethodID(godot_native_bridge_class, "nativeBuildEnvCancel", "(I)V");
 	_build_env_clean_project = p_env->GetMethodID(godot_native_bridge_class, "nativeBuildEnvCleanProject", "(Ljava/lang/String;Ljava/lang/String;Lorg/godotengine/godot/variant/Callable;)V");
+	_is_screen_reader_active = p_env->GetMethodID(godot_native_bridge_class, "isScreenReaderActive", "()Z");
+	_is_high_contrast_active = p_env->GetMethodID(godot_native_bridge_class, "isHighContrastActive", "()Z");
+	_is_animation_disabled = p_env->GetMethodID(godot_native_bridge_class, "isAnimationDisabled", "()Z");
 
 	// PiP mode method ids.
 	_is_pip_mode_supported = p_env->GetMethodID(godot_native_bridge_class, "nativeIsPiPModeSupported", "()Z");
@@ -529,6 +532,36 @@ void GodotJavaWrapper::dump_benchmark(const String &benchmark_file) {
 		jstring j_benchmark_file = env->NewStringUTF(benchmark_file.utf8().get_data());
 		env->CallVoidMethod(godot_native_bridge, _dump_benchmark, j_benchmark_file);
 		env->DeleteLocalRef(j_benchmark_file);
+	}
+}
+
+bool GodotJavaWrapper::is_screen_reader_active() {
+	if (_is_screen_reader_active) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL_V(env, false);
+		return env->CallBooleanMethod(godot_native_bridge, _is_screen_reader_active);
+	} else {
+		return false;
+	}
+}
+
+bool GodotJavaWrapper::is_animation_disabled() {
+	if (_is_animation_disabled) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL_V(env, false);
+		return env->CallBooleanMethod(godot_native_bridge, _is_animation_disabled);
+	} else {
+		return false;
+	}
+}
+
+bool GodotJavaWrapper::is_high_contrast_active() {
+	if (_is_high_contrast_active) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_NULL_V(env, false);
+		return env->CallBooleanMethod(godot_native_bridge, _is_high_contrast_active);
+	} else {
+		return false;
 	}
 }
 

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -96,6 +96,9 @@ private:
 	jmethodID _enter_pip_mode = nullptr;
 	jmethodID _set_pip_mode_aspect_ratio = nullptr;
 	jmethodID _set_auto_enter_pip_mode_on_background = nullptr;
+	jmethodID _is_screen_reader_active = nullptr;
+	jmethodID _is_high_contrast_active = nullptr;
+	jmethodID _is_animation_disabled = nullptr;
 
 public:
 	GodotJavaWrapper(JNIEnv *p_env, jobject p_godot_native_bridge);
@@ -136,6 +139,9 @@ public:
 	void begin_benchmark_measure(const String &p_context, const String &p_label);
 	void end_benchmark_measure(const String &p_context, const String &p_label);
 	void dump_benchmark(const String &benchmark_file);
+	bool is_screen_reader_active();
+	bool is_high_contrast_active();
+	bool is_animation_disabled();
 
 	// Return the list of gdextensions config file.
 	Vector<String> get_gdextension_list_config_file() const;

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -530,7 +530,7 @@ def configure(env: "SConsEnvironment"):
                 "The screen reader support driver requires dependencies to be installed.\n"
                 f"You can install them by running `python {os.path.join('misc', 'scripts', 'install_accesskit.py')}`.\n"
                 "See the documentation for more information:\n"
-                "\thttps://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_linuxbsd.html\n"
+                "\thttps://docs.godotengine.org/en/latest/engine_details/development/compiling/compiling_for_linuxbsd.html#compiling-with-accesskit-support\n"
                 "Alternatively, disable this driver by compiling with `accesskit=no` explicitly."
             )
             env["accesskit"] = False

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -765,7 +765,7 @@ public:
 	void set_accessibility_flow_to_nodes(const TypedArray<NodePath> &p_node_path);
 	TypedArray<NodePath> get_accessibility_flow_to_nodes() const;
 
-	virtual Transform2D get_accessibility_transform() const override { return get_transform(); }
+	virtual Transform2D get_accessibility_transform() const override { return get_global_transform(); }
 
 	// Rendering.
 

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -108,6 +108,7 @@ void CanvasItem::_handle_visibility_change(bool p_visible) {
 	} else {
 		emit_signal(SceneStringName(hidden));
 	}
+	queue_accessibility_update();
 
 	_block();
 	for (int i = 0; i < get_child_count(); i++) {
@@ -374,7 +375,7 @@ void CanvasItem::_notification(int p_what) {
 			RID ae = get_accessibility_element();
 			ERR_FAIL_COND(ae.is_null());
 
-			AccessibilityServer::get_singleton()->update_set_flag(ae, AccessibilityServerEnums::AccessibilityFlags::FLAG_HIDDEN, !visible);
+			AccessibilityServer::get_singleton()->update_set_flag(ae, AccessibilityServerEnums::AccessibilityFlags::FLAG_HIDDEN, !is_visible_in_tree());
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {

--- a/servers/display/accessibility_server.h
+++ b/servers/display/accessibility_server.h
@@ -69,6 +69,7 @@ public:
 
 	virtual bool window_create(DisplayServerEnums::WindowID p_window_id, void *p_handle) = 0;
 	virtual void window_destroy(DisplayServerEnums::WindowID p_window_id) = 0;
+	virtual bool has_window(DisplayServerEnums::WindowID p_window_id) = 0;
 
 	virtual RID create_element(DisplayServerEnums::WindowID p_window_id, AccessibilityServerEnums::AccessibilityRole p_role) = 0;
 	virtual RID create_sub_element(const RID &p_parent_rid, AccessibilityServerEnums::AccessibilityRole p_role, int p_insert_pos = -1) = 0;
@@ -153,6 +154,11 @@ public:
 	virtual void update_set_color_value(const RID &p_id, const Color &p_color) = 0;
 	virtual void update_set_background_color(const RID &p_id, const Color &p_color) = 0;
 	virtual void update_set_foreground_color(const RID &p_id, const Color &p_color) = 0;
+
+	virtual void *native_create_node_info(DisplayServerEnums::WindowID p_window_id, void *p_host, int p_view_id) = 0;
+	virtual void *native_find_focus(DisplayServerEnums::WindowID p_window_id, void *p_host, int p_focus_type) = 0;
+	virtual bool native_perform_action(DisplayServerEnums::WindowID p_window_id, void *p_host, int p_view_id, int p_action, void *p_arguments) = 0;
+	virtual bool native_on_hover(DisplayServerEnums::WindowID p_window_id, void *p_host, int p_action, float p_x, float p_y) = 0;
 
 	static void register_create_function(const char *p_name, CreateFunction p_function);
 	static int get_create_function_count();

--- a/servers/display/accessibility_server_dummy.h
+++ b/servers/display/accessibility_server_dummy.h
@@ -45,6 +45,7 @@ protected:
 public:
 	virtual bool window_create(DisplayServerEnums::WindowID p_window_id, void *p_handle) override { return true; }
 	virtual void window_destroy(DisplayServerEnums::WindowID p_window_id) override {}
+	virtual bool has_window(DisplayServerEnums::WindowID p_window_id) override { return true; }
 
 	virtual RID create_element(DisplayServerEnums::WindowID p_window_id, AccessibilityServerEnums::AccessibilityRole p_role) override { return RID(); }
 	virtual RID create_sub_element(const RID &p_parent_rid, AccessibilityServerEnums::AccessibilityRole p_role, int p_insert_pos = -1) override { return RID(); }
@@ -129,6 +130,11 @@ public:
 	virtual void update_set_color_value(const RID &p_id, const Color &p_color) override {}
 	virtual void update_set_background_color(const RID &p_id, const Color &p_color) override {}
 	virtual void update_set_foreground_color(const RID &p_id, const Color &p_color) override {}
+
+	virtual void *native_create_node_info(DisplayServerEnums::WindowID p_window_id, void *p_host, int p_view_id) override { return nullptr; }
+	virtual void *native_find_focus(DisplayServerEnums::WindowID p_window_id, void *p_host, int p_focus_type) override { return nullptr; }
+	virtual bool native_perform_action(DisplayServerEnums::WindowID p_window_id, void *p_host, int p_view_id, int p_action, void *p_arguments) override { return false; }
+	virtual bool native_on_hover(DisplayServerEnums::WindowID p_window_id, void *p_host, int p_action, float p_x, float p_y) override { return false; }
 
 	AccessibilityServerDummy() {}
 	virtual ~AccessibilityServerDummy() {}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

This PR builds on the work from @bruvzg in https://github.com/godotengine/godot/pull/117785 to enable eye input hovers effects for the Android editor on Android XR devices that support eye tracking.

When running a 'flat' app on Android XR devices that supports eye tracking (like Galaxy XR), the Android XR runtime uses the Android Accessibility API in order to identify which UI elements the user is looking at, and highlight it with a hover effect.

That behavior was not working for the Android editor given our custom UI and lack of integration with the Android Accessibility APIs. This was fixed in https://github.com/godotengine/godot/pull/117785 with the addition of AccessKit support for Android, which behind the scenes integrates with the Android Accessibility APIs.

Before:


https://github.com/user-attachments/assets/78cb3ce7-4067-4369-803e-6ada672203b6



After:



https://github.com/user-attachments/assets/2f5999a3-afc5-4781-a427-518832374e22





Keeping the PR in draft until https://github.com/godotengine/godot/pull/117785 is merged.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
