### PR TITLE
Change terrain id and terrain property editor to enum editor

### DIFF
--- a/modules/tilemap/editor/tile_data_editors.cpp
+++ b/modules/tilemap/editor/tile_data_editors.cpp
@@ -31,6 +31,7 @@
 #include "tile_data_editors.h"
 
 #include "tile_set_editor.h"
+#include "tiles_editor_plugin.h"
 
 #include "core/math/geometry_2d.h"
 #include "core/math/random_pcg.h"
@@ -1883,43 +1884,14 @@ void TileDataTerrainsEditor::_update_terrain_selector() {
 	ERR_FAIL_COND(tile_set.is_null());
 
 	// Update the terrain set selector.
-	Vector<String> options;
-	options.push_back(String(TTR("No terrains")) + String(":-1"));
-	for (int i = 0; i < tile_set->get_terrain_sets_count(); i++) {
-		options.push_back(vformat("Terrain Set %d", i));
-	}
-	terrain_set_property_editor->setup(options);
-	terrain_set_property_editor->update_property();
+	TileTerrainEditorPlugin::update_terrain_set_property_editor(terrain_set_property_editor, tile_set);
 
 	// Update the terrain selector.
 	int terrain_set = int(dummy_object->get("terrain_set"));
 	if (terrain_set == -1) {
 		terrain_property_editor->hide();
 	} else {
-		options.clear();
-		options.push_back(String(TTR("No terrain")) + String(":-1"));
-		for (int i = 0; i < tile_set->get_terrains_count(terrain_set); i++) {
-			String name = tile_set->get_terrain_name(terrain_set, i);
-			if (name.is_empty()) {
-				options.push_back(vformat("Terrain %d", i));
-			} else {
-				options.push_back(name);
-			}
-		}
-		terrain_property_editor->setup(options);
-		terrain_property_editor->update_property();
-
-		const Size2i terrain_icon_size = Size2(16, 16) * EDSCALE;
-		// Kind of a hack to set icons.
-		// We could provide a way to modify that in the EditorProperty.
-		OptionButton *option_button = terrain_property_editor->get_option_button();
-		for (int terrain = 0; terrain < tile_set->get_terrains_count(terrain_set); terrain++) {
-			Ref<Image> img = Image::create_empty(1, 1, false, Image::FORMAT_RGBA8);
-			img->set_pixel(0, 0, tile_set->get_terrain_color(terrain_set, terrain));
-			Ref<ImageTexture> icon = ImageTexture::create_from_image(img);
-			icon->set_size_override(terrain_icon_size);
-			option_button->set_item_icon(terrain + 1, icon);
-		}
+		TileTerrainEditorPlugin::update_terrain_property_editor(terrain_property_editor, tile_set, terrain_set);
 		terrain_property_editor->show();
 	}
 }

--- a/modules/tilemap/editor/tile_set_atlas_source_editor.cpp
+++ b/modules/tilemap/editor/tile_set_atlas_source_editor.cpp
@@ -2604,12 +2604,16 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 
 	// Tile inspector.
 	tile_inspector = memnew(EditorInspector);
+	Ref<TileTerrainEditorPlugin> plugin;
+	plugin.instantiate();
+	tile_inspector->add_inspector_plugin(plugin);
 	tile_inspector->set_v_size_flags(SIZE_EXPAND_FILL);
 	tile_inspector->set_show_categories(false, true);
 	tile_inspector->set_use_doc_hints(true);
 	tile_inspector->set_use_folding(true);
 	tile_inspector->set_theme_type_variation("ScrollContainerSecondary");
 	tile_inspector->connect("property_selected", callable_mp(this, &TileSetAtlasSourceEditor::_inspector_property_selected));
+
 	middle_vbox_container->add_child(tile_inspector);
 
 	tile_inspector_no_tile_selected_label = memnew(Label);

