### PR TITLE
Select root node for newly opened scenes

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -854,6 +854,11 @@ void EditorData::set_edited_scene_root(Node *p_root) {
 	set_scene_root(current_edited_scene, p_root);
 }
 
+bool EditorData::has_edited_scene_selection(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, edited_scene.size(), false);
+	return !edited_scene[p_idx].selection.is_empty();
+}
+
 int EditorData::get_edited_scene_count() const {
 	return edited_scene.size();
 }

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -203,6 +203,7 @@ public:
 	void set_scene_root(int p_idx, Node *p_root);
 	void set_edited_scene(int p_idx);
 	void set_edited_scene_root(Node *p_root);
+	bool has_edited_scene_selection(int p_idx) const;
 	int get_edited_scene() const;
 	int get_edited_scene_from_path(const String &p_path) const;
 	Node *get_edited_scene_root(int p_idx = -1);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4827,6 +4827,13 @@ void EditorNode::_set_current_scene_nocheck(int p_idx, bool p_ignore_state) {
 		scene_root->add_child(new_scene, true);
 	}
 
+	// For newly loaded scene, save root node to history so global selection is loaded later in restore_edited_scene_state
+	if (new_scene && !editor_data.has_edited_scene_selection(p_idx)) {
+		editor_selection->add_node(new_scene);
+		editor_history.add_object(new_scene->get_instance_id());
+		editor_data.save_edited_scene_state(editor_selection, &editor_history, Dictionary());
+	}
+
 	if (editor_data.check_and_update_scene(p_idx)) {
 		if (!editor_data.get_scene_path(p_idx).is_empty()) {
 			editor_folding.load_scene_folding(editor_data.get_edited_scene_root(p_idx), scene_path);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #122369

Selects the root node of a newly opened scene that was not loaded in Editor before.

## Additional information

Saves a new EditorState with its root node selected for a new Scene before reloading the Scene Editor.

<details>
<summary>Verification</summary>

https://github.com/user-attachments/assets/69d37245-bdff-4f6e-8c44-f378d328e5b5

Notice that newly opened scenes update global selection status compared to #122369's videos

</details>