### PR TITLE
[RTL] Fix RichTextLabel vertical alignment calculation regression

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -875,26 +875,26 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 	}
 
 	// Add zero-width space to the end if line did not end with /n to ensure uniform height.
-	if (it_prev) {
-		Ref<Font> font = p_base_font;
-		int font_size = p_base_font_size;
+	// if (it_prev) {
+	// 	Ref<Font> font = p_base_font;
+	// 	int font_size = p_base_font_size;
 
-		ItemFont *font_it = _find_font(it_prev);
-		if (font_it) {
-			if (font_it->font.is_valid()) {
-				font = font_it->font;
-			}
-			if (font_it->font_size > 0) {
-				font_size = font_it->font_size;
-			}
-		}
-		ItemFontSize *font_size_it = _find_font_size(it_prev);
-		if (font_size_it && font_size_it->font_size > 0) {
-			font_size = font_size_it->font_size;
-		}
-		l.text_buf->add_string(String::chr(0x200B), font, font_size, String(), it_prev->rid);
-		txt += "\n";
-	}
+	// 	ItemFont *font_it = _find_font(it_prev);
+	// 	if (font_it) {
+	// 		if (font_it->font.is_valid()) {
+	// 			font = font_it->font;
+	// 		}
+	// 		if (font_it->font_size > 0) {
+	// 			font_size = font_it->font_size;
+	// 		}
+	// 	}
+	// 	ItemFontSize *font_size_it = _find_font_size(it_prev);
+	// 	if (font_size_it && font_size_it->font_size > 0) {
+	// 		font_size = font_size_it->font_size;
+	// 	}
+	// 	l.text_buf->add_string(String::chr(0x200B), font, font_size, String(), it_prev->rid);
+	// 	txt += "\n";
+	// }
 
 	// Apply BiDi override.
 	TextServer::StructuredTextParser stt = _find_stt(l.from);

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -875,26 +875,26 @@ float RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 	}
 
 	// Add zero-width space to the end if line did not end with /n to ensure uniform height.
-	// if (it_prev) {
-	// 	Ref<Font> font = p_base_font;
-	// 	int font_size = p_base_font_size;
+	if (it_prev && txt.is_empty()) {
+		Ref<Font> font = p_base_font;
+		int font_size = p_base_font_size;
 
-	// 	ItemFont *font_it = _find_font(it_prev);
-	// 	if (font_it) {
-	// 		if (font_it->font.is_valid()) {
-	// 			font = font_it->font;
-	// 		}
-	// 		if (font_it->font_size > 0) {
-	// 			font_size = font_it->font_size;
-	// 		}
-	// 	}
-	// 	ItemFontSize *font_size_it = _find_font_size(it_prev);
-	// 	if (font_size_it && font_size_it->font_size > 0) {
-	// 		font_size = font_size_it->font_size;
-	// 	}
-	// 	l.text_buf->add_string(String::chr(0x200B), font, font_size, String(), it_prev->rid);
-	// 	txt += "\n";
-	// }
+		ItemFont *font_it = _find_font(it_prev);
+		if (font_it) {
+			if (font_it->font.is_valid()) {
+				font = font_it->font;
+			}
+			if (font_it->font_size > 0) {
+				font_size = font_it->font_size;
+			}
+		}
+		ItemFontSize *font_size_it = _find_font_size(it_prev);
+		if (font_size_it && font_size_it->font_size > 0) {
+			font_size = font_size_it->font_size;
+		}
+		l.text_buf->add_string(String::chr(0x200B), font, font_size, String(), it_prev->rid);
+		txt += "\n";
+	}
 
 	// Apply BiDi override.
 	TextServer::StructuredTextParser stt = _find_stt(l.from);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Assessed #122374

## Additional information

Commit facdd8eea63450ce585037b2632682e372a9180e added a zero-width space (`U+200B`) to lines in `RichTextLabel::_shape_line()` to ensure uniform line height with fallback fonts. However, appending `U+200B` causes `TextServer` to append an extra glyph run that inflates `text_buf->get_size().y` by 3px for standard fonts. This inflated total height causes `VERTICAL_ALIGNMENT_BOTTOM` to be offset by 3px and `VERTICAL_ALIGNMENT_CENTER` to be offset by ~1.5px.

I have used AI to help me as a first time contributor, helped me with some of the git commands and in finding the right file locations.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
