### PR TITLE
End friendship between AudioBusLayout and AudioServer

### DIFF
--- a/doc/classes/AudioBusLayout.xml
+++ b/doc/classes/AudioBusLayout.xml
@@ -4,8 +4,22 @@
 		Stores information about the audio buses.
 	</brief_description>
 	<description>
-		Stores position, muting, solo, bypass, effects, effect position, volume, and the connections between buses. See [AudioServer] for usage.
+		Stores position, muting, solo, bypass, effects, effect position, volume, and the connections between buses.
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="generate_from_server_bus_layout">
+			<return type="void" />
+			<description>
+				Clears and generates the layout based on the current buses of the [AudioServer].
+			</description>
+		</method>
+		<method name="set_server_bus_layout">
+			<return type="void" />
+			<description>
+				Applies the layout to the [AudioServer] buses.
+			</description>
+		</method>
+	</methods>
 </class>

--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -29,7 +29,7 @@
 				Adds an [AudioEffect] effect to the bus [param bus_idx] at [param at_position].
 			</description>
 		</method>
-		<method name="generate_bus_layout" qualifiers="const">
+		<method name="generate_bus_layout" qualifiers="const" deprecated="Use [method AudioBusLayout.generate_from_server_bus_layout] instead.">
 			<return type="AudioBusLayout" />
 			<description>
 				Generates an [AudioBusLayout] using the available buses and effects.
@@ -287,7 +287,7 @@
 				If [code]true[/code], the effect at index [param effect_idx] on the bus at index [param bus_idx] is enabled.
 			</description>
 		</method>
-		<method name="set_bus_layout">
+		<method name="set_bus_layout" deprecated="Use [method AudioBusLayout.set_server_bus_layout] instead.">
 			<return type="void" />
 			<param index="0" name="bus_layout" type="AudioBusLayout" />
 			<description>

--- a/servers/audio/audio_bus_layout.cpp
+++ b/servers/audio/audio_bus_layout.cpp
@@ -30,8 +30,101 @@
 
 #include "audio_bus_layout.h"
 
+#include "core/object/class_db.h"
 #include "scene/scene_string_names.h"
 #include "servers/audio/audio_effect.h" // IWYU pragma: keep. For Bus::Effect.
