### PR TITLE
Fix grammar in `AudioStreamPlayback` description

### DIFF
--- a/doc/classes/AudioStreamPlayback.xml
+++ b/doc/classes/AudioStreamPlayback.xml
@@ -4,7 +4,7 @@
 		Meta class for playing back audio.
 	</brief_description>
 	<description>
-		Can play, loop, pause a scroll through audio. See [AudioStream] and [AudioStreamOggVorbis] for usage.
+		Can play, loop, and pause seeking through audio. See [AudioStream] and [AudioStreamOggVorbis] for usage.
 	</description>
 	<tutorials>
 		<link title="Audio Generator Demo">https://godotengine.org/asset-library/asset/2759</link>


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

```
Can play, loop, pause a scroll through audio.
```
to
```
Can play, loop, and pause seeking through audio.
```

"And" was missing here. Also, I don't really know what "a scroll" through audio is, especially since there's no UI here. I think "seeking" was meant here, the more proper jargon.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
