### PR TITLE
Fix out of bounds error when reparenting `SpringBoneSimulator3D`

### DIFF
--- a/scene/3d/spring_bone_simulator_3d.cpp
+++ b/scene/3d/spring_bone_simulator_3d.cpp
@@ -1718,6 +1718,12 @@ void SpringBoneSimulator3D::_process_modification(double p_delta) {
 	if (!skeleton) {
 		return;
 	}
+
+	// Immediately flush joint updates if dirty to prevent 1 frame deferred latency
+	if (joints_dirty) {
+		_update_joints(false);
+	}
+
 	_find_collisions();
 	_process_collisions();
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #122049 

## Additional information

Prevents out of bounds errors when reparenting to a skeleton with fewer bones by checking if the dirty flag is set & if it is, we update the joints array immediately. 

### Showcase:

https://github.com/user-attachments/assets/a35ccb4c-6319-4550-9778-5424f7cc756d


### AI Disclosure:
This PR doesn't use AI, it's all human written code & same goes for the desc 🙃