### PR TITLE
Fix `update_maximum_size` docs

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1015,7 +1015,7 @@
 		<method name="update_maximum_size">
 			<return type="void" />
 			<description>
-				Invalidates the maximum size cache in this node and in parent nodes up to top level. Intended to be used with [method get_maximum_size] when the return value is changed. Setting [member custom_maximum_size] directly calls this method automatically.
+				Invalidates the maximum size cache in this node and in child nodes with [member CanvasItem.top_level] set to [code]false[/code]. Intended to be used with [method get_maximum_size] when the return value is changed. Setting [member custom_maximum_size] directly calls this method automatically.
 				[b]Note:[/b] Calling this method also calls [method update_minimum_size] since the combined minimum size may be affected by the maximum size change.
 			</description>
 		</method>


### PR DESCRIPTION
## What problem(s) does this PR solve?

The docs for `update_maximum_size` state that the method "Invalidates the maximum size cache in this node and in parent nodes up to top level.". However, the code in the method invalidates the cache in it and its child nodes instead:

https://github.com/godotengine/godot/blob/63b7e027254e6b77b3d1036c89973060fb5be088/scene/gui/control.cpp#L1782-L1791

## Additional information

No AI usage.