### PR TITLE
OpenXR: Don't give warning about Vulkan subsampled images on OpenGL

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -2538,7 +2538,7 @@ bool OpenXRAPI::pre_draw_viewport(RID p_render_target) {
 		bool use_subsampled_images = subsampled_images_enabled && subsampled_images_allowed;
 		if (render_state.use_subsampled_images != use_subsampled_images) {
 			render_state.use_subsampled_images = use_subsampled_images;
-			if (!subsampled_images_allowed) {
+			if (subsampled_images_enabled && !subsampled_images_allowed) {
 				WARN_PRINT("Foveation with subsampled images was enabled, but rendering features are in use that have forced it to be disabled.");
 			}
 			should_recreate_swapchain = true;


### PR DESCRIPTION
When Vulkan subsampled images is enabled, but there's rendering features that are incompatible with it, we show this warning:

```
Foveation with subsampled images was enabled, but rendering features are in use that have forced it to be disabled.
```

However, it would also always get shown when using OpenGL, but that doesn't make any sense because this is a Vulkan-only feature.

This PR makes it so that the message will only be shown if subsampled images is actually supported