### PR TITLE
Update Emscripten to 6.0.1

### DIFF
--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -9,7 +9,7 @@ env:
     dev_mode=yes
     debug_symbols=no
     use_closure_compiler=yes
-  EM_VERSION: 4.0.11
+  EM_VERSION: 6.0.1
 
 jobs:
   web-template:

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -214,8 +214,8 @@ static String locale;
 static String log_file;
 static bool show_help = false;
 static uint64_t quit_after = 0;
-static ProcessID editor_pid = 0;
 #ifdef TOOLS_ENABLED
+static ProcessID editor_pid = 0;
 static bool found_project = false;
 static bool recovery_mode = false;
 static bool auto_build_solutions = false;
@@ -1889,6 +1889,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 					"To be able to use it, use the `target=template_debug` SCons option when compiling Godot.\n");
 			goto error;
 #endif // defined(DEBUG_ENABLED) || defined (TOOLS_ENABLED)
+#ifdef TOOLS_ENABLED
 		} else if (arg == "--editor-pid") { // not exposed to user
 			if (N) {
 				editor_pid = N->get().to_int();
@@ -1897,6 +1898,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing editor PID argument, aborting.\n");
 				goto error;
 			}
+#endif // TOOLS_ENABLED
 		} else if (arg == "--disable-render-loop") {
 			disable_render_loop = true;
 		} else if (arg == "--fixed-fps") {
@@ -2257,9 +2259,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 #if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	EngineDebugger::initialize(debug_uri, skip_breakpoints, ignore_error_breaks, breakpoints, []() {
+#ifdef TOOLS_ENABLED
 		if (editor_pid) {
 			DisplayServer::get_singleton()->enable_for_stealing_focus(editor_pid);
 		}
+#endif
 	});
 #endif
 

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -114,8 +114,8 @@ def configure(env: "SConsEnvironment"):
     cc_semver = (cc_version["major"], cc_version["minor"], cc_version["patch"])
 
     # Minimum emscripten requirements.
-    if cc_semver < (4, 0, 0):
-        print_error("The minimum Emscripten version to build Godot is 4.0.0, detected: %s.%s.%s" % cc_semver)
+    if cc_semver < (6, 0, 1):
+        print_error("The minimum Emscripten version to build Godot is 6.0.1, detected: %s.%s.%s" % cc_semver)
         sys.exit(255)
 
     env.Append(LIBEMITTER=[library_emitter])
@@ -168,12 +168,6 @@ def configure(env: "SConsEnvironment"):
     if env["lto"] == "auto":  # Enable LTO for production.
         env["lto"] = "thin"
 
-    if env["lto"] == "thin" and cc_semver < (4, 0, 9):
-        print_warning(
-            '"lto=thin" support requires Emscripten 4.0.9 (detected %s.%s.%s), using "lto=full" instead.' % cc_semver
-        )
-        env["lto"] = "full"
-
     if env["lto"] != "none":
         if env["lto"] == "thin":
             env.Append(CCFLAGS=["-flto=thin"])
@@ -199,13 +193,6 @@ def configure(env: "SConsEnvironment"):
         env.Append(LINKFLAGS=["-sSAFE_HEAP=1"])
 
     # Closure compiler
-    if env["use_closure_compiler"] and cc_semver < (4, 0, 11):
-        print_warning(
-            '"use_closure_compiler=yes" support requires Emscripten 4.0.11 (detected %s.%s.%s), using "use_closure_compiler=no" instead.'
-            % cc_semver
-        )
-        env["use_closure_compiler"] = False
-
     if env["use_closure_compiler"]:
         # For emscripten support code.
         env.Append(LINKFLAGS=["--closure", "1"])
@@ -269,11 +256,11 @@ def configure(env: "SConsEnvironment"):
     if env["threads"]:
         # Thread support (via SharedArrayBuffer).
         env.Append(CPPDEFINES=["PTHREAD_NO_RENAME"])
-        env.Append(CCFLAGS=["-sUSE_PTHREADS=1"])
-        env.Append(LINKFLAGS=["-sUSE_PTHREADS=1"])
+        env.Append(CCFLAGS=["-pthread"])
+        env.Append(LINKFLAGS=["-pthread"])
         env.Append(LINKFLAGS=["-sDEFAULT_PTHREAD_STACK_SIZE=%sKB" % env["default_pthread_stack_size"]])
         env.Append(LINKFLAGS=["-sPTHREAD_POOL_SIZE=\"Module['emscriptenPoolSize']||8\""])
