### PR TITLE
Remove character skipping in Label3D

### DIFF
--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -356,7 +356,7 @@ void Label3D::_generate_glyph_surfaces(const Glyph &p_glyph, Vector2 &r_offset, 
 		gl_of = Vector2(0, -gl_sz.y);
 	}
 
-	if (gl_uv.size.x <= 2 || gl_uv.size.y <= 2) {
+	if (p_glyph.font_rid.is_valid() && tex.is_null()) {
 		r_offset.x += p_glyph.advance * pixel_size * p_glyph.repeat; // Nothing to draw.
 		return;
 	}


### PR DESCRIPTION
Fixes: #122338 

The characters in Label3D were skipped if their uv size was smaller than 2. My guess is that it was done for performance, to not draw invisible characters. This however breaks with pixelart style fonts and thin fonts.

I would expect all of the characters to be drawn no matter what.

The changes were only tested on Windows 11 machine.