### PR TITLE
Make linked resource accounting lazy to fix SceneTree performance regression

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1814,7 +1814,9 @@ void EditorNode::save_resource_in_path(const Ref<Resource> &p_resource, const St
 	saving_resources_in_path.erase(p_resource);
 
 	_resource_saved(p_resource, path);
-	clear_node_reference(p_resource); // // Check if Resource is saved to disk to potentially remove it from resource_count
+	if (!is_resource_internal_to_scene(p_resource)) {
+		invalidate_resource_usage_cache();
+	}
 	emit_signal(SNAME("resource_saved"), p_resource);
 	editor_data.notify_resource_saved(p_resource);
 
@@ -2039,71 +2041,218 @@ void EditorNode::gather_resources(const Variant &p_variant, List<Ref<Resource>> 
 	}
 }
 
-void EditorNode::update_resource_count(Node *p_node, bool p_remove) {
-	if (!get_edited_scene()) {
+void EditorNode::_queue_resource_usage_changed() {
+	if (resource_usage_notification_queued) {
+		return;
+	}
+	resource_usage_notification_queued = true;
+	callable_mp(this, &EditorNode::_flush_resource_usage_changed).call_deferred();
+}
+
+void EditorNode::_flush_resource_usage_changed() {
+	resource_usage_notification_queued = false;
+	emit_signal(SNAME("resource_counter_changed"));
+}
+
+void EditorNode::_reset_resource_usage_cache() {
+	for (const KeyValue<Ref<Resource>, HashSet<ObjectID>> &E : resource_node_usage) {
+		const Callable callback = callable_mp(this, &EditorNode::_resource_usage_changed).bind(E.key->get_instance_id());
+		E.key->disconnect_changed(callback);
+	}
+	node_resource_usage.clear();
+	resource_node_usage.clear();
+	dirty_resource_usage_nodes.clear();
+	resource_usage_scene_id = get_edited_scene() ? get_edited_scene()->get_instance_id() : ObjectID();
+	resource_usage_initialized = false;
+	resource_usage_invalid = false;
+	resource_usage_updating = false;
+	_queue_resource_usage_changed();
+}
+
+void EditorNode::invalidate_resource_usage_cache() {
+	if (!resource_usage_initialized || resource_usage_invalid) {
+		return;
+	}
+	resource_usage_invalid = true;
+	_queue_resource_usage_changed();
+}
+
+bool EditorNode::_is_node_in_resource_usage_scope(Node *p_node) const {
+	Node *scene = get_editor_data().get_edited_scene_root();
+	if (!scene || !p_node || (p_node != scene && !scene->is_ancestor_of(p_node))) {
+		return false;
+	}
+	return p_node == scene || p_node->get_owner() == scene || (p_node->get_owner() && scene->is_editable_instance(p_node->get_owner()));
+}
+
+void EditorNode::_collect_node_resource_usage(Node *p_node, HashSet<Ref<Resource>> &r_resources) {
+	List<Ref<Resource>> resources;
+	HashSet<Object *> scanned_objects;
+	gather_resources(p_node, resources, scanned_objects, true);
+	for (const Ref<Resource> &resource : resources) {
+		if (resource.is_valid() && is_resource_internal_to_scene(resource)) {
+			r_resources.insert(resource);
+		}
+	}
+}
+
+void EditorNode::_remove_resource_usage_snapshot(ObjectID p_node_id) {
+	HashSet<Ref<Resource>> *old_resources = node_resource_usage.getptr(p_node_id);
+	if (!old_resources) {
+		return;
+	}
+	for (const Ref<Resource> &resource : *old_resources) {
+		HashSet<ObjectID> *nodes = resource_node_usage.getptr(resource);
+		if (!nodes) {
+			continue;
+		}
+		nodes->erase(p_node_id);
+		if (nodes->is_empty()) {
+			const Callable callback = callable_mp(this, &EditorNode::_resource_usage_changed).bind(resource->get_instance_id());
+			resource->disconnect_changed(callback);
+			resource_node_usage.erase(resource);
+		}
+	}
+	node_resource_usage.erase(p_node_id);
+}
+
+void EditorNode::_reconcile_node_resource_usage(Node *p_node) {
+	ERR_FAIL_NULL(p_node);
+	const ObjectID node_id = p_node->get_instance_id();
+	if (!_is_node_in_resource_usage_scope(p_node)) {
+		_remove_resource_usage_snapshot(node_id);
 		return;
 	}
 
-	List<Ref<Resource>> res_list;
-	HashSet<Object *> scanned_objects;
-	gather_resources(p_node, res_list, scanned_objects, true);
+	HashSet<Ref<Resource>> resources;
+	_collect_node_resource_usage(p_node, resources);
+	_remove_resource_usage_snapshot(node_id);
+	node_resource_usage.insert(node_id, resources);
+	for (const Ref<Resource> &resource : resources) {
+		HashSet<ObjectID> &nodes = resource_node_usage[resource];
+		if (nodes.is_empty()) {
+			const Callable callback = callable_mp(this, &EditorNode::_resource_usage_changed).bind(resource->get_instance_id());
+			resource->connect_changed(callback);
+		}
+		nodes.insert(node_id);
+	}
+}
 
-	for (Ref<Resource> &R : res_list) {
-		List<Node *>::Element *E = resource_count[R].find(p_node);
-		if (E) {
-			if (p_remove) {
-				resource_count[R].erase(E);
+void EditorNode::_rebuild_resource_usage_cache() {
+	Node *scene = get_edited_scene();
+	_reset_resource_usage_cache();
+	resource_usage_initialized = true;
+	resource_usage_updating = true;
+	if (scene) {
+		List<Node *> pending;
+		pending.push_back(scene);
+		while (!pending.is_empty()) {
+			Node *node = pending.front()->get();
+			pending.pop_front();
+			if (_is_node_in_resource_usage_scope(node)) {
+				_reconcile_node_resource_usage(node);
 			}
-		} else {
-			resource_count[R].push_back(p_node);
+			for (int i = 0; i < node->get_child_count(false); i++) {
+				pending.push_back(node->get_child(i, false));
+			}
 		}
 	}
+	resource_usage_updating = false;
+}
 
-	emit_signal(SNAME("resource_counter_changed"));
+void EditorNode::_ensure_resource_usage_cache() {
+	const ObjectID scene_id = get_edited_scene() ? get_edited_scene()->get_instance_id() : ObjectID();
+	if (!resource_usage_initialized || resource_usage_invalid || resource_usage_scene_id != scene_id) {
+		_rebuild_resource_usage_cache();
+		return;
+	}
+	if (resource_usage_updating || dirty_resource_usage_nodes.is_empty()) {
+		return;
+	}
+	resource_usage_updating = true;
+	HashSet<ObjectID> dirty(dirty_resource_usage_nodes);
+	dirty_resource_usage_nodes.clear();
+	for (const ObjectID &node_id : dirty) {
+		Node *node = ObjectDB::get_instance<Node>(node_id);
+		if (node) {
+			_reconcile_node_resource_usage(node);
+		} else {
+			_remove_resource_usage_snapshot(node_id);
+		}
+	}
+	resource_usage_updating = false;
+}
+
+void EditorNode::_mark_resource_usage_subtree_dirty(Node *p_node) {
+	if (!resource_usage_initialized || !p_node) {
+		return;
+	}
+
+	List<Node *> pending;
+	pending.push_back(p_node);
+	while (!pending.is_empty()) {
+		Node *node = pending.front()->get();
+		pending.pop_front();
+		dirty_resource_usage_nodes.insert(node->get_instance_id());
+		for (int i = 0; i < node->get_child_count(false); i++) {
+			pending.push_back(node->get_child(i, false));
+		}
+	}
+	_queue_resource_usage_changed();
+}
+
+void EditorNode::mark_node_resource_usage_dirty(Node *p_node) {
+	if (!resource_usage_initialized || !p_node) {
+		return;
+	}
+	dirty_resource_usage_nodes.insert(p_node->get_instance_id());
+	_queue_resource_usage_changed();
+}
+
+void EditorNode::remove_node_from_resource_usage_cache(Node *p_node) {
+	if (!resource_usage_initialized || !p_node) {
+		return;
+	}
+	dirty_resource_usage_nodes.erase(p_node->get_instance_id());
+	_remove_resource_usage_snapshot(p_node->get_instance_id());
+	_queue_resource_usage_changed();
+}
+
+void EditorNode::_resource_usage_changed(ObjectID p_resource_id) {
+	if (!resource_usage_initialized) {
+		return;
+	}
+	if (resource_usage_updating) {
+		resource_usage_invalid = true;
+		_queue_resource_usage_changed();
+		return;
+	}
+	Resource *resource = ObjectDB::get_instance<Resource>(p_resource_id);
+	if (!resource) {
+		invalidate_resource_usage_cache();
+		return;
+	}
+	HashSet<ObjectID> *nodes = resource_node_usage.getptr(Ref<Resource>(resource));
+	if (!nodes) {
+		return;
+	}
+	for (const ObjectID &node_id : *nodes) {
+		dirty_resource_usage_nodes.insert(node_id);
+	}
+	_queue_resource_usage_changed();
+}
+
+void EditorNode::_undo_redo_resource_usage_changed() {
+	// Inspector actions mark affected nodes dirty; invalidate for other actions.
+	if (resource_usage_initialized && dirty_resource_usage_nodes.is_empty()) {
+		invalidate_resource_usage_cache();
+	}
 }
 
 int EditorNode::get_resource_count(Ref<Resource> p_res) {
-	List<Node *> *L = resource_count.getptr(p_res);
-	return L ? L->size() : 0;
-}
-
-List<Node *> EditorNode::get_resource_node_list(Ref<Resource> p_res) {
-	List<Node *> *L = resource_count.getptr(p_res);
-	return L == nullptr ? List<Node *>() : List<Node *>(*L);
-}
-
-void EditorNode::update_node_reference(const Variant &p_value, Node *p_node, bool p_remove) {
-	List<Ref<Resource>> list;
-	Ref<Resource> res = p_value;
-	HashSet<Object *> scanned_objects;
-	gather_resources(p_value, list, scanned_objects, true); //Gather all Resources and their SubResources to remove p_node from their lists.
-
-	if (res.is_valid() && is_resource_internal_to_scene(res)) {
-		// Avoid external Resources from being added in.
-		list.push_back(res);
-	}
-
-	for (Ref<Resource> &R : list) {
-		if (!p_remove) {
-			resource_count[R].push_back(p_node);
-		} else {
-			List<Node *>::Element *E = resource_count[R].find(p_node);
-			if (E) {
-				resource_count[R].erase(E);
-			}
-		}
-	}
-	emit_signal(SNAME("resource_counter_changed"));
-}
-
-void EditorNode::clear_node_reference(Ref<Resource> p_res) {
-	if (is_resource_internal_to_scene(p_res)) {
-		return;
-	}
-	List<Node *> *node_list = resource_count.getptr(p_res);
-	if (node_list != nullptr) {
-		node_list->clear();
-	}
+	_ensure_resource_usage_cache();
+	HashSet<ObjectID> *nodes = resource_node_usage.getptr(p_res);
+	return nodes ? nodes->size() : 0;
 }
 
 void EditorNode::_menu_option(int p_option) {
@@ -4684,6 +4833,9 @@ void EditorNode::set_edited_scene_root(Node *p_scene, bool p_auto_add) {
 	if (p_auto_add && p_scene) {
 		scene_root->add_child(p_scene, true);
 	}
+	if (p_scene != old_edited_scene_root) {
+		_reset_resource_usage_cache();
+	}
 }
 
 String EditorNode::get_preview_locale() const {
@@ -4834,7 +4986,7 @@ void EditorNode::_set_current_scene_nocheck(int p_idx, bool p_ignore_state) {
 
 		EditorUndoRedoManager::get_singleton()->clear_history(editor_data.get_scene_history_id(p_idx), false);
 	}
-	resource_count.clear();
+	_reset_resource_usage_cache();
 	SceneTreeDock::get_singleton()->get_tree_editor()->update_tree();
 
 	_update_title();
@@ -7963,7 +8115,7 @@ void EditorNode::_bind_methods() {
 
 	ClassDB::bind_method("stop_child_process", &EditorNode::stop_child_process);
 
-	ClassDB::bind_method(D_METHOD("update_node_reference", "value", "node", "remove"), &EditorNode::update_node_reference, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("mark_node_resource_usage_dirty", "node"), &EditorNode::mark_node_resource_usage_dirty);
 
 	ADD_SIGNAL(MethodInfo("request_help_search"));
 	ADD_SIGNAL(MethodInfo("script_add_function_request", PropertyInfo(Variant::OBJECT, "obj"), PropertyInfo(Variant::STRING, "function"), PropertyInfo(Variant::PACKED_STRING_ARRAY, "args")));
@@ -8477,8 +8629,10 @@ EditorNode::EditorNode() {
 
 	EditorUndoRedoManager::get_singleton()->connect("version_changed", callable_mp(this, &EditorNode::_update_undo_redo_allowed));
 	EditorUndoRedoManager::get_singleton()->connect("version_changed", callable_mp(this, &EditorNode::_update_unsaved_cache));
+	EditorUndoRedoManager::get_singleton()->connect("version_changed", callable_mp(this, &EditorNode::_undo_redo_resource_usage_changed));
 	EditorUndoRedoManager::get_singleton()->connect("history_changed", callable_mp(this, &EditorNode::_update_undo_redo_allowed));
 	EditorUndoRedoManager::get_singleton()->connect("history_changed", callable_mp(this, &EditorNode::_update_unsaved_cache));
+	EditorUndoRedoManager::get_singleton()->connect("history_changed", callable_mp(this, &EditorNode::_undo_redo_resource_usage_changed));
 	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &EditorNode::_update_from_settings));
 	GDExtensionManager::get_singleton()->connect("extensions_reloaded", callable_mp(this, &EditorNode::_gdextensions_reloaded));
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -121,6 +121,7 @@ struct EditorProgress {
 
 class EditorNode : public Node {
 	GDCLASS(EditorNode, Node);
+	friend class SceneTreeEditor;
 
 public:
 	enum SceneNameCasing {
@@ -464,7 +465,18 @@ private:
 
 	Ref<Resource> saving_resource;
 	HashSet<Ref<Resource>> saving_resources_in_path;
-	HashMap<Ref<Resource>, List<Node *>> resource_count; // Keeps track of linked Resources from a Scene.
+
+	// Lazily built index of scene-internal Resources used by each edited-scene Node.
+	// The forward snapshots make removals cheap and allow dirty Nodes to be reconciled
+	// without rescanning the entire scene.
+	HashMap<ObjectID, HashSet<Ref<Resource>>> node_resource_usage;
+	HashMap<Ref<Resource>, HashSet<ObjectID>> resource_node_usage;
+	HashSet<ObjectID> dirty_resource_usage_nodes;
+	ObjectID resource_usage_scene_id;
+	bool resource_usage_initialized = false;
+	bool resource_usage_invalid = false;
+	bool resource_usage_updating = false;
+	bool resource_usage_notification_queued = false;
 
 	uint64_t update_spinner_step_msec = 0;
 	uint64_t update_spinner_step_frame = 0;
@@ -588,6 +600,19 @@ private:
 	void _viewport_resized();
 
 	void _update_undo_redo_allowed();
+
+	void _queue_resource_usage_changed();
+	void _flush_resource_usage_changed();
+	void _reset_resource_usage_cache();
+	void _ensure_resource_usage_cache();
+	void _rebuild_resource_usage_cache();
+	void _reconcile_node_resource_usage(Node *p_node);
+	void _collect_node_resource_usage(Node *p_node, HashSet<Ref<Resource>> &r_resources);
+	void _remove_resource_usage_snapshot(ObjectID p_node_id);
+	void _mark_resource_usage_subtree_dirty(Node *p_node);
+	void _resource_usage_changed(ObjectID p_resource_id);
+	void _undo_redo_resource_usage_changed();
+	bool _is_node_in_resource_usage_scope(Node *p_node) const;
 
 	int _save_external_resources(bool p_also_save_external_data = false);
 	void _save_scene_silently();
@@ -834,11 +859,10 @@ public:
 	void save_resource_as(const Ref<Resource> &p_resource, const String &p_at_path = String());
 	bool is_resource_internal_to_scene(Ref<Resource> p_resource);
 	void gather_resources(const Variant &p_variant, List<Ref<Resource>> &r_list, HashSet<Object *> &r_scanned_objects, bool p_subresources = false, bool p_allow_external = false);
-	void update_resource_count(Node *p_node, bool p_remove = false);
-	void update_node_reference(const Variant &p_value, Node *p_node, bool p_remove = false);
-	void clear_node_reference(Ref<Resource> p_res);
+	void invalidate_resource_usage_cache();
+	void mark_node_resource_usage_dirty(Node *p_node);
+	void remove_node_from_resource_usage_cache(Node *p_node);
 	int get_resource_count(Ref<Resource> p_res);
-	List<Node *> get_resource_node_list(Ref<Resource> p_res);
 
 	void show_about() { _menu_option_confirm(HELP_ABOUT, false); }
 

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -5703,6 +5703,11 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 	if (!undo_redo || bool(object->call("_dont_undo_redo"))) {
 		object->set(p_name, p_value);
+		if (Node *node = Object::cast_to<Node>(object)) {
+			EditorNode::get_singleton()->mark_node_resource_usage_dirty(node);
+		} else if (Object::cast_to<Resource>(object)) {
+			EditorNode::get_singleton()->invalidate_resource_usage_cache();
+		}
 		if (p_refresh_all) {
 			_edit_request_change(object, "");
 		} else {
@@ -5723,7 +5728,6 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 		undo_redo->add_do_property(object, p_name, p_value);
 		bool valid = false;
 		Variant value = object->get(p_name, &valid);
-		Variant::Type type = p_value.get_type();
 		if (valid) {
 			if (Object::cast_to<Control>(object) && (p_name == "anchors_preset" || p_name == "layout_mode")) {
 				undo_redo->add_undo_method(object, "_edit_set_state", Object::cast_to<Control>(object)->_edit_get_state());
@@ -5731,14 +5735,9 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 				undo_redo->add_undo_property(object, p_name, value);
 			}
 			Node *N = Object::cast_to<Node>(object);
-			bool double_counting = Object::cast_to<Node>(p_value) == N || Object::cast_to<Node>(value) == N;
-			if (N && !double_counting && (type == Variant::OBJECT || type == Variant::ARRAY || type == Variant::DICTIONARY) && value != p_value) {
-				undo_redo->add_do_method(EditorNode::get_singleton(), "update_node_reference", value, N, true);
-				undo_redo->add_do_method(EditorNode::get_singleton(), "update_node_reference", p_value, N, false);
-				// Perhaps an inefficient way of updating the resource count.
-				// We could go in depth and check which Resource values changed/got removed and which ones stayed the same, but this is more readable at the moment.
-				undo_redo->add_undo_method(EditorNode::get_singleton(), "update_node_reference", p_value, N, true);
-				undo_redo->add_undo_method(EditorNode::get_singleton(), "update_node_reference", value, N, false);
+			if (N && value != p_value) {
+				undo_redo->add_do_method(EditorNode::get_singleton(), "mark_node_resource_usage_dirty", N);
+				undo_redo->add_undo_method(EditorNode::get_singleton(), "mark_node_resource_usage_dirty", N);
 			}
 		}
 
@@ -5790,18 +5789,6 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 		Resource *r = Object::cast_to<Resource>(object);
 
 		if (r) {
-			//Setting a Subresource. Since there's possibly multiple Nodes referencing 'r', we need to link them to the Subresource.
-			List<Node *> shared_nodes = EditorNode::get_singleton()->get_resource_node_list(r);
-			for (Node *N : shared_nodes) {
-				if ((type == Variant::OBJECT || type == Variant::ARRAY || type == Variant::DICTIONARY) && value != p_value) {
-					undo_redo->add_do_method(EditorNode::get_singleton(), "update_node_reference", value, N, true);
-					undo_redo->add_do_method(EditorNode::get_singleton(), "update_node_reference", p_value, N, false);
-					// Perhaps an inefficient way of updating the resource count.
-					// We could go in depth and check which Resource values changed/got removed and which ones stayed the same, but this is more readable at the moment.
-					undo_redo->add_undo_method(EditorNode::get_singleton(), "update_node_reference", p_value, N, true);
-					undo_redo->add_undo_method(EditorNode::get_singleton(), "update_node_reference", value, N, false);
-				}
-			}
 			if (String(p_name) == "resource_local_to_scene") {
 				bool prev = object->get(p_name);
 				bool next = p_value;
@@ -6299,6 +6286,11 @@ void EditorInspector::_notification(int p_what) {
 void EditorInspector::_changed_callback() {
 	//this is called when property change is notified via notify_property_list_changed()
 	if (object != nullptr) {
+		if (Node *node = Object::cast_to<Node>(object)) {
+			EditorNode::get_singleton()->mark_node_resource_usage_dirty(node);
+		} else {
+			EditorNode::get_singleton()->invalidate_resource_usage_cache();
+		}
 		_update_current_favorites();
 		_edit_request_change(object, String());
 	}

--- a/editor/inspector/multi_node_edit.cpp
+++ b/editor/inspector/multi_node_edit.cpp
@@ -102,16 +102,10 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 
 		if (p_undo_redo) {
 			ur->add_undo_property(n, name, n->get(name));
-			Variant old_value = n->get(p_name);
-			Variant::Type type = old_value.get_type();
-			if ((type == Variant::OBJECT || type == Variant::ARRAY || type == Variant::DICTIONARY) && old_value != new_value) {
-				ur->add_do_method(EditorNode::get_singleton(), "update_node_reference", old_value, n, true);
-				ur->add_do_method(EditorNode::get_singleton(), "update_node_reference", new_value, n, false);
-				// Perhaps an inefficient way of updating the resource count.
-				// We could go in depth and check which Resource values changed/got removed and which ones stayed the same, but this is more readable at the moment.
-				ur->add_undo_method(EditorNode::get_singleton(), "update_node_reference", new_value, n, true);
-				ur->add_undo_method(EditorNode::get_singleton(), "update_node_reference", old_value, n, false);
-			}
+			ur->add_do_method(EditorNode::get_singleton(), "mark_node_resource_usage_dirty", n);
+			ur->add_undo_method(EditorNode::get_singleton(), "mark_node_resource_usage_dirty", n);
+		} else {
+			EditorNode::get_singleton()->mark_node_resource_usage_dirty(n);
 		}
 	}
 

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -441,8 +441,6 @@ void SceneTreeEditor::_update_node_subtree(Node *p_node, TreeItem *p_parent, boo
 		is_new = true;
 	}
 
-	EditorNode::get_singleton()->update_resource_count(p_node);
-
 	if (!(p_force || I->value.dirty)) {
 		// Nothing to do.
 		return;
@@ -516,6 +514,12 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 	p_item->set_icon(0, icon);
 	p_item->set_metadata(0, p_node->get_path());
 
+	HashMap<Node *, CachedNode>::Iterator cache_entry = node_cache.get(p_node);
+	if (cache_entry) {
+		Node *scene = get_scene_node();
+		cache_entry->value.editable_instance = scene && scene->is_ancestor_of(p_node) && scene->is_editable_instance(p_node);
+	}
+
 	if (!p_node->is_connected("child_order_changed", callable_mp(this, &SceneTreeEditor::_node_child_order_changed))) {
 		p_node->connect("child_order_changed", callable_mp(this, &SceneTreeEditor::_node_child_order_changed).bind(p_node));
 	}
@@ -528,6 +532,9 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 		if (!p_node->is_connected(CoreStringName(script_changed), callable_mp(this, &SceneTreeEditor::_node_script_changed))) {
 			p_node->connect(CoreStringName(script_changed), callable_mp(this, &SceneTreeEditor::_node_script_changed).bind(p_node));
 		}
+	}
+	if (is_scene_tree_dock && !p_node->is_connected(CoreStringName(property_list_changed), callable_mp(this, &SceneTreeEditor::_node_property_list_changed))) {
+		p_node->connect(CoreStringName(property_list_changed), callable_mp(this, &SceneTreeEditor::_node_property_list_changed).bind(p_node));
 	}
 
 	if (connecting_signal) {
@@ -873,8 +880,18 @@ void SceneTreeEditor::_node_script_changed(Node *p_node) {
 	}
 
 	node_cache.mark_dirty(p_node);
+	if (is_scene_tree_dock) {
+		EditorNode::get_singleton()->mark_node_resource_usage_dirty(p_node);
+	}
 
 	_update_if_clean();
+}
+
+void SceneTreeEditor::_node_property_list_changed(Node *p_node) {
+	if (!node_cache.has(p_node)) {
+		return;
+	}
+	EditorNode::get_singleton()->mark_node_resource_usage_dirty(p_node);
 }
 
 void SceneTreeEditor::_move_node_children(HashMap<Node *, CachedNode>::Iterator &p_I) {
@@ -972,6 +989,15 @@ void SceneTreeEditor::_node_editor_state_changed(Node *p_node) {
 			// All our children also change process mode.
 			node_cache.mark_children_dirty(p_node, true);
 		}
+		if (is_scene_tree_dock) {
+			Node *scene = get_scene_node();
+			const bool editable_instance = scene && scene->is_ancestor_of(p_node) && scene->is_editable_instance(p_node);
+			if (editable_instance != I->value.editable_instance) {
+				EditorNode::get_singleton()->_mark_resource_usage_subtree_dirty(p_node);
+			} else {
+				EditorNode::get_singleton()->mark_node_resource_usage_dirty(p_node);
+			}
+		}
 	}
 
 	_update_if_clean();
@@ -987,6 +1013,9 @@ void SceneTreeEditor::_node_added(Node *p_node) {
 	}
 
 	node_cache.mark_dirty(p_node);
+	if (is_scene_tree_dock) {
+		EditorNode::get_singleton()->mark_node_resource_usage_dirty(p_node);
+	}
 	_update_if_clean();
 }
 
@@ -2591,7 +2620,7 @@ void SceneTreeEditor::NodeCache::remove(Node *p_node, bool p_recursive) {
 	HashMap<Node *, CachedNode>::Iterator I = cache.find(p_node);
 	if (I) {
 		if (editor->is_scene_tree_dock) {
-			EditorNode::get_singleton()->update_resource_count(I->key, true);
+			EditorNode::get_singleton()->remove_node_from_resource_usage_cache(I->key);
 		}
 		if (p_recursive) {
 			int cc = p_node->get_child_count(false);

--- a/editor/scene/scene_tree_editor.h
+++ b/editor/scene/scene_tree_editor.h
@@ -75,6 +75,7 @@ class SceneTreeEditor : public Control {
 
 		// To know whether to update children or not.
 		bool can_process = false;
+		bool editable_instance = false;
 
 		CachedNode() = delete; // Always an error.
 		CachedNode(Node *p_node, TreeItem *p_item) :
@@ -203,6 +204,7 @@ class SceneTreeEditor : public Control {
 	void _process_selection_update();
 	void _update_selection(TreeItem *item);
 	void _node_script_changed(Node *p_node);
+	void _node_property_list_changed(Node *p_node);
 	void _node_visibility_changed(Node *p_node);
 	void _update_visibility_color(Node *p_node, TreeItem *p_item);
 	void _set_item_custom_color(TreeItem *p_item, Color p_color);


### PR DESCRIPTION
### What was the issue and what does it fix

This fixes a scene tree performance regression affecting scripted nodes, with the biggest impact on C# tool scripts.

The regression came from the linked-resource indicator added in commit [804188d320](https://github.com/godotengine/godot/commit/804188d320a1d6405d8f42c6277b511b51bd005e). Resource usage was being updated whenever the scene tree was populated or refreshed. That meant recursively scanning nodes for resources and requesting their property lists, even when most of those nodes had not changed during later updates.

This is especially costly for C# tool scripts, since retrieving and validating managed properties can cross the managed boundary. Removing a single node could also trigger another scan of all the unchanged nodes still in the tree.

These are the results from a Windows Mono build with 5,000 nodes, averaged over three runs:

| Operation | None | GDScript | C# |
| :--- | :--- | :--- | :--- |
| Spawn | 0.343 s | 0.358 s | 0.633 s |
| Remove one | 0.147 s | 0.149 s | 0.148 s |

For comparison, Godot 4.5.1 took 0.306/0.343/0.571 seconds to spawn the same nodes and around 0.45 seconds to remove one. Spawn performance is now close to the previous results, while removal is faster and no longer carries a script language penalty.

### What changed?

Linked resource usage is no longer calculated while the scene tree is being populated. Instead, the cache is built lazily the first time the resource count is requested aka needed

The editor remembers which resources belong to each node, as well as which nodes refer to a given resource. When a node changes, only that node needs to be scanned again and its cached resource information is replaced. Nodes that have not changed arent touched

This also works with resources shared by multiple nodes, including resources inside other resources. By the time a node is removed, its resources have already been recorded. Scanning its properties again did the same work twice for no real benefit. That information is cleared when changing scenes, since it is no longer useful anyway.

In cases where the editor cannot reliably identify the affected node, it discards the cache and rebuilds it the next time the resource count is queried. Existing behavior is the same for dynamic properties, arrays, dictionaries, nested and shared resources, undo/redo, owner changes, and editable instances. I didnt change any core or scripting APIs

I made this a separate PR because it is a larger fix than #122395, which only avoids redundant scans during scene tree updates where nothing changed. This PR changes how the resource usage cache is maintained and addresses both the spawn and removal regressions. It supersedes #122395 if merged


I also tried to break it with shared and nested resources, arrays, dictionaries, dynamic properties, undo/redo, scene changes, reparenting, owner and editable instance changes, and removing and adding nodes back. Everything behaved as expected.

Closes #122386
