### PR TITLE
Move application ID to the project settings.

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -389,6 +389,33 @@ bool ProjectSettings::_get(const StringName &p_name, Variant &r_ret) const {
 	return true;
 }
 
+String ProjectSettings::_get_property_warning(const StringName &p_name) const {
+	if (!props.has(p_name)) {
+		return String();
+	}
+	if (p_name == "application/config/id.macos" || p_name == "application/config/id.ios" || p_name == "application/config/id.visionos") {
+		String value = app_id_from_name(props[p_name].variant, APP_ID_APPLE);
+		String warnings;
+		if (!value.is_empty() && !validate_app_id(value, APP_ID_APPLE, &warnings)) {
+			return warnings;
+		}
+	} else if (p_name == "application/config/id.linuxbsd" || p_name == "application/config/id.android") {
+		String value = app_id_from_name(props[p_name].variant, APP_ID_FREEDESKTOP);
+		String warnings;
+		if (!value.is_empty() && !validate_app_id(value, APP_ID_FREEDESKTOP, &warnings)) {
+			return warnings;
+		}
+	} else if (p_name == "application/config/id.windows") {
+		String value = app_id_from_name(props[p_name].variant, APP_ID_WINDOWS);
+		String warnings;
+		if (!value.is_empty() && !validate_app_id(value, APP_ID_WINDOWS, &warnings)) {
+			return warnings;
+		}
+	}
+
+	return String();
+}
+
 Variant ProjectSettings::get_setting_with_override_and_custom_features(const StringName &p_name, const Vector<String> &p_features) const {
 	_THREAD_SAFE_METHOD_
 
@@ -1630,6 +1657,8 @@ Variant ProjectSettings::get_editor_setting_override(const String &p_setting) co
 }
 
 void ProjectSettings::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_get_property_warning", "name"), &ProjectSettings::_get_property_warning);
+
 	ClassDB::bind_method(D_METHOD("has_setting", "name"), &ProjectSettings::has_setting);
 	ClassDB::bind_method(D_METHOD("set_setting", "name", "value"), &ProjectSettings::set_setting);
 	ClassDB::bind_method(D_METHOD("get_setting", "name", "default_value"), &ProjectSettings::get_setting, DEFVAL(Variant()));
@@ -1680,6 +1709,151 @@ void ProjectSettings::_add_builtin_input_map() {
 	}
 }
 
+bool ProjectSettings::validate_app_id(const String &p_id, AppIDType p_type, String *r_error) const {
+	if (p_id.length() == 0) {
+#ifdef TOOLS_ENABLED
+		if (r_error) {
+			*r_error = TTR("Application ID is missing.");
+		}
+#endif
+		return false;
+	}
+
+	int segments = 0;
+	bool first = true;
+	for (int i = 0; i < p_id.length(); i++) {
+		char32_t c = p_id[i];
+		if (first && c == '.') {
+#ifdef TOOLS_ENABLED
+			if (r_error) {
+				*r_error = TTR("Application ID segments must be of non-zero length.");
+			}
+#endif
+			return false;
+		}
+		if (c == '.') {
+			segments++;
+			first = true;
+			continue;
+		}
+		switch (p_type) {
+			case APP_ID_FREEDESKTOP: {
+				if (first && is_digit(c)) {
+#ifdef TOOLS_ENABLED
+					if (r_error) {
+						*r_error = TTR("A digit cannot be the first character in an application ID segment.");
+					}
+#endif
+					return false;
+				}
+				if (first && is_underscore(c)) {
+#ifdef TOOLS_ENABLED
+					if (r_error) {
+						*r_error = vformat(TTR("The character '%s' cannot be the first character in an application ID segment."), String::chr(c));
+					}
+#endif
+					return false;
+				}
+				if (is_underscore(c)) {
+					first = false;
+					continue;
+				}
+			} break;
+			case APP_ID_APPLE: {
+				if (first && c == '-') {
+#ifdef TOOLS_ENABLED
+					if (r_error) {
+						*r_error = vformat(TTR("The character '%s' cannot be the first character in an application ID segment."), String::chr(c));
+					}
+#endif
+					return false;
+				}
+				if (c == '-') {
+					first = false;
+					continue;
+				}
+			} break;
+			case APP_ID_WINDOWS: {
+				if (first && !is_ascii_upper_case(c)) {
+#ifdef TOOLS_ENABLED
+					if (r_error) {
+						*r_error = TTR("The first character in an application ID segment should be upper case.");
+					}
+#endif
+					return false;
+				}
+				if (is_underscore(c) || c == '-') {
+					first = false;
+					continue;
+				}
+			} break;
+		}
+		if (!is_ascii_alphanumeric_char(c)) {
+#ifdef TOOLS_ENABLED
+			if (r_error) {
+				*r_error = vformat(TTR("The character '%s' is not allowed in application ID."), String::chr(c));
+			}
+#endif
+			return false;
+		}
+		first = false;
+	}
+	if (segments == 0) {
+#ifdef TOOLS_ENABLED
+		if (r_error) {
+			*r_error = TTR("Application IDe must have at least one '.' separator.");
+		}
+#endif
+		return false;
+	}
+	if (first) {
+#ifdef TOOLS_ENABLED
+		if (r_error) {
+			*r_error = TTR("Application ID segments must be of non-zero length.");
+		}
+#endif
+		return false;
+	}
+	if (p_type == APP_ID_WINDOWS && p_id.length() > 128) {
+#ifdef TOOLS_ENABLED
+		if (r_error) {
+			*r_error = TTR("Application ID can have no more than 128 characters.");
+		}
+#endif
+		return false;
+	}
+	return true;
+}
+
+String ProjectSettings::app_id_from_name(const String &p_id, AppIDType p_type) const {
+	String name = GLOBAL_GET("application/config/name");
+	String ascii_name;
+	for (int i = 0; i < name.length(); i++) {
+		char32_t c = name[i];
+		if (is_ascii_alphanumeric_char(c) || is_whitespace(c)) {
+			ascii_name += c;
+		}
+	}
+	ascii_name = ascii_name.strip_edges();
+	if (ascii_name.is_empty()) {
+		ascii_name = "Unnamed Project";
+	}
+
+	switch (p_type) {
+		case APP_ID_FREEDESKTOP: {
+			ascii_name = ascii_name.to_snake_case();
+		} break;
+		case APP_ID_APPLE: {
+			ascii_name = ascii_name.to_kebab_case();
+		} break;
+		case APP_ID_WINDOWS: {
+			ascii_name = ascii_name.substr(0, 128 - (p_id.length() - 8));
+			ascii_name = ascii_name.to_pascal_case();
+		} break;
+	};
+	return p_id.replace("$genname", ascii_name);
+}
+
 ProjectSettings::ProjectSettings() {
 	// Initialization of engine variables should be done in the setup() method,
 	// so that the values can be overridden from project.godot or project.binary.
@@ -1701,6 +1875,15 @@ ProjectSettings::ProjectSettings() {
 #endif
 
 	GLOBAL_DEF_BASIC("application/config/name", "");
+
+	GLOBAL_DEF_BASIC("application/config/id", "");
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/config/id.android", PROPERTY_HINT_PLACEHOLDER_TEXT, "com.example.game_name"), "com.example.$genname");
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/config/id.ios", PROPERTY_HINT_PLACEHOLDER_TEXT, "com.example.game-name"), "com.example.$genname");
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/config/id.linuxbsd", PROPERTY_HINT_PLACEHOLDER_TEXT, "com.example.game_name"), "com.example.$genname");
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/config/id.macos", PROPERTY_HINT_PLACEHOLDER_TEXT, "com.example.game-name"), "com.example.$genname");
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/config/id.visionos", PROPERTY_HINT_PLACEHOLDER_TEXT, "com.example.game-name"), "com.example.$genname");
+	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/config/id.windows", PROPERTY_HINT_PLACEHOLDER_TEXT, "Example.GameName"), "Example.$genname");
+
 	GLOBAL_DEF(PropertyInfo(Variant::DICTIONARY, "application/config/name_localized", PROPERTY_HINT_LOCALIZABLE_STRING), Dictionary());
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::STRING, "application/config/description", PROPERTY_HINT_MULTILINE_TEXT), "");
 	GLOBAL_DEF_BASIC("application/config/version", "");

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -123,6 +123,7 @@ protected:
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	bool _property_can_revert(const StringName &p_name) const;
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
+	String _get_property_warning(const StringName &p_name) const;
 
 	void _queue_changed(const StringName &p_name);
 	void _emit_changed();
@@ -243,6 +244,15 @@ public:
 
 	// Testing a version allows fast cached GET_GLOBAL macros.
 	uint32_t get_version() const { return _version; }
+
+	enum AppIDType {
+		APP_ID_FREEDESKTOP,
+		APP_ID_APPLE,
+		APP_ID_WINDOWS,
+	};
+
+	bool validate_app_id(const String &p_id, AppIDType p_type, String *r_error) const;
+	String app_id_from_name(const String &p_id, AppIDType p_type) const;
 
 #ifdef TOOLS_ENABLED
 	virtual void get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const override;

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -1587,7 +1587,7 @@
 			<param index="0" name="id" type="int" />
 			<description>
 				Hides the toast notification with [param id] returned by [method send_toast_notification].
