### PR TITLE
Fix Asset store plugin button

### DIFF
--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -105,7 +105,8 @@ void ProjectSettingsEditor::_save() {
 }
 
 void ProjectSettingsEditor::set_plugins_page() {
-	tab_container->set_current_tab(tab_container->get_tab_idx_from_control(plugin_settings));
+	tab_container->set_current_tab(tab_container->get_tab_idx_from_control(addons_container));
+	addons_container->set_current_tab(0);
 }
 
 void ProjectSettingsEditor::set_general_page(const String &p_category) {
@@ -847,7 +848,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	group_settings->connect("group_changed", callable_mp(this, &ProjectSettingsEditor::queue_save));
 	globals_container->add_child(group_settings);
 
-	TabContainer *addons_container = memnew(TabContainer);
+	addons_container = memnew(TabContainer);
 	addons_container->set_theme_type_variation("TabContainerInner");
 	addons_container->set_name(TTRC("Addons"));
 	tab_container->add_child(addons_container);

--- a/editor/settings/project_settings_editor.h
+++ b/editor/settings/project_settings_editor.h
@@ -70,6 +70,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	EditorAutoloadSettings *autoload_settings = nullptr;
 	ShaderGlobalsEditor *shaders_global_shader_uniforms_editor = nullptr;
 	GroupSettingsEditor *group_settings = nullptr;
+	TabContainer *addons_container = nullptr;
 	EditorPluginSettings *plugin_settings = nullptr;
 	ProjectSettingsGDExtension *gdextension_settings = nullptr;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/122375

## Additional information

Was thinking about if we should rename button from Plugins to Addons to match the tab name in ProjectSettings. But not sure what to do here?
