### PR TITLE
Make native classes without assigned icons in the "Inherited By" or "Inherits" sections show their base class's icon in the class reference doc

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -1041,7 +1041,7 @@ void EditorHelp::_update_doc() {
 
 		String inherits = cd.inherits;
 		while (!inherits.is_empty()) {
-			_add_type_icon(inherits, theme_cache.doc_font_size, "Object");
+			_add_type_icon(inherits, theme_cache.doc_font_size, "");
 			class_desc->add_text(nbsp); // Otherwise icon borrows hyperlink from `_add_type()`.
 			_add_type(inherits);
 
@@ -1070,7 +1070,7 @@ void EditorHelp::_update_doc() {
 				class_desc->add_text(" , ");
 			}
 
-			_add_type_icon(itr->get(), theme_cache.doc_font_size, "Object");
+			_add_type_icon(itr->get(), theme_cache.doc_font_size, edited_class);
 			class_desc->add_text(nbsp); // Otherwise icon borrows hyperlink from `_add_type()`.
 			_add_type(itr->get());
 		}


### PR DESCRIPTION


<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Fixes #122364

## Additional information
This is the "Inherited By:" section test:
<img width="592" height="181" alt="Screenshot 2026-08-14 at 6 51 17 PM" src="https://github.com/user-attachments/assets/759d1959-b986-4a6d-bd80-03ddad664a07" />

This is the "Inherits:" section test (`AudioEffectFilter` specifically):
<img width="619" height="99" alt="Screenshot 2026-08-14 at 6 51 47 PM" src="https://github.com/user-attachments/assets/8fd3a870-63df-4e1b-96af-41b5ba416cc6" />

N/AI (bots don't know how to use Godot :D )
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
