### PR TITLE
Push error when class or member name hides global enums, constants or `Variant`

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -282,7 +282,17 @@ Error GDScriptAnalyzer::check_native_member_name_conflict(const StringName &p_me
 		return ERR_PARSE_ERROR;
 	}
 
-	if (GDScriptParser::get_builtin_type(p_member_name) < Variant::VARIANT_MAX) {
+	if (CoreConstants::is_global_enum(p_member_name)) {
+		push_error(vformat(R"(The member "%s" shadows a global enum.)", p_member_name), p_member_node);
+		return ERR_PARSE_ERROR;
+	}
+
+	if (CoreConstants::is_global_constant(p_member_name)) {
+		push_error(vformat(R"(The member "%s" shadows a global constant.)", p_member_name), p_member_node);
+		return ERR_PARSE_ERROR;
+	}
+
+	if (p_member_name == SNAME("Variant") || GDScriptParser::get_builtin_type(p_member_name) < Variant::VARIANT_MAX) {
 		push_error(vformat(R"(The member "%s" cannot have the same name as a builtin type.)", p_member_name), p_member_node);
 		return ERR_PARSE_ERROR;
 	}
@@ -397,8 +407,12 @@ Error GDScriptAnalyzer::resolve_class_inheritance(GDScriptParser::ClassNode *p_c
 
 	if (p_class->identifier) {
 		StringName class_name = p_class->identifier->name;
-		if (GDScriptParser::get_builtin_type(class_name) < Variant::VARIANT_MAX) {
+		if (class_name == SNAME("Variant") || GDScriptParser::get_builtin_type(class_name) < Variant::VARIANT_MAX) {
 			push_error(vformat(R"(Class "%s" hides a built-in type.)", class_name), p_class->identifier);
+		} else if (CoreConstants::is_global_enum(class_name)) {
+			push_error(vformat(R"(Class "%s" hides a global enum.)", class_name), p_class->identifier);
+		} else if (CoreConstants::is_global_constant(class_name)) {
+			push_error(vformat(R"(Class "%s" hides a global constant.)", class_name), p_class->identifier);
 		} else if (class_exists(class_name)) {
 			push_error(vformat(R"(Class "%s" hides a native class.)", class_name), p_class->identifier);
 		} else if (ScriptServer::is_global_class(class_name) && (!GDScript::is_canonically_equal_paths(ScriptServer::get_global_class_path(class_name), parser->script_path) || p_class != parser->head)) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Can close #111010

## Additional information

I guess this would break compat, but having constants or enums or _`Variant`_ as class names is bound to lead to bugs and errors (like in the issue above). (I'm really not sure why `Variant` is allowed :p ) As for members, maybe there's more leeway, since they can be accessed through the class, but for principle, of course. If wanted, I can remove the restriction for members, though, if that would break compat for some projects (because they're already serialized for example). (Or just add a `not DISABLE_DEPRECATED` block around it)

This PR helped me realize that there was already global constants for `INT32_MIN`, `UINT32_MIN`, etc. so I didn't have to rely on a helper script for it. So I think it might be useful for some people.

N/AI (I did my own research and code)

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
