### PR TITLE
Fix `SpotLight3D`/`OmniLight3D` `light_projector` doesn't render when `shadow_enabled` is `false`

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1154,9 +1154,40 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 			}
 		}
 
-		if (needs_shadow && in_shadow_range) {
-			// fill in the shadow information
+		const bool has_shadow = needs_shadow && in_shadow_range;
+		const bool has_projector = projector.is_valid();
 
+		Projection cm;
+
+		// We only calculate the projector/shadow transform matrix if either feature requires it
+		if (has_shadow || has_projector) {
+			if (type == RSE::LIGHT_OMNI || type == RSE::LIGHT_AREA) {
+				Transform3D proj = (inverse_transform * light_transform).inverse();
+				RendererRD::MaterialStorage::store_transform(proj, light_data.shadow_matrix);
+			} else if (type == RSE::LIGHT_SPOT) {
+				Transform3D modelview = (inverse_transform * light_transform).inverse();
+				Projection bias;
+				bias.set_light_bias();
+
+				Projection correction;
+				correction.set_depth_correction(false, true, false);
+
+				if (has_shadow) {
+					cm = light_instance->shadow_transform[0].camera;
+				} else {
+					// Fallback projection when shadow map is inactive
+					cm.set_perspective(spot_angle * 2.0, 1.0, 0.05, radius);
+				}
+
+				cm = correction * cm;
+
+				Projection shadow_mtx = bias * cm * modelview;
+				RendererRD::MaterialStorage::store_camera(shadow_mtx, light_data.shadow_matrix);
+			}
+		}
+
+		// We should populate shadow atlas properties only when active shadows are rendered
+		if (has_shadow) {
 			light_data.shadow_opacity = light->param[RSE::LIGHT_PARAM_SHADOW_OPACITY] * shadow_opacity_fade;
 
 			float shadow_texel_size = light_instance_get_shadow_texel_size(light_instance->self, p_shadow_atlas);
@@ -1181,10 +1212,6 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 			light_data.soft_shadow_scale = light->param[RSE::LIGHT_PARAM_SHADOW_BLUR];
 
 			if (type == RSE::LIGHT_OMNI) {
-				Transform3D proj = (inverse_transform * light_transform).inverse();
-
-				RendererRD::MaterialStorage::store_transform(proj, light_data.shadow_matrix);
-
 				if (size > 0.0 && light_data.soft_shadow_scale > 0.0) {
 					// Only enable PCSS-like soft shadows if blurring is enabled.
 					// Otherwise, performance would decrease with no visual difference.
@@ -1197,10 +1224,6 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 				light_data.direction[0] = omni_offset.x * float(rect.size.width);
 				light_data.direction[1] = omni_offset.y * float(rect.size.height);
 			} else if (type == RSE::LIGHT_AREA) {
-				Transform3D proj = (inverse_transform * light_transform).inverse();
-
-				RendererRD::MaterialStorage::store_transform(proj, light_data.shadow_matrix);
-
 				if (light_data.size > 0.0 && light_data.soft_shadow_scale > 0.0) {
 					// Only enable PCSS-like soft shadows if blurring is enabled.
 					// Otherwise, performance would decrease with no visual difference.
@@ -1210,16 +1233,6 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 					light_data.soft_shadow_scale *= RendererSceneRenderRD::get_singleton()->shadows_quality_radius_get(); // Only use quality radius for PCF
 				}
 			} else if (type == RSE::LIGHT_SPOT) {
-				Transform3D modelview = (inverse_transform * light_transform).inverse();
-				Projection bias;
-				bias.set_light_bias();
-
-				Projection correction;
-				correction.set_depth_correction(false, true, false);
-				Projection cm = correction * light_instance->shadow_transform[0].camera;
-				Projection shadow_mtx = bias * cm * modelview;
-				RendererRD::MaterialStorage::store_camera(shadow_mtx, light_data.shadow_matrix);
-
 				if (size > 0.0 && light_data.soft_shadow_scale > 0.0) {
 					// Only enable PCSS-like soft shadows if blurring is enabled.
 					// Otherwise, performance would decrease with no visual difference.


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #121615 

## Additional information

### The Problem
When `shadow_enabled` is set to `false` on a SpotLight3D/OmniLight3D, `LightStorage::update_light_buffers` previously skipped calculating `light_data.shadow_matrix` altogether. However, the spotlight shader relies on `shadow_matrix` to calculate projector UVs whenever a `light_projector` texture is assigned but since `shadow_matrix` was never written when shadows were disabled, the shader read garbage/uninitialized matrix data, resulting in broken projector UVs, black output or visual glitches from stale memory.

### The Solution
This PR adds a fallback check inside `LightStorage::update_light_buffers` for when shadows are disabled (`has_shadow` is `false`). If a spotlight has a valid projector texture assigned (`has_projector` is `true`), the matrix is now calculated manually using the spotlight's parameters (`spot_angle`, `radius`, `light_transform`) & stored into `light_data.shadow_matrix`.

<table>
  <tr>
    <th align="center">Before (SpotLight3D)</th>
    <th align="center">After (SpotLight3D)</th>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/0f4bbc07-674f-46be-9d54-698ea4310c3f" width="100%" alt="Before View" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/8fe196fe-aab8-4721-b2b9-7d6f8cbcf3f8" width="100%" alt="After View" />
    </td>
  </tr>
</table>

<table>
  <tr>
    <th align="center">Before (OmniLight3D)</th>
    <th align="center">After (OmniLight3D)</th>
  </tr>
  <tr>
    <td>
      <img src="https://github.com/user-attachments/assets/6e3e5dbc-6764-4fb7-b2d7-dcbc157f50fc" width="100%" alt="Before View" />
    </td>
    <td>
      <img src="https://github.com/user-attachments/assets/56662dcc-96d6-474d-8049-2d68f739f685" width="100%" alt="After View" />
    </td>
  </tr>
</table>

### MRP (with both):
[121615.zip](https://github.com/user-attachments/files/30376960/121615.zip)

### AI Disclosure:
This PR doesn't use AI, it's all human written code & same goes for the desc 🙃