### PR TITLE
AudioStream._get_parameter_list docs: fix typo

### DIFF
--- a/doc/classes/AudioStream.xml
+++ b/doc/classes/AudioStream.xml
@@ -42,7 +42,7 @@
 		<method name="_get_parameter_list" qualifiers="virtual const">
 			<return type="Dictionary[]" />
 			<description>
-				Return the controllable parameters of this stream. This array contains dictionaries with a property info description format (see [method Object.get_property_list]). Additionally, the default value for this parameter must be added tho each dictionary in "default_value" field.
+				Return the controllable parameters of this stream. This array contains dictionaries with a property info description format (see [method Object.get_property_list]). Additionally, the default value for this parameter must be added to each dictionary in "default_value" field.
 			</description>
 		</method>
 		<method name="_get_stream_name" qualifiers="virtual const" deprecated="This method is not used by the engine.">


### PR DESCRIPTION
## What problem(s) does this PR solve?

There is a typo in this docstring: "tho" should be "to".