### PR TITLE
Fix shortcuts for menu options only in the context menu

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3295,13 +3295,25 @@ void ScriptEditor::shortcut_input(const Ref<InputEvent> &p_event) {
 		document_list->goto_next_document(true);
 		accept_event();
 	}
-	if (ED_IS_SHORTCUT("script_editor/move_document_up", p_event)) {
-		_menu_option(FILE_MENU_MOVE_UP);
-		accept_event();
-	}
-	if (ED_IS_SHORTCUT("script_editor/move_document_down", p_event)) {
-		_menu_option(FILE_MENU_MOVE_DOWN);
-		accept_event();
+
+	static const HashMap<String, int> shortcut_mappings = {
+		{ "script_editor/close_other_tabs", FILE_MENU_CLOSE_OTHER_TABS },
+		{ "script_editor/close_tabs_below", FILE_MENU_CLOSE_TABS_BELOW },
+		{ "script_editor/close_docs", FILE_MENU_CLOSE_DOCS },
+		{ "script_editor/copy_path", FILE_MENU_COPY_PATH },
+		{ "script_editor/copy_uid", FILE_MENU_COPY_UID },
+		{ "script_editor/show_in_file_system", FILE_MENU_SHOW_IN_FILE_SYSTEM },
+		{ "script_editor/move_document_up", FILE_MENU_MOVE_UP },
+		{ "script_editor/move_document_down", FILE_MENU_MOVE_DOWN },
+		{ "script_editor/sort_documents", FILE_MENU_SORT },
+	};
+
+	for (const KeyValue<String, int> &E : shortcut_mappings) {
+		if (ED_IS_SHORTCUT(E.key, p_event)) {
+			_menu_option(E.value);
+			accept_event();
+			break;
+		}
 	}
 
 	if (p_event->is_echo()) {
@@ -4229,9 +4241,11 @@ ScriptEditor::ScriptEditor(const String &p_config_section, const String &p_cache
 	file_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_editor/close_file"), FILE_MENU_CLOSE);
 	file_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_editor/close_all"), FILE_MENU_CLOSE_ALL);
 	file_menu->get_popup()->add_separator();
-	file_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_editor/reload_script_soft"), FILE_MENU_SOFT_RELOAD_TOOL);
-	file_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_editor/run_file"), FILE_MENU_RUN);
-	file_menu->get_popup()->add_separator();
+	if (this == script_editor) {
+		file_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_editor/reload_script_soft"), FILE_MENU_SOFT_RELOAD_TOOL);
+		file_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_editor/run_file"), FILE_MENU_RUN);
+		file_menu->get_popup()->add_separator();
+	}
 	file_menu->get_popup()->add_submenu_node_item(TTRC("Theme"), theme_submenu, FILE_MENU_THEME_SUBMENU);
 	file_menu->get_popup()->add_separator();
 	file_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("script_editor/toggle_files_panel"), FILE_MENU_TOGGLE_FILES_PANEL);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Addresses https://github.com/godotengine/godot/pull/121709#issuecomment-5296921233 @kitbdev 

## Additional information

> This breaks shortcuts of all items that were removed from the file menu like I mentioned earlier.
Close other tabs, copy file path, etc can all be assigned a shortcut and they do not work if they are only in the context menu.
They should either be added to shortcut_input() or put back.

Fixed

> History forward and back shortcuts now highlight the buttons as if they were pressed, but only if it isn't being disabled at the start/end of the history. Probably fine, but something to be aware of.

Does happen with the `ALT` + `RIGHT`/`LEFT` shortcuts but not with `FORWARD`/`BACK`. This may be a deeper issue with inconsistent behavior between mouse and non-mouse shortcuts. For example when removing `script_forward->set_shortcut_context(this);` the shortcuts apply not only to the focused editor (one has higher priority but when it reaches the histories end the shortcut is applied in the other editor) while the mouse shortcuts only work on the focused editor. Couldn't find a quick fix.

> This adds disabled options "Soft reload tool script" and "Run" to the shader editor file menu, they shouldn't be added there.
IMO ideally they would be removed completely when the selected item isn't a tool script at all rather than just disabled.

Removed from the shader editor file menu. Tried removing the options from file menu when selected item isn't a tool script by rebuilding the menu when it is opened but this caused a crash when closing it which I could not find the exact cause for.