+#include "servers/audio/audio_server.h"
+
+void AudioBusLayout::set_server_bus_layout() {
+	// AudioServer::_set_server_bus_layout() exists for compatibility.
+	// AudioServer::set_bus_layout() is deprecated and no longer part of all builds.
+	// More internal untangling in the AudioServer is required
+	// to apply bus layouts without involving Resources
+	// and this function is the stopgap until that is done.
+	AudioServer::get_singleton()->_set_server_bus_layout(this);
+}
+
+void AudioBusLayout::generate_from_server_bus_layout() {
+	AudioServer *audioserver = AudioServer::get_singleton();
+	ERR_FAIL_NULL(audioserver);
+
+	const int server_bus_size = audioserver->get_bus_count();
+
+	buses.resize(server_bus_size);
+
+	Bus *buses_ptrw = buses.ptrw();
+
+	for (int i = 0; i < server_bus_size; i++) {
+		buses_ptrw[i].name = audioserver->get_bus_name(i);
+		buses_ptrw[i].send = audioserver->get_bus_send(i);
+		buses_ptrw[i].mute = audioserver->is_bus_mute(i);
+		buses_ptrw[i].solo = audioserver->is_bus_solo(i);
+		buses_ptrw[i].bypass = audioserver->is_bus_bypassing_effects(i);
+		buses_ptrw[i].volume_db = audioserver->get_bus_volume_db(i);
+
+		const int server_bus_effect_size = audioserver->get_bus_effect_count(i);
+
+		buses_ptrw[i].effects.clear();
+
+		for (int j = 0; j < server_bus_effect_size; j++) {
+			AudioBusLayout::Bus::Effect fx;
+			fx.effect = audioserver->get_bus_effect(i, j);
+			fx.enabled = audioserver->is_bus_effect_enabled(i, j);
+			buses_ptrw[i].effects.push_back(fx);
+		}
+	}
+}
+
+int AudioBusLayout::get_bus_count() const {
+	return buses.size();
+}
+
+int AudioBusLayout::get_bus_effect_count(int p_bus) const {
+	ERR_FAIL_INDEX_V(p_bus, buses.size(), 0);
+	return buses[p_bus].effects.size();
+}
+
+String AudioBusLayout::get_bus_name(int p_bus) const {
+	ERR_FAIL_INDEX_V(p_bus, buses.size(), String());
+	return buses[p_bus].name;
+}
+
+StringName AudioBusLayout::get_bus_send(int p_bus) const {
+	ERR_FAIL_INDEX_V(p_bus, buses.size(), StringName());
+	return buses[p_bus].send;
+}
+
+bool AudioBusLayout::is_bus_mute(int p_bus) const {
+	ERR_FAIL_INDEX_V(p_bus, buses.size(), false);
+	return buses[p_bus].mute;
+}
+
+bool AudioBusLayout::is_bus_solo(int p_bus) const {
+	ERR_FAIL_INDEX_V(p_bus, buses.size(), false);
+	return buses[p_bus].solo;
+}
+
+bool AudioBusLayout::is_bus_bypassing_effects(int p_bus) const {
+	ERR_FAIL_INDEX_V(p_bus, buses.size(), false);
+	return buses[p_bus].bypass;
+}
+
+float AudioBusLayout::get_bus_volume_db(int p_bus) const {
+	ERR_FAIL_INDEX_V(p_bus, buses.size(), 0);
+	return buses[p_bus].volume_db;
+}
+
+Ref<AudioEffect> AudioBusLayout::get_bus_effect(int p_bus, int p_effect) {
+	ERR_FAIL_INDEX_V(p_bus, buses.size(), Ref<AudioEffect>());
+	ERR_FAIL_INDEX_V(p_effect, buses[p_bus].effects.size(), Ref<AudioEffect>());
+	return buses[p_bus].effects[p_effect].effect;
+}
+
+bool AudioBusLayout::is_bus_effect_enabled(int p_bus, int p_effect) const {
+	ERR_FAIL_INDEX_V(p_bus, buses.size(), false);
+	ERR_FAIL_INDEX_V(p_effect, buses[p_bus].effects.size(), false);
+	return buses[p_bus].effects[p_effect].enabled;
+}
 
 bool AudioBusLayout::_set(const StringName &p_name, const Variant &p_value) {
 	String s = p_name;
@@ -151,6 +244,11 @@ void AudioBusLayout::_get_property_list(List<PropertyInfo> *p_list) const {
 			p_list->push_back(PropertyInfo(Variant::BOOL, "bus/" + itos(i) + "/effect/" + itos(j) + "/enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
 		}
 	}
+}
+
+void AudioBusLayout::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("generate_from_server_bus_layout"), &AudioBusLayout::generate_from_server_bus_layout);
+	ClassDB::bind_method(D_METHOD("set_server_bus_layout"), &AudioBusLayout::set_server_bus_layout);
 }
 
 AudioBusLayout::AudioBusLayout() {

--- a/servers/audio/audio_bus_layout.h
+++ b/servers/audio/audio_bus_layout.h
@@ -37,8 +37,6 @@ class AudioEffect;
 class AudioBusLayout : public Resource {
 	GDCLASS(AudioBusLayout, Resource);
 
-	friend class AudioServer;
-
 	struct Bus {
 		StringName name;
 		bool solo = false;
@@ -65,6 +63,24 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
+	static void _bind_methods();
+
 public:
+	int get_bus_count() const;
+	int get_bus_effect_count(int p_bus) const;
+
+	String get_bus_name(int p_bus) const;
+	StringName get_bus_send(int p_bus) const;
+	bool is_bus_mute(int p_bus) const;
+	bool is_bus_solo(int p_bus) const;
+	bool is_bus_bypassing_effects(int p_bus) const;
+	float get_bus_volume_db(int p_bus) const;
+
+	Ref<AudioEffect> get_bus_effect(int p_bus, int p_effect);
+	bool is_bus_effect_enabled(int p_bus, int p_effect) const;
+
+	void generate_from_server_bus_layout();
+	void set_server_bus_layout();
+
 	AudioBusLayout();
 };

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -1424,7 +1424,7 @@ void AudioServer::load_default_bus_layout() {
 	if (ResourceLoader::exists(layout_path)) {
 		Ref<AudioBusLayout> default_layout = ResourceLoader::load(layout_path);
 		if (default_layout.is_valid()) {
-			set_bus_layout(default_layout);
+			_set_server_bus_layout(default_layout);
 		}
 	}
 }
@@ -1530,44 +1530,52 @@ void AudioServer::remove_listener_changed_callback(AudioCallback p_callback, voi
 	}
 }
 
+#ifndef DISABLE_DEPRECATED
 void AudioServer::set_bus_layout(const Ref<AudioBusLayout> &p_bus_layout) {
-	ERR_FAIL_COND(p_bus_layout.is_null() || p_bus_layout->buses.is_empty());
+	ERR_FAIL_COND(p_bus_layout.is_null());
+	// Forward for compatibility.
+	p_bus_layout->set_server_bus_layout();
+}
+#endif // DISABLE_DEPRECATED
+
+void AudioServer::_set_server_bus_layout(const Ref<AudioBusLayout> &p_bus_layout) {
+	ERR_FAIL_COND(p_bus_layout.is_null() || p_bus_layout->get_bus_count() == 0);
 
 	lock();
 	for (int i = 0; i < buses.size(); i++) {
 		memdelete(buses[i]);
 	}
-	buses.resize(p_bus_layout->buses.size());
+	buses.resize(p_bus_layout->get_bus_count());
 	bus_map.clear();
 
 	AudioDriver::get_singleton()->set_sample_bus_count(buses.size());
 
-	for (int i = 0; i < p_bus_layout->buses.size(); i++) {
+	for (int i = 0; i < p_bus_layout->get_bus_count(); i++) {
 		Bus *bus = memnew(Bus);
 		if (i == 0) {
 			bus->name = SceneStringName(Master);
 		} else {
-			bus->name = p_bus_layout->buses[i].name;
-			bus->send = p_bus_layout->buses[i].send;
+			bus->name = p_bus_layout->get_bus_name(i);
+			bus->send = p_bus_layout->get_bus_send(i);
 			AudioDriver::get_singleton()->set_sample_bus_send(i, bus->send);
 		}
 
-		bus->solo = p_bus_layout->buses[i].solo;
-		bus->mute = p_bus_layout->buses[i].mute;
-		bus->bypass = p_bus_layout->buses[i].bypass;
-		bus->volume_db = p_bus_layout->buses[i].volume_db;
+		bus->solo = p_bus_layout->is_bus_solo(i);
+		bus->mute = p_bus_layout->is_bus_mute(i);
+		bus->bypass = p_bus_layout->is_bus_bypassing_effects(i);
+		bus->volume_db = p_bus_layout->get_bus_volume_db(i);
 
 		AudioDriver::get_singleton()->set_sample_bus_solo(i, bus->solo);
 		AudioDriver::get_singleton()->set_sample_bus_mute(i, bus->mute);
 		AudioDriver::get_singleton()->set_sample_bus_volume_db(i, bus->volume_db);
 
-		for (int j = 0; j < p_bus_layout->buses[i].effects.size(); j++) {
-			Ref<AudioEffect> fx = p_bus_layout->buses[i].effects[j].effect;
+		for (int j = 0; j < p_bus_layout->get_bus_effect_count(i); j++) {
+			Ref<AudioEffect> fx = p_bus_layout->get_bus_effect(i, j);
 
 			if (fx.is_valid()) {
 				Bus::Effect bfx;
 				bfx.effect = fx;
-				bfx.enabled = p_bus_layout->buses[i].effects[j].enabled;
+				bfx.enabled = p_bus_layout->is_bus_effect_enabled(i, j);
 #ifdef DEBUG_ENABLED
 				bfx.prof_time = 0;
 #endif
@@ -1592,29 +1600,16 @@ void AudioServer::set_bus_layout(const Ref<AudioBusLayout> &p_bus_layout) {
 	// Samples bus sync.
 }
 
+#ifndef DISABLE_DEPRECATED
 Ref<AudioBusLayout> AudioServer::generate_bus_layout() const {
 	Ref<AudioBusLayout> state;
 	state.instantiate();
 
-	state->buses.resize(buses.size());
-
-	for (int i = 0; i < buses.size(); i++) {
-		state->buses.write[i].name = buses[i]->name;
-		state->buses.write[i].send = buses[i]->send;
-		state->buses.write[i].mute = buses[i]->mute;
-		state->buses.write[i].solo = buses[i]->solo;
-		state->buses.write[i].bypass = buses[i]->bypass;
-		state->buses.write[i].volume_db = buses[i]->volume_db;
-		for (int j = 0; j < buses[i]->effects.size(); j++) {
-			AudioBusLayout::Bus::Effect fx;
-			fx.effect = buses[i]->effects[j].effect;
-			fx.enabled = buses[i]->effects[j].enabled;
-			state->buses.write[i].effects.push_back(fx);
-		}
-	}
+	state->generate_from_server_bus_layout();
 
 	return state;
 }
+#endif // DISABLE_DEPRECATED
 
 PackedStringArray AudioServer::get_output_device_list() {
 	return AudioDriver::get_singleton()->get_output_device_list();
@@ -1884,8 +1879,10 @@ void AudioServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_input_buffer_length_frames"), &AudioServer::get_input_buffer_length_frames);
 	ClassDB::bind_method(D_METHOD("get_input_frames", "frames"), &AudioServer::get_input_frames);
 
+#ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("set_bus_layout", "bus_layout"), &AudioServer::set_bus_layout);
 	ClassDB::bind_method(D_METHOD("generate_bus_layout"), &AudioServer::generate_bus_layout);
+#endif // DISABLE_DEPRECATED
 
 	ClassDB::bind_method(D_METHOD("set_enable_tagging_used_audio_streams", "enable"), &AudioServer::set_enable_tagging_used_audio_streams);
 

--- a/servers/audio/audio_server.h
+++ b/servers/audio/audio_server.h
@@ -332,8 +332,13 @@ public:
 	void add_mix_callback(AudioCallback p_callback, void *p_userdata);
 	void remove_mix_callback(AudioCallback p_callback, void *p_userdata);
 
+#ifndef DISABLE_DEPRECATED
 	void set_bus_layout(const Ref<AudioBusLayout> &p_bus_layout);
 	Ref<AudioBusLayout> generate_bus_layout() const;
+#endif // DISABLE_DEPRECATED
+
+	// Stopgap, see AudioBusLayout::set_server_bus_layout().
+	void _set_server_bus_layout(const Ref<AudioBusLayout> &p_bus_layout);
 
 	PackedStringArray get_output_device_list();
 	String get_output_device();


### PR DESCRIPTION
Ends friendship between `AudioBusLayout` and `AudioServer` and deprecates AudioServer `set_bus_layout()` and `generate_bus_layout()`.

Since applying buses is currently a mega-spaghetti on the server internals that can not be quickly replaced adds AudioServer::_set_server_bus_layout() as a stopgap so stuff still can work with no deprecated builds.

### Why?
This entire direct Resource use found everywhere on the old API of the AudioServer needs to stop. A server should neither accept or return a Resource. 

A Resource should only be able to "talk" with the server on the internal over the servers existing API functions. The only thing a server is allowed to accept is RIDs and RefCounted but not Resources. Resources are for serialization and for SceneTree and Node data sharing. Servers ignore the existence of Resources same as they ignore the existence of Nodes and the SceneTree.

