### PR TITLE
🤖 Use `GDSOFTCLASS` for internal `NativeMenu` and 2D navigation implementations

### DIFF
--- a/modules/navigation_2d/2d/godot_navigation_server_2d.h
+++ b/modules/navigation_2d/2d/godot_navigation_server_2d.h
@@ -68,7 +68,7 @@ struct SetCommand2D {
 
 // This server exposes the `NavigationServer3D` features in the 2D world.
 class GodotNavigationServer2D : public NavigationServer2D {
-	GDCLASS(GodotNavigationServer2D, NavigationServer2D);
+	GDSOFTCLASS(GodotNavigationServer2D, NavigationServer2D);
 
 	Mutex commands_mutex;
 	/// Mutex used to make any operation threadsafe.

--- a/platform/macos/native_menu_macos.h
+++ b/platform/macos/native_menu_macos.h
@@ -38,7 +38,7 @@
 #import <ApplicationServices/ApplicationServices.h>
 
 class NativeMenuMacOS : public NativeMenu {
-	GDCLASS(NativeMenuMacOS, NativeMenu)
+	GDSOFTCLASS(NativeMenuMacOS, NativeMenu)
 
 	struct MenuData {
 		NSMenu *menu = nullptr;

--- a/platform/windows/native_menu_windows.h
+++ b/platform/windows/native_menu_windows.h
@@ -38,7 +38,7 @@
 #include <windows.h>
 
 class NativeMenuWindows : public NativeMenu {
-	GDCLASS(NativeMenuWindows, NativeMenu)
+	GDSOFTCLASS(NativeMenuWindows, NativeMenu)
 
 	enum GlobalMenuCheckType {
 		CHECKABLE_TYPE_NONE,


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes _maintainer edit: not_ #120370

`NativeMenuMacOS`, `NativeMenuWindows` and `GodotNavigationServer2D` are internal
implementations. They are never registered in `ClassDB` via `ClassDB::register_class()`
and define no `_bind_methods()`. However, `GDCLASS` adds them to `ClassDB` anyway through
`initialize_class()`, so `ClassDB.get_class_list()` lists them even though scripts cannot
reference them:

    SCRIPT ERROR: Parse Error: Identifier "GodotNavigationServer2D" not declared in the current scope.

`GDSOFTCLASS` exists for exactly this case — its doc comment states it is for "`Object`
subclasses that are not registered in `ClassDB`". This is the same fix already applied to
the internal `IP` implementations in ce098a9264.

Note that `GodotNavigationServer3D` already does not use `GDCLASS`, so the 2D counterpart
was inconsistent with it.

Neither class has a `doc/classes/*.xml` entry, which is further indication that they were
not intended to be exposed.

## Testing

Built on macOS (x86_64, OpenGL3/Compatibility) and inspected `ClassDB.get_class_list()`
from a script:

| Class | before | after |
|---|---|---|
| `GodotNavigationServer2D` | listed | not listed |
| `NativeMenuMacOS` | listed | not listed |

`NativeMenuMacOS` is only added to `ClassDB` once `DisplayServerMacOS` instantiates it, so
this requires a non-headless run to observe. `NativeMenuWindows` receives the identical
change but was not verified locally (no Windows machine available); it is covered by CI.

Checked for functional regressions:

- `NativeMenu.has_feature(FEATURE_GLOBAL_MENU)` still returns `true` and
  `get_system_menu(MAIN_MENU_ID)` still returns a valid RID, confirming the platform
  implementation is still in use.
- `NavigationServer2D` map and agent creation/destruction still work.
- Full unit test suite passes: 1419 test cases, 421648 assertions, 0 failed.

## Additional information

> [!NOTE]
> **AI disclosure**: This contribution was authored with the assistance of an autonomous AI
> coding agent (Claude), acting on my behalf. The agent identified the root cause, made the
> change, and ran the builds and verification described above. I reviewed the result before
> submitting.
