### PR TITLE
🤖 Fix crash calling `XRVRS.make_vrs_texture()` without a RenderingDevice

### DIFF
--- a/servers/xr/xr_vrs.cpp
+++ b/servers/xr/xr_vrs.cpp
@@ -106,6 +106,9 @@ void XRVRS::set_vrs_render_region(const Rect2i &p_vrs_render_region) {
 RID XRVRS::make_vrs_texture(const Size2 &p_target_size, const Vector<Vector2> &p_eye_foci) {
 	ERR_FAIL_COND_V(p_eye_foci.is_empty(), RID());
 
+	// VRS textures are only available on rendering methods backed by a RenderingDevice.
+	ERR_FAIL_NULL_V_MSG(RD::get_singleton(), RID(), "VRS textures require a RenderingDevice-based rendering method.");
+
 	Size2i texel_size = RD::get_singleton()->vrs_get_texel_size();
 
 	// Should return sensible data or graphics API does not support VRS.

--- a/tests/servers/test_xr_vrs.cpp
+++ b/tests/servers/test_xr_vrs.cpp
@@ -1,0 +1,64 @@
+/**************************************************************************/
+/*  test_xr_vrs.cpp                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_xr_vrs)
+
+#include "servers/xr/xr_vrs.h"
+
+namespace TestXRVRS {
+
+TEST_SUITE("[XRVRS]") {
+	TEST_CASE("[XRVRS] make_vrs_texture without a RenderingDevice") {
+		// VRS textures are backed by a RenderingDevice. Rendering methods that do not
+		// provide one (Compatibility, headless) must fail gracefully rather than
+		// dereferencing a null singleton.
+		XRVRS vrs;
+
+		ERR_PRINT_OFF;
+		const RID texture = vrs.make_vrs_texture(Size2(100, 100), { Vector2(0, 0) });
+		ERR_PRINT_ON;
+
+		CHECK_MESSAGE(texture.is_null(), "Should return an invalid RID instead of crashing.");
+	}
+
+	TEST_CASE("[XRVRS] make_vrs_texture with empty eye foci") {
+		XRVRS vrs;
+
+		ERR_PRINT_OFF;
+		const RID texture = vrs.make_vrs_texture(Size2(100, 100), Vector<Vector2>());
+		ERR_PRINT_ON;
+
+		CHECK_MESSAGE(texture.is_null(), "Should return an invalid RID when no eye foci are given.");
+	}
+}
+
+} // namespace TestXRVRS


### PR DESCRIPTION
> [!INFO] *AI disclosure*: This contribution was authored by on an autonomous AI agent, on behalf of a user to fix the reported crash.



`XRVRS::make_vrs_texture()` is bound to scripting, but dereferenced `RD::get_singleton()` without checking it:

https://github.com/godotengine/godot/blob/master/servers/xr/xr_vrs.cpp#L109

Rendering methods that are not backed by a `RenderingDevice` (Compatibility, headless) leave that singleton null, so calling the method from a script segfaulted the engine rather than failing gracefully. This matches the backtrace in the issue, where the crash surfaces inside `RenderingDevice::vrs_get_texel_size()` because `this` is null.

The guard mirrors what the destructor in the same file already does for `RS::get_singleton()`, and returns an invalid `RID` consistently with the two existing `ERR_FAIL_COND_V` early-outs in the method.

### Testing

Added `tests/servers/test_xr_vrs.cpp`. The unit test suite runs headless with no `RenderingDevice`, so it exercises exactly the crashing path.

Verified both ways on macOS (arm64, `vulkan=no metal=no opengl3=no`, so `RD::get_singleton()` is null):

- Without the guard: `FATAL ERROR: test case CRASHED: SIGSEGV - Segmentation violation signal`
- With the guard: `test cases: 2 | 2 passed | 0 failed`

Full suite after the change: `1420 passed | 0 failed`, `421419 assertions`. `clang-format` clean.

I do not have XR hardware, so this is verified through the scripting-facing path rather than an actual VR session.