### PR TITLE
Fix redundant resource scans in scene tree updates

### DIFF
--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -441,11 +441,13 @@ void SceneTreeEditor::_update_node_subtree(Node *p_node, TreeItem *p_parent, boo
 		is_new = true;
 	}
 
-	EditorNode::get_singleton()->update_resource_count(p_node);
-
 	if (!(p_force || I->value.dirty)) {
 		// Nothing to do.
 		return;
+	}
+
+	if (is_scene_tree_dock) {
+		EditorNode::get_singleton()->update_resource_count(p_node);
 	}
 
 	_update_node(p_node, item, part_of_subscene);


### PR DESCRIPTION
Fixes #122386 

Resource counting was performed before the clean-cache early return in SceneTreeEditor::_update_node_subtree(), causing every SceneTree refresh to retrieve property lists for all visible nodes. 

For C# tool scripts this repeatedly crossed the managed boundary
Move resource counting after the clean-cache check and restrict it to the actual SceneTree dock. 

New, dirty, forced, and removed nodes keep their existing bookkeeping.

Benchmark on current master, 5000 owned nodes, 3 runs:
- C# removal: 3.401 s -> 0.643 s (-81.1%)
- GDScript removal: 2.632 s -> 0.645 s (-75.5%)
- C# overhead over scriptless: +374.7% -> +3.4%

I planned to include more data like the logs thats why I closed the other issue but honestly its not necessary