### PR TITLE
Fix child placement when SpringArm3D has negative ray length

### DIFF
--- a/scene/3d/physics/spring_arm_3d.cpp
+++ b/scene/3d/physics/spring_arm_3d.cpp
@@ -178,7 +178,7 @@ void SpringArm3D::process_spring() {
 			if (intersected) {
 				real_t dist = get_global_transform().origin.distance_to(r.position);
 				dist -= margin;
-				motion_delta = dist / (spring_length);
+				motion_delta = dist / Math::abs(spring_length);
 			}
 		}
 	} else {


### PR DESCRIPTION
Closes #122370.
The bug was present only with rays, shape casts already handled things correctly.