### PR TITLE
Fix NodePath property subname duplication when moving nodes in scene …

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -2074,45 +2074,33 @@ bool SceneTreeDock::_update_node_path(Node *p_root_node, NodePath &r_node_path, 
 	Node *target_node = p_root_node->get_node_or_null(r_node_path);
 	ERR_FAIL_NULL_V_MSG(target_node, false, "Found invalid node path '" + String(r_node_path) + "' on node '" + String(scene_root->get_path_to(p_root_node)) + "'");
 
-	// Try to find the target node in modified node paths.
 	HashMap<Node *, NodePath>::Iterator found_node_path = p_renames->find(target_node);
-	if (found_node_path) {
-		if (found_node_path->value.is_empty()) {
-			r_node_path = found_node_path->value;
-			return true;
-		}
-
-		String old_subnames;
-		if (r_node_path.get_subname_count() > 0) {
-			old_subnames = ":" + r_node_path.get_concatenated_subnames();
-		}
-
-		HashMap<Node *, NodePath>::Iterator found_root_path = p_renames->find(p_root_node);
-		NodePath root_path_new = found_root_path ? found_root_path->value : p_root_node->get_path();
-		r_node_path = NodePath(String(root_path_new.rel_path_to(found_node_path->value)) + old_subnames);
-
-		return true;
-	}
-
-	// Update the path if the base node has changed and has not been deleted.
 	HashMap<Node *, NodePath>::Iterator found_root_path = p_renames->find(p_root_node);
-	if (found_root_path) {
-		NodePath root_path_new = found_root_path->value;
-		if (!root_path_new.is_empty()) {
-			String old_subnames;
-			if (r_node_path.get_subname_count() > 0) {
-				old_subnames = ":" + r_node_path.get_concatenated_subnames();
-			}
 
-			NodePath old_abs_path = NodePath(String(p_root_node->get_path()).path_join(String(r_node_path)));
-			old_abs_path.simplify();
-			r_node_path = NodePath(String(root_path_new.rel_path_to(old_abs_path)) + old_subnames);
-		}
+	if (!found_node_path && !found_root_path) {
+		return false;
+	}
 
+	if (found_node_path && found_node_path->value.is_empty()) {
+		r_node_path = NodePath();
 		return true;
 	}
 
-	return false;
+	NodePath target_path_new = found_node_path ? found_node_path->value : target_node->get_path();
+	NodePath root_path_new = found_root_path ? found_root_path->value : p_root_node->get_path();
+
+	if (root_path_new.is_empty()) {
+		return false;
+	}
+
+	NodePath rel_path = root_path_new.rel_path_to(target_path_new);
+	Vector<StringName> names;
+	if (r_node_path.get_name_count() > 0) {
+		names = rel_path.get_names();
+	}
+	r_node_path = NodePath(names, r_node_path.get_subnames(), false);
+
+	return true;
 }
 
 _ALWAYS_INLINE_ static bool _recurse_into_property(const PropertyInfo &p_property) {

--- a/tests/core/string/test_node_path.cpp
+++ b/tests/core/string/test_node_path.cpp
@@ -222,4 +222,26 @@ TEST_CASE("[NodePath] Slice") {
 			"Slice of an empty absolute path should be an empty absolute path.");
 }
 
+TEST_CASE("[NodePath] Relative path calculation with rel_path_to and subnames") {
+	const NodePath root_path_old = NodePath("/root/MyNode");
+	const NodePath root_path_new = NodePath("/root/Parent/MyNode");
+	const NodePath target_path = NodePath("/root/OtherNode");
+
+	const NodePath rel_old = root_path_old.rel_path_to(target_path);
+	CHECK_MESSAGE(
+			rel_old == NodePath("../OtherNode"),
+			"Relative path from old root to target should match expected value.");
+
+	const NodePath rel_new = root_path_new.rel_path_to(target_path);
+	CHECK_MESSAGE(
+			rel_new == NodePath("../../OtherNode"),
+			"Relative path from new root to target should match expected value.");
+
+	const NodePath orig_node_path = NodePath("../OtherNode:property:subproperty");
+	const NodePath updated_node_path = NodePath(rel_new.get_names(), orig_node_path.get_subnames(), false);
+	CHECK_MESSAGE(
+			updated_node_path == NodePath("../../OtherNode:property:subproperty"),
+			"Updated node path with subnames should preserve subnames without duplication.");
+}
+
 } // namespace TestNodePath


### PR DESCRIPTION
…tree

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Fixes an issue where `NodePath` property subnames (the portion after the colon `:`) were duplicated when moving or reparenting nodes in the scene tree editor.


- 

## Additional information

### Root Cause
When moving or reparenting a node (`p_root_node`) in the scene tree editor, `SceneTreeDock::_update_node_path()` previously constructed an absolute path `old_abs_path` that included the property subnames (e.g. `["property"]`). 
Calling `root_path_new.rel_path_to(old_abs_path)` returned a `NodePath` that already preserved `old_abs_path`'s subnames (producing e.g. `"../../OtherNode:property"`). The method then explicitly appended `+ old_subnames` (`":property"`) via string concatenation, resulting in duplicated subnames (e.g. `"../../OtherNode:property:property"`).
### Solution
- Refactored `SceneTreeDock::_update_node_path()` to compute `target_path_new` and `root_path_new` directly from node paths without subnames.
- Used `root_path_new.rel_path_to(target_path_new)` to calculate the updated relative node path.
- Constructed the new `NodePath` directly via `NodePath(names, r_node_path.get_subnames(), false)`, preserving subnames cleanly without string formatting or duplication.
- Added unit tests in `test_node_path.cpp` covering relative path calculation and subname preservation.
*AI Disclosure: AI pair programmer (Google Antigravity) was used to analyze the root cause, draft the fix in `SceneTreeDock::_update_node_path()`, and write unit tests.*
