### PR TITLE
Fix Remote Debugger Tree Item Text Trimming

### DIFF
--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -258,6 +258,7 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 		// Add this node.
 		TreeItem *item = create_item(parent);
 		item->set_text(0, node.name);
+		item->set_text_overrun_behavior(0, TextServer::OVERRUN_NO_TRIMMING);
 		if (node.scene_file_path.is_empty()) {
 			item->set_tooltip_text(0, node.name + "\n" + TTR("Type:") + " " + node.type_name);
 		} else {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #120951

## Additional information

Set per item Text Overrun Behaviour to not be trimmed, as done in the local scene tree as well:

https://github.com/godotengine/godot/blob/00932449c9f372b30301d8b5fdc1be70ec12b5c0/editor/scene/scene_tree_editor.cpp#L503

<details>
<summary>Validation</summary>

Before:
<img width="292" height="436" alt="Screenshot 2026-08-16 132108" src="https://github.com/user-attachments/assets/b3699e5f-e990-48ef-8358-5e18f7408c5b" />

After:
<img width="304" height="477" alt="Screenshot 2026-08-16 132508" src="https://github.com/user-attachments/assets/70e78b97-e14a-44a5-839a-7ad6935c6726" />


</details>