### PR TITLE
Fix bug in insertion of lightmap caches into unwrap_cache

### DIFF
--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -539,16 +539,22 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 				// MD5 is stored at the beginning of the cache data.
 				const String new_md5 = String::md5(lightmap_cache.ptr());
 
+				bool inserted = false;
 				for (int i = 0; i < r_lightmap_caches.size(); i++) {
 					const String md5 = String::md5(r_lightmap_caches[i].ptr());
 					if (new_md5 < md5) {
 						r_lightmap_caches.insert(i, lightmap_cache);
+						inserted = true;
 						break;
 					}
 
 					if (new_md5 == md5) {
+						inserted = true;
 						break;
 					}
+				}
+				if (!inserted) {
+					r_lightmap_caches.push_back(lightmap_cache);
 				}
 			}
 		}

--- a/editor/import/3d/resource_importer_scene.cpp
+++ b/editor/import/3d/resource_importer_scene.cpp
@@ -2837,16 +2837,22 @@ Node *ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_
 						} else {
 							String new_md5 = String::md5(lightmap_cache.ptr()); // MD5 is stored at the beginning of the cache data
 
+							bool inserted = false;
 							for (int i = 0; i < r_lightmap_caches.size(); i++) {
 								String md5 = String::md5(r_lightmap_caches[i].ptr());
 								if (new_md5 < md5) {
 									r_lightmap_caches.insert(i, lightmap_cache);
+									inserted = true;
 									break;
 								}
 
 								if (new_md5 == md5) {
+									inserted = true;
 									break;
 								}
+							}
+							if (!inserted) {
+								r_lightmap_caches.push_back(lightmap_cache);
 							}
 						}
 					}


### PR DESCRIPTION
The insertion of lightmap caches into the unwrap_cache was silently dropping entries in some cases.
Fixes issue #117752 about uv2 differing across OSes.

## What problem(s) does this PR solve?

- Closes #117752

## Additional information

As fas as I could understand, we are not cross-platform deterministic with generated lightmap UVs. This is why we have unwrap_cache.

While troubleshooting the issue (#117752), I noticed the we are silently dropping entries when inserting lightmap caches for individual meshes into an unwrap_cache. I assume the code meant to do a standard insertion sort, but forgets to add entries that sort higher than all existing entries.
So we silently drop them.

I've done some tests, and we do indeed drop entries from the unwrap_cache, and so I think we are forced to re-unwrap them on each machine, making it non-deterministic.

This fix is pretty basic, in that it just makes sure the entry is added if it wasn't already.