### PR TITLE
GDScript: Add setting to disable auto opening braces when completing  functions and annotations

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1593,6 +1593,9 @@
 			- Connecting signals from the Signals dock;
 			- Creating variables prefixed with [annotation @GDScript.@onready], by dropping nodes from the Scene dock into the script editor while holding [kbd]Ctrl[/kbd].
 		</member>
+		<member name="text_editor/completion/auto_brace_open" type="bool", setter="", getter="">
+			If [code]true[/code], automatically inserts an opening brace in functions, signals, and anything else that requires an opening brace. This includes brackets ([code]()[/code], [code][][/code], [code]{}[/code]), string quotation marks ([code]''[/code], [code]""[/code]), and comments ([code]/**/[/code]) if the language supports it.
+		</member>
 		<member name="text_editor/completion/auto_brace_complete" type="bool" setter="" getter="">
 			If [code]true[/code], automatically inserts the matching closing brace when the opening brace is inserted by typing or autocompletion. Also automatically removes the closing brace when pressing [kbd]Backspace[/kbd] on the opening brace. This includes brackets ([code]()[/code], [code][][/code], [code]{}[/code]), string quotation marks ([code]''[/code], [code]""[/code]), and comments ([code]/**/[/code]) if the language supports it.
 		</member>

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -885,6 +885,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Completion
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay", 1.5, "0.1,10,0.01")
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay_with_errors_found", 0.5, "0.1,5,0.01")
+	_initial_set("text_editor/completion/auto_brace_open", true, true);
 	_initial_set("text_editor/completion/auto_brace_complete", true, true);
 	_initial_set("text_editor/completion/code_complete_enabled", true, true);
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/code_complete_delay", 0.3, "0.01,5,0.01,or_greater")

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -78,6 +78,13 @@ static String _get_indentation() {
 	return "\t";
 }
 
