### PR TITLE
Surface orphan bits in @export_flags inspector after a flag is removed

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -1034,6 +1034,39 @@ void EditorPropertyFlags::_flag_toggled(int p_index) {
 void EditorPropertyFlags::update_property() {
 	uint32_t value = get_edited_property_value();
 
+	// Surface bits that no longer map to any current flag (e.g. a flag was
+	// removed from the script while its bit stayed set) as extra "Bit N"
+	// checkboxes, so they can be inspected and unticked instead of silently
+	// lingering in the stored value.
+	uint32_t new_orphans = value & ~all_flags_mask & ~orphan_mask;
+	while (new_orphans) {
+		const uint32_t bit = new_orphans & (~new_orphans + 1); // Lowest set bit.
+		int bit_index = 0;
+		for (uint32_t b = bit; b > 1; b >>= 1) {
+			bit_index++;
+		}
+		const int flag_index = flags.size();
+
+		CheckBox *cb = memnew(CheckBox);
+		cb->set_text(vformat(TTR("Bit %d (unknown flag)"), bit_index));
+		cb->set_clip_text(true);
+		cb->set_disabled(is_read_only());
+		cb->connect(SceneStringName(pressed), callable_mp(this, &EditorPropertyFlags::_flag_toggled).bind(flag_index));
+		add_focusable(cb);
+		vbox->add_child(cb);
+		flags.push_back(cb);
+		flag_values.push_back(bit);
+		orphan_mask |= bit;
+
+		// When every named flag was removed, the orphan boxes are the only
+		// controls, so anchor the property label/focus to the first one.
+		if (flag_index == 0) {
+			set_label_reference(cb);
+		}
+
+		new_orphans &= ~bit;
+	}
+
 	for (int i = 0; i < flags.size(); i++) {
 		flags[i]->set_pressed((value & flag_values[i]) == flag_values[i]);
 	}
@@ -1064,6 +1097,7 @@ void EditorPropertyFlags::setup(const Vector<String> &p_options) {
 			current_val = 1u << i;
 		}
 		flag_values.push_back(current_val);
+		all_flags_mask |= current_val;
 
 		// Create a CheckBox for the current flag.
 		CheckBox *cb = memnew(CheckBox);

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -299,6 +299,8 @@ class EditorPropertyFlags : public EditorProperty {
 	VBoxContainer *vbox = nullptr;
 	Vector<CheckBox *> flags;
 	Vector<uint32_t> flag_values;
+	uint32_t all_flags_mask = 0; // OR of every value that maps to a current flag.
+	uint32_t orphan_mask = 0; // Bits already surfaced as "Bit N" checkboxes for removed flags.
 
 	void _flag_toggled(int p_index);
 


### PR DESCRIPTION
## Bugfix


### Problem

When a flag is removed from an `@export_flags` declaration, any bit that was set for the removed flag stays in the stored value. `EditorPropertyFlags` only builds checkboxes for flags that still exist, so:

- `update_property()` only reflects bits that have a checkbox, so the orphaned bit never shows up in the inspector;
- `_flag_toggled()` reads the full stored value and only OR/ANDs the toggled bit, so the orphaned bit survives every toggle.

The result is a bit that can't be cleared from the inspector and keeps being reported at runtime, e.g. the reproduction from the issue still printing `4` after `"Test 3"` is removed.

### Change

- Accumulate `all_flags_mask` (the OR of every value that maps to a current flag) while building the checkboxes in `setup()`.
- In `update_property()`, surface every stored bit that maps to no current flag as an extra **"Bit N (unknown flag)"** checkbox, wired to the same `_flag_toggled()` path as regular flags. The user can untick it to clear the orphaned bit, and nothing is silently dropped.
- When every named flag has been removed, the orphan checkboxes are the only controls, so the property's label/focus reference is anchored to the first one.

Values with no orphaned bits are unaffected — identical UI and identical emitted values.

### Alternative considered

A smaller alternative is to simply mask out orphaned bits and emit the cleaned value on load. It was rejected here because it rewrites stored data on open (marking scenes/resources modified and dropping bits without the user's knowledge). Happy to switch to that approach if maintainers prefer the minimal patch.

### How to verify

1. Attach a script with `@export_flags("Test", "Test 2", "Test 3") var test_flags = 0` and print `test_flags` in `_ready()`.
2. Enable the last flag, then remove `"Test 3"` from the declaration.
3. Before this change the removed flag's bit is invisible and still prints; with this change it appears as a **"Bit 2 (unknown flag)"** checkbox that can be unticked to clear it.

### Known limitation (pre-existing, out of scope)

Partially-set multi-bit flags declared with an explicit value (e.g. `"Combo:6"`) can still leave an individual bit without UI representation. This is pre-existing behavior unrelated to the positional-flag case in #72010 and would be better addressed separately.
