### PR TITLE
Centralize command palette history restoration

### DIFF
--- a/editor/settings/editor_command_palette.cpp
+++ b/editor/settings/editor_command_palette.cpp
@@ -217,37 +217,34 @@ void EditorCommandPalette::remove_command(String p_key_name) {
 	commands.erase(p_key_name);
 }
 
-void EditorCommandPalette::add_command(String p_command_name, String p_key_name, Callable p_action, const Ref<Shortcut> &p_shortcut) {
-	ERR_FAIL_COND_MSG(commands.has(p_key_name), "The Command '" + String(p_command_name) + "' already exists. Unable to add it.");
-
-	Command command;
-	command.name = p_command_name;
-	command.callable = p_action;
-	if (p_shortcut.is_null()) {
-		command.shortcut_text = "None";
-	} else {
-		command.shortcut = p_shortcut;
-		command.shortcut_text = p_shortcut->get_as_text();
-	}
-
-	commands[p_key_name] = command;
-}
-
-void EditorCommandPalette::_add_command(String p_command_name, String p_key_name, Callable p_binded_action, String p_shortcut_text) {
+void EditorCommandPalette::_add_command_internal(const String &p_command_name, const String &p_key_name, const Callable &p_binded_action, const Ref<Shortcut> &p_shortcut, const String &p_shortcut_text) {
 	ERR_FAIL_COND_MSG(commands.has(p_key_name), "The Command '" + String(p_command_name) + "' already exists. Unable to add it.");
 
 	Command command;
 	command.name = p_command_name;
 	command.callable = p_binded_action;
+	command.shortcut = p_shortcut;
 	command.shortcut_text = p_shortcut_text;
 
-	// Commands added from plugins don't exist yet when the history is loaded, so we assign the last use time here if it was recorded.
+	// Assign the last use time here if it was recorded.
 	Dictionary command_history = EditorSettings::get_singleton()->get_project_metadata("command_palette", "command_history", Dictionary());
 	if (command_history.has(p_key_name)) {
 		command.last_used = command_history[p_key_name];
 	}
 
 	commands[p_key_name] = command;
+}
+
+void EditorCommandPalette::add_command(String p_command_name, String p_key_name, Callable p_action, const Ref<Shortcut> &p_shortcut) {
+	String shortcut_text = "None";
+	if (p_shortcut.is_valid()) {
+		shortcut_text = p_shortcut->get_as_text();
+	}
+	_add_command_internal(p_command_name, p_key_name, p_action, p_shortcut, shortcut_text);
+}
+
+void EditorCommandPalette::_add_command(String p_command_name, String p_key_name, Callable p_binded_action, String p_shortcut_text) {
+	_add_command_internal(p_command_name, p_key_name, p_binded_action, Ref<Shortcut>(), p_shortcut_text);
 }
 
 void EditorCommandPalette::execute_command(const String &p_command_key) {
@@ -275,15 +272,6 @@ void EditorCommandPalette::register_shortcuts_as_command() {
 		add_command(command_name, E.key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::push_input).bind(ev, false), shortcut);
 	}
 	unregistered_shortcuts.clear();
-
-	// Load command use history.
-	Dictionary command_history = EditorSettings::get_singleton()->get_project_metadata("command_palette", "command_history", Dictionary());
-	for (const KeyValue<Variant, Variant> &history_kv : command_history) {
-		const String &history_key = history_kv.key;
-		if (commands.has(history_key)) {
-			commands[history_key].last_used = history_kv.value;
-		}
-	}
 }
 
 Ref<Shortcut> EditorCommandPalette::add_shortcut_command(const String &p_command, const String &p_key, Ref<Shortcut> p_shortcut) {

--- a/editor/settings/editor_command_palette.h
+++ b/editor/settings/editor_command_palette.h
@@ -81,6 +81,7 @@ class EditorCommandPalette : public ConfirmationDialog {
 	void _update_command_search(const String &search_text);
 	float _score_path(const String &p_search, const String &p_path);
 	void _confirmed();
+	void _add_command_internal(const String &p_command_name, const String &p_key_name, const Callable &p_binded_action, const Ref<Shortcut> &p_shortcut, const String &p_shortcut_text);
 	void _add_command(String p_command_name, String p_key_name, Callable p_binded_action, String p_shortcut_text = "None");
 	void _save_history() const;
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #122450

## Additional information

This PR creates a new method `_add_command_internal` and have both `add_command` and `_add_command` delegate to it. This approach preserves their APIs so there is no compatibility breaking. The new behavior is that `_add_command_internal` restores the history, while before only `_add_command` did.

This PR also removes the restoration of history in `register_shortcuts_as_command` which is no longer necessary, as it calls `add_command`, which now restores history on its own.

Notes:

- `_add_command` is accesible from GDScript as `add_command`. This continues to work.
- `add_command` is called from `editor_script_plugin.cpp` to populate the `EditorScript` commands, from `localization_editor.cpp` to add a "Generate Translation Template" command, and internally from `register_shortcuts_as_command`. This continues to work.