+static bool _will_open_brace() {
+#ifdef TOOLS_ENABLED
+	return EDITOR_GET("text_editor/completion/auto_brace_open");
+#endif
+	return true;
+}
+
 Vector<String> GDScriptLanguage::get_comment_delimiters() const {
 	static const Vector<String> delimiters = { "#" };
 	return delimiters;
@@ -1287,10 +1294,14 @@ static void _find_identifiers_in_class(const GDScriptParser::ClassNode *p_class,
 						option = ScriptLanguage::CodeCompletionOption(member.function->identifier->name, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION, location);
 						if (p_add_braces) {
 							if (member.function->parameters.size() > 0 || (member.function->info.flags & METHOD_FLAG_VARARG)) {
-								option.insert_text += "(";
+								if (_will_open_brace()) {
+									option.insert_text += "(";
+								}
 								option.display += U"(\u2026)";
 							} else {
-								option.insert_text += "()";
+								if (_will_open_brace()) {
+									option.insert_text += "()";
+								}
 								option.display += "()";
 							}
 						}
@@ -1334,7 +1345,9 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 	if (!p_types_only && base_type.is_meta_type && base_type.kind != GDScriptParser::DataType::BUILTIN && base_type.kind != GDScriptParser::DataType::ENUM) {
 		ScriptLanguage::CodeCompletionOption option("new", ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION, ScriptLanguage::LOCATION_LOCAL);
 		if (p_add_braces) {
-			option.insert_text += "(";
+			if (_will_open_brace()) {
+				option.insert_text += "(";
+			}
 			option.display += U"(\u2026)";
 		}
 		r_result.insert(option.display, option);
@@ -1399,10 +1412,14 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 							ScriptLanguage::CodeCompletionOption option(E.name, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION, location);
 							if (p_add_braces) {
 								if (E.arguments.size() || (E.flags & METHOD_FLAG_VARARG)) {
-									option.insert_text += "(";
+									if (_will_open_brace()) {
+										option.insert_text += "(";
+									}
 									option.display += U"(\u2026)";
 								} else {
-									option.insert_text += "()";
+									if (_will_open_brace()) {
+										option.insert_text += "()";
+									}
 									option.display += "()";
 								}
 							}
@@ -1492,10 +1509,14 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 					ScriptLanguage::CodeCompletionOption option(E.name, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION, location);
 					if (p_add_braces) {
 						if (E.arguments.size() || (E.flags & METHOD_FLAG_VARARG)) {
-							option.insert_text += "(";
+							if (_will_open_brace()) {
+								option.insert_text += "(";
+							}
 							option.display += U"(\u2026)";
 						} else {
-							option.insert_text += "()";
+							if (_will_open_brace()) {
+								option.insert_text += "()";
+							}
 							option.display += "()";
 						}
 					}
@@ -1588,10 +1609,14 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 					ScriptLanguage::CodeCompletionOption option(E.name, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION, location);
 					if (p_add_braces) {
 						if (E.arguments.size() || (E.flags & METHOD_FLAG_VARARG)) {
-							option.insert_text += "(";
+							if (_will_open_brace()) {
+								option.insert_text += "(";
+							}
 							option.display += U"(\u2026)";
 						} else {
-							option.insert_text += "()";
+							if (_will_open_brace()) {
+								option.insert_text += "()";
+							}
 							option.display += "()";
 						}
 					}
@@ -1625,10 +1650,14 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 		ScriptLanguage::CodeCompletionOption option(String(E), ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);
 		if (p_add_braces) {
 			if (function.arguments.size() || (function.flags & METHOD_FLAG_VARARG)) {
-				option.insert_text += "(";
+				if (_will_open_brace()) {
+					option.insert_text += "(";
+				}
 				option.display += U"(\u2026)";
 			} else {
-				option.insert_text += "()";
+				if (_will_open_brace()) {
+					option.insert_text += "()";
+				}
 				option.display += "()";
 			}
 		}
@@ -1677,7 +1706,9 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 	while (*kwa) {
 		ScriptLanguage::CodeCompletionOption option(*kwa, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);
 		if (p_add_braces) {
-			option.insert_text += "(";
+			if (_will_open_brace()) {
+				option.insert_text += "(";
+			}
 			option.display += U"(\u2026)";
 		}
 		r_result.insert(option.display, option);
@@ -1690,7 +1721,9 @@ static void _find_identifiers(const GDScriptParser::CompletionContext &p_context
 	for (const StringName &util_func_name : utility_func_names) {
 		ScriptLanguage::CodeCompletionOption option(util_func_name, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);
 		if (p_add_braces) {
-			option.insert_text += "(";
+			if (_will_open_brace()) {
+				option.insert_text += "(";
+			}
 			option.display += U"(\u2026)"; // As all utility functions contain an argument or more, this is hardcoded here.
 		}
 		r_result.insert(option.display, option);
@@ -3482,7 +3515,9 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 			for (const MethodInfo &E : annotations) {
 				ScriptLanguage::CodeCompletionOption option(E.name.substr(1), ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
 				if (E.arguments.size() > 0) {
-					option.insert_text += "(";
+					if (_will_open_brace()) {
+						option.insert_text += "(";
+					}
 				}
 				options.insert(option.display, option);
 			}
@@ -3520,9 +3555,13 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 						ScriptLanguage::CodeCompletionOption option(E, ScriptLanguage::CODE_COMPLETION_KIND_FUNCTION);
 						if (!_guess_expecting_callable(completion_context)) {
 							if (Variant::get_builtin_method_argument_count(completion_context.builtin_type, E) > 0 || Variant::is_builtin_method_vararg(completion_context.builtin_type, E)) {
-								option.insert_text += "(";
+								if (_will_open_brace()) {
+									option.insert_text += "(";
+								}
 							} else {
-								option.insert_text += "()";
+								if (_will_open_brace()) {
+									option.insert_text += "()";
+								}
 							}
 						}
 						options.insert(option.display, option);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

No generative AI was used in the making of this PR.

## What problem(s) does this PR solve?

Addresses [Proposal #6312](https://github.com/godotengine/godot-proposals/issues/6312#issuecomment-5304832568)

The purpose of this commit is to add the option to enable and disable the auto opening of parentheses when a function is autocompleted. Unlike the proposal, this doesn't deal with quotations. [I was encouraged to open this PR recently as I mainly just tested it on my own time without creating a proper fork or pull request, over a year ago](https://github.com/godotengine/godot-proposals/issues/6312#issuecomment-2657544671).

Here it is being used within the GDScript editor:

https://github.com/user-attachments/assets/d538d81c-28b2-40f6-970e-abb17a948313

Here it is being used within an external editor, such as VSCode:

https://github.com/user-attachments/assets/8bf4ce2e-cd03-4751-9212-dd0991d41c0a

## Technical Overview

The bulk of the changes are made in gdscript_editor.cpp, which pull from a created editor setting 'auto_brace_open' which allows for users of the engine to enable and disable the auto opening of parentheses. These editor settings are created through EditorSettings.xml and editor_settings.cpp. 

In gdscript_editor.cpp, a static bool function `_will_open_brace()` was created to handle the retrieving of this editor setting, and all instances of opening and closing braces involves the use of this function under all instances of `option.insert_text += "("`, as well as `option.insert_text += "()"`, but no modifications to `option.display` is made in any of these instances. 

I am also unsure of the use of `p_add_braces`, if that has anything to do with internal functionality or more general functionality that isn't related to any user configurable setting. If it is important, I would like to know!