### PR TITLE
Fix crash in editor when exceeding maximum number of reflection probes 

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1809,7 +1809,6 @@ bool LightStorage::reflection_probe_instance_begin_render(RID p_instance, RID p_
 	}
 
 	ERR_FAIL_COND_V(rpi->atlas_index == -1, false);
-
 	RD::get_singleton()->draw_command_begin_label("Reflection Probe Render"); 
 	atlas->reflections.write[rpi->atlas_index].owner = p_instance;
 	rpi->atlas = p_reflection_atlas;

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1709,8 +1709,6 @@ bool LightStorage::reflection_probe_instance_begin_render(RID p_instance, RID p_
 		atlas->render_buffers.instantiate();
 	}
 
-	RD::get_singleton()->draw_command_begin_label("Reflection Probe Render");
-
 	const bool update_always = LightStorage::get_singleton()->reflection_probe_get_update_mode(rpi->probe) == RSE::REFLECTION_PROBE_UPDATE_ALWAYS;
 	if (update_always && atlas->reflection.is_valid() && atlas->size != 256) {
 		WARN_PRINT("ReflectionProbes set to UPDATE_ALWAYS must have an atlas size of 256. Please update the atlas size in the ProjectSettings.");
@@ -1810,10 +1808,12 @@ bool LightStorage::reflection_probe_instance_begin_render(RID p_instance, RID p_
 		}
 	}
 
-	if (rpi->atlas_index != -1) { // should we fail if this is still -1 ?
-		atlas->reflections.write[rpi->atlas_index].owner = p_instance;
-	}
+	ERR_FAIL_COND_V(rpi->atlas_index == -1, false);
 
+	RD::get_singleton()->draw_command_begin_label("Reflection Probe Render"); 
+
+	atlas->reflections.write[rpi->atlas_index].owner = p_instance;
+	
 	rpi->atlas = p_reflection_atlas;
 	rpi->rendering = true;
 	rpi->dirty = false;
@@ -1833,11 +1833,6 @@ bool LightStorage::reflection_probe_instance_end_render(RID p_instance, RID p_re
 
 	ReflectionProbeInstance *rpi = reflection_probe_instance_owner.get_or_null(p_instance);
 	ERR_FAIL_NULL_V(rpi, false);
-
-	ERR_PRINT(vformat(
-			"atlas_index = %d, reflections.size() = %d",
-			rpi->atlas_index,
-			atlas->reflections.size()));
 
 	RD::get_singleton()->draw_command_begin_label("Convert reflection probe to octahedral");
 	copy_effects->copy_cubemap_to_octmap(atlas->color_buffer, atlas->reflections.write[rpi->atlas_index].data.layers[0].mipmaps[0].framebuffer, atlas->uv_border_size);

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1811,9 +1811,7 @@ bool LightStorage::reflection_probe_instance_begin_render(RID p_instance, RID p_
 	ERR_FAIL_COND_V(rpi->atlas_index == -1, false);
 
 	RD::get_singleton()->draw_command_begin_label("Reflection Probe Render"); 
-
 	atlas->reflections.write[rpi->atlas_index].owner = p_instance;
-	
 	rpi->atlas = p_reflection_atlas;
 	rpi->rendering = true;
 	rpi->dirty = false;

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1809,7 +1809,9 @@ bool LightStorage::reflection_probe_instance_begin_render(RID p_instance, RID p_
 	}
 
 	ERR_FAIL_COND_V(rpi->atlas_index == -1, false);
+
 	RD::get_singleton()->draw_command_begin_label("Reflection Probe Render"); 
+
 	atlas->reflections.write[rpi->atlas_index].owner = p_instance;
 	rpi->atlas = p_reflection_atlas;
 	rpi->rendering = true;

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1810,6 +1810,7 @@ bool LightStorage::reflection_probe_instance_begin_render(RID p_instance, RID p_
 
 	ERR_FAIL_COND_V(rpi->atlas_index == -1, false);
 
+
 	RD::get_singleton()->draw_command_begin_label("Reflection Probe Render"); 
 
 	atlas->reflections.write[rpi->atlas_index].owner = p_instance;

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1809,9 +1809,7 @@ bool LightStorage::reflection_probe_instance_begin_render(RID p_instance, RID p_
 	}
 
 	ERR_FAIL_COND_V(rpi->atlas_index == -1, false);
-
-
-	RD::get_singleton()->draw_command_begin_label("Reflection Probe Render"); 
+	RD::get_singleton()->draw_command_begin_label("Reflection Probe Render");
 
 	atlas->reflections.write[rpi->atlas_index].owner = p_instance;
 	rpi->atlas = p_reflection_atlas;

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1798,7 +1798,7 @@ bool LightStorage::reflection_probe_instance_begin_render(RID p_instance, RID p_
 		//find the one used last
 		if (rpi->atlas_index == -1) {
 			//everything is in use, find the one least used via LRU
-			uint64_t pass_min = 0;
+			uint64_t pass_min = std::numeric_limits<uint64_t>::max();
 
 			for (int i = 0; i < atlas->reflections.size(); i++) {
 				ReflectionProbeInstance *rpi2 = reflection_probe_instance_owner.get_or_null(atlas->reflections[i].owner);
@@ -1833,6 +1833,11 @@ bool LightStorage::reflection_probe_instance_end_render(RID p_instance, RID p_re
 
 	ReflectionProbeInstance *rpi = reflection_probe_instance_owner.get_or_null(p_instance);
 	ERR_FAIL_NULL_V(rpi, false);
+
+	ERR_PRINT(vformat(
+			"atlas_index = %d, reflections.size() = %d",
+			rpi->atlas_index,
+			atlas->reflections.size()));
 
 	RD::get_singleton()->draw_command_begin_label("Convert reflection probe to octahedral");
 	copy_effects->copy_cubemap_to_octmap(atlas->color_buffer, atlas->reflections.write[rpi->atlas_index].data.layers[0].mipmaps[0].framebuffer, atlas->uv_border_size);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->I used AI to reason about the codebase and suggest potential trouble spots to check

## What problem(s) does this PR solve?

- Closes #122418

## Additional information

MRP no longer crashes Godot. Number of reflection probes increased to 128, no issue.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
