### PR TITLE
docs: Clarify Object custom-property name collision in class reference

### DIFF
--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -83,6 +83,7 @@
 			<description>
 				Override this method to provide a custom list of additional properties to handle by the engine.
 				Should return a property list, as an [Array] of dictionaries. The result is added to the array of [method get_property_list], and should be formatted in the same way. Each [Dictionary] must at least contain the [code]name[/code] and [code]type[/code] entries.
+				[b]Note:[/b] The [code]name[/code] of a property added here must not match an existing member variable or built-in property (including one defined with [annotation @GDScript.@export]). If it does, the engine handles it as that built-in property, and your [method _get] and [method _set] overrides are [i]not[/i] called for it.
 				You can use [method _property_can_revert] and [method _property_get_revert] to customize the default values of the properties added by this method.
 				The example below displays a list of numbers shown as words going from [code]ZERO[/code] to [code]FIVE[/code], with [code]number_count[/code] controlling the size of the list:
 				[codeblocks]


### PR DESCRIPTION
## What this changes

Adds a clarifying `Note:` to the `_get_property_list()` description in the `Object` class reference (`doc/classes/Object.xml`), warning that a custom property's `name` must not collide with an existing member variable or built-in property (including `@export` vars).

## Why

Reported in #64227: a user defined a real member variable *and* returned a property with the same name from `_get_property_list()`, then overrode `_set()` to react to changes. Their `_set()` was never called, so the inspector never refreshed. Prefixing the name (e.g. `/my_property`) made it work, because the name no longer matched a real member.

This is intended behavior, confirmed by @HolonProduction in the issue thread — `_get()`/`_set()` are not called for built-in properties, and a `_get_property_list()` entry whose name matches a member collides with that built-in property.

The existing `_get()`/`_set()` notes already state the "not called for built-in properties" half. What was missing is the connection: **don't reuse a member variable's name for a custom property.** This PR adds exactly that, at the method that adds the names.

## The note

> The `name` of a property added here must not match an existing member variable or built-in property (including one defined with `@export`). If it does, the engine handles it as that built-in property, and your `_get()` and `_set()` overrides are *not* called for it.

Prose-only (no code sample), so it can't drift out of sync across the GDScript/C# examples. It frames the rule generally rather than documenting the `/` prefix as a supported feature, since that's an incidental side effect of the name no longer matching a member.

## Scope

Docs-only. No C++, no scripting API, no other XML files. The GDScript *tutorial* prose quoted in the report lives in `godot-docs` and could get a matching clarification as a follow-up there.

## Testing

- `make_rst.py doc/classes modules platform --dry-run` reports no warnings or errors; all `[method ...]` / `[annotation ...]` references resolve.
- `git diff --stat` shows only `doc/classes/Object.xml` changed.

