### PR TITLE
🤖 Fix AudioStreamWAV forward loop skipping a frame and reading past the sample data

### DIFF
--- a/doc/classes/AudioStreamWAV.xml
+++ b/doc/classes/AudioStreamWAV.xml
@@ -67,7 +67,7 @@
 			The loop start point (in number of samples, relative to the beginning of the stream).
 		</member>
 		<member name="loop_end" type="int" setter="set_loop_end" getter="get_loop_end" default="0">
-			The loop end point (in number of samples, relative to the beginning of the stream).
+			The loop end point (in number of samples, relative to the beginning of the stream). This sample is part of the loop: it is played, and playback then returns to [member loop_begin]. Values past the last sample of the stream are clamped to it.
 		</member>
 		<member name="loop_mode" type="int" setter="set_loop_mode" getter="get_loop_mode" enum="AudioStreamWAV.LoopMode" default="0">
 			The loop mode.

--- a/scene/resources/audio/audio_stream_wav.cpp
+++ b/scene/resources/audio/audio_stream_wav.cpp
@@ -246,6 +246,12 @@ int AudioStreamPlaybackWAV::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 
 	int64_t loop_begin = base->loop_begin;
 	int64_t loop_end = base->loop_end;
+	if (base->loop_mode != AudioStreamWAV::LOOP_DISABLED) {
+		/* `loop_end` is inclusive, so it can never address past the last frame. Clamping here
+		   keeps an out-of-range loop point from reading outside the sample data. */
+		loop_end = CLAMP(loop_end, 0, (int64_t)len - 1);
+		loop_begin = CLAMP(loop_begin, 0, loop_end);
+	}
 	int64_t begin_limit = (base->loop_mode != AudioStreamWAV::LOOP_DISABLED) ? loop_begin : 0;
 	int64_t end_limit = (base->loop_mode != AudioStreamWAV::LOOP_DISABLED) ? loop_end : len - 1;
 	bool is_stereo = base->stereo;