--- a/modules/tilemap/editor/tiles_editor_plugin.cpp
+++ b/modules/tilemap/editor/tiles_editor_plugin.cpp
@@ -578,3 +578,92 @@ TileSetEditorPlugin::TileSetEditorPlugin() {
 TileSetEditorPlugin::~TileSetEditorPlugin() {
 	tile_set_plugin_singleton = nullptr;
 }
+
+bool TileTerrainEditorPlugin::can_handle(Object *p_object) {
+	return Object::cast_to<TileSetAtlasSourceEditor::AtlasTileProxyObject>(p_object);
+}
+
+bool TileTerrainEditorPlugin::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) {
+	if (p_path == "terrain_set" || p_path == "terrain") {
+		TileSetAtlasSourceEditor::AtlasTileProxyObject *p_tile_data = Object::cast_to<TileSetAtlasSourceEditor::AtlasTileProxyObject>(p_object);
+		if (!p_tile_data || p_tile_data->get_edited_tiles().is_empty()) {
+			return false;
+		}
+
+		Ref<TileSetAtlasSource> tile_set_atlas = p_tile_data->get_edited_tile_set_atlas_source();
+		Ref<TileSet> tile_set(p_tile_data->get_edited_tile_set_atlas_source()->get_tile_set());
+		TileSetAtlasSourceEditor::TileSelection tile_selected = p_tile_data->get_edited_tiles().front()->get();
+		TileData *p_tile = tile_set_atlas->get_tile_data(tile_selected.tile, tile_selected.alternative);
+
+		if (p_path == "terrain_set") {
+			auto terrain_set_property_editor = memnew(EditorPropertyEnum);
+			terrain_set_property_editor->set_object_and_property(p_tile, "terrain_set");
+			terrain_set_property_editor->set_label("Terrain Set");
+			add_custom_control(terrain_set_property_editor);
+
+			update_terrain_set_property_editor(terrain_set_property_editor, tile_set);
+		}
+
+		if (p_path == "terrain") {
+			auto terrain_property_editor = memnew(EditorPropertyEnum);
+			terrain_property_editor->set_object_and_property(p_tile, "terrain");
+			terrain_property_editor->set_label("Terrain");
+			add_custom_control(terrain_property_editor);
+
+			int terrain_set = int(p_tile->get("terrain_set"));
+			if (terrain_set == -1) {
+				terrain_property_editor->hide();
+			}
+			if (terrain_set != -1) {
+				update_terrain_property_editor(terrain_property_editor, tile_set, terrain_set);
+				terrain_property_editor->show();
+			}
+		}
+		return true;
+	}
+	return false;
+}
+
+void TileTerrainEditorPlugin::update_terrain_set_property_editor(EditorPropertyEnum *p_editor, Ref<TileSet> &tile_set) {
+	ERR_FAIL_COND(p_editor == nullptr);
+	ERR_FAIL_COND(tile_set.is_null());
+
+	Vector<String> options;
+	options.push_back(String(TTR("No terrains")) + String(":-1"));
+	for (int i = 0; i < tile_set->get_terrain_sets_count(); i++) {
+		options.push_back(vformat("Terrain Set %d", i));
+	}
+	p_editor->setup(options);
+	p_editor->update_property();
+}
+
+void TileTerrainEditorPlugin::update_terrain_property_editor(EditorPropertyEnum *p_editor, Ref<TileSet> &tile_set, int terrain_set) {
+	ERR_FAIL_COND(p_editor == nullptr);
+	ERR_FAIL_COND(tile_set.is_null());
+
+	Vector<String> options;
+	options.push_back(String(TTR("No terrain")) + String(":-1"));
+	for (int i = 0; i < tile_set->get_terrains_count(terrain_set); i++) {
+		String name = tile_set->get_terrain_name(terrain_set, i);
+		if (name.is_empty()) {
+			options.push_back(vformat("Terrain %d", i));
+		} else {
+			options.push_back(name);
+		}
+	}
+	p_editor->setup(options);
+	p_editor->update_property();
+
+	// Colors
+	const Size2i terrain_icon_size = Size2(16, 16) * EDSCALE;
+	// Kind of a hack to set icons.
+	// We could provide a way to modify that in the EditorProperty.
+	OptionButton *option_button = p_editor->get_option_button();
+	for (int terrain = 0; terrain < tile_set->get_terrains_count(terrain_set); terrain++) {
+		Ref<Image> img = Image::create_empty(1, 1, false, Image::FORMAT_RGBA8);
+		img->set_pixel(0, 0, tile_set->get_terrain_color(terrain_set, terrain));
+		Ref<ImageTexture> icon = ImageTexture::create_from_image(img);
+		icon->set_size_override(terrain_icon_size);
+		option_button->set_item_icon(terrain + 1, icon);
+	}
+}

--- a/modules/tilemap/editor/tiles_editor_plugin.h
+++ b/modules/tilemap/editor/tiles_editor_plugin.h
@@ -172,3 +172,17 @@ public:
 	TileSetEditorPlugin();
 	~TileSetEditorPlugin();
 };
+
+class TileTerrainEditorPlugin : public EditorInspectorPlugin {
+	GDCLASS(TileTerrainEditorPlugin, EditorInspectorPlugin);
+
+public:
+	bool can_handle(Object *p_object) override;
+	bool parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const BitField<PropertyUsageFlags> p_usage, const bool p_wide) override;
+
+	static void update_terrain_set_property_editor(EditorPropertyEnum *p_editor, Ref<TileSet> &tile_set);
+	static void update_terrain_property_editor(EditorPropertyEnum *p_editor, Ref<TileSet> &tile_set, int terrain_set);
+
+	TileTerrainEditorPlugin() = default;
+	~TileTerrainEditorPlugin() = default;
+};


### PR DESCRIPTION
I setup `EditorPropertyEnum` through `EditorInspectorPlugin` to have nicer property editors for terrain setup in the TileSet "select" panel. Now, instead of setting the `terrain_set`/`terrain` using int, with the special value of `-1`, the user can have a nice list of "Terrain Set" and "Terrain" available, making it easy to spot which terrain to use. Also, this is closer to that the user is seeing when using the paint mode.

<img width="1280" height="578" alt="new_editors_1" src="https://github.com/user-attachments/assets/97faea26-8f39-481b-9164-7c98fd8c25f4" />

<img width="638" height="538" alt="new_editors_2" src="https://github.com/user-attachments/assets/5c4f7e0f-ec7b-4817-888b-b7ffee7ab582" />

## What problem(s) does this PR solve?

I wanted to make the user interface nicer to use :).

## Additional information

About my implementation, I rely on the **really nice** :+1:  plugin feature for the `EditorInspector` and reuse the code to setup items of the enum property editor that was already done for the paint mode (without code duplication).
I wondered if the property editors should be reconstructed from scratch (`memnew`) everytime, but it seems other plugins did not care about that.