### PR TITLE
Prevent overwriting loaded scene state when opening a scene from an empty tab

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5060,13 +5060,15 @@ Error EditorNode::open_scene(const String &p_scene, bool p_ignore_broken_deps, b
 		}
 	}
 
+	bool ignore_state = !editor_data.get_edited_scene_root();
+
 	RETURN_IF_ERROR(load_scene(p_scene, p_ignore_broken_deps, p_set_inherited, p_force_open_imported));
 
 	int current_scene_idx = editor_data.get_edited_scene_count() - 1;
 	Node *new_scene = editor_data.get_edited_scene_root(current_scene_idx);
 	ERR_FAIL_NULL_V(new_scene, ERR_BUG);
 
-	_set_current_scene_nocheck(current_scene_idx);
+	_set_current_scene_nocheck(current_scene_idx, ignore_state);
 
 	// When editor plugins load in, they might use node transforms during their own setup, so make sure they're up to date.
 	get_tree()->flush_transform_notifications();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #122369 

## Additional information
When opening a scene, the edited scene state (including the selection), was always loaded. However, when a scene was opened from an existing empty tab, Godot would save the state of the empty scene right before switching. This would overwrite the loaded scene state.
Now, `EditorNode::open_scene` checks if the current scene is empty to determine whether to ignore the state of the tab when setting the scene. If it is empty, it passes `p_ignore_state = true` so the empty scene's state is not saved.

Before:

https://github.com/user-attachments/assets/e3d1d660-cd59-44a4-ac00-e8a30eba7ef7

(The selection and zoom are lost, which doesn't happen when opening from a tab that isn't empty)

After:

https://github.com/user-attachments/assets/7976fc0a-1f72-4fe3-a296-922674f05fb8