### PR TITLE
Fix `EditorSpinSlider::get_minimum_size()` & `EditorSpinSlider::_draw_spin_slider()`

### DIFF
--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -66,8 +66,13 @@ Size2 EditorSpinSlider::get_minimum_size() const {
 	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("LineEdit"));
 
 	Size2 ms = sb->get_minimum_size();
+
+	const int sep = 4 * EDSCALE + sb->get_offset().x;
+	const int label_width = font->get_string_size(label, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size).width;
+
 	Ref<Texture2D> updown = read_only ? theme_cache.updown_disabled_icon : theme_cache.updown_icon;
-	ms.width += updown->get_width();
+
+	ms.width += label_width + sep + updown->get_width();
 
 	ms.height += font->get_height(font_size);
 	ms.height = MAX(ms.height, get_theme_constant(SNAME("inspector_property_height"), EditorStringName(Editor)));
@@ -386,30 +391,53 @@ void EditorSpinSlider::_draw_spin_slider() {
 		draw_string(font, Vector2(Math::round(sb->get_offset().x), vofs), label, HORIZONTAL_ALIGNMENT_LEFT, -1, font_size, lc * Color(1, 1, 1, 0.5));
 	}
 
-	int suffix_start = numstr.length();
 	RID num_rid = TS->create_shaped_text();
 	TS->shaped_text_add_string(num_rid, numstr + U"\u2009" + suffix, font->get_rids(), font_size, font->get_opentype_features());
 
 	float text_start = rtl ? Math::round(sb->get_offset().x) : Math::round(sb->get_offset().x + label_width + sep);
 	Vector2 text_ofs = rtl ? Vector2(text_start + (number_width - TS->shaped_text_get_width(num_rid)), vofs) : Vector2(text_start, vofs);
-	int v_size = TS->shaped_text_get_glyph_count(num_rid);
-	const Glyph *glyphs = TS->shaped_text_get_glyphs(num_rid);
-	for (int i = 0; i < v_size; i++) {
-		for (int j = 0; j < glyphs[i].repeat; j++) {
-			if (text_ofs.x >= text_start && (text_ofs.x + glyphs[i].advance) <= (text_start + number_width)) {
-				Color color = fc;
-				if (glyphs[i].start >= suffix_start) {
-					color.a *= 0.4;
-				}
-				if (glyphs[i].font_rid != RID()) {
-					TS->font_draw_glyph(glyphs[i].font_rid, ci, glyphs[i].font_size, text_ofs + Vector2(glyphs[i].x_off, glyphs[i].y_off), glyphs[i].index, color);
-				} else if (((glyphs[i].flags & TextServer::GRAPHEME_IS_VIRTUAL) != TextServer::GRAPHEME_IS_VIRTUAL) && ((glyphs[i].flags & TextServer::GRAPHEME_IS_EMBEDDED_OBJECT) != TextServer::GRAPHEME_IS_EMBEDDED_OBJECT)) {
-					TS->draw_hex_code_box(ci, glyphs[i].font_size, text_ofs + Vector2(glyphs[i].x_off, glyphs[i].y_off), glyphs[i].index, color);
-				}
-			}
-			text_ofs.x += glyphs[i].advance;
+
+	double clip_l = -1.0;
+	double clip_r = -1.0;
+
+	if (editing_integer && control_state == CONTROL_STATE_DEFAULT) {
+		Ref<Texture2D> updown2 = read_only ? theme_cache.updown_disabled_icon : theme_cache.updown_icon;
+
+		if (rtl) {
+			clip_l = text_start + sb->get_margin(SIDE_LEFT) + updown2->get_width();
+		} else {
+			clip_r = size.width - sb->get_margin(SIDE_RIGHT) - updown2->get_width();
+		}
+	} else {
+		if (rtl) {
+			clip_l = text_start + sb->get_margin(SIDE_LEFT);
+		} else {
+			clip_r = size.width - sb->get_margin(SIDE_RIGHT);
 		}
 	}
+
+	if (!numstr.is_empty()) {
+		RID value_rid = TS->shaped_text_substr(num_rid, 0, numstr.length());
+
+		if (clip_r == -1 || clip_r - text_ofs.x > 0) {
+			TS->shaped_text_draw(value_rid, ci, text_ofs, (clip_l >= 0) ? clip_l - text_ofs.x : -1, (clip_r >= 0) ? clip_r - text_ofs.x : -1, fc);
+		}
+
+		TS->free_rid(value_rid);
+	}
+
+	if (!suffix.is_empty()) {
+		RID suffix_rid = TS->shaped_text_substr(num_rid, numstr.length(), suffix.length() + 1);
+
+		Vector2 value_offset = text_ofs + Vector2(TS->shaped_text_get_width(num_rid) - TS->shaped_text_get_width(suffix_rid), 0);
+
+		if (clip_r == -1 || clip_r - value_offset.x > 0) {
+			TS->shaped_text_draw(suffix_rid, ci, value_offset, (clip_l >= 0) ? clip_l - value_offset.x : -1, (clip_r >= 0) ? clip_r - value_offset.x : -1, fc * Color(1, 1, 1, 0.4));
+		}
+
+		TS->free_rid(suffix_rid);
+	}
+
 	TS->free_rid(num_rid);
 
 	if (control_state != CONTROL_STATE_HIDE) {


### PR DESCRIPTION
## What problem(s) does this PR solve?
This PR solves 2 problems.

### The first issue:
Firstly, `EditorSpinSlider::get_minimum_size()` only accounts for the stylebox & the up/down buttons when reporting its minimum width. As a result, the control can report a minimum width that is too small to display its contents correctly. When the control is constrained by a layout container (such as in sub-inspectors), the numeric value overlaps the up/down buttons because no width is reserved for the label, separator or editable numeric text.
This issue became noticeable when four `EditorSpinSlider`s were laid out horizontally in `Vector4/Vector4i` property editors, but it also affects standalone `EditorSpinSlider`s when their width is reduced sufficiently.

### The first issue in Editor:
<img width="163" height="289" alt="image" src="https://github.com/user-attachments/assets/aed1ca0b-6661-4887-9261-31f7ceabfc70" />
<img width="196" height="277" alt="image" src="https://github.com/user-attachments/assets/fbecb9d0-33a8-4229-89fa-971b7bc67394" />

### The solution for the first issue in Editor:
<img width="228" height="484" alt="image" src="https://github.com/user-attachments/assets/2ab3bd07-5428-4fa9-b3a7-0f6c446b982b" />

### The second issue:
Secondly, although the minimum size change prevents the value from overlapping the up/down buttons under normal layouts, the numeric text could still extend into the arrow button area if the control was made narrower than its minimum size or if the value contained enough digits. This happened because `EditorSpinSlider::_draw_spin_slider()` manually drew each glyph without limiting the drawing region. As a result, the value continued rendering underneath the up/down buttons instead of stopping at their left edge.
### The second issue in Editor:
<img width="1366" height="723" alt="image" src="https://github.com/user-attachments/assets/9d817735-f43c-45e1-babd-e0686636f99b" />

### The solution for the second issue in Editor:
https://github.com/user-attachments/assets/747c16b1-6138-4b10-8030-98af80d965be


https://github.com/user-attachments/assets/33ff3cc6-0161-4fe0-9f22-a1464a8f0937

### AI Disclosure:
This PR doesn't use AI, it's all human written code & same goes for the desc 🙃
