### PR TITLE
[Android editor] Enable multi instance runs on standalone XR devices

### DIFF
--- a/editor/run/editor_run.cpp
+++ b/editor/run/editor_run.cpp
@@ -168,6 +168,13 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie, const V
 			instance_starting_callback(i, instance_args);
 		}
 
+#ifdef ANDROID_ENABLED
+		// Each run instance is mapped to a specific process on Android, so for multiple instances run, we need to
+		// specify which process to use by specifying the run instance number.
+		instance_args.push_back("--run_instance");
+		instance_args.push_back(itos(i));
+#endif
+
 		if (OS::get_singleton()->is_stdout_verbose()) {
 			PackedStringArray output;
 			output.reserve_exact(instance_args.size() + 1);

--- a/editor/run/run_instances_dialog.cpp
+++ b/editor/run/run_instances_dialog.cpp
@@ -357,10 +357,22 @@ RunInstancesDialog::RunInstancesDialog() {
 	enable_multiple_instances_checkbox->set_pressed(EditorSettings::get_singleton()->get_project_metadata("debug_options", "multiple_instances_enabled", false));
 	instance_hb->add_child(enable_multiple_instances_checkbox);
 	enable_multiple_instances_checkbox->connect(SceneStringName(pressed), callable_mp(this, &RunInstancesDialog::_start_main_timer));
+#ifdef ANDROID_ENABLED
+	// On Android, multiple instances are only supported on XR devices.
+	bool is_xr_editor = OS::get_singleton()->has_feature("xr_editor");
+	enable_multiple_instances_checkbox->set_visible(is_xr_editor);
+	enable_multiple_instances_checkbox->set_disabled(!is_xr_editor);
+#endif
 
 	instance_count = memnew(SpinBox);
 	instance_count->set_min(1);
+#ifdef ANDROID_ENABLED
+	// Multi-instance support is limited on Android.
+	instance_count->set_max(2);
+	instance_count->set_visible(is_xr_editor);
+#else
 	instance_count->set_max(20);
+#endif
 	instance_count->set_value(EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_instance_count", stored_data.size()));
 	instance_count->set_accessibility_name(TTRC("Number of Instances"));
 

--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -104,14 +104,31 @@
             </intent-filter>
         </activity-alias>
         <activity
-            android:name=".GodotGame"
+            android:name=".GodotGame0"
             android:configChanges="layoutDirection|locale|orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
             android:exported="false"
             android:icon="@mipmap/ic_play_window"
             android:label="@string/godot_game_activity_name"
             android:launchMode="singleTask"
-            android:process=":GodotGame"
-            android:taskAffinity=":game"
+            android:process=":GodotGame0"
+            android:taskAffinity=":game0"
+            android:autoRemoveFromRecents="true"
+            android:theme="@style/GodotGameTheme"
+            android:supportsPictureInPicture="true"
+            android:screenOrientation="userLandscape">
+            <layout
+                android:defaultWidth="@dimen/editor_default_window_width"
+                android:defaultHeight="@dimen/editor_default_window_height" />
+        </activity>
+        <activity
+            android:name=".GodotGame1"
+            android:configChanges="layoutDirection|locale|orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
+            android:exported="false"
+            android:icon="@mipmap/ic_play_window"
+            android:label="@string/godot_game_activity_name"
+            android:launchMode="singleTask"
+            android:process=":GodotGame1"
+            android:taskAffinity=":game1"
             android:autoRemoveFromRecents="true"
             android:theme="@style/GodotGameTheme"
             android:supportsPictureInPicture="true"

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -108,12 +108,19 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 		internal const val XR_MODE_ARG = "--xr-mode"
 		private const val SCENE_ARG = "--scene"
 		private const val PATH_ARG = "--path"
+		private const val RUN_INSTANCE_ARG = "--run_instance"
 
 		// Info for the various classes used by the editor.
 		internal val EDITOR_MAIN_INFO = EditorWindowInfo(GodotEditor::class.java, 777, "")
-		internal val RUN_GAME_INFO = EditorWindowInfo(GodotGame::class.java, 667, ":GodotGame", LaunchPolicy.AUTO)
 		internal val EMBEDDED_RUN_GAME_INFO = EditorWindowInfo(EmbeddedGodotGame::class.java, 2667, ":EmbeddedGodotGame")
 		internal val XR_RUN_GAME_INFO = EditorWindowInfo(GodotXRGame::class.java, 1667, ":GodotXRGame")
+
+		internal val RUN_GAME_INFO_0 = EditorWindowInfo(GodotGame0::class.java, 667, ":GodotGame0", LaunchPolicy.AUTO)
+		internal val RUN_GAME_INFO_1 = EditorWindowInfo(GodotGame1::class.java, 668, ":GodotGame1", LaunchPolicy.AUTO)
+
+		private fun isRunGameInfo(editorWindowInfo: EditorWindowInfo): Boolean {
+			return editorWindowInfo == RUN_GAME_INFO_0 || editorWindowInfo == RUN_GAME_INFO_1
+		}
 
 		/** Default behavior, means we check project settings **/
 		private const val XR_MODE_DEFAULT = "default"
@@ -253,7 +260,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 		installSplashScreen()
 
 		val editorWindowInfo = getEditorWindowInfo()
-		if (editorWindowInfo == EDITOR_MAIN_INFO || editorWindowInfo == RUN_GAME_INFO) {
+		if (editorWindowInfo == EDITOR_MAIN_INFO || isRunGameInfo(editorWindowInfo)) {
 			enableEdgeToEdge()
 		}
 
@@ -479,7 +486,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 
 	private fun updateWindowAppearance() {
 		val editorWindowInfo = getEditorWindowInfo()
-		if (editorWindowInfo == EDITOR_MAIN_INFO || editorWindowInfo == RUN_GAME_INFO) {
+		if (editorWindowInfo == EDITOR_MAIN_INFO || isRunGameInfo(editorWindowInfo)) {
 			godot?.apply {
 				enableImmersiveMode(isInImmersiveMode(), true)
 				enableEdgeToEdge(isInEdgeToEdgeMode(), true)
@@ -504,7 +511,8 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 		if (getEditorWindowInfo() == EDITOR_MAIN_INFO &&
 			godot?.isEditorHint() == true &&
 			(editorMessageDispatcher.hasEditorConnection(EMBEDDED_RUN_GAME_INFO) ||
-				editorMessageDispatcher.hasEditorConnection(RUN_GAME_INFO))) {
+				editorMessageDispatcher.hasEditorConnection(RUN_GAME_INFO_0) ||
+				editorMessageDispatcher.hasEditorConnection(RUN_GAME_INFO_1))) {
 			// If this is the editor window, and this is not the project manager, and we have a running game, then show
 			// a hint for how to resume the playing game.
 			val sharedPrefs = PreferenceManager.getDefaultSharedPreferences(applicationContext)
@@ -537,6 +545,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 	protected fun retrieveEditorWindowInfo(args: Array<String>, gameEmbedMode: GameEmbedMode): EditorWindowInfo {
 		var hasEditor = false
 		var xrMode = XR_MODE_DEFAULT
+		var runInstance = 0
 
 		var i = 0
 		while (i < args.size) {
@@ -544,6 +553,14 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 				EDITOR_ARG, EDITOR_ARG_SHORT, EDITOR_PROJECT_MANAGER_ARG, EDITOR_PROJECT_MANAGER_ARG_SHORT -> hasEditor = true
 				XR_MODE_ARG -> {
 					xrMode = args[i++]
+				}
+				RUN_INSTANCE_ARG -> {
+					val runInstanceValue = args[i++]
+					try {
+						runInstance = runInstanceValue.toInt()
+					} catch (e: NumberFormatException) {
+						Log.w(TAG, "Unable to parse run instance number: $runInstanceValue", e)
+					}
 				}
 			}
 		}
@@ -561,26 +578,29 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 			if ((xrMode == XR_MODE_DEFAULT && GodotLib.getGlobal("xr/openxr/enabled").toBoolean())) {
 				val hybridLaunchMode = getHybridAppLaunchMode()
 
-				return if (hybridLaunchMode == HybridMode.PANEL) {
-					RUN_GAME_INFO
+				if (hybridLaunchMode != HybridMode.PANEL) {
+					return XR_RUN_GAME_INFO
 				} else {
-					XR_RUN_GAME_INFO
+					// Hybrid launch mode is PANEL, fall-through and return RUN_GAME_INFO.
 				}
 			}
 
-			// Native XR devices don't support embed mode yet.
-			return RUN_GAME_INFO
+			// XR devices support doing multiple runs; check which run we are performing.
+			return when (runInstance) {
+				1 -> RUN_GAME_INFO_1
+				else -> RUN_GAME_INFO_0
+			}
 		}
 
 		// Project manager doesn't support embed mode.
 		if (godot?.isProjectManagerHint() == true) {
-			return RUN_GAME_INFO
+			return RUN_GAME_INFO_0
 		}
 
-		// Check for embed mode launch.
+		// Check for embed mode launch (not supported on native XR devices).
 		val resolvedEmbedMode = resolveGameEmbedModeIfNeeded(gameEmbedMode)
 		return if (resolvedEmbedMode == GameEmbedMode.DISABLED) {
-			RUN_GAME_INFO
+			RUN_GAME_INFO_0
 		} else {
 			EMBEDDED_RUN_GAME_INFO
 		}
@@ -588,7 +608,8 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 
 	private fun getEditorWindowInfoForInstanceId(instanceId: Int): EditorWindowInfo? {
 		return when (instanceId) {
-			RUN_GAME_INFO.windowId -> RUN_GAME_INFO
+			RUN_GAME_INFO_0.windowId -> RUN_GAME_INFO_0
+			RUN_GAME_INFO_1.windowId -> RUN_GAME_INFO_1
 			EDITOR_MAIN_INFO.windowId -> EDITOR_MAIN_INFO
 			XR_RUN_GAME_INFO.windowId -> XR_RUN_GAME_INFO
 			EMBEDDED_RUN_GAME_INFO.windowId -> EMBEDDED_RUN_GAME_INFO
@@ -601,7 +622,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 		// fullscreen mode, we want to remain in fullscreen mode.
 		// This doesn't apply to the play / game window since for that window fullscreen is
 		// controlled by the game logic.
-		val updatedArgs = if ((editorWindowInfo == EDITOR_MAIN_INFO || editorWindowInfo == RUN_GAME_INFO) &&
+		val updatedArgs = if ((editorWindowInfo == EDITOR_MAIN_INFO || isRunGameInfo(editorWindowInfo)) &&
 			godot?.isInImmersiveMode() == true &&
 			!args.contains(FULLSCREEN_ARG) &&
 			!args.contains(FULLSCREEN_ARG_SHORT)
@@ -892,7 +913,9 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 	internal fun onEditorConnected(editorId: Int) {
 		Log.d(TAG, "Editor $editorId connected!")
 		when (editorId) {
-			EMBEDDED_RUN_GAME_INFO.windowId, RUN_GAME_INFO.windowId -> {
+			EMBEDDED_RUN_GAME_INFO.windowId,
+			RUN_GAME_INFO_0.windowId,
+			RUN_GAME_INFO_1.windowId -> {
 				runOnUiThread {
 					embeddedGameViewContainerWindow?.isVisible = false
 				}
@@ -934,7 +957,9 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 		activeWorkspace = workspace
 
 		if (workspace == GAME_WORKSPACE && shouldShowGameMenuBar()) {
-			if (editorMessageDispatcher.bringEditorWindowToFront(EMBEDDED_RUN_GAME_INFO) || editorMessageDispatcher.bringEditorWindowToFront(RUN_GAME_INFO)) {
+			if (editorMessageDispatcher.bringEditorWindowToFront(EMBEDDED_RUN_GAME_INFO) ||
+				editorMessageDispatcher.bringEditorWindowToFront(RUN_GAME_INFO_0) ||
+				editorMessageDispatcher.bringEditorWindowToFront(RUN_GAME_INFO_1)) {
 				return
 			}
 

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotGame.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotGame.kt
@@ -44,7 +44,7 @@ import org.godotengine.openxr.vendors.utils.*
 /**
  * Drives the 'run project' window of the Godot Editor.
  */
-open class GodotGame : BaseGodotGame() {
+abstract class GodotGame : BaseGodotGame() {
 
 	companion object {
 		private val TAG = GodotGame::class.java.simpleName
@@ -100,8 +100,6 @@ open class GodotGame : BaseGodotGame() {
 	}
 
 	override fun getGodotAppLayout() = R.layout.godot_game_layout
-
-	override fun getEditorWindowInfo() = RUN_GAME_INFO
 
 	override fun getEditorGameEmbedMode() = GameMenuUtils.GameEmbedMode.DISABLED
 
@@ -229,7 +227,7 @@ open class GodotGame : BaseGodotGame() {
 
 	override fun isMinimizedButtonEnabled() = isTaskRoot && !isNativeXRDevice(applicationContext)
 
-	override fun isCloseButtonEnabled() = !isHorizonOSDevice(applicationContext)
+	override fun isCloseButtonEnabled() = !isNativeXRDevice(applicationContext)
 
 	override fun isPiPButtonEnabled() = isPiPModeSupported()
 

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotGame0.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotGame0.kt
@@ -1,0 +1,39 @@
+/**************************************************************************/
+/*  GodotGame0.kt                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+package org.godotengine.editor
+
+/**
+ * First instance for the Game window. Typically, this is the default instance launched when multi-instance is not
+ * enabled / supported.
+ */
+class GodotGame0: GodotGame() {
+	override fun getEditorWindowInfo() = RUN_GAME_INFO_0
+}

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotGame1.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotGame1.kt
@@ -1,0 +1,40 @@
+/**************************************************************************/
+/*  GodotGame1.kt                                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+package org.godotengine.editor
+
+/**
+ * Second instance for the Game window.
+ *
+ * Used when multi-instance is enabled.
+ */
+class GodotGame1: GodotGame() {
+	override fun getEditorWindowInfo() = RUN_GAME_INFO_1
+}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Multi-instance runs are disabled in the Android editor due to screen size and UX limitations. However, standalone XR devices have virtually an infinite screen, so they are not suggest to the same constraints. As such this PR adds support for multi-instance runs on standalone XR devices.

On Android, each activity process needs to be defined in the `AndroidManifest`, so multi-instance runs in the Android editor are limited to `2` at the moment. 

https://github.com/user-attachments/assets/d0c01fac-e6ba-4642-9f6e-775dabc61920



## Additional information

Addresses https://github.com/godotengine/godot-proposals/issues/11937 for standalone XR devices.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
