### PR TITLE
Make emit show signal args in intellisense

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3224,6 +3224,10 @@ static void _list_call_arguments(GDScriptParser::CompletionContext &p_context, c
 						return;
 					}
 				}
+				if (p_base.type.builtin_type == Variant::Type::SIGNAL && method == SNAME("emit")) {
+					r_arghint = _make_arguments_hint(p_base.type.method_info, p_argidx, true);
+					return;
+				}
 
 				List<MethodInfo> methods;
 				base.get_method_list(&methods);

--- a/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_no_args.cfg
+++ b/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_no_args.cfg
@@ -1,0 +1,3 @@
+[input]
+[output]
+call_hint="signal_b()"

--- a/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_no_args.gd
+++ b/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_no_args.gd
@@ -1,0 +1,7 @@
+extends Node
+
+signal signal_b()
+
+func test():
+    signal_b.emit(➡)
+    pass

--- a/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_on_untyped_self_var.cfg
+++ b/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_on_untyped_self_var.cfg
@@ -1,0 +1,3 @@
+[input]
+[output]
+call_hint="signal_a(￿a: int￿)"

--- a/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_on_untyped_self_var.gd
+++ b/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_on_untyped_self_var.gd
@@ -1,0 +1,8 @@
+extends Node
+
+signal signal_a(a: int)
+
+func test():
+    var other_me = self
+    other_me.signal_a.emit(➡)
+    pass

--- a/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_signal_lacking_parenthesis.cfg
+++ b/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_signal_lacking_parenthesis.cfg
@@ -1,0 +1,3 @@
+[input]
+[output]
+call_hint="signal_e()"

--- a/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_signal_lacking_parenthesis.gd
+++ b/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_signal_lacking_parenthesis.gd
@@ -1,0 +1,7 @@
+extends Node
+
+signal signal_e
+
+func test():
+    signal_e.emit(➡)
+    pass

--- a/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_signal_through_var.cfg
+++ b/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_signal_through_var.cfg
@@ -1,0 +1,3 @@
+[input]
+[output]
+call_hint="signal_d(￿a: int￿)"

--- a/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_signal_through_var.gd
+++ b/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_signal_through_var.gd
@@ -1,0 +1,8 @@
+extends Node
+
+signal signal_d(a: int)
+
+func test():
+    var my_signal_var = signal_d
+    my_signal_var.emit(➡)
+    pass

--- a/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_typed_args.cfg
+++ b/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_typed_args.cfg
@@ -1,0 +1,3 @@
+[input]
+[output]
+call_hint="signal_c(￿a: String￿, b: int)"

--- a/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_typed_args.gd
+++ b/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_typed_args.gd
@@ -1,0 +1,7 @@
+extends Node
+
+signal signal_c(a: String, b: int)
+
+func test():
+    signal_c.emit(➡)
+    pass

--- a/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_untyped_args.cfg
+++ b/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_untyped_args.cfg
@@ -1,0 +1,3 @@
+[input]
+[output]
+call_hint="signalf(￿a: Variant￿, b: Variant)"

--- a/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_untyped_args.gd
+++ b/modules/gdscript/tests/scripts/completion/signal_emit_args/emit_untyped_args.gd
@@ -1,0 +1,7 @@
+extends Node
+
+signal signalf(a, b)
+
+func test():
+    signalf.emit(➡)
+    pass


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/discussions/15375
- Addresses https://github.com/godotengine/godot-proposals/issues/12779 (which for some reason was closed)

## Additional information
Only one file is code changes (only 4 lines), the rest are test cases.

Referencing @AThousandShips example from the second issue above, these all show intellisense
```gdscript
extends Node2D
class_name MyClass

signal my_signal(foo: String, bar: int)

func foo():
    # My comment, not in the original: all of these do show intellisense with this pr
    my_signal.emit(3, 4)  # Would work here.
    var me: MyClass = self
    me.my_signal.emit()  # Would work here too.
    var other_me = self
    other_me.my_signal.emit()  # DOES work here.
    var my_signal_var = my_signal
    my_signal_var.emit()  # DOES work here.
```
After PR
<img width="812" height="325" alt="image" src="https://github.com/user-attachments/assets/eeb9a72f-3cbd-4c0d-a68a-057cdf3304f8" />

Before PR
<img width="657" height="108" alt="image" src="https://github.com/user-attachments/assets/2d545baa-9b7c-4c24-8ef3-f94d7fc7475d" />

Also works when the signal has no types (after PR):


<img width="877" height="91" alt="image" src="https://github.com/user-attachments/assets/03e4e080-5503-458b-b31a-583dbdac4e12" />


A check could be added for similar situations like emit_signal
