### PR TITLE
🤖 Import: Reject built-in resources in scene import options

### DIFF
--- a/editor/docks/import_dock.cpp
+++ b/editor/docks/import_dock.cpp
@@ -61,6 +61,13 @@ public:
 
 	bool _set(const StringName &p_name, const Variant &p_value) {
 		if (values.has(p_name)) {
+			// Import options are stored in the text `.import` file, so they can only reference
+			// saved resources. A built-in one would get an unusable `res://::` path (GH-118407).
+			Ref<Resource> res_value = p_value;
+			if (res_value.is_valid() && res_value->is_built_in()) {
+				EditorNode::get_singleton()->show_warning(TTR("Import options can only reference resources saved to a file. Save the resource to disk first, then select it here."));
+				return false;
+			}
 			values[p_name] = p_value;
 			if (checking) {
 				checked.insert(p_name);

--- a/editor/import/3d/scene_import_settings.cpp
+++ b/editor/import/3d/scene_import_settings.cpp
@@ -68,6 +68,14 @@ class SceneImportSettingsData : public Object {
 
 	bool _set(const StringName &p_name, const Variant &p_value) {
 		if (settings) {
+			// Import options are stored in the text `.import` file, so they can only reference
+			// saved resources. A built-in one would get an unusable `res://::` path (GH-118407).
+			Ref<Resource> res_value = p_value;
+			if (res_value.is_valid() && res_value->is_built_in()) {
+				EditorNode::get_singleton()->show_warning(TTR("Import options can only reference resources saved to a file. Save the resource to disk first, then select it here."));
+				return false;
+			}
+
 			if (defaults.has(p_name) && defaults[p_name] == p_value) {
 				settings->erase(p_name);
 			} else {


### PR DESCRIPTION
> [!NOTE]
> **AI disclosure:** AI-assisted (Claude via Claude Code), human-directed and reviewed. The contributor picked the issue, chose the approach, and verified the change, working from a spec-driven (BMAD) process.



The "Root Script" import option (and other resource options) is edited with the generic resource picker, whose "New Script..." entry creates an in-memory built-in resource. Import options are stored in the text `.import` file and can only
reference resources saved on disk, so the built-in one gets a synthetic `res://::<id>` path. The import dialog has no owner for it, leaving the owner part empty and producing an unusable path like `res://::GDScript_j3pel`, which then
fails to load:

```
ERROR: Resource file not found: res://::GDScript_j3pel (expected type: Script)
```

Reject a built-in resource assigned to an import option, both in the Import dock and in the Advanced Import Settings dialog: the option is left unset and a warning explains that the resource must be saved to a file first. Picking an existing script file still works. The guard sits at the data layer, so it also covers per-node scripts and any other resource option.

Verified so far: the editor builds and links cleanly with the change, and the Root Script option is present on a glTF scene import. ~The runtime before/after in the editor UI still needs a manual check, which is why this is a draft.~ Manual check done
