### PR TITLE
Fix Flashing lights in volumetric fog when attenuation is above 1

### DIFF
--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl
@@ -240,7 +240,8 @@ float get_omni_attenuation(float dist, float inv_range, float decay) {
 	nd *= nd; // nd^4
 	nd = max(1.0 - nd, 0.0);
 	nd *= nd; // nd^2
-	return nd * pow(max(dist, 0.0001), -decay);
+	float attenuation = nd * pow(max(dist, 0.0001), -decay);
+	return min(attenuation, 1.0);
 }
 
 void cluster_get_item_range(uint p_offset, out uint item_min, out uint item_max, out uint item_from, out uint item_to) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #87578
- The issue is also listed in the tracker https://github.com/godotengine/godot/issues/69579

## Additional information
First of all, sorry for my English it's not my first language.
I did cap the light attenuation based on @Calinou's proposed solution. it fixed the Flashing issue. a kinda similar workaround is used in AreaLights [volumetric_fog_process.glsl](https://github.com/godotengine/godot/blob/7b7bd1dceab61b7a5e6b6da10dd091d73549dd50/servers/rendering/renderer_rd/shaders/environment/volumetric_fog_process.glsl#L636-L643) (line 636 of that commit). but not OmniLight and SpotLight.

test results:
attenuation 1,3,10 left to right

(4.7.1 Stable)
<img width="3240" height="1080" alt="combined-image(2)" src="https://github.com/user-attachments/assets/b4fc9253-c746-4df0-8bb9-ba6ebfae301e" />


(this PR)
<img width="3240" height="1080" alt="combined-image(3)" src="https://github.com/user-attachments/assets/bc5d8353-146e-4b4d-8dc8-a4af3f934e50" />


it also keeps flashing on attenuation value as low as 1.6 on stable 4.7.1:

https://github.com/user-attachments/assets/ddef6e20-4835-4688-a52a-885830f5edc5

it kinda works but it changes how the lights react to volumetric fog in almost all the projects out there that have lights with attenuation higher than 1.0. the near-light area is going to have it's calculated volumetric fog attenuation capped at 1.0. because otherwise the temporal rep would freak out duo to high frequency data in the froxels. AreaLight3D uses a different workaround. it clamps the distance to atlease 1.0. the comment says:
```
// Due to jitter, we get extreme flickering at voxels intersecting the 
// A quick fix is to set the distance to be at least 1.0. This has the side 
// that a light with a range of less than 1.0 will not affect fog, but that is an uncommon scenario.
```

the hard-coded max attenuation could be exposed as a project setting (or maybe inside WorldEnvironment?). I've mostly tested this on max attenuation of 1.0.
the limitation with this code is, it flattens the near-light brightness which was not the behavior in previous releases. it used to get progressively brighter toward the center and because of that, a higher fog volume size could improve the resolution but it makes little to no difference here. there may be more ways to go about this. we could possibly calculate a minimum distance based on the world-space size of each froxel if that makes sense. this could let higher fog resolutions have more detail while preventing the flickering shenanigans. but I'm not sure if this is the right approach or what kind of bugs it may have. I need to test it in another branch.

I'm not an expert in computer graphics beyond soome toy game projects and shader experiments. I'm still learning so I would appreciate your opinion about this @clayjohn  

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