-				[b]Note:[/b] This method is only implemented on Windows.
+				[b]Note:[/b] This method is implemented on Linux and Windows.
 			</description>
 		</method>
 		<method name="ime_get_selection" qualifiers="const">
@@ -1909,11 +1909,11 @@
 			<return type="int" />
 			<param index="0" name="title" type="String" />
 			<param index="1" name="text" type="String" />
-			<param index="2" name="image" type="Texture2D" />
-			<param index="3" name="callback" type="Callable" />
+			<param index="2" name="image" type="Texture2D" default="null" />
+			<param index="3" name="callback" type="Callable" default="Callable()" />
 			<description>
 				Displays a toast notification with [param title], [param text], and optionally [param image]. [param image] should be square, have a maximum edge length of 512 pixels, and should not exceed 4 MB when encoded as PNG. [param callback] should accept two arguments: [int] (notification ID) and [enum NotificationStatus]. Returns the notification ID or [constant INVALID_NOTIFICATION_ID] if it failed.
-				[b]Note:[/b] This method is only implemented on Windows.
+				[b]Note:[/b] This method is implemented on Linux and Windows.
 			</description>
 		</method>
 		<method name="set_hardware_keyboard_connection_change_callback">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -338,6 +338,33 @@
 		<member name="application/config/icon" type="String" setter="" getter="" default="&quot;&quot;">
 			Icon used for the project, set when project loads. Exporters will also use this icon as a fallback if necessary.
 		</member>
