### PR TITLE
Prevent `Node not found:` error from empty input in `EditorPropertyNodePath`

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3137,8 +3137,12 @@ void EditorPropertyNodePath::_accept_text() {
 }
 
 void EditorPropertyNodePath::_text_submitted(const String &p_text) {
-	NodePath np = p_text;
-	_node_selected(np, false);
+	if (p_text.is_empty()) {
+		_menu_option(ACTION_CLEAR);
+	} else {
+		NodePath np = p_text;
+		_node_selected(np, false);
+	}
 	edit->hide();
 	assign->show();
 	menu->show();


### PR DESCRIPTION


<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Alleviates #121678

## Additional information

I think this is better than having it error, and also seems more intuitive. I doubt there should be any controversy. N/AI

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
