### PR TITLE
Fix silent crash when creating texture in headless mode

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/render_scene_buffers_rd.cpp
@@ -291,6 +291,7 @@ bool RenderSceneBuffersRD::has_texture(const StringName &p_context, const String
 
 RID RenderSceneBuffersRD::create_texture(const StringName &p_context, const StringName &p_texture_name, const RD::DataFormat p_data_format, const uint32_t p_usage_bits, const RD::TextureSamples p_texture_samples, const Size2i p_size, const uint32_t p_layers, const uint32_t p_mipmaps, bool p_unique, bool p_discardable) {
 	// Keep some useful data, we use default values when these are 0.
+
 	Size2i size = p_size == Size2i(0, 0) ? internal_size : p_size;
 	uint32_t layers = p_layers == 0 ? view_count : p_layers;
 	uint32_t mipmaps = p_mipmaps == 0 ? 1 : p_mipmaps;

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -1537,6 +1537,9 @@ RID RenderingDevice::texture_buffer_create(uint32_t p_size_elements, DataFormat 
 
 RID RenderingDevice::texture_create(const TextureFormat &p_format, const TextureView &p_view, const Vector<Vector<uint8_t>> &p_data) {
 	// Some adjustments will happen.
+	ERR_FAIL_COND_V_MSG(DisplayServer::get_singleton()->get_name() == "headless", RID(),
+			"Cannot create texture in headless mode");
+
 	TextureFormat format = p_format;
 
 	if (format.shareable_formats.size()) {

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -39,6 +39,7 @@
 #include "core/templates/rid_owner.h"
 #include "core/variant/type_info.h"
 #include "core/variant/typed_array.h"
+#include "servers/display/display_server.h"
 #include "servers/display/display_server_enums.h"
 #include "servers/rendering/rendering_device_commons.h"
 #include "servers/rendering/rendering_device_driver.h"


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #121298

## Additional information

- Added check if current session is in headless mode and thus not enable users to create new texture

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
