### PR TITLE
Expose additional `EditorSettings` property metadata methods

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -194,6 +194,22 @@
 				Removes the shortcut specified by [param path].
 			</description>
 		</method>
+		<method name="set_as_basic">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="basic" type="bool" />
+			<description>
+				Defines if the specified setting is considered basic or advanced. Basic settings will always be shown in the project settings. Advanced settings will only be shown if the user enables the "Advanced Settings" option.
+			</description>
+		</method>
+		<method name="set_as_internal">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="internal" type="bool" />
+			<description>
+				Defines if the specified setting is considered internal. An internal setting won't show up in the Project Settings dialog. This is mostly useful for addons that need to store their own internal settings without exposing them directly to the user.
+			</description>
+		</method>
 		<method name="set_builtin_action_override">
 			<return type="void" />
 			<param index="0" name="name" type="String" />
@@ -232,6 +248,15 @@
 			<param index="0" name="dirs" type="PackedStringArray" />
 			<description>
 				Sets the list of recently visited folders in the file dialog for this project.
+			</description>
+		</method>
+		<method name="set_restart_if_changed">
+			<return type="void" />
+			<param index="0" name="name" type="StringName" />
+			<param index="1" name="restart" type="bool" />
+			<description>
+				Sets whether a setting requires restarting the editor to properly take effect.
+				[b]Note:[/b] This is just a hint to display to the user that the editor must be restarted for changes to take effect. Enabling [method set_restart_if_changed] does [i]not[/i] delay the setting being set when changed.
 			</description>
 		</method>
 		<method name="set_setting">

--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1669,6 +1669,15 @@ void EditorSettings::set_basic(const StringName &p_setting, bool p_basic) {
 	props[p_setting].basic = p_basic;
 }
 
+void EditorSettings::set_as_internal(const StringName &p_setting, bool p_internal) {
+	_THREAD_SAFE_METHOD_
+
+	if (!props.has(p_setting)) {
+		return;
+	}
+	props[p_setting].hide_from_editor = p_internal;
+}
+
 void EditorSettings::set_initial_value(const StringName &p_setting, const Variant &p_value, bool p_update_current) {
 	_THREAD_SAFE_METHOD_
 
@@ -2403,7 +2412,8 @@ void EditorSettings::get_argument_options(const StringName &p_function, int p_id
 	const String pf = p_function;
 	if (p_idx == 0) {
 		if (pf == "has_setting" || pf == "set_setting" || pf == "get_setting" || pf == "erase" ||
-				pf == "set_initial_value" || pf == "set_as_basic" || pf == "mark_setting_changed") {
+				pf == "set_initial_value" || pf == "set_as_basic" || pf == "set_as_internal" ||
+				pf == "set_restart_if_changed" || pf == "mark_setting_changed") {
 			for (const KeyValue<String, VariantContainer> &E : props) {
 				if (E.value.hide_from_editor) {
 					continue;
@@ -2431,6 +2441,9 @@ void EditorSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_setting", "name"), &EditorSettings::get_setting);
 	ClassDB::bind_method(D_METHOD("erase", "property"), &EditorSettings::erase);
 	ClassDB::bind_method(D_METHOD("set_initial_value", "name", "value", "update_current"), &EditorSettings::set_initial_value);
+	ClassDB::bind_method(D_METHOD("set_as_basic", "name", "basic"), &EditorSettings::set_basic);
+	ClassDB::bind_method(D_METHOD("set_restart_if_changed", "name", "restart"), &EditorSettings::set_restart_if_changed);
+	ClassDB::bind_method(D_METHOD("set_as_internal", "name", "internal"), &EditorSettings::set_as_internal);
 	ClassDB::bind_method(D_METHOD("add_property_info", "info"), &EditorSettings::_add_property_info_bind);
 
 	ClassDB::bind_method(D_METHOD("set_project_metadata", "section", "key", "data"), &EditorSettings::set_project_metadata);

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -163,6 +163,7 @@ public:
 	void set_initial_value(const StringName &p_setting, const Variant &p_value, bool p_update_current = false);
 	void set_restart_if_changed(const StringName &p_setting, bool p_restart);
 	void set_basic(const StringName &p_setting, bool p_basic);
+	void set_as_internal(const StringName &p_setting, bool p_internal);
 	void set_manually(const StringName &p_setting, const Variant &p_value, bool p_emit_signal = false) {
 		if (p_emit_signal) {
 			_set(p_setting, p_value);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #115456 

(I forgot to work on it before :sweat_smile:)

## Additional information

Adds `set_as_internal` & exposes it alongside with `set_as_basic` & `set_restart_if_changed`. For `set_as_internal`, we use the `hide_from_editor` flag which is the same as the `internal` flag in `ProjectSettings`.

### Showcase:

https://github.com/user-attachments/assets/6e14e329-6a1b-42ad-81d3-aa07ad9686c9

### MRP:
[mrp.zip](https://github.com/user-attachments/files/30663780/mrp.zip)

In order to run the project, just press the `Run` button & it should appear in `EditorSettings`. 

### AI Disclosure:
This PR doesn't use AI, it's all human written code & same goes for the desc 🙃