+		<member name="application/config/id" type="String" setter="" getter="" default="&quot;&quot;">
+			Unique application identifier.
+		</member>
+		<member name="application/config/id.android" type="String" setter="" getter="" default="&quot;com.example.$genname&quot;">
+			Unique application identifier in a reverse-DNS format. The reverse DNS format should preferably match a domain name you control, but this is not strictly required. For instance, if you own [code]example.com[/code], your package unique name should preferably be of the form [code]com.example.mygame[/code]. This identifier can only contain lowercase alphanumeric characters ([code]a-z[/code], and [code]0-9[/code]), underscores ([code]_[/code]), and periods ([code].[/code]). Each component of the reverse DNS format must start with a letter: for instance, [code]com.example.8game[/code] is not valid.
+			If [code]$genname[/code] is present in the value, it will be replaced by the project name converted to lowercase. If there are invalid characters in the project name, they will be stripped. If all characters in the project name are stripped, [code]$genname[/code] is replaced by [code]unnamed_project[/code].
+		</member>
+		<member name="application/config/id.ios" type="String" setter="" getter="" default="&quot;com.example.$genname&quot;">
+			Unique application identifier in a reverse-DNS format. The reverse DNS format should preferably match a domain name you control, but this is not strictly required. For instance, if you own [code]example.com[/code], your package unique name should preferably be of the form [code]com.example.mygame[/code]. This identifier can only contain alphanumeric characters ([code]A-Z[/code], [code]a-z[/code], and [code]0-9[/code]), hyphens ([code]-[/code]), and periods ([code].[/code]).
+			If [code]$genname[/code] is present in the value, it will be replaced by the project name converted to lowercase. If there are invalid characters in the project name, they will be stripped. If all characters in the project name are stripped, [code]$genname[/code] is replaced by [code]unnamed-project[/code].
+		</member>
+		<member name="application/config/id.linuxbsd" type="String" setter="" getter="" default="&quot;com.example.$genname&quot;">
+			Unique application identifier in a reverse-DNS format. The reverse DNS format should preferably match a domain name you control, but this is not strictly required. For instance, if you own [code]example.com[/code], your package unique name should preferably be of the form [code]com.example.mygame[/code]. This identifier can only contain lowercase alphanumeric characters ([code]a-z[/code], and [code]0-9[/code]), underscores ([code]_[/code]), and periods ([code].[/code]). Each component of the reverse DNS format must start with a letter: for instance, [code]com.example.8game[/code] is not valid.
+			If [code]$genname[/code] is present in the value, it will be replaced by the project name converted to lowercase. If there are invalid characters in the project name, they will be stripped. If all characters in the project name are stripped, [code]$genname[/code] is replaced by [code]unnamed_project[/code].
+		</member>
+		<member name="application/config/id.macos" type="String" setter="" getter="" default="&quot;com.example.$genname&quot;">
+			Unique application identifier in a reverse-DNS format. The reverse DNS format should preferably match a domain name you control, but this is not strictly required. For instance, if you own [code]example.com[/code], your package unique name should preferably be of the form [code]com.example.mygame[/code]. This identifier can only contain alphanumeric characters ([code]A-Z[/code], [code]a-z[/code], and [code]0-9[/code]), hyphens ([code]-[/code]), and periods ([code].[/code]).
+			If [code]$genname[/code] is present in the value, it will be replaced by the project name converted to lowercase. If there are invalid characters in the project name, they will be stripped. If all characters in the project name are stripped, [code]$genname[/code] is replaced by [code]unnamed-project[/code].
+		</member>
+		<member name="application/config/id.visionos" type="String" setter="" getter="" default="&quot;com.example.$genname&quot;">
+			Unique application identifier in a reverse-DNS format. The reverse DNS format should preferably match a domain name you control, but this is not strictly required. For instance, if you own [code]example.com[/code], your package unique name should preferably be of the form [code]com.example.mygame[/code]. This identifier can only contain alphanumeric characters ([code]A-Z[/code], [code]a-z[/code], and [code]0-9[/code]), hyphens ([code]-[/code]), and periods ([code].[/code]).
+			If [code]$genname[/code] is present in the value, it will be replaced by the project name converted to lowercase. If there are invalid characters in the project name, they will be stripped. If all characters in the project name are stripped, [code]$genname[/code] is replaced by [code]unnamed-project[/code].
+		</member>
+		<member name="application/config/id.windows" type="String" setter="" getter="" default="&quot;Example.$genname&quot;">
+			Unique application identifier in a [code]CompanyName.ProductName.SubProduct.VersionInformation[/code] format. This identifier can only contain lowercase alphanumeric characters ([code]a-z[/code], and [code]0-9[/code]), underscores ([code]_[/code]), hyphens ([code]-[/code]), and periods ([code].[/code]). Each component should be pascal-cased.
+			If [code]$genname[/code] is present in the value, it will be replaced by the project name. If there are invalid characters in the project name, they will be stripped. If all characters in the project name are stripped, [code]$genname[/code] is replaced by [code]UnnamedProject[/code].
+		</member>
 		<member name="application/config/macos_native_icon" type="String" setter="" getter="" default="&quot;&quot;">
 			Icon set in [code].icns[/code] format used on macOS to set the game's icon. This is done automatically on start by calling [method DisplayServer.set_native_icon].
 		</member>

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -181,9 +181,9 @@ String EditorExportPlatformAppleEmbedded::get_export_option_warning(const Editor
 				return TTR("App Store Team ID not specified.") + "\n";
 			}
 		} else if (p_name == "application/bundle_identifier") {
-			String identifier = p_preset->get("application/bundle_identifier");
+			String identifier = _get_app_id(Ref<EditorExportPreset>(p_preset));
 			String pn_err;
-			if (!is_package_name_valid(identifier, &pn_err)) {
+			if (!ProjectSettings::get_singleton()->validate_app_id(identifier, ProjectSettings::APP_ID_APPLE, &pn_err)) {
 				return TTR("Invalid Identifier:") + " " + pn_err;
 			}
 		} else if (p_name == "privacy/file_timestamp_access_reasons") {
@@ -404,6 +404,14 @@ void EditorExportPlatformAppleEmbedded::_fix_config_file(const Ref<EditorExportP
 	}
 }
 
+String EditorExportPlatformAppleEmbedded::_get_app_id(const Ref<EditorExportPreset> &p_preset) const {
+	String id = p_preset->get("application/bundle_identifier");
+	if (id.is_empty()) {
+		id = get_project_setting(p_preset, "application/config/id");
+	}
+	return ProjectSettings::get_singleton()->app_id_from_name(id, ProjectSettings::APP_ID_APPLE);
+}
+
 String EditorExportPlatformAppleEmbedded::_process_config_file_line(const Ref<EditorExportPreset> &p_preset, const String &p_line, const AppleEmbeddedConfigData &p_config, bool p_debug, const CodeSigningDetails &p_code_signing) {
 	String strnew;
 	if (p_line.contains("$binary")) {
@@ -425,7 +433,7 @@ String EditorExportPlatformAppleEmbedded::_process_config_file_line(const Ref<Ed
 	} else if (p_line.contains("$name")) {
 		strnew += p_line.replace("$name", p_config.pkg_name) + "\n";
 	} else if (p_line.contains("$bundle_identifier")) {
-		strnew += p_line.replace("$bundle_identifier", p_preset->get("application/bundle_identifier")) + "\n";
+		strnew += p_line.replace("$bundle_identifier", _get_app_id(p_preset)) + "\n";
 	} else if (p_line.contains("$short_version")) {
 		strnew += p_line.replace("$short_version", p_preset->get_version("application/short_version")) + "\n";
 	} else if (p_line.contains("$version")) {
@@ -1253,7 +1261,7 @@ Error EditorExportPlatformAppleEmbedded::_copy_asset(const Ref<EditorExportPrese
 		destination = destination_dir;
 
 		// Convert to framework and copy.
-		RETURN_IF_ERROR(_convert_to_framework(p_asset, destination, p_preset->get("application/bundle_identifier")));
+		RETURN_IF_ERROR(_convert_to_framework(p_asset, destination, _get_app_id(p_preset)));
 	} else if (p_is_framework && asset.ends_with(".xcframework")) {
 		// For Apple Embedded platforms we need to turn .dylib inside .xcframework
 		// into .framework to be able to send application to AppStore
@@ -1279,7 +1287,7 @@ Error EditorExportPlatformAppleEmbedded::_copy_asset(const Ref<EditorExportPrese
 
 		if (dylibs > 0) {
 			// Convert to framework and copy.
-			RETURN_IF_ERROR(_convert_to_framework(p_asset, destination, p_preset->get("application/bundle_identifier")));
+			RETURN_IF_ERROR(_convert_to_framework(p_asset, destination, _get_app_id(p_preset)));
 		} else {
 			// Copy as is.
 			if (!filesystem_da->dir_exists(destination_dir)) {
@@ -2425,29 +2433,6 @@ String EditorExportPlatformAppleEmbedded::get_option_tooltip(int p_index) const 
 	return "UUID: " + devices[p_index].id;
 }
 
-bool EditorExportPlatformAppleEmbedded::is_package_name_valid(const String &p_package, String *r_error) const {
-	String pname = p_package;
-
-	if (pname.length() == 0) {
-		if (r_error) {
-			*r_error = TTR("Identifier is missing.");
-		}
-		return false;
-	}
-
-	for (int i = 0; i < pname.length(); i++) {
-		char32_t c = pname[i];
-		if (!(is_ascii_alphanumeric_char(c) || c == '-' || c == '.')) {
-			if (r_error) {
-				*r_error = vformat(TTR("The character '%s' is not allowed in Identifier."), String::chr(c));
-			}
-			return false;
-		}
-	}
-
-	return true;
-}
-
 #ifdef MACOS_ENABLED
 bool EditorExportPlatformAppleEmbedded::_check_xcode_install() {
 	static bool xcode_found = false;
@@ -2910,7 +2895,7 @@ Error EditorExportPlatformAppleEmbedded::run(const Ref<EditorExportPreset> &p_pr
 			args.push_back("--terminate-existing");
 			args.push_back("-d");
 			args.push_back(dev.id);
-			args.push_back(p_preset->get("application/bundle_identifier"));
+			args.push_back(_get_app_id(p_preset));
 			for (const String &E : cmd_args_list) {
 				args.push_back(E);
 			}

--- a/editor/export/editor_export_platform_apple_embedded.h
+++ b/editor/export/editor_export_platform_apple_embedded.h
@@ -203,8 +203,7 @@ private:
 	Error _export_apple_embedded_plugins(const Ref<EditorExportPreset> &p_preset, AppleEmbeddedConfigData &p_config_data, const String &p_dest_dir, const Vector<String> &p_module_libs, Vector<AppleEmbeddedExportAsset> &r_exported_assets, bool p_debug);
 
 	Error _export_project_helper(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags, bool p_notify, bool p_oneclick);
-
-	bool is_package_name_valid(const String &p_package, String *r_error = nullptr) const;
+	String _get_app_id(const Ref<EditorExportPreset> &p_preset) const;
 
 protected:
 	virtual String _process_config_file_line(const Ref<EditorExportPreset> &p_preset, const String &p_line, const AppleEmbeddedConfigData &p_config, bool p_debug, const CodeSigningDetails &p_code_signing);

--- a/editor/inspector/editor_sectioned_inspector.cpp
+++ b/editor/inspector/editor_sectioned_inspector.cpp
@@ -128,6 +128,18 @@ class SectionedInspectorFilter : public Object {
 		return true;
 	}
 
+	String _get_property_warning(const StringName &p_name) const {
+		if (edited->has_method("_get_property_warning")) {
+			return edited->call("_get_property_warning", section + "/" + p_name);
+		}
+		return String();
+	}
+
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("_get_property_warning", "name"), &SectionedInspectorFilter::_get_property_warning);
+	}
+
 public:
 	void set_section(const String &p_section, bool p_allow_sub) {
 		section = p_section;

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -521,13 +521,6 @@ String EditorExportPlatformAndroid::get_project_name(const Ref<EditorExportPrese
 	return aname;
 }
 
-String EditorExportPlatformAndroid::get_package_name(const Ref<EditorExportPreset> &p_preset, const String &p_package) const {
-	String pname = p_package;
-	String name = get_valid_basename(p_preset);
-	pname = pname.replace("$genname", name);
-	return pname;
-}
-
 // Returns the project name without invalid characters
 // or the "noname" string if all characters are invalid.
 String EditorExportPlatformAndroid::get_valid_basename(const Ref<EditorExportPreset> &p_preset) const {
@@ -557,80 +550,6 @@ String EditorExportPlatformAndroid::get_valid_basename(const Ref<EditorExportPre
 String EditorExportPlatformAndroid::get_assets_directory(const Ref<EditorExportPreset> &p_preset, int p_export_format) const {
 	String gradle_build_directory = ExportTemplateManager::get_android_build_directory(p_preset);
 	return gradle_build_directory.path_join(p_export_format == EXPORT_FORMAT_AAB ? AAB_ASSETS_DIRECTORY : APK_ASSETS_DIRECTORY);
-}
-
-bool EditorExportPlatformAndroid::is_package_name_valid(const Ref<EditorExportPreset> &p_preset, const String &p_package, String *r_error) const {
-	String pname = get_package_name(p_preset, p_package);
-
-	if (pname.length() == 0) {
-		if (r_error) {
-			*r_error = TTR("Package name is missing.");
-		}
-		return false;
-	}
-
-	int segments = 0;
-	bool first = true;
-	for (int i = 0; i < pname.length(); i++) {
-		char32_t c = pname[i];
-		if (first && c == '.') {
-			if (r_error) {
-				*r_error = TTR("Package segments must be of non-zero length.");
-			}
-			return false;
-		}
-		if (c == '.') {
-			segments++;
-			first = true;
-			continue;
-		}
-		if (!is_ascii_identifier_char(c)) {
-			if (r_error) {
-				*r_error = vformat(TTR("The character '%s' is not allowed in Android application package names."), String::chr(c));
-			}
-			return false;
-		}
-		if (first && is_digit(c)) {
-			if (r_error) {
-				*r_error = TTR("A digit cannot be the first character in a package segment.");
-			}
-			return false;
-		}
-		if (first && is_underscore(c)) {
-			if (r_error) {
-				*r_error = vformat(TTR("The character '%s' cannot be the first character in a package segment."), String::chr(c));
-			}
-			return false;
-		}
-		first = false;
-	}
-
-	if (segments == 0) {
-		if (r_error) {
-			*r_error = TTR("The package must have at least one '.' separator.");
-		}
-		return false;
-	}
-
-	if (first) {
-		if (r_error) {
-			*r_error = TTR("Package segments must be of non-zero length.");
-		}
-		return false;
-	}
-
-	return true;
-}
-
-bool EditorExportPlatformAndroid::is_project_name_valid(const Ref<EditorExportPreset> &p_preset) const {
-	// Get the original project name and convert to lowercase.
-	String basename = get_project_setting(p_preset, "application/config/name");
-	basename = basename.to_lower();
-	// Check if there are invalid characters.
-	if (basename != get_valid_basename(p_preset)) {
-		return false;
-	}
-	return true;
 }
 
 bool EditorExportPlatformAndroid::_should_compress_asset(const String &p_path, const Vector<uint8_t> &p_data) {
@@ -1242,7 +1161,7 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 
 	String version_name = p_preset->get_version("version/name");
 	int version_code = p_preset->get("version/code");
-	String package_name = p_preset->get("package/unique_name");
+	String package_name = _get_app_id(p_preset);
 
 	const int screen_orientation =
 			_get_android_orientation_value(DisplayServerEnums::ScreenOrientation(int(get_project_setting(p_preset, "display/window/handheld/orientation"))));
@@ -1330,7 +1249,7 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 
 					//replace project information
 					if (tname == "manifest" && attrname == "package") {
-						string_table.write[attr_value] = get_package_name(p_preset, package_name);
+						string_table.write[attr_value] = package_name;
 					}
 
 					if (tname == "manifest" && attrname == "versionCode") {
@@ -1378,7 +1297,7 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 					}
 
 					if (tname == "provider" && attrname == "authorities") {
-						string_table.write[attr_value] = get_package_name(p_preset, package_name) + String(".fileprovider");
+						string_table.write[attr_value] = package_name + String(".fileprovider");
 					}
 
 					if (tname == "supports-screens") {
@@ -2083,13 +2002,21 @@ void EditorExportPlatformAndroid::get_preset_features(const Ref<EditorExportPres
 	}
 }
 
+String EditorExportPlatformAndroid::_get_app_id(const Ref<EditorExportPreset> &p_preset) const {
+	String id = p_preset->get("package/unique_name");
+	if (id.is_empty()) {
+		id = get_project_setting(p_preset, "application/config/id");
+	}
+	return ProjectSettings::get_singleton()->app_id_from_name(id, ProjectSettings::APP_ID_FREEDESKTOP);
+}
+
 String EditorExportPlatformAndroid::get_export_option_warning(const EditorExportPreset *p_preset, const StringName &p_name) const {
 	if (p_preset) {
 		if (p_name == "package/unique_name") {
-			String pn = p_preset->get("package/unique_name");
+			String pn = _get_app_id(Ref<EditorExportPreset>(p_preset));
 			String pn_err;
 
-			if (!is_package_name_valid(Ref<EditorExportPreset>(p_preset), pn, &pn_err)) {
+			if (!ProjectSettings::get_singleton()->validate_app_id(pn, ProjectSettings::APP_ID_FREEDESKTOP, &pn_err)) {
 				return TTR("Invalid package name:") + " " + pn_err;
 			}
 		} else if (p_name == "gesture/swipe_to_dismiss") {
@@ -2231,7 +2158,7 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "version/code", PROPERTY_HINT_RANGE, "1,4096,1,or_greater"), 1));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "version/name", PROPERTY_HINT_PLACEHOLDER_TEXT, "Leave empty to use project version"), ""));
 
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "package/unique_name", PROPERTY_HINT_PLACEHOLDER_TEXT, "ext.domain.name"), "com.example.$genname", false, true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "package/unique_name", PROPERTY_HINT_PLACEHOLDER_TEXT, "ext.domain.name"), "", false, true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "package/name", PROPERTY_HINT_PLACEHOLDER_TEXT, "Game Name [default if blank]"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "package/signed"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "package/app_category", PROPERTY_HINT_ENUM, "Accessibility,Audio,Game,Image,Maps,News,Productivity,Social,Video,Undefined"), APP_CATEGORY_GAME));
@@ -2469,7 +2396,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 	String output;
 
 	bool remove_prev = EDITOR_GET("export/android/one_click_deploy_clear_previous_install");
-	String package_name = p_preset->get("package/unique_name");
+	String package_name = _get_app_id(p_preset);
 
 	if (remove_prev) {
 		if (ep.step(TTR("Uninstalling..."), 1)) {
@@ -2485,7 +2412,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 			args.push_back("--user");
 			args.push_back("0");
 		}
-		args.push_back(get_package_name(p_preset, package_name));
+		args.push_back(package_name);
 
 		output.clear();
 		err = OS::get_singleton()->execute(adb, args, &output, &rv, true);
@@ -2593,7 +2520,7 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 				args.push_back("--no-vd-system-decorations");
 			}
 		}
-		args.push_back("--start-app=+" + get_package_name(p_preset, package_name));
+		args.push_back("--start-app=+" + package_name);
 
 		Dictionary data = OS::get_singleton()->execute_with_pipe(scrcpy, args, false);
 		if (!data.has("pid") || data["pid"].operator int() <= 0) {
@@ -2646,16 +2573,16 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 		// Going with implicit launch first based on the LAUNCHER category and the app's package.
 		args.push_back("-c");
 		args.push_back("android.intent.category.LAUNCHER");
-		args.push_back(get_package_name(p_preset, package_name));
+		args.push_back(package_name);
 
 		output.clear();
 		err = OS::get_singleton()->execute(adb, args, &output, &rv, true);
 		print_verbose(output);
 		if (err || rv != 0 || output.contains("Error: Activity not started")) {
 			// The implicit launch failed, let's try an explicit launch by specifying the component name before giving up.
-			const String component_name = get_package_name(p_preset, package_name) + "/com.godot.game.GodotAppLauncher";
+			const String component_name = package_name + "/com.godot.game.GodotAppLauncher";
 			print_line("Implicit launch failed... Trying explicit launch using", component_name);
-			args.erase(get_package_name(p_preset, package_name));
+			args.erase(package_name);
 			args.push_back("-n");
 			args.push_back(component_name);
 
@@ -3202,13 +3129,6 @@ bool EditorExportPlatformAndroid::has_valid_project_configuration(const Ref<Edit
 			err += vformat(TTR("\"Min SDK\" should be greater or equal to %d for the \"%s\" renderer."), VULKAN_MIN_SDK_VERSION, current_renderer);
 			err += "\n";
 		}
-	}
-
-	String package_name = p_preset->get("package/unique_name");
-	if (package_name.contains("$genname") && !is_project_name_valid(p_preset)) {
-		// Warning only, so don't override `valid`.
-		err += vformat(TTR("The project name does not meet the requirement for the package name format and will be updated to \"%s\". Please explicitly specify the package name if needed."), get_valid_basename(p_preset));
-		err += "\n";
 	}
 
 	r_error = err;
@@ -3868,7 +3788,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		String build_path = ProjectSettings::get_singleton()->globalize_path(gradle_build_directory);
 		build_command = build_path.path_join(build_command);
 
-		String package_name = get_package_name(p_preset, p_preset->get("package/unique_name"));
+		String package_name = _get_app_id(p_preset);
 		String version_code = itos(p_preset->get("version/code"));
 		String version_name = p_preset->get_version("version/name");
 		String min_sdk_version = p_preset->get("gradle_build/min_sdk");

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -116,14 +116,9 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 
 	String get_project_name(const Ref<EditorExportPreset> &p_preset, const String &p_name) const;
 
-	String get_package_name(const Ref<EditorExportPreset> &p_preset, const String &p_package) const;
-
 	String get_valid_basename(const Ref<EditorExportPreset> &p_preset) const;
 
 	String get_assets_directory(const Ref<EditorExportPreset> &p_preset, int p_export_format) const;
-
-	bool is_package_name_valid(const Ref<EditorExportPreset> &p_preset, const String &p_package, String *r_error = nullptr) const;
-	bool is_project_name_valid(const Ref<EditorExportPreset> &p_preset) const;
 
 	static bool _should_compress_asset(const String &p_path, const Vector<uint8_t> &p_data);
 
@@ -204,6 +199,8 @@ class EditorExportPlatformAndroid : public EditorExportPlatform {
 	bool _uses_vulkan(const Ref<EditorExportPreset> &p_preset) const;
 
 	Error _generate_sparse_pck_metadata(const Ref<EditorExportPreset> &p_preset, PackData &p_pack_data, Vector<uint8_t> &r_data);
+
+	String _get_app_id(const Ref<EditorExportPreset> &p_preset) const;
 
 protected:
 	void _notification(int p_what);

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -690,15 +690,9 @@ void FreeDesktopPortalDesktop::_register_app_id() {
 	}
 
 	if (Engine::get_singleton()->is_editor_hint()) {
-		app_id = "org.godotengine.Godot";
+		app_id = "org.godotengine.godot";
 	} else {
-		String name = GLOBAL_GET("application/config/name");
-		app_id = name.to_pascal_case();
-		for (int i = 0; i < app_id.length(); i++) {
-			if (!is_ascii_alphanumeric_char(app_id[i]) && app_id[i] != '_' && app_id[i] != '.') {
-				app_id[i] = '_';
-			}
-		}
+		app_id = ProjectSettings::get_singleton()->app_id_from_name(GLOBAL_GET("application/config/id"), ProjectSettings::APP_ID_FREEDESKTOP);
 	}
 	print_verbose(vformat("Registering application ID: %s", app_id));
 

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -32,6 +32,7 @@
 
 #ifdef DBUS_ENABLED
 
+#include "core/config/project_settings.h"
 #include "core/crypto/crypto_core.h"
 #include "core/error/error_macros.h"
 #include "core/object/callable_mp.h"
@@ -39,6 +40,7 @@
 #include "core/string/ustring.h"
 #include "core/variant/typed_array.h"
 #include "core/variant/variant.h"
+#include "scene/resources/texture.h"
 #include "servers/display/display_server.h"
 
 #ifdef SOWRAP_ENABLED
@@ -58,6 +60,8 @@
 #define BUS_INTERFACE_SCREENSHOT "org.freedesktop.portal.Screenshot"
 #define BUS_INTERFACE_INHIBIT "org.freedesktop.portal.Inhibit"
 #define BUS_INTERFACE_REQUEST "org.freedesktop.portal.Request"
+#define BUS_INTERFACE_NOTIFICATION "org.freedesktop.portal.Notification"
+#define BUS_INTERFACE_REGISTRY "org.freedesktop.host.portal.Registry"
 
 #define INHIBIT_FLAG_IDLE 8
 
@@ -680,6 +684,175 @@ bool FreeDesktopPortalDesktop::send_request(DBusMessage *p_message, const String
 	return true;
 }
 
+void FreeDesktopPortalDesktop::_register_app_id() {
+	if (unsupported) {
+		return;
+	}
+
+	if (Engine::get_singleton()->is_editor_hint()) {
+		app_id = "org.godotengine.Godot";
+	} else {
+		String name = GLOBAL_GET("application/config/name");
+		app_id = name.to_pascal_case();
+		for (int i = 0; i < app_id.length(); i++) {
+			if (!is_ascii_alphanumeric_char(app_id[i]) && app_id[i] != '_' && app_id[i] != '.') {
+				app_id[i] = '_';
+			}
+		}
+	}
+	print_verbose(vformat("Registering application ID: %s", app_id));
+
+	DBusMessage *message = dbus_message_new_method_call(BUS_OBJECT_NAME, BUS_OBJECT_PATH, BUS_INTERFACE_REGISTRY, "Register");
+	{
+		DBusMessageIter iter;
+		dbus_message_iter_init_append(message, &iter);
+
+		append_dbus_string(&iter, app_id);
+
+		DBusMessageIter arr_iter;
+		dbus_message_iter_open_container(&iter, DBUS_TYPE_ARRAY, "{sv}", &arr_iter);
+
+		//No options set.
+
+		dbus_message_iter_close_container(&iter, &arr_iter);
+	}
+
+	DBusError error;
+	dbus_error_init(&error);
+
+	DBusMessage *reply = dbus_connection_send_with_reply_and_block(monitor_connection, message, DBUS_TIMEOUT_USE_DEFAULT, &error);
+	dbus_message_unref(message);
+	if (dbus_error_is_set(&error)) {
+		WARN_VERBOSE(vformat("Failed to register application ID: %s.", String::utf8(error.message)));
+		dbus_error_free(&error);
+	} else if (reply) {
+		dbus_message_unref(reply);
+	}
+}
+
+bool FreeDesktopPortalDesktop::send_toast_notification(DisplayServerEnums::NotificationID p_id, const String &p_title, const String &p_text, const Ref<Texture2D> &p_image, const Callable &p_callback) {
+	if (unsupported) {
+		return false;
+	}
+
+	NotificationData nd;
+	nd.callback = p_callback;
+	nd.id = p_id;
+	nd.id_s = vformat("godot_notification_%s_%x_%x", app_id, OS::get_singleton()->get_process_id(), p_id);
+
+	String token;
+	Error err = make_request_token(token);
+	if (err != OK) {
+		return false;
+	}
+
+	DBusMessage *message = dbus_message_new_method_call(BUS_OBJECT_NAME, BUS_OBJECT_PATH, BUS_INTERFACE_NOTIFICATION, "AddNotification");
+	{
+		DBusMessageIter iter;
+		dbus_message_iter_init_append(message, &iter);
+		append_dbus_string(&iter, nd.id_s);
+
+		DBusMessageIter arr_iter;
+		dbus_message_iter_open_container(&iter, DBUS_TYPE_ARRAY, "{sv}", &arr_iter);
+
+		append_dbus_dict_string(&arr_iter, "title", p_title);
+		append_dbus_dict_string(&arr_iter, "body", p_text);
+		append_dbus_dict_string(&arr_iter, "default-action", "gd_activate");
+		if (p_image.is_valid()) {
+			Ref<Image> img = p_image->get_image();
+			if (img.is_valid()) {
+				img = img->duplicate();
+				img->convert(Image::FORMAT_RGBA8);
+				if (img->get_width() != img->get_height() || img->get_width() > 512) {
+					int max_d = MIN(512, MAX(img->get_width(), img->get_height()));
+					img->resize(max_d, max_d, Image::INTERPOLATE_LANCZOS);
+				}
+				DBusMessageIter dict_iter;
+				DBusMessageIter var_iter;
+				DBusMessageIter struct_iter;
+				DBusMessageIter var_data_iter;
+				DBusMessageIter arr_data_iter;
+				dbus_message_iter_open_container(&arr_iter, DBUS_TYPE_DICT_ENTRY, nullptr, &dict_iter);
+				append_dbus_string(&dict_iter, "icon");
+
+				dbus_message_iter_open_container(&dict_iter, DBUS_TYPE_VARIANT, "(sv)", &var_iter);
+				dbus_message_iter_open_container(&var_iter, DBUS_TYPE_STRUCT, nullptr, &struct_iter);
+				append_dbus_string(&struct_iter, "bytes");
+
+				dbus_message_iter_open_container(&struct_iter, DBUS_TYPE_VARIANT, "ay", &var_data_iter);
+				dbus_message_iter_open_container(&var_data_iter, DBUS_TYPE_ARRAY, "y", &arr_data_iter);
+				Vector<uint8_t> data = img->save_png_to_buffer();
+				for (int i = 0; i < data.size(); i++) {
+					dbus_message_iter_append_basic(&arr_data_iter, DBUS_TYPE_BYTE, &data[i]);
+				}
+				dbus_message_iter_close_container(&var_data_iter, &arr_data_iter);
+				dbus_message_iter_close_container(&struct_iter, &var_data_iter);
+
+				dbus_message_iter_close_container(&var_iter, &struct_iter);
+				dbus_message_iter_close_container(&dict_iter, &var_iter);
+
+				dbus_message_iter_close_container(&arr_iter, &dict_iter);
+			}
+		}
+
+		dbus_message_iter_close_container(&iter, &arr_iter);
+	}
+
+	DBusError error;
+	dbus_error_init(&error);
+
+	DBusMessage *reply = dbus_connection_send_with_reply_and_block(monitor_connection, message, DBUS_TIMEOUT_USE_DEFAULT, &error);
+	dbus_message_unref(message);
+	if (dbus_error_is_set(&error)) {
+		ERR_PRINT(vformat("Failed to send notification: %s.", String::utf8(error.message)));
+		dbus_error_free(&error);
+	} else if (reply) {
+		dbus_message_unref(reply);
+	}
+
+	MutexLock lock(notification_mutex);
+	notifications.push_back(nd);
+
+	return true;
+}
+
+void FreeDesktopPortalDesktop::hide_toast_notification(DisplayServerEnums::NotificationID p_id) {
+	if (unsupported) {
+		return;
+	}
+
+	String id_s = vformat("godot_notification_%s_%x_%x", app_id, OS::get_singleton()->get_process_id(), p_id);
+
+	DBusMessage *message = dbus_message_new_method_call(BUS_OBJECT_NAME, BUS_OBJECT_PATH, BUS_INTERFACE_NOTIFICATION, "RemoveNotification");
+	{
+		DBusMessageIter iter;
+		dbus_message_iter_init_append(message, &iter);
+
+		append_dbus_string(&iter, id_s);
+	}
+
+	DBusError error;
+	dbus_error_init(&error);
+
+	DBusMessage *reply = dbus_connection_send_with_reply_and_block(monitor_connection, message, DBUS_TIMEOUT_USE_DEFAULT, &error);
+	dbus_message_unref(message);
+	if (dbus_error_is_set(&error)) {
+		ERR_PRINT(vformat("Failed to hide notification: %s.", String::utf8(error.message)));
+		dbus_error_free(&error);
+	} else if (reply) {
+		dbus_message_unref(reply);
+	}
+
+	MutexLock lock(notification_mutex);
+	for (int i = 0; i < notifications.size(); i++) {
+		FreeDesktopPortalDesktop::NotificationData &nd = notifications.write[i];
+		if (nd.id_s == id_s) {
+			notifications.remove_at(i);
+			break;
+		}
+	}
+}
+
 Error FreeDesktopPortalDesktop::file_dialog_show(DisplayServerEnums::WindowID p_window_id, const String &p_xid, const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb) {
 	if (unsupported) {
 		return FAILED;
@@ -880,6 +1053,22 @@ void FreeDesktopPortalDesktop::process_callbacks() {
 		}
 	}
 	{
+		MutexLock lock(notification_mutex);
+		while (!pending_notification_cbs.is_empty()) {
+			NotificationCallback cb = pending_notification_cbs.front()->get();
+			pending_notification_cbs.pop_front();
+
+			Variant ret;
+			Callable::CallError ce;
+			const Variant *args[2] = { &cb.id, &cb.status };
+
+			cb.callback.callp(args, 2, ret, ce);
+			if (ce.error != Callable::CallError::CALL_OK) {
+				ERR_PRINT(vformat("Failed to execute notification callback: %s.", Variant::get_callable_error_text(cb.callback, args, 2, ce)));
+			}
+		}
+	}
+	{
 		MutexLock lock(color_picker_mutex);
 		while (!pending_color_cbs.is_empty()) {
 			ColorPickerCallback cb = pending_color_cbs.front()->get();
@@ -918,6 +1107,43 @@ void FreeDesktopPortalDesktop::_thread_monitor(void *p_ud) {
 
 						if (name_space == "org.freedesktop.appearance" && (key == "color-scheme" || key == "accent-color")) {
 							callable_mp(portal, &FreeDesktopPortalDesktop::_system_theme_changed_callback).call_deferred();
+						}
+					}
+				} else if (dbus_message_is_signal(msg, "org.freedesktop.portal.Notification", "ActionInvoked")) {
+					{
+						String id_s;
+						String act_s;
+
+						DBusMessageIter iter;
+						if (dbus_message_iter_init(msg, &iter)) {
+							// Parse.
+							const char *id = nullptr;
+							dbus_message_iter_get_basic(&iter, &id);
+							id_s = String::utf8(id);
+							dbus_message_iter_next(&iter);
+							const char *act = nullptr;
+							dbus_message_iter_get_basic(&iter, &act);
+							act_s = String::utf8(act);
+						}
+
+						MutexLock lock(portal->notification_mutex);
+						for (int i = 0; i < portal->notifications.size(); i++) {
+							FreeDesktopPortalDesktop::NotificationData &nd = portal->notifications.write[i];
+							if (nd.id_s == id_s) {
+								if (nd.callback.is_valid()) {
+									NotificationCallback cb;
+									cb.id = nd.id;
+									if (act_s == "gd_activate") {
+										cb.status = DisplayServerEnums::NOTIFICATION_ACTIVATED;
+									} else {
+										cb.status = DisplayServerEnums::NOTIFICATION_DISMISSED;
+									}
+									cb.callback = nd.callback;
+									portal->pending_notification_cbs.push_back(cb);
+								}
+								portal->notifications.remove_at(i);
+								break;
+							}
 						}
 					}
 				} else if (dbus_message_is_signal(msg, "org.freedesktop.portal.Request", "Response")) {
@@ -1032,8 +1258,17 @@ FreeDesktopPortalDesktop::FreeDesktopPortalDesktop() {
 	if (dbus_error_is_set(&err)) {
 		dbus_error_free(&err);
 	} else {
+		_register_app_id();
+
 		theme_path = "type='signal',sender='org.freedesktop.portal.Desktop',interface='org.freedesktop.portal.Settings',member='SettingChanged'";
 		dbus_bus_add_match(monitor_connection, theme_path.utf8().get_data(), &err);
+		if (dbus_error_is_set(&err)) {
+			dbus_error_free(&err);
+			dbus_connection_unref(monitor_connection);
+			monitor_connection = nullptr;
+		}
+		noti_path = "type='signal',sender='org.freedesktop.portal.Desktop',interface='org.freedesktop.portal.Notification',member='ActionInvoked'";
+		dbus_bus_add_match(monitor_connection, noti_path.utf8().get_data(), &err);
 		if (dbus_error_is_set(&err)) {
 			dbus_error_free(&err);
 			dbus_connection_unref(monitor_connection);
@@ -1063,6 +1298,10 @@ FreeDesktopPortalDesktop::~FreeDesktopPortalDesktop() {
 		}
 		dbus_error_init(&err);
 		dbus_bus_remove_match(monitor_connection, theme_path.utf8().get_data(), &err);
+		dbus_error_free(&err);
+
+		dbus_error_init(&err);
+		dbus_bus_remove_match(monitor_connection, noti_path.utf8().get_data(), &err);
 		dbus_error_free(&err);
 		dbus_connection_unref(monitor_connection);
 	}

--- a/platform/linuxbsd/freedesktop_portal_desktop.h
+++ b/platform/linuxbsd/freedesktop_portal_desktop.h
@@ -41,6 +41,7 @@
 struct DBusMessage;
 struct DBusConnection;
 struct DBusMessageIter;
+class Texture2D;
 
 class FreeDesktopPortalDesktop : public Object {
 	GDSOFTCLASS(FreeDesktopPortalDesktop, Object);
@@ -108,11 +109,30 @@ private:
 
 	Mutex file_dialog_mutex;
 	Vector<FileDialogData> file_dialogs;
+
+	struct NotificationData {
+		Callable callback;
+		DisplayServerEnums::NotificationID id;
+		String id_s;
+	};
+
+	struct NotificationCallback {
+		Callable callback;
+		Variant id;
+		Variant status = DisplayServerEnums::NOTIFICATION_ACTIVATED;
+	};
+	List<NotificationCallback> pending_notification_cbs;
+
+	Mutex notification_mutex;
+	Vector<NotificationData> notifications;
+
 	Thread monitor_thread;
 	SafeFlag monitor_thread_abort;
 	DBusConnection *monitor_connection = nullptr;
 
+	String app_id;
 	String theme_path;
+	String noti_path;
 	Callable system_theme_changed;
 	void _system_theme_changed_callback();
 	bool _is_interface_supported(const char *p_iface, uint32_t p_minimum_version);
@@ -120,6 +140,8 @@ private:
 	Mutex inhibit_mutex;
 	String inhibit_path;
 	String inhibit_filter;
+
+	void _register_app_id();
 
 	static void _thread_monitor(void *p_ud);
 
@@ -132,6 +154,10 @@ public:
 	bool is_settings_supported();
 	bool is_screenshot_supported();
 	bool is_inhibit_supported();
+
+	// org.freedesktop.portal.Notification methods.
+	bool send_toast_notification(DisplayServerEnums::NotificationID p_id, const String &p_title, const String &p_text, const Ref<Texture2D> &p_image, const Callable &p_callback);
+	void hide_toast_notification(DisplayServerEnums::NotificationID p_id);
 
 	// org.freedesktop.portal.FileChooser methods.
 	Error file_dialog_show(DisplayServerEnums::WindowID p_window_id, const String &p_xid, const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb);

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1753,6 +1753,27 @@ void DisplayServerWayland::cursor_set_custom_image(const Ref<Resource> &p_cursor
 	}
 }
 
+DisplayServerEnums::NotificationID DisplayServerWayland::send_toast_notification(const String &p_title, const String &p_text, const Ref<Texture2D> &p_image, const Callable &p_callback) {
+#ifdef DBUS_ENABLED
+	if (!portal_desktop) {
+		return DisplayServerEnums::INVALID_NOTIFICATION_ID;
+	}
+	DisplayServerEnums::NotificationID id = noti_id++;
+	if (portal_desktop->send_toast_notification(id, p_title, p_text, p_image, p_callback)) {
+		return id;
+	}
+#endif
+	return DisplayServerEnums::INVALID_NOTIFICATION_ID;
+}
+
+void DisplayServerWayland::hide_toast_notification(DisplayServerEnums::NotificationID p_id) {
+#ifdef DBUS_ENABLED
+	ERR_FAIL_COND(p_id < 0 || p_id >= noti_id);
+	if (portal_desktop) {
+		portal_desktop->hide_toast_notification(p_id);
+	}
+#endif
+}
 bool DisplayServerWayland::get_swap_cancel_ok() {
 	return swap_cancel_ok;
 }
@@ -2294,6 +2315,35 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Dis
 #endif // SOWRAP_ENABLED
 #endif // defined(GLES3_ENABLED) || defined(DBUS_ENABLED)
 
+// Note: Portal init should be done before Wayland init to ensure application ID is correctly registered.
+#ifdef DBUS_ENABLED
+	bool dbus_ok = true;
+#ifdef SOWRAP_ENABLED
+	if (initialize_dbus(dylibloader_verbose) != 0) {
+		print_verbose("Failed to load DBus library!");
+		dbus_ok = false;
+	}
+#endif
+	if (dbus_ok) {
+		bool ver_ok = false;
+		int version_major = 0;
+		int version_minor = 0;
+		int version_rev = 0;
+		dbus_get_version(&version_major, &version_minor, &version_rev);
+		ver_ok = (version_major == 1 && version_minor >= 10) || (version_major > 1); // 1.10.0
+		print_verbose(vformat("DBus %d.%d.%d detected.", version_major, version_minor, version_rev));
+		if (!ver_ok) {
+			print_verbose("Unsupported DBus library version!");
+			dbus_ok = false;
+		}
+	}
+	if (dbus_ok) {
+		portal_desktop = memnew(FreeDesktopPortalDesktop);
+		screensaver = memnew(FreeDesktopScreenSaver);
+		atspi_monitor = memnew(FreeDesktopAtSPIMonitor);
+	}
+#endif // DBUS_ENABLED
+
 	r_error = ERR_UNAVAILABLE;
 	context = p_context;
 
@@ -2530,34 +2580,6 @@ DisplayServerWayland::DisplayServerWayland(const String &p_rendering_driver, Dis
 		RendererCompositorRD::make_current();
 	}
 #endif // RD_ENABLED
-
-#ifdef DBUS_ENABLED
-	bool dbus_ok = true;
-#ifdef SOWRAP_ENABLED
-	if (initialize_dbus(dylibloader_verbose) != 0) {
-		print_verbose("Failed to load DBus library!");
-		dbus_ok = false;
-	}
-#endif
-	if (dbus_ok) {
-		bool ver_ok = false;
-		int version_major = 0;
-		int version_minor = 0;
-		int version_rev = 0;
-		dbus_get_version(&version_major, &version_minor, &version_rev);
-		ver_ok = (version_major == 1 && version_minor >= 10) || (version_major > 1); // 1.10.0
-		print_verbose(vformat("DBus %d.%d.%d detected.", version_major, version_minor, version_rev));
-		if (!ver_ok) {
-			print_verbose("Unsupported DBus library version!");
-			dbus_ok = false;
-		}
-	}
-	if (dbus_ok) {
-		screensaver = memnew(FreeDesktopScreenSaver);
-		portal_desktop = memnew(FreeDesktopPortalDesktop);
-		atspi_monitor = memnew(FreeDesktopAtSPIMonitor);
-	}
-#endif // DBUS_ENABLED
 
 	screen_set_keep_on(GLOBAL_GET("display/window/energy_saving/keep_screen_on"));
 

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -139,6 +139,8 @@ class DisplayServerWayland : public DisplayServer {
 
 	WaylandThread wayland_thread;
 
+	DisplayServerEnums::NotificationID noti_id = 0;
+
 	DisplayServerEnums::Context context;
 	bool swap_cancel_ok = false;
 
@@ -356,6 +358,9 @@ public:
 	virtual void cursor_set_shape(DisplayServerEnums::CursorShape p_shape) override;
 	virtual DisplayServerEnums::CursorShape cursor_get_shape() const override;
 	virtual void cursor_set_custom_image(const Ref<Resource> &p_cursor, DisplayServerEnums::CursorShape p_shape, const Vector2 &p_hotspot) override;
+
+	virtual DisplayServerEnums::NotificationID send_toast_notification(const String &p_title, const String &p_text, const Ref<Texture2D> &p_image, const Callable &p_callback) override;
+	virtual void hide_toast_notification(DisplayServerEnums::NotificationID p_id) override;
 
 	virtual bool get_swap_cancel_ok() override;
 

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -3748,6 +3748,28 @@ void DisplayServerX11::cursor_set_custom_image(const Ref<Resource> &p_cursor, Di
 	}
 }
 
+DisplayServerEnums::NotificationID DisplayServerX11::send_toast_notification(const String &p_title, const String &p_text, const Ref<Texture2D> &p_image, const Callable &p_callback) {
+#ifdef DBUS_ENABLED
+	if (!portal_desktop) {
+		return DisplayServerEnums::INVALID_NOTIFICATION_ID;
+	}
+	DisplayServerEnums::NotificationID id = noti_id++;
+	if (portal_desktop->send_toast_notification(id, p_title, p_text, p_image, p_callback)) {
+		return id;
+	}
+#endif
+	return DisplayServerEnums::INVALID_NOTIFICATION_ID;
+}
+
+void DisplayServerX11::hide_toast_notification(DisplayServerEnums::NotificationID p_id) {
+#ifdef DBUS_ENABLED
+	ERR_FAIL_COND(p_id < 0 || p_id >= noti_id);
+	if (portal_desktop) {
+		portal_desktop->hide_toast_notification(p_id);
+	}
+#endif
+}
+
 bool DisplayServerX11::get_swap_cancel_ok() {
 	return swap_cancel_ok;
 }
@@ -6966,6 +6988,35 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 
 	r_error = OK;
 
+// Note: Portal init should be done before X11 init to ensure application ID is correctly registered.
+#ifdef DBUS_ENABLED
+	bool dbus_ok = true;
+#ifdef SOWRAP_ENABLED
+	if (initialize_dbus(dylibloader_verbose) != 0) {
+		print_verbose("Failed to load DBus library!");
+		dbus_ok = false;
+	}
+#endif
+	if (dbus_ok) {
+		bool ver_ok = false;
+		int version_major = 0;
+		int version_minor = 0;
+		int version_rev = 0;
+		dbus_get_version(&version_major, &version_minor, &version_rev);
+		ver_ok = (version_major == 1 && version_minor >= 10) || (version_major > 1); // 1.10.0
+		print_verbose(vformat("DBus %d.%d.%d detected.", version_major, version_minor, version_rev));
+		if (!ver_ok) {
+			print_verbose("Unsupported DBus library version!");
+			dbus_ok = false;
+		}
+	}
+	if (dbus_ok) {
+		portal_desktop = memnew(FreeDesktopPortalDesktop);
+		screensaver = memnew(FreeDesktopScreenSaver);
+		atspi_monitor = memnew(FreeDesktopAtSPIMonitor);
+	}
+#endif // DBUS_ENABLED
+
 #ifdef SOWRAP_ENABLED
 	{
 		if (!XcursorImageCreate || !XcursorImageLoadCursor || !XcursorImageDestroy || !XcursorGetDefaultSize || !XcursorGetTheme || !XcursorLibraryLoadImage) {
@@ -7479,34 +7530,6 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, DisplayServ
 	events_thread.start(_poll_events_thread, this);
 
 	_update_real_mouse_position(windows[DisplayServerEnums::MAIN_WINDOW_ID]);
-
-#ifdef DBUS_ENABLED
-	bool dbus_ok = true;
-#ifdef SOWRAP_ENABLED
-	if (initialize_dbus(dylibloader_verbose) != 0) {
-		print_verbose("Failed to load DBus library!");
-		dbus_ok = false;
-	}
-#endif
-	if (dbus_ok) {
-		bool ver_ok = false;
-		int version_major = 0;
-		int version_minor = 0;
-		int version_rev = 0;
-		dbus_get_version(&version_major, &version_minor, &version_rev);
-		ver_ok = (version_major == 1 && version_minor >= 10) || (version_major > 1); // 1.10.0
-		print_verbose(vformat("DBus %d.%d.%d detected.", version_major, version_minor, version_rev));
-		if (!ver_ok) {
-			print_verbose("Unsupported DBus library version!");
-			dbus_ok = false;
-		}
-	}
-	if (dbus_ok) {
-		screensaver = memnew(FreeDesktopScreenSaver);
-		portal_desktop = memnew(FreeDesktopPortalDesktop);
-		atspi_monitor = memnew(FreeDesktopAtSPIMonitor);
-	}
-#endif // DBUS_ENABLED
 
 	screen_set_keep_on(GLOBAL_GET("display/window/energy_saving/keep_screen_on"));
 

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -221,6 +221,8 @@ class DisplayServerX11 : public DisplayServer {
 	void _create_xic(WindowData &wd);
 	DisplayServerEnums::WindowID _create_window(DisplayServerEnums::WindowMode p_mode, DisplayServerEnums::VSyncMode p_vsync_mode, uint32_t p_flags, const Rect2i &p_rect, Window p_parent_window);
 
+	DisplayServerEnums::NotificationID noti_id = 0;
+
 	String internal_clipboard;
 	String internal_clipboard_primary;
 	Window xdnd_source_window = 0;
@@ -551,6 +553,9 @@ public:
 	virtual void cursor_set_shape(DisplayServerEnums::CursorShape p_shape) override;
 	virtual DisplayServerEnums::CursorShape cursor_get_shape() const override;
 	virtual void cursor_set_custom_image(const Ref<Resource> &p_cursor, DisplayServerEnums::CursorShape p_shape, const Vector2 &p_hotspot) override;
+
+	virtual DisplayServerEnums::NotificationID send_toast_notification(const String &p_title, const String &p_text, const Ref<Texture2D> &p_image, const Callable &p_callback) override;
+	virtual void hide_toast_notification(DisplayServerEnums::NotificationID p_id) override;
 
 	virtual bool get_swap_cancel_ok() override;
 

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -103,9 +103,9 @@ String EditorExportPlatformMacOS::get_export_option_warning(const EditorExportPr
 		}
 
 		if (p_name == "application/bundle_identifier") {
-			String identifier = p_preset->get("application/bundle_identifier");
+			String identifier = _get_app_id(Ref<EditorExportPreset>(p_preset));
 			String pn_err;
-			if (!is_package_name_valid(identifier, &pn_err)) {
+			if (!ProjectSettings::get_singleton()->validate_app_id(identifier, ProjectSettings::APP_ID_APPLE, &pn_err)) {
 				return TTR("Invalid bundle identifier:") + " " + pn_err;
 			}
 		}
@@ -842,6 +842,14 @@ void EditorExportPlatformMacOS::_fix_privacy_manifest(const Ref<EditorExportPres
 	}
 }
 
+String EditorExportPlatformMacOS::_get_app_id(const Ref<EditorExportPreset> &p_preset) const {
+	String id = p_preset->get("application/bundle_identifier");
+	if (id.is_empty()) {
+		id = get_project_setting(p_preset, "application/config/id");
+	}
+	return ProjectSettings::get_singleton()->app_id_from_name(id, ProjectSettings::APP_ID_APPLE);
+}
+
 void EditorExportPlatformMacOS::_fix_plist(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &plist, const String &p_binary, bool p_lg_icon_exported, const String &p_lg_icon) {
 	String str = String::utf8((const char *)plist.ptr(), plist.size());
 	String strnew;
@@ -852,7 +860,7 @@ void EditorExportPlatformMacOS::_fix_plist(const Ref<EditorExportPreset> &p_pres
 		} else if (lines[i].contains("$name")) {
 			strnew += lines[i].replace("$name", get_project_setting(p_preset, "application/config/name").operator String().xml_escape(true)) + "\n";
 		} else if (lines[i].contains("$bundle_identifier")) {
-			strnew += lines[i].replace("$bundle_identifier", p_preset->get("application/bundle_identifier")) + "\n";
+			strnew += lines[i].replace("$bundle_identifier", _get_app_id(p_preset)) + "\n";
 		} else if (lines[i].contains("$short_version")) {
 			strnew += lines[i].replace("$short_version", p_preset->get_version("application/short_version")) + "\n";
 		} else if (lines[i].contains("$version")) {
@@ -1228,7 +1236,7 @@ void EditorExportPlatformMacOS::_code_sign(const Ref<EditorExportPreset> &p_pres
 			args.push_back("runtime");
 
 			if (p_set_id) {
-				String app_id = p_preset->get("application/bundle_identifier");
+				String app_id = _get_app_id(p_preset);
 				args.push_back("--binary-identifier");
 				args.push_back(app_id);
 			}
@@ -1293,7 +1301,7 @@ void EditorExportPlatformMacOS::_code_sign(const Ref<EditorExportPreset> &p_pres
 			}
 
 			if (p_set_id) {
-				String app_id = p_preset->get("application/bundle_identifier");
+				String app_id = _get_app_id(p_preset);
 				args.push_back("-i");
 				args.push_back(app_id);
 			}
@@ -1423,7 +1431,7 @@ Error EditorExportPlatformMacOS::_copy_and_sign_files(Ref<DirAccess> &dir_access
 			add_message(EXPORT_MESSAGE_WARNING, TTR("Export"), vformat(TTR("\"%s\": Info.plist missing or invalid, new Info.plist generated."), p_src_path.get_file()));
 			// Generate Info.plist
 			String lib_name = p_src_path.get_basename().get_file();
-			String lib_id = p_preset->get("application/bundle_identifier");
+			String lib_id = _get_app_id(p_preset);
 			String lib_clean_name = lib_name;
 			for (int i = 0; i < lib_clean_name.length(); i++) {
 				if (!is_ascii_alphanumeric_char(lib_clean_name[i]) && lib_clean_name[i] != '.' && lib_clean_name[i] != '-') {
@@ -2190,7 +2198,7 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 				if (dist_type == 2) {
 					String pprof = p_preset->get_or_env("codesign/provisioning_profile", ENV_MAC_CODESIGN_PROFILE);
 					String teamid = p_preset->get("codesign/apple_team_id");
-					String bid = p_preset->get("application/bundle_identifier");
+					String bid = _get_app_id(p_preset);
 					if (!pprof.is_empty() && !teamid.is_empty()) {
 						ent_f->store_line("<key>com.apple.developer.team-identifier</key>");
 						ent_f->store_line("<string>" + teamid + "</string>");

--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -97,31 +97,10 @@ class EditorExportPlatformMacOS : public EditorExportPlatform {
 	Error _create_dmg(const String &p_dmg_path, const String &p_pkg_name, const String &p_app_path_name);
 	Error _create_pkg(const Ref<EditorExportPreset> &p_preset, const String &p_pkg_path, const String &p_app_path_name);
 	Error _export_debug_script(const Ref<EditorExportPreset> &p_preset, const String &p_app_name, const String &p_pkg_name, const String &p_path);
+	String _get_app_id(const Ref<EditorExportPreset> &p_preset) const;
 
 	bool use_codesign() const { return true; }
 
-	bool is_package_name_valid(const String &p_package, String *r_error = nullptr) const {
-		String pname = p_package;
-
-		if (pname.length() == 0) {
-			if (r_error) {
-				*r_error = TTR("Identifier is missing.");
-			}
-			return false;
-		}
-
-		for (int i = 0; i < pname.length(); i++) {
-			char32_t c = pname[i];
-			if (!(is_ascii_alphanumeric_char(c) || c == '-' || c == '.')) {
-				if (r_error) {
-					*r_error = vformat(TTR("The character '%s' is not allowed in Identifier."), String::chr(c));
-				}
-				return false;
-			}
-		}
-
-		return true;
-	}
 	bool is_shebang(const String &p_path) const;
 
 protected:

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -879,19 +879,7 @@ String DisplayServerWindows::_get_app_id() const {
 		if (Engine::get_singleton()->is_editor_hint()) {
 			appname = "Godot.GodotEditor." + String(GODOT_VERSION_FULL_CONFIG);
 		} else {
-			String name = GLOBAL_GET("application/config/name");
-			String version = GLOBAL_GET("application/config/version");
-			if (version.is_empty()) {
-				version = "0";
-			}
-			String clean_app_name = name.to_pascal_case();
-			for (int i = 0; i < clean_app_name.length(); i++) {
-				if (!is_ascii_alphanumeric_char(clean_app_name[i]) && clean_app_name[i] != '_' && clean_app_name[i] != '.') {
-					clean_app_name[i] = '_';
-				}
-			}
-			clean_app_name = clean_app_name.substr(0, 120 - version.length()).trim_suffix(".");
-			appname = "Godot." + clean_app_name + "." + version;
+			appname = ProjectSettings::get_singleton()->app_id_from_name(GLOBAL_GET("application/config/id"), ProjectSettings::APP_ID_WINDOWS);
 		}
 	}
 	return appname;
@@ -8042,26 +8030,11 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Dis
 
 	_register_raw_input_devices(DisplayServerEnums::INVALID_WINDOW_ID);
 
-	String appname;
-	if (Engine::get_singleton()->is_editor_hint()) {
-		appname = "Godot.GodotEditor." + String(GODOT_VERSION_FULL_CONFIG);
-	} else {
-		String name = GLOBAL_GET("application/config/name");
-		String version = GLOBAL_GET("application/config/version");
-		if (version.is_empty()) {
-			version = "0";
-		}
-		String clean_app_name = name.to_pascal_case();
-		for (int i = 0; i < clean_app_name.length(); i++) {
-			if (!is_ascii_alphanumeric_char(clean_app_name[i]) && clean_app_name[i] != '_' && clean_app_name[i] != '.') {
-				clean_app_name[i] = '_';
-			}
-		}
-		clean_app_name = clean_app_name.substr(0, 120 - version.length()).trim_suffix(".");
-		appname = "Godot." + clean_app_name + "." + version;
-
+	String appname = _get_app_id();
 #ifndef TOOLS_ENABLED
+	if (!Engine::get_singleton()->is_editor_hint()) {
 		// Set for exported projects only.
+		String name = GLOBAL_GET("application/config/name");
 		HKEY key;
 		if (RegOpenKeyW(HKEY_CURRENT_USER_LOCAL_SETTINGS, L"Software\\Microsoft\\Windows\\Shell\\MuiCache", &key) == ERROR_SUCCESS) {
 			Char16String cs_name = name.utf16();
@@ -8069,8 +8042,8 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Dis
 			RegSetValueExW(key, (LPCWSTR)value_name.utf16().get_data(), 0, REG_SZ, (const BYTE *)cs_name.get_data(), cs_name.size() * sizeof(WCHAR));
 			RegCloseKey(key);
 		}
-#endif
 	}
+#endif
 	SetCurrentProcessExplicitAppUserModelID((PCWSTR)appname.utf16().get_data());
 
 	mouse_monitor = SetWindowsHookEx(WH_MOUSE, ::MouseProc, nullptr, GetCurrentThreadId());

--- a/platform/windows/winrt_utils.cpp
+++ b/platform/windows/winrt_utils.cpp
@@ -612,6 +612,7 @@ DisplayServerEnums::NotificationID WinRTUtils::send_toast_notification(const Str
 }
 
 void WinRTUtils::hide_toast_notification(DisplayServerEnums::NotificationID p_id) {
+	ERR_FAIL_COND(p_id < 0 || p_id >= notification_id);
 	if (!notifier) {
 		return;
 	}

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -1682,7 +1682,7 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("cursor_get_shape"), &DisplayServer::cursor_get_shape);
 	ClassDB::bind_method(D_METHOD("cursor_set_custom_image", "cursor", "shape", "hotspot"), &DisplayServer::cursor_set_custom_image, DEFVAL(DisplayServerEnums::CURSOR_ARROW), DEFVAL(Vector2()));
 
-	ClassDB::bind_method(D_METHOD("send_toast_notification", "title", "text", "image", "callback"), &DisplayServer::send_toast_notification);
+	ClassDB::bind_method(D_METHOD("send_toast_notification", "title", "text", "image", "callback"), &DisplayServer::send_toast_notification, DEFVAL(Ref<Texture2D>()), DEFVAL(Callable()));
 	ClassDB::bind_method(D_METHOD("hide_toast_notification", "id"), &DisplayServer::hide_toast_notification);
 
 	ClassDB::bind_method(D_METHOD("get_swap_cancel_ok"), &DisplayServer::get_swap_cancel_ok);

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -498,7 +498,7 @@ public:
 
 	/* NOTIFICATIONS */
 
-	virtual DisplayServerEnums::NotificationID send_toast_notification(const String &p_title, const String &p_text, const Ref<Texture2D> &p_image, const Callable &p_callback);
+	virtual DisplayServerEnums::NotificationID send_toast_notification(const String &p_title, const String &p_text, const Ref<Texture2D> &p_image = Ref<Texture2D>(), const Callable &p_callback = Callable());
 	virtual void hide_toast_notification(DisplayServerEnums::NotificationID p_id);
 
 	/* DIALOGS */


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Inconsistent application ID handling.

## Additional information

Depends on https://github.com/godotengine/godot/pull/119417
Supersede https://github.com/godotengine/godot/pull/119821

- Adds project setting for application ID (used by notification code, and exporters).
- Allows generated names in all cases (based on existing Android exporter code).
- Adds property validation support to `ProjectSettings`.

