### PR TITLE
Allow creating directories in Create Script/Shader Dialog

### DIFF
--- a/editor/script/script_create_dialog.cpp
+++ b/editor/script/script_create_dialog.cpp
@@ -259,9 +259,10 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 	}
 
 	{
+		missing_base_dir = false;
 		Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		if (da->change_dir(p.get_base_dir()) != OK) {
-			return TTRC("Base path is invalid.");
+			missing_base_dir = true;
 		}
 	}
 
@@ -340,6 +341,16 @@ void ScriptCreateDialog::_template_changed(int p_template) {
 }
 
 void ScriptCreateDialog::ok_pressed() {
+	if (missing_base_dir) {
+		String path = file_path->get_text();
+		Error err = EditorFileSystem::get_singleton()->make_dir_recursive(path.strip_edges().get_base_dir());
+		if (err != OK) {
+			alert->set_text(TTR("Error - Could not create the directory for the script."));
+			alert->popup_centered();
+			return;
+		}
+	}
+
 	if (is_new_script_created) {
 		_create_new();
 		if (_can_be_built_in()) {
@@ -610,6 +621,10 @@ void ScriptCreateDialog::_update_dialog() {
 	_update_template_menu();
 
 	// Is script path/name valid (order from top to bottom)?
+
+	if (missing_base_dir) {
+		validation_panel->set_message(MSG_ID_SCRIPT, TTRC("Base path is invalid, the target folder will be created automatically."), EditorValidationPanel::MSG_WARNING);
+	}
 
 	if (!is_built_in && !is_path_valid) {
 		validation_panel->set_message(MSG_ID_SCRIPT, TTRC("Invalid path."), EditorValidationPanel::MSG_ERROR);

--- a/editor/script/script_create_dialog.h
+++ b/editor/script/script_create_dialog.h
@@ -79,6 +79,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	bool load_enabled = true;
 	int default_language;
 	bool re_check_path = false;
+	bool missing_base_dir = false;
 
 	Control *path_controls[2];
 	Control *name_controls[2];

--- a/editor/shader/shader_create_dialog.cpp
+++ b/editor/shader/shader_create_dialog.cpp
@@ -37,6 +37,7 @@
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "editor/editor_node.h"
+#include "editor/file_system/editor_file_system.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/gui/editor_validation_panel.h"
 #include "editor/settings/editor_settings.h"
@@ -121,6 +122,16 @@ void ShaderCreateDialog::_template_changed(int p_template) {
 }
 
 void ShaderCreateDialog::ok_pressed() {
+	if (missing_base_dir) {
+		String path = file_path->get_text();
+		Error err = EditorFileSystem::get_singleton()->make_dir_recursive(path.strip_edges().get_base_dir());
+		if (err != OK) {
+			alert->set_text(TTR("Error - Could not create the directory for the shader."));
+			alert->popup_centered();
+			return;
+		}
+	}
+
 	if (is_new_shader_created) {
 		_create_new();
 		if (built_in_enabled) {
@@ -402,9 +413,10 @@ String ShaderCreateDialog::_validate_path(const String &p_path) {
 		return TTRC("Path is not local.");
 	}
 
+	missing_base_dir = false;
 	Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	if (d->change_dir(stripped_file_path.get_base_dir()) != OK) {
-		return TTRC("Invalid base path.");
+		missing_base_dir = true;
 	}
 
 	Ref<DirAccess> f = DirAccess::create(DirAccess::ACCESS_RESOURCES);
@@ -425,6 +437,9 @@ String ShaderCreateDialog::_validate_path(const String &p_path) {
 }
 
 void ShaderCreateDialog::_update_dialog() {
+	if (missing_base_dir) {
+		validation_panel->set_message(MSG_ID_SHADER, TTRC("Base path is invalid, the target folder will be created automatically."), EditorValidationPanel::MSG_WARNING);
+	}
 	if (!is_built_in && !is_path_valid) {
 		validation_panel->set_message(MSG_ID_SHADER, TTRC("Invalid path."), EditorValidationPanel::MSG_ERROR);
 	}

--- a/editor/shader/shader_create_dialog.h
+++ b/editor/shader/shader_create_dialog.h
@@ -78,6 +78,7 @@ class ShaderCreateDialog : public ConfirmationDialog {
 	int current_type = -1;
 	int current_mode = 0;
 	int current_template = 0;
+	bool missing_base_dir = false;
 
 	virtual void _update_language_info();
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Allows folders to be created in the "Attach Node Script" dialog and the "Create Shader" dialog inside the LineEdit to change the path.

Before:

<img width="487" height="409" alt="image" src="https://github.com/user-attachments/assets/3ed8d33a-5e30-43b8-92b4-61c025c9b197" />


After:

<img width="487" height="473" alt="image" src="https://github.com/user-attachments/assets/428b4767-82c0-455b-9b1a-c4c16b3a4b1f" />


- Closes https://github.com/godotengine/godot-proposals/issues/12561
- Closes https://github.com/godotengine/godot-proposals/issues/15334 (arguable, but the goal was to be able to create folders easier, this is just another solution that has the same goal)

## Additional information

Salvage of https://github.com/godotengine/godot/pull/107484
