### PR TITLE
Add note under `has_cached` as a warning that cache is removed after resource is freed.

### DIFF
--- a/doc/classes/ResourceLoader.xml
+++ b/doc/classes/ResourceLoader.xml
@@ -84,6 +84,7 @@
 			<description>
 				Returns whether a cached resource is available for the given [param path].
 				Once a resource has been loaded by the engine, it is cached in memory for faster access, and future calls to the [method load] method will use the cached version. The cached resource can be overridden by using [method Resource.take_over_path] on a new resource for that same path.
+				[b]Note:[/b] When the resource is freed from memory, its cache will also be deleted.
 			</description>
 		</method>
 		<method name="list_directory">


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

It's mentioned in  this comment https://github.com/godotengine/godot/issues/90344#issuecomment-2041474551 that `has_cached` should clarify that resource cache is remove from memory once it gets freed, and I noticed it still didn't have anything in it.

So I did.