### PR TITLE
Free reflection atlas color buffer and face views

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1557,6 +1557,17 @@ void LightStorage::_reflection_atlas_clear(ReflectionAtlas *p_reflection_atlas) 
 	RD::get_singleton()->free_rid(p_reflection_atlas->reflection);
 	p_reflection_atlas->reflection = RID();
 
+	for (int i = 0; i < 6; i++) {
+		RD::get_singleton()->free_rid(p_reflection_atlas->color_fbs[i]);
+		p_reflection_atlas->color_fbs[i] = RID();
+
+		RD::get_singleton()->free_rid(p_reflection_atlas->color_views[i]);
+		p_reflection_atlas->color_views[i] = RID();
+	}
+
+	RD::get_singleton()->free_rid(p_reflection_atlas->color_buffer);
+	p_reflection_atlas->color_buffer = RID();
+
 	RD::get_singleton()->free_rid(p_reflection_atlas->depth_fb);
 	p_reflection_atlas->depth_fb = RID();
 


### PR DESCRIPTION
Fixes #122461.

`LightStorage::_reflection_atlas_update()` allocates `color_buffer` — the
`TEXTURE_TYPE_CUBE` a probe renders into before it is copied to the octmap — and
six slice views of it, but `_reflection_atlas_clear()` frees only `reflection`,
`depth_fb` and `depth_buffer`. Neither field is passed to `free_rid()` anywhere
else in the engine, so both leak. Because `reflection_atlas_free()` also goes
through `_reflection_atlas_clear()`, freeing the atlas outright does not release
them either: the seven RIDs survive the `Scenario` that owned them.

That makes it a growing leak rather than a shutdown artifact — 7 textures per
atlas the process has ever built:

| situation | leaked at exit, before this PR |
|---|---|
| one probe, one world | 7 |
| one probe, then switched to `UPDATE_ALWAYS` (rebuilds the atlas mid-run) | 14 |
| four `World3D`s with a probe each, created and freed one at a time | 28 |

The framebuffers in `color_fbs` are freed here before their attachments, the way
`depth_fb` already is, rather than left to dependency cleanup.

The fields were added in #107902 and were not added to the teardown path; 4.5 is
unaffected, 4.6 onwards is.

### Testing

Built from `master` (`00932449c9`) on Windows 11 / MSVC, Vulkan 1.4.349,
AMD Radeon RX 7800 XT, with the MRP from the issue:

| build | one probe | four worlds |
|---|---|---|
| master | `7 RIDs of type "Texture" were leaked` | `28 RIDs ... leaked` |
| this PR | clean | clean |

Same for Forward Mobile. Rendering is unaffected: screenshots of a mirrored
sphere in a coloured room, taken by both builds — including after a mid-run
switch to `UPDATE_ALWAYS`, which exercises the changed code path while the game
runs — are byte-identical (same SHA-256).