### PR TITLE
Add editor settings `localize_editor` and `localize_documentation`

### DIFF
--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -40,6 +40,10 @@
 #include "core/string/locales.h"
 #include "core/variant/typed_array.h"
 
+#ifdef TOOLS_ENABLED
+#include "editor/settings/editor_settings.h"
+#endif // TOOLS_ENABLED
+
 void TranslationServer::init_locale_info() {
 	// Init locale info.
 	language_map.clear();
@@ -482,7 +486,14 @@ void TranslationServer::set_locale(const String &p_locale) {
 	ERR_FAIL_COND_MSG(p_locale.is_empty(), "Locale cannot be an empty string.");
 
 	String new_locale = standardize_locale(p_locale);
-	if (locale == new_locale) {
+
+	bool done = (locale == new_locale);
+#ifdef TOOLS_ENABLED
+	if (EditorSettings::get_singleton()) {
+		done = done && !EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/localization/localize_editor") && !EditorSettings::get_singleton()->check_changed_settings_in_group("interface/editor/localization/localize_documentation");
+	}
+#endif // TOOLS_ENABLED
+	if (done) {
 		return;
 	}
 

--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1118,8 +1118,14 @@
 			The language to use for the editor interface. If set to [b]Auto[/b], the language is automatically determined based on the system locale. See also [method EditorInterface.get_editor_language].
 			Translations are provided by the community. If you spot a mistake, [url=https://contributing.godotengine.org/en/latest/documentation/translation/index.html]contribute to editor translations on Weblate![/url]
 		</member>
+		<member name="interface/editor/localization/localize_documentation" type="bool" setter="" getter="">
+			If [code]true[/code], the documentation and tooltips in the editor are localized when possible. See also [member interface/editor/localization/localize_editor] and [member interface/editor/localization/localize_settings].
+		</member>
+		<member name="interface/editor/localization/localize_editor" type="bool" setter="" getter="">
+			If [code]true[/code], the editor and project manager are localized when possible. See also [member interface/editor/localization/localize_documentation] and [member interface/editor/localization/localize_settings].
+		</member>
 		<member name="interface/editor/localization/localize_settings" type="bool" setter="" getter="">
-			If [code]true[/code], setting names in the editor are localized when possible.
+			If [code]true[/code], setting names in the editor are localized when possible. See also [member interface/editor/localization/localize_documentation] and [member interface/editor/localization/localize_editor].
 			[b]Note:[/b] This setting affects most [EditorInspector]s in the editor UI, primarily Project Settings and Editor Settings. To control names displayed in the Inspector dock, use [member interface/inspector/default_property_name_style] instead.
 		</member>
 		<member name="interface/editor/localization/ui_layout_direction" type="int" setter="" getter="">

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -474,6 +474,8 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	/* Interface */
 
 	// Editor
+	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/localization/localize_editor", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
+	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/localization/localize_documentation", true, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	EDITOR_SETTING(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/localization/localize_settings", true, "")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/docks/dock_tab_style", 0, "Text Only,Icon Only,Text and Icon")
 	EDITOR_SETTING_BASIC(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/docks/bottom_dock_tab_style", 0, "Text Only,Icon Only,Text and Icon")
@@ -1501,6 +1503,9 @@ void EditorSettings::setup_language(bool p_initial_setup) {
 		}
 	}
 
+	TranslationServer::get_singleton()->get_editor_domain()->set_locale_override((has_setting("interface/editor/localization/localize_editor") && !get_setting("interface/editor/localization/localize_editor")) ? "en" : "");
+	TranslationServer::get_singleton()->get_doc_domain()->set_locale_override((has_setting("interface/editor/localization/localize_documentation") && !get_setting("interface/editor/localization/localize_documentation")) ? "en" : "");
+
 	if (lang == "en") {
 		TranslationServer::get_singleton()->set_locale(lang);
 		emit_signal("_translation_changed");
@@ -2409,7 +2414,7 @@ void EditorSettings::notify_changes() {
 	}
 	root->propagate_notification(NOTIFICATION_EDITOR_SETTINGS_CHANGED);
 
-	if (check_changed_settings_in_group("interface/editor/localization/editor_language")) {
+	if (check_changed_settings_in_group("interface/editor/localization/editor_language") || check_changed_settings_in_group("interface/editor/localization/localize_editor") || check_changed_settings_in_group("interface/editor/localization/localize_documentation")) {
 		setup_language(false);
 	}
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

Closes https://github.com/godotengine/godot-proposals/issues/77
Closes https://github.com/godotengine/godot-proposals/issues/13728

## Additional information

Changes:
- Adds new editor settings to `localize_editor` and `localize_documentation` separately.
  - `localize_editor` applies to the editor and project manager.
  - `localize_documentation` applies to the offline doc and tooltips.
  - Changing these two settings currently requires a restart (see PR 102562).

Screenshots:
<img width="565" height="279" alt="Image 2026-08-14_15-42-17" src="https://github.com/user-attachments/assets/3c331556-da9b-4781-bfcf-8736826a77b0" />

(Note: I chose `uk` for testing because it is 100% translated on [Webslate](https://hosted.weblate.org/projects/godot-engine/).)
| `en` Editor, `uk` Doc | `uk` Editor, `en` Doc |
| ------------- | ------------- |
| <img width="1280" height="764" alt="Image 2026-08-14_02-51-37" src="https://github.com/user-attachments/assets/141cfe13-3a62-40a6-9add-9ad4c7281abd" /> | <img width="1280" height="764" alt="Image 2026-08-14_02-49-29" src="https://github.com/user-attachments/assets/4c46f5a7-cea6-4af9-8326-0d10177be689" /> |

Notes for reviewers:
- The same language is used for both the offline doc and tooltips for consistency.
- The offline doc is updated without a restart, but the tooltips (currently) are not, so changing `localize_documentation` requires a restart (for now).
- A localization toggle is preferred over a separate language dropdown menu (see [comment](https://github.com/godotengine/godot-proposals/issues/13728#issuecomment-5083185775)).
- `localize_properties` is not added because `localize_settings` and `default_property_name_style` serve the same purpose.
- Resolved. ~Not sure if:~
  - ~adding helper functions (e.g. in `TranslationServer`) is needed?~
  - ~updating existing functions (e.g. `EditorSettings::get_language()`) is needed?~
  - ~subheadings (e.g. "Class", "Description") & labels (e.g. "Deprecated") should follow the doc's locale (instead of the editor's locale)?~

## Author disclosure

I wrote this PR by myself.