### PR TITLE
Fix refocusing window ignores key that had been held down beforehand.

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -873,9 +873,11 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 	//   require additional handling by this class.
 
 	Ref<InputEventKey> k = p_event;
-	if (k.is_valid() && !k->is_echo() && k->get_keycode() != Key::NONE) {
+	if (k.is_valid() && k->get_keycode() != Key::NONE) {
 		if (k->is_pressed()) {
-			keys_pressed.insert(k->get_keycode());
+			if (!k->is_echo() || !keys_pressed.has(k->get_keycode())) {
+				keys_pressed.insert(k->get_keycode());
+			}
 		} else {
 			keys_pressed.erase(k->get_keycode());
 		}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #79516

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

If you hold down the key while the window is not in focus, then click on the window to focus, the window will only receive key events that key is down and `echo` is true.

The `Input` just filters out events where `echo` is true when a key is pressed, and unfocused window cannot receive the initial event beforehand when the `echo` is just `false`.