@@ -293,8 +299,8 @@ int AudioStreamPlaybackWAV::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 					increment = -increment;
 					sign *= -1;
 				} else {
-					/* go to loop-end */
-					offset = loop_end - (loop_begin - offset);
+					/* go to loop-end (inclusive, so the loop spans `loop_end - loop_begin + 1` frames) */
+					offset = loop_end - (loop_begin - offset) + 1;
 				}
 			} else {
 				/* check for sample not reaching beginning */
@@ -305,7 +311,10 @@ int AudioStreamPlaybackWAV::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 			}
 		} else {
 			/* going forward */
-			if (loop_format != AudioStreamWAV::LOOP_DISABLED && offset >= loop_end) {
+			/* ping-pong reflects at `loop_end`, while a forward loop must wrap only once
+			   `loop_end` itself has been mixed. */
+			int64_t forward_wrap = (loop_format == AudioStreamWAV::LOOP_PINGPONG) ? loop_end : loop_end + 1;
+			if (loop_format != AudioStreamWAV::LOOP_DISABLED && offset >= forward_wrap) {
 				/* loopend reached */
 
 				if (loop_format == AudioStreamWAV::LOOP_PINGPONG) {
@@ -324,7 +333,7 @@ int AudioStreamPlaybackWAV::_mix_internal(AudioFrame *p_buffer, int p_frames) {
 						}
 						offset = loop_begin;
 					} else {
-						offset = loop_begin + (offset - loop_end);
+						offset = loop_begin + (offset - loop_end - 1);
 					}
 				}
 			} else {

--- a/tests/scene/test_audio_stream_wav.cpp
+++ b/tests/scene/test_audio_stream_wav.cpp
@@ -37,6 +37,7 @@ TEST_FORCE_LINK(test_audio_stream_wav)
 #include "core/math/math_defs.h"
 #include "core/math/math_funcs.h"
 #include "scene/resources/audio/audio_stream_wav.h"
+#include "servers/audio/audio_server.h"
 #include "tests/test_utils.h"
 
 namespace TestAudioStreamWAV {
@@ -216,6 +217,136 @@ TEST_CASE("[Audio][AudioStreamWAV] Saving IMA ADPCM is not supported") {
 	ERR_PRINT_OFF;
 	CHECK(stream->save_to_wav(save_path) == ERR_UNAVAILABLE);
 	ERR_PRINT_ON;
+}
+
+/* Builds a mono 16-bit PCM stream whose frames all hold distinct, easily recognizable values,
+ * so that the exact frame a mixer produced can be identified from its output. */
+Ref<AudioStreamWAV> gen_loop_test_stream(const Vector<int16_t> &p_samples) {
+	Vector<uint8_t> data;
+	data.resize(p_samples.size() * 2);
+	uint8_t *write_ptr = data.ptrw();
+	for (int i = 0; i < p_samples.size(); i++) {
+		encode_uint16((uint16_t)p_samples[i], write_ptr + i * 2);
+	}
+
+	Ref<AudioStreamWAV> stream = memnew(AudioStreamWAV);
+	stream->set_format(AudioStreamWAV::FORMAT_16_BITS);
+	stream->set_data(data);
+	/* Matching the server's rate keeps the resampler at a 1:1 ratio, where cubic interpolation
+	   reduces to passing each source frame through unchanged. */
+	stream->set_mix_rate(AudioServer::get_singleton()->get_mix_rate());
+	stream->set_loop_mode(AudioStreamWAV::LOOP_FORWARD);
+	return stream;
+}
+
+/* `loop_end` is inclusive: it names the last frame that is played before wrapping back to
+ * `loop_begin`. A forward loop must therefore replay the whole range on every pass, and must
+ * never read outside the sample data. Regression test for GH-119778. */
+TEST_CASE("[Audio][AudioStreamWAV] Forward loop plays every frame of the loop range") {
+	const Vector<int16_t> samples = { 24000, 18000, 12000, 6000 };
+	const int frame_count = samples.size();
+
+	// Number of leading frames to discard, covering the resampler's cubic interpolation history.
+	constexpr int PRIMING = 8;
+	constexpr int MIX_FRAMES = 128;
+
+	SUBCASE("Whole-file loop replays loop_begin on every pass") {
+		Ref<AudioStreamWAV> stream = gen_loop_test_stream(samples);
+		stream->set_loop_begin(0);
+		stream->set_loop_end(frame_count - 1);
+
+		Ref<AudioStreamPlayback> playback = stream->instantiate_playback();
+		REQUIRE(playback.is_valid());
+		playback->start();
+
+		AudioFrame buffer[MIX_FRAMES];
+		playback->mix(buffer, 1.0, MIX_FRAMES);
+
+		// Every mixed frame must be one of the source frames, never data from outside the stream.
+		for (int i = PRIMING; i < MIX_FRAMES; i++) {
+			bool found = false;
+			for (int j = 0; j < frame_count; j++) {
+				if (Math::is_equal_approx(buffer[i].left, samples[j] / 32767.0f)) {
+					found = true;
+					break;
+				}
+			}
+			CHECK_MESSAGE(found, "Mixed frame ", i, " is not one of the source frames.");
+		}
+
+		/* Every source frame must still be reachable after wrapping. Treating `loop_end` as
+		   exclusive when wrapping drops `loop_begin` from every pass after the first. */
+		for (int j = 0; j < frame_count; j++) {
+			bool found = false;
+			for (int i = PRIMING; i < MIX_FRAMES; i++) {
+				if (Math::is_equal_approx(buffer[i].left, samples[j] / 32767.0f)) {
+					found = true;
+					break;
+				}
+			}
+			CHECK_MESSAGE(found, "Frame ", j, " is never played after the loop wraps.");
+		}
+
+		// The loop is periodic over its whole length, not a shorter range.
+		for (int i = PRIMING; i < MIX_FRAMES - frame_count; i++) {
+			CHECK(Math::is_equal_approx(buffer[i].left, buffer[i + frame_count].left));
+		}
+	}
+
+	SUBCASE("Sub-range loop replays loop_begin on every pass") {
+		const int loop_begin = 1;
+		const int loop_end = 2;
+		Ref<AudioStreamWAV> stream = gen_loop_test_stream(samples);
+		stream->set_loop_begin(loop_begin);
+		stream->set_loop_end(loop_end);
+
+		Ref<AudioStreamPlayback> playback = stream->instantiate_playback();
+		REQUIRE(playback.is_valid());
+		playback->start();
+
+		AudioFrame buffer[MIX_FRAMES];
+		playback->mix(buffer, 1.0, MIX_FRAMES);
+
+		const int loop_length = loop_end - loop_begin + 1;
+		for (int j = loop_begin; j <= loop_end; j++) {
+			bool found = false;
+			for (int i = PRIMING; i < MIX_FRAMES; i++) {
+				if (Math::is_equal_approx(buffer[i].left, samples[j] / 32767.0f)) {
+					found = true;
+					break;
+				}
+			}
+			CHECK_MESSAGE(found, "Frame ", j, " is never played after the loop wraps.");
+		}
+		for (int i = PRIMING; i < MIX_FRAMES - loop_length; i++) {
+			CHECK(Math::is_equal_approx(buffer[i].left, buffer[i + loop_length].left));
+		}
+	}
+
+	SUBCASE("Out-of-range loop_end does not read past the sample data") {
+		Ref<AudioStreamWAV> stream = gen_loop_test_stream(samples);
+		stream->set_loop_begin(0);
+		// One past the last valid frame, which an inclusive `loop_end` can never address.
+		stream->set_loop_end(frame_count);
+
+		Ref<AudioStreamPlayback> playback = stream->instantiate_playback();
+		REQUIRE(playback.is_valid());
+		playback->start();
+
+		AudioFrame buffer[MIX_FRAMES];
+		playback->mix(buffer, 1.0, MIX_FRAMES);
+
+		for (int i = PRIMING; i < MIX_FRAMES; i++) {
+			bool found = false;
+			for (int j = 0; j < frame_count; j++) {
+				if (Math::is_equal_approx(buffer[i].left, samples[j] / 32767.0f)) {
+					found = true;
+					break;
+				}
+			}
+			CHECK_MESSAGE(found, "Mixed frame ", i, " was read from outside the sample data.");
+		}
+	}
 }
 
 } // namespace TestAudioStreamWAV


### PR DESCRIPTION
## What problem(s) does this PR solve?

`AudioStreamPlaybackWAV::_mix_internal()` uses `loop_end` with two incompatible boundary conventions, as reported by @cosformula, whose analysis of the two call sites this PR follows.

The decode limit treats `loop_end` as **inclusive**: `end_limit` is `len - 1` when looping is disabled, and the mix count is `(limit - offset) / increment + 1`. The forward wrap treated it as **exclusive**: `offset = loop_begin + (offset - loop_end)`, which lands one frame *past* `loop_begin`.

So every pass after the first dropped the first frame of the loop. For a 4-frame whole-file loop the mixer produces frames `0,1,2,3,1,2,3,1,2,3…` instead of `0,1,2,3,0,1,2,3…`.

Separately, setting `loop_end` to the frame count — the natural thing to do under an exclusive reading — made the mixer read one frame **past the end of the sample data**, since the inclusive decode limit then includes that index.

## Which convention, and why inclusive

The issue notes the code is inconsistent either way and asks which convention is intended. The rest of the class already answers it:

- `end_limit` is `len - 1` for non-looping playback, so the decode limit is inclusive by construction.
- The WAV importer resolves a negative `edit/loop_end` to `frames - 1` (`CLAMP(loop_end + frames, 0, frames - 1)`), i.e. the last frame — under an exclusive reading that would silently drop it.
- The RIFF `smpl` chunk, which the importer reads loop points from directly, specifies its loop end as a played endpoint.

Choosing inclusive therefore leaves the importer and `smpl` handling already correct; only the mixer needed changing. The docs for `loop_end` did not state the convention, so this PR spells it out.

## What changed

- **Forward wrap** happens only once `loop_end` itself has been mixed, using the inclusive loop length.
- **Ping-pong is deliberately untouched.** It reflects at `loop_end` rather than wrapping, and is already consistent with the inclusive convention — it produces `0,1,2,3,2,1,0,1,2,3…` and is unchanged by this PR, which the tests below confirm.
- **Backward wrap** to `loop_end` had the mirrored off-by-one (it produced `0,2,1,0,2,1…` for a whole-file backward loop, never playing the last frame) and is corrected the same way.
- **Out-of-range `loop_end` is clamped** to the last frame, so an inclusive limit can no longer address outside the sample data.

## Testing

Three regression subcases were added to `tests/scene/test_audio_stream_wav.cpp`, covering a whole-file loop, a sub-range loop, and an out-of-range `loop_end`. They mix through the public `AudioStreamPlayback::mix()` path with the stream rate matched to the server rate, and assert that every mixed frame comes from the sample data, that every frame of the loop range is still reached after wrapping, and that the output is periodic over the full loop length.

Verified by building both ways on macOS (arm64, `target=editor tests=yes`):

- **Before the fix**, with the tests already in place: `Status: FAILURE`, 148 failed assertions — `Frame 0 is never played after the loop wraps`, `Frame 1 is never played after the loop wraps` (sub-range), and 30 × `was read from outside the sample data`.
- **After the fix**: that test passes 483/483 assertions, the `[Audio]` suite passes 10/10 cases, and the full suite passes **1419/1419 test cases, 421900 assertions**.

Both changed C++ files are `clang-format` clean.

## Note on one detail from the issue

The issue asks that the produced sequence be independent of where the mix block is split. That property does hold after this change, but it is worth being precise that it is currently latent rather than user-visible: `AudioStreamPlaybackResampled::mix()` always calls `_mix_internal()` with `INTERNAL_BUFFER_LEN` (128) frames, so end users cannot vary the block size today. The defects this PR fixes that *are* reachable through the public path are the skipped loop frame and the read past the sample data.