-        env.Append(LINKFLAGS=["-sWASM_MEM_MAX=2048MB"])
+        env.Append(LINKFLAGS=["-sMAXIMUM_MEMORY=2048MB"])
         if not env["dlink_enabled"]:
             # Workaround https://github.com/emscripten-core/emscripten/issues/21844#issuecomment-2116936414.
             # Not needed (and potentially dangerous) when dlink_enabled=yes, since we set EXPORT_ALL=1 in that case.

--- a/platform/web/js/libs/library_godot_webgl2.externs.js
+++ b/platform/web/js/libs/library_godot_webgl2.externs.js
@@ -1,41 +1,5 @@
 
 /**
- * @constructor OVR_multiview2
- */
-function OVR_multiview2() {}
-
-/**
- * @type {number}
- */
-OVR_multiview2.prototype.FRAMEBUFFER_ATTACHMENT_TEXTURE_NUM_VIEWS_OVR;
-
-/**
- * @type {number}
- */
-OVR_multiview2.prototype.FRAMEBUFFER_ATTACHMENT_TEXTURE_BASE_VIEW_INDEX_OVR;
-
-/**
- * @type {number}
- */
-OVR_multiview2.prototype.MAX_VIEWS_OVR;
-
-/**
- * @type {number}
- */
-OVR_multiview2.prototype.FRAMEBUFFER_INCOMPLETE_VIEW_TARGETS_OVR;
-
-/**
- * @param {number} target
- * @param {number} attachment
- * @param {WebGLTexture} texture
- * @param {number} level
- * @param {number} baseViewIndex
- * @param {number} numViews
- * @return {void}
- */
-OVR_multiview2.prototype.framebufferTextureMultiviewOVR = function(target, attachment, texture, level, baseViewIndex, numViews) {};
-
-/**
  * @constructor OCULUS_multiview
  */
 function OCULUS_multiview() {}

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -656,6 +656,7 @@ Patches:
 - `0001-msvc-node-debug-rename.patch` ([GH-75769](https://github.com/godotengine/godot/pull/75769))
 - `0002-msvc-arm64-fpstrict.patch` ([GH-94655](https://github.com/godotengine/godot/pull/94655))
 - `0003-clang-cl-sse2-sse41-avx2.patch` ([GH-92316](https://github.com/godotengine/godot/pull/92316))
+- `0004-emscripten-cppdefine.patch` ([GH-122412](https://github.com/godotengine/godot/pull/122412))
 
 
 ## linuxbsd_headers

--- a/thirdparty/libwebp/patches/0004-emscripten-cppdefine.patch
+++ b/thirdparty/libwebp/patches/0004-emscripten-cppdefine.patch
@@ -1,0 +1,13 @@
+diff --git a/thirdparty/libwebp/src/dsp/cpu.c b/thirdparty/libwebp/src/dsp/cpu.c
+index 816892fbc..b707fc38d 100644
+--- a/thirdparty/libwebp/src/dsp/cpu.c
++++ b/thirdparty/libwebp/src/dsp/cpu.c
+@@ -179,7 +179,7 @@ static int AndroidCPUInfo(CPUFeature feature) {
+ }
+ WEBP_EXTERN VP8CPUInfo VP8GetCPUInfo;
+ VP8CPUInfo VP8GetCPUInfo = AndroidCPUInfo;
+-#elif defined(EMSCRIPTEN) // also needs to be before generic NEON test
++#elif defined(__EMSCRIPTEN__) // also needs to be before generic NEON test
+ // Use compile flags as an indicator of SIMD support instead of a runtime check.
+ static int wasmCPUInfo(CPUFeature feature) {
+   switch (feature) {

--- a/thirdparty/libwebp/src/dsp/cpu.c
+++ b/thirdparty/libwebp/src/dsp/cpu.c
@@ -179,7 +179,7 @@ static int AndroidCPUInfo(CPUFeature feature) {
 }
 WEBP_EXTERN VP8CPUInfo VP8GetCPUInfo;
 VP8CPUInfo VP8GetCPUInfo = AndroidCPUInfo;
-#elif defined(EMSCRIPTEN) // also needs to be before generic NEON test
+#elif defined(__EMSCRIPTEN__) // also needs to be before generic NEON test
 // Use compile flags as an indicator of SIMD support instead of a runtime check.
 static int wasmCPUInfo(CPUFeature feature) {
   switch (feature) {


### PR DESCRIPTION
Build containers PR: godotengine/build-containers#168.
Documentation PR: godotengine/godot-docs#12279.

Fixes #121902.
Fixes https://github.com/godotengine/godot/issues/122341.

This bumps the minimum required Emscripten version from "4.0.0+" to 6.0.1. See the relevant upstream changelog [here](https://github.com/emscripten-core/emscripten/blob/8fd74d6a84c2ac89c3e92d080beb70f62a81c03a/ChangeLog.md?plain=1#L131-L392).

I opted for 6.0.1 in the interest of being somewhat conservative, as that seems to be the latest version that affects us in terms of breakage (as best I can tell) but if we'd rather just use the latest version (6.0.6 at the time of writing) that's fine as well.

This brings with it a number of changes:

1. `platform/web/detect.py` updates its minimum version, and drops the now redundant feature-specific version checks.
2. Google Closure Compiler has been updated, which brings with it [extern declarations](https://github.com/google/closure-compiler/blob/cfa2a389d3df048e660def32322974b8e20e8b16/externs/browser/webgl.js#L3548-L3558) that conflict with ours, specifically `OVR_multiview2`, so ours has been removed.
3. `-sUSE_PTHREADS` has been replaced with `-pthread`, due to deprecation.
4. `-sMEMORY64` has been replaced with `-m64`, due to deprecation.
5. We patch/backport libwebp to use `__EMSCRIPTEN__` instead of `EMSCRIPTEN`, since the former is no longer implicitly defined everywhere.
6. `-sWASM_MEM_MAX` has long since been [renamed](https://emscripten.org/docs/tools_reference/settings_reference.html#maximum-memory) to `-sMAXIMUM_MEMORY`, so I threw that in as well.
7. Emscripten now requires Python 3.10+, as opposed to our documented 3.9+, so I'll adjust the documentation accordingly.
8. We seem to be recommending "Recent versions of mainstream browsers" in the system requirements, so I guess this doesn't really matter, but it's maybe worth noting that Emscripten 6.0.0 bumped the minimum Chrome version from 74 to 85, Firefox from 68 to 79 and Safari from 12.1 to 14.1.

---

<details><summary><i>[Resolved issue, click to expand/collapse]</i></summary>
<p>

There are two changelog entries that I'm unsure if they impact Godot in some way, but which look like they might cause trouble:

```rst
4.0.23 - 01/10/26
-----------------
- The `select()` and `poll()` system calls can now block under certain
  circumstances.  Specifically, if they are called from a background thread and
  file descriptors include pipes.  (#25523, #25990)

5.0.7 - 04/30/26
----------------
- The filesystem opteration that create new files now honor the global umask,
  which defaults for 0o222 and can be updated by calling `umask()`. (#50739)
```

</p>
</details> 

---

I've mostly only tested to see that the `arch=wasm32` editor and templates (both `threads=yes` and `threads=no`) are able to start/run/export an arbitrary project.

I am seeing that `arch=wasm64 target=editor` is failing with some error about `Cannot mix BigInt and other types` during `godot_js_config_locale_get` on startup, so that probably needs to be looked at.

I have not tested `dlink_enabled=yes` at all yet. There are a few entries in the Emscripten changelog that might impact GDExtension support in some way:

```rst
4.0.21 - 12/02/25
-----------------
- A new `-sFAKE_DYLIBS` setting was added.  When enabled you get the current
  emscripten behavior of the `-shared` flag, which is to produce regular object
  files instead of actual shared libraries (side modules).  Because this
  setting is enabled by default this doesn't change the default behavior of the
  compiler. If you want to experiment with real shared libraries you can
  explicitly disable this setting. (#25826)

6.0.0 - 06/04/26
----------------
- The `FAKE_DYLIBS` setting is now disabled by default. This means that
  `-shared` will produce real dynamic libraries by default (`-sSIDE_MODULE` is
  implied).  Also, if you include real dynamic libraries in your link command
  emscripten will now automatically produce a dynamically linked program
  (`-sMAIN_MODULE=2` is implied). (#25930)

6.0.1 - 06/22/26
----------------
- Dynamic linking now explicitly requires asynchronous Wasm compilation. The
  process of loading side modules at startup currently depends on this. (#27086)
```

---

So I guess the to-do list would be:

- [x] ~~Figure out if the `select()`/`poll()` and `umask()` stuff above is relevant to us~~ (it isn't).
- [x] Figure out why `arch=wasm64 target=editor` (and maybe templates as well) is broken.
- [x] Test GDExtension support (`dlink_enabled=yes`).
- [x] Test WebXR to make sure the `OVR_multiview2` change didn't break anything.