### PR TITLE
[TextEdit] Add clear_undo_history parameter to clear()

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -155,8 +155,9 @@
 		</method>
 		<method name="clear">
 			<return type="void" />
+			<param index="0" name="clear_undo_history" type="bool" default="false" />
 			<description>
-				Performs a full reset of [TextEdit], including undo history.
+				Clears all text and related state. This clears the text content, selections, carets, and gutter line data. If [param clear_undo_history] is [code]true[/code], clears the undo history, otherwise preserves it. Does [b]not[/b] reset other values (such as [member placeholder_text], font, colors, etc.) to their defaults.
 			</description>
 		</method>
 		<method name="clear_undo_history">

--- a/misc/extension_api_validation/4.7-stable/GH-122377.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-122377.txt
@@ -1,0 +1,6 @@
+GH-122377
+--------------
+Validate extension JSON: Error: Field 'classes/OpenXRSpatialEntityExtension/methods/create_spatial_context/arguments': size changed value in new API, from 3 to 4.
+Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/TextEdit/methods/clear': arguments
+
+Added new optional `p_clear_undo_history` parameter to `TextEdit::clear()`.

--- a/scene/gui/text_edit.compat.inc
+++ b/scene/gui/text_edit.compat.inc
@@ -34,6 +34,10 @@
 
 #include "core/object/class_db.h"
 
+void TextEdit::_clear_bind_compat_122377() {
+	clear(false);
+}
+
 void TextEdit::_set_selection_mode_bind_compat_86978(SelectionMode p_mode, int p_line, int p_column, int p_caret) {
 	set_selection_mode(p_mode);
 }
@@ -43,6 +47,7 @@ Point2i TextEdit::_get_line_column_at_pos_bind_compat_100913(const Point2i &p_po
 }
 
 void TextEdit::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("clear"), &TextEdit::_clear_bind_compat_122377);
 	ClassDB::bind_compatibility_method(D_METHOD("set_selection_mode", "mode", "line", "column", "caret_index"), &TextEdit::_set_selection_mode_bind_compat_86978, DEFVAL(-1), DEFVAL(-1), DEFVAL(0));
 	ClassDB::bind_compatibility_method(D_METHOD("get_line_column_at_pos", "position", "allow_out_of_bounds"), &TextEdit::_get_line_column_at_pos_bind_compat_100913, DEFVAL(true));
 }

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4443,15 +4443,15 @@ bool TextEdit::is_empty_selection_clipboard_enabled() const {
 }
 
 // Text manipulation
-void TextEdit::clear() {
+void TextEdit::clear(bool p_clear_undo_history) {
 	setting_text = true;
-	_clear();
+	_clear(p_clear_undo_history);
 	setting_text = false;
 	emit_signal(SNAME("text_set"));
 }
 
-void TextEdit::_clear() {
-	if (editable && undo_enabled) {
+void TextEdit::_clear(bool p_clear_undo_history) {
+	if (!p_clear_undo_history && undo_enabled && is_inside_tree()) {
 		remove_secondary_carets();
 		_move_caret_document_start(false);
 		begin_complex_operation();
@@ -5137,7 +5137,7 @@ void TextEdit::menu_option(int p_option) {
 		} break;
 		case MENU_CLEAR: {
 			if (editable) {
-				clear();
+				clear(false);
 			}
 		} break;
 		case MENU_SELECT_ALL: {
@@ -7790,7 +7790,7 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_empty_selection_clipboard_enabled"), &TextEdit::is_empty_selection_clipboard_enabled);
 
 	// Text manipulation
-	ClassDB::bind_method(D_METHOD("clear"), &TextEdit::clear);
+	ClassDB::bind_method(D_METHOD("clear", "clear_undo_history"), &TextEdit::clear, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("set_text", "text"), &TextEdit::set_text);
 	ClassDB::bind_method(D_METHOD("get_text"), &TextEdit::get_text);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -346,7 +346,7 @@ private:
 	TextServer::StructuredTextParser st_parser = TextServer::STRUCTURED_TEXT_DEFAULT;
 	Array st_args;
 
-	void _clear();
+	void _clear(bool p_clear_undo_history = false);
 	void _update_caches(bool p_invalidate_all = false);
 
 	void _close_ime_window();
@@ -748,6 +748,7 @@ protected:
 	static void _bind_methods();
 
 #ifndef DISABLE_DEPRECATED
+	void _clear_bind_compat_122377();
 	void _set_selection_mode_bind_compat_86978(SelectionMode p_mode, int p_line = -1, int p_column = -1, int p_caret = 0);
 	Point2i _get_line_column_at_pos_bind_compat_100913(const Point2i &p_pos, bool p_allow_out_of_bounds = true) const;
 	static void _bind_compatibility_methods();
@@ -920,7 +921,7 @@ public:
 	bool is_empty_selection_clipboard_enabled() const;
 
 	// Text manipulation
-	void clear();
+	void clear(bool p_clear_undo_history = false);
 
 	void _set_text(const String &p_text, bool p_emit_signal = false);
 	void set_text(const String &p_text);

--- a/tests/scene/test_text_edit.cpp
+++ b/tests/scene/test_text_edit.cpp
@@ -132,9 +132,59 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			// Can clear even if not editable.
 			text_edit->set_editable(false);
 
+			text_edit->clear();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "");
+			CHECK(text_edit->get_caret_column() == 0);
+			SIGNAL_CHECK("text_set", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_changed");
+
+			text_edit->set_editable(true);
+
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "test text");
+			CHECK(text_edit->get_caret_column() == 0);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("text_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_set");
+
+			// Test clear(true) - clears undo history.
+			text_edit->set_text("test text");
+			MessageQueue::get_singleton()->flush();
+			SIGNAL_CHECK("text_set", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_args);
+			SIGNAL_CHECK("caret_changed", empty_signal_args);
+			SIGNAL_CHECK_FALSE("text_changed");
+
 			Array lines_edited_clear_args = { { 0, 0 } };
 
-			text_edit->clear();
+			text_edit->clear(true);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "");
+			CHECK(text_edit->get_caret_column() == 0);
+			SIGNAL_CHECK("text_set", empty_signal_args);
+			SIGNAL_CHECK("lines_edited_from", lines_edited_clear_args);
+			SIGNAL_CHECK_FALSE("caret_changed");
+			SIGNAL_CHECK_FALSE("text_changed");
+
+			// Undo should NOT restore the text (undo history was cleared).
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_text() == "");
+			CHECK(text_edit->get_caret_column() == 0);
+			SIGNAL_CHECK_FALSE("text_set");
+			SIGNAL_CHECK_FALSE("lines_edited_from");
+			SIGNAL_CHECK_FALSE("text_changed");
+			SIGNAL_CHECK_FALSE("caret_changed");
+
+			// Even if not editable.
+			text_edit->set_editable(false);
+
+			text_edit->clear(true);
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "");
 			CHECK(text_edit->get_caret_column() == 0);
@@ -145,6 +195,7 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 
 			text_edit->set_editable(true);
 
+			// Undo should NOT restore the text (undo history was cleared)
 			text_edit->undo();
 			MessageQueue::get_singleton()->flush();
 			CHECK(text_edit->get_text() == "");


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/122002
- Closes https://github.com/godotengine/godot-proposals/issues/15363

This fixes the inconsistency where `TextEdit`'s` clear()` function did preserve undo history, if `editable = true`.

- `clear()` now clears undo history, if `p_clear_undo_history` is `true` (default `false`)
- Update tests to verify new behavior
- Improve documentation for `clear()` to clarify its behavior.


## Additional information

Validated by building the Windows editor with SCons and testing it.