### PR TITLE
Document units and measures for RenderingServer.LIGHT_PARAM_SIZE

### DIFF
--- a/doc/classes/Light3D.xml
+++ b/doc/classes/Light3D.xml
@@ -55,7 +55,7 @@
 			If [code]true[/code], the light only appears in the editor and will not be visible at runtime. If [code]true[/code], the light will never be baked in [LightmapGI] regardless of its [member light_bake_mode].
 		</member>
 		<member name="light_angular_distance" type="float" setter="set_param" getter="get_param" default="0.0" keywords="pcss">
-			The light's angular size in degrees. Increasing this will make shadows softer at greater distances (also called percentage-closer soft shadows, or PCSS). Only available for [DirectionalLight3D]s. For reference, the Sun from the Earth is approximately [code]0.5[/code]. Increasing this value above [code]0.0[/code] for lights with shadows enabled will have a noticeable performance cost due to PCSS.
+			The light's angular radius in degrees. Increasing this will make shadows softer at greater distances (also called percentage-closer soft shadows, or PCSS). Only available for [DirectionalLight3D]s. For reference, the Sun from the Earth is approximately [code]0.5[/code]. Increasing this value above [code]0.0[/code] for lights with shadows enabled will have a noticeable performance cost due to PCSS.
 			[b]Note:[/b] [member light_angular_distance] is not affected by [member Node3D.scale] (the light's scale or its parent's scale).
 			[b]Note:[/b] PCSS for directional lights is only supported in the Forward+ rendering method, not Mobile or Compatibility.
 		</member>
@@ -95,7 +95,7 @@
 			[b]Note:[/b] Light projector textures are only supported in the Forward+ and Mobile rendering methods, not Compatibility.
 		</member>
 		<member name="light_size" type="float" setter="set_param" getter="get_param" default="0.0" keywords="pcss">
-			The simulated size of the light in Godot units, affecting shading and shadows. For [OmniLight3D]s and [SpotLight3D]s, increasing this value simulates a spherical area light, expanding the size of specular highlights. If shadows are enabled, a penumbra is rendered, making shadows appear blurrier. For [AreaLight3D]s, only the shadows are affected. Penumbras are simulated with percentage-closer soft shadows, or PCSS, which has a noticeable performance cost for values above [code]0.0[/code].
+			The radius of the source of the light in meters, affecting shading and shadows. Not to be confused with [member OmniLight3D.omni_range] and [member SpotLight3D.spot_range]. For [OmniLight3D]s and [SpotLight3D]s, increasing this value simulates a spherical area light, expanding the size of specular highlights. If shadows are enabled, a penumbra is rendered, making shadows appear blurrier. For [AreaLight3D]s, only the shadows are affected. Penumbras are simulated with percentage-closer soft shadows, or PCSS, which has a noticeable performance cost for values above [code]0.0[/code].
 			[b]Note:[/b] [member light_size] is not affected by [member Node3D.scale] (the light's scale or its parent's scale).
 			[b]Note:[/b] PCSS for positional lights is only supported in the Forward+ and Mobile rendering methods, not Compatibility.
 		</member>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -5107,7 +5107,11 @@
 			The light's range.
 		</constant>
 		<constant name="LIGHT_PARAM_SIZE" value="5" enum="LightParam">
-			The size of the light when using spot light or omni light. The angular size of the light when using directional light.
+			The size of the light, with different units depending on the type of light, affecting shading and shadows.
+			- For directional lights, this is an angular radius in degrees. It affects both shadows and the size of the displayed sun in the sky. Increasing this will make shadows softer at greater distances.
+			- For spot and omni lights, this is a radius in meters. A non-zero value simulates a spherical area light, expanding the size of specular highlights. If shadows are enabled, a penumbra is rendered, making shadows appear blurrier.
+			- For area lights, this is a radius in meters. Only shadows are affected by this parameter. The full 2D area size should also be adjusted with [method light_area_set_size] for the proper effect.
+			[b]Note:[/b] Penumbras are simulated with percentage-closer soft shadows, or PCSS, which has a noticeable performance cost for values above [code]0.0[/code]. PCSS for positional lights is only supported in the Forward+ and Mobile renderers, not Compatibility.
 		</constant>
 		<constant name="LIGHT_PARAM_ATTENUATION" value="6" enum="LightParam">
 			The light's attenuation.

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -823,8 +823,8 @@ void RasterizerSceneGLES3::_setup_sky(const RenderDataGLES3 *p_render_data, cons
 
 				sky_light_data.enabled = true;
 
-				float angular_diameter = light_storage->light_get_param(base, RSE::LIGHT_PARAM_SIZE);
-				sky_light_data.size = Math::deg_to_rad(angular_diameter);
+				float angular_radius_degrees = light_storage->light_get_param(base, RSE::LIGHT_PARAM_SIZE);
+				sky_light_data.size = Math::deg_to_rad(angular_radius_degrees);
 				sky_globals.directional_light_count++;
 				if (sky_globals.directional_light_count >= sky_globals.max_directional_lights) {
 					break;
@@ -1779,8 +1779,8 @@ void RasterizerSceneGLES3::_setup_lights(const RenderDataGLES3 *p_render_data, b
 				light_data.color[1] = linear_col.g;
 				light_data.color[2] = linear_col.b;
 
-				float size = light_storage->light_get_param(base, RSE::LIGHT_PARAM_SIZE);
-				light_data.size = 1.0 - Math::cos(Math::deg_to_rad(size)); //angle to cosine offset
+				float angular_radius_degrees = light_storage->light_get_param(base, RSE::LIGHT_PARAM_SIZE);
+				light_data.size = 1.0 - Math::cos(Math::deg_to_rad(angular_radius_degrees)); //angle to cosine offset
 
 				light_data.specular = light_storage->light_get_param(base, RSE::LIGHT_PARAM_SPECULAR);
 
@@ -1976,9 +1976,9 @@ void RasterizerSceneGLES3::_setup_lights(const RenderDataGLES3 *p_render_data, b
 		light_data.direction[1] = direction.y;
 		light_data.direction[2] = direction.z;
 
-		float size = light_storage->light_get_param(base, RSE::LIGHT_PARAM_SIZE);
+		float size_radius_meters = light_storage->light_get_param(base, RSE::LIGHT_PARAM_SIZE);
 
-		light_data.size = size;
+		light_data.size = size_radius_meters;
 
 		float sign = light_storage->light_is_negative(base) ? -1 : 1;
 		Color linear_col = light_storage->light_get_color(base).srgb_to_linear();

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -1144,8 +1144,8 @@ void SkyRD::setup_sky(const RenderDataRD *p_render_data, const Size2i p_screen_s
 
 				sky_light_data.enabled = true;
 
-				float angular_diameter = light_storage->light_get_param(base, RSE::LIGHT_PARAM_SIZE);
-				sky_light_data.size = Math::deg_to_rad(angular_diameter);
+				float angular_radius_degrees = light_storage->light_get_param(base, RSE::LIGHT_PARAM_SIZE);
+				sky_light_data.size = Math::deg_to_rad(angular_radius_degrees);
 				sky_scene_state.ubo.directional_light_count++;
 				if (sky_scene_state.ubo.directional_light_count >= sky_scene_state.max_directional_lights) {
 					break;

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -774,27 +774,26 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 				light_data.volumetric_fog_energy = light->param[RSE::LIGHT_PARAM_VOLUMETRIC_FOG_ENERGY];
 				light_data.mask = light->cull_mask;
 
-				float size = light->param[RSE::LIGHT_PARAM_SIZE];
+				float angular_radius_degrees = light->param[RSE::LIGHT_PARAM_SIZE];
 
-				light_data.size = 1.0 - Math::cos(Math::deg_to_rad(size)); //angle to cosine offset
+				light_data.size = 1.0 - Math::cos(Math::deg_to_rad(angular_radius_degrees)); //angle to cosine offset
 
 				light_data.shadow_opacity = (p_using_shadows && light->shadow)
 						? light->param[RSE::LIGHT_PARAM_SHADOW_OPACITY]
 						: 0.0;
 
-				float angular_diameter = light->param[RSE::LIGHT_PARAM_SIZE];
-				if (angular_diameter > 0.0) {
+				if (angular_radius_degrees > 0.0) {
 					// I know tan(0) is 0, but let's not risk it with numerical precision.
 					// technically this will keep expanding until reaching the sun, but all we care
 					// is expand until we reach the radius of the near plane (there can't be more occluders than that)
-					angular_diameter = Math::tan(Math::deg_to_rad(angular_diameter));
+					angular_radius_degrees = Math::tan(Math::deg_to_rad(angular_radius_degrees));
 					if (light->shadow && light->param[RSE::LIGHT_PARAM_SHADOW_BLUR] > 0.0) {
 						// Only enable PCSS-like soft shadows if blurring is enabled.
 						// Otherwise, performance would decrease with no visual difference.
 						r_directional_light_soft_shadows = true;
 					}
 				} else {
-					angular_diameter = 0.0;
+					angular_radius_degrees = 0.0;
 				}
 
 				light_data.bake_mode = light->bake_mode;
@@ -803,9 +802,9 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 					RSE::LightDirectionalShadowMode smode = light->directional_shadow_mode;
 
 					light_data.soft_shadow_scale = light->param[RSE::LIGHT_PARAM_SHADOW_BLUR];
-					light_data.softshadow_angle = angular_diameter;
+					light_data.softshadow_angle = angular_radius_degrees;
 
-					if (angular_diameter <= 0.0) {
+					if (angular_radius_degrees <= 0.0) {
 						light_data.soft_shadow_scale *= RendererSceneRenderRD::get_singleton()->directional_shadow_quality_radius_get(); // Only use quality radius for PCF
 					}
 
@@ -1057,8 +1056,8 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 		light_data.volumetric_fog_energy = light->param[RSE::LIGHT_PARAM_VOLUMETRIC_FOG_ENERGY];
 		light_data.bake_mode = light->bake_mode;
 
-		float radius = MAX(0.001, light->param[RSE::LIGHT_PARAM_RANGE]);
-		light_data.inv_radius = 1.0 / radius;
+		float range_radius_meters = MAX(0.001, light->param[RSE::LIGHT_PARAM_RANGE]);
+		light_data.inv_radius = 1.0 / range_radius_meters;
 		Vector2 area_size = light->area_size;
 		Vector3 pos = inverse_transform.xform(light_transform.origin);
 		light_data.position[0] = pos.x;
@@ -1071,9 +1070,9 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 		light_data.direction[1] = direction.y;
 		light_data.direction[2] = direction.z;
 
-		float size = light->param[RSE::LIGHT_PARAM_SIZE];
+		float size_radius_meters = light->param[RSE::LIGHT_PARAM_SIZE];
 
-		light_data.size = size;
+		light_data.size = size_radius_meters;
 
 		light_data.inv_spot_attenuation = 1.0f / light->param[RSE::LIGHT_PARAM_SPOT_ATTENUATION];
 		float spot_angle = light->param[RSE::LIGHT_PARAM_SPOT_ANGLE];
@@ -1089,7 +1088,7 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 			light_data.area_height[0] = area_vec_b.x;
 			light_data.area_height[1] = area_vec_b.y;
 			light_data.area_height[2] = area_vec_b.z;
-			light_data.inv_spot_attenuation = 1.0 / (radius + area_size.length() / 2.0); // center range
+			light_data.inv_spot_attenuation = 1.0 / (range_radius_meters + area_size.length() / 2.0); // center range
 
 			if (light->area_normalize_energy) {
 				// normalization to make larger lights output same amount of light as smaller lights with same energy
@@ -1185,10 +1184,10 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 
 				RendererRD::MaterialStorage::store_transform(proj, light_data.shadow_matrix);
 
-				if (size > 0.0 && light_data.soft_shadow_scale > 0.0) {
+				if (size_radius_meters > 0.0 && light_data.soft_shadow_scale > 0.0) {
 					// Only enable PCSS-like soft shadows if blurring is enabled.
 					// Otherwise, performance would decrease with no visual difference.
-					light_data.soft_shadow_size = size;
+					light_data.soft_shadow_size = size_radius_meters;
 				} else {
 					light_data.soft_shadow_size = 0.0;
 					light_data.soft_shadow_scale *= RendererSceneRenderRD::get_singleton()->shadows_quality_radius_get(); // Only use quality radius for PCF
@@ -1220,11 +1219,11 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 				Projection shadow_mtx = bias * cm * modelview;
 				RendererRD::MaterialStorage::store_camera(shadow_mtx, light_data.shadow_matrix);
 
-				if (size > 0.0 && light_data.soft_shadow_scale > 0.0) {
+				if (size_radius_meters > 0.0 && light_data.soft_shadow_scale > 0.0) {
 					// Only enable PCSS-like soft shadows if blurring is enabled.
 					// Otherwise, performance would decrease with no visual difference.
 					float half_np = cm.get_z_near() * Math::tan(Math::deg_to_rad(spot_angle));
-					light_data.soft_shadow_size = (size * 0.5 / radius) / (half_np / cm.get_z_near()) * rect.size.width;
+					light_data.soft_shadow_size = (size_radius_meters * 0.5 / range_radius_meters) / (half_np / cm.get_z_near()) * rect.size.width;
 				} else {
 					light_data.soft_shadow_size = 0.0;
 					light_data.soft_shadow_scale *= RendererSceneRenderRD::get_singleton()->shadows_quality_radius_get(); // Only use quality radius for PCF
@@ -1238,7 +1237,7 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 		light_instance->cull_mask = light->cull_mask;
 
 		// hook for subclass to do further processing.
-		RendererSceneRenderRD::get_singleton()->setup_added_light(type, light_transform, radius, spot_angle, area_size);
+		RendererSceneRenderRD::get_singleton()->setup_added_light(type, light_transform, range_radius_meters, spot_angle, area_size);
 
 		r_positional_light_count++;
 	}

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2298,11 +2298,11 @@ void RendererSceneCull::_light_instance_setup_directional_shadow(int p_shadow_in
 			z_min_cam = z_vec.dot(center) - radius;
 
 			{
-				float soft_shadow_angle = RSG::light_storage->light_get_param(p_instance->base, RSE::LIGHT_PARAM_SIZE);
+				float soft_shadow_angular_radius_degrees = RSG::light_storage->light_get_param(p_instance->base, RSE::LIGHT_PARAM_SIZE);
 
-				if (soft_shadow_angle > 0.0) {
+				if (soft_shadow_angular_radius_degrees > 0.0) {
 					float z_range = (z_vec.dot(center) + radius + pancake_size) - z_min_cam;
-					soft_shadow_expand = Math::tan(Math::deg_to_rad(soft_shadow_angle)) * z_range;
+					soft_shadow_expand = Math::tan(Math::deg_to_rad(soft_shadow_angular_radius_degrees)) * z_range;
 
 					x_max += soft_shadow_expand;
 					y_max += soft_shadow_expand;


### PR DESCRIPTION
## What problem(s) does this PR solve?

The old description for `LIGHT_PARAM_SIZE` was:

> The size of the light when using spot light or omni light. The angular size of the light when using directional light.

This is not informative. What "size"? What is it measuring, radius or diameter? What unit is it, meters, degrees, radians? What does it affect, shadows, suns in the sky?

Most of this text was already present in the `Light3D` documentation in a combination of the `light_angular_distance` and `light_size` properties, but that text was still missing the specific units. This PR updates those properties with units, and adds this information to `RenderingServer`. I also renamed some internal variables for clarity.

## Additional information

I did not use AI to write any of the text or code in this PR. I did use AI to help identify the nature of these values, and I used AI to search for badly named variables worth renaming.