### PR TITLE
[3.x] Fix some `tsan` data races

### DIFF
--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -34,6 +34,8 @@
 #include "core/os/semaphore.h"
 #include "core/os/thread.h"
 
+#include <atomic>
+
 VARIANT_ENUM_CAST(IP::ResolverStatus);
 
 /************* RESOLVER ******************/
@@ -73,7 +75,7 @@ struct _IP_ResolverPrivate {
 
 	Thread thread;
 	//Semaphore* semaphore;
-	bool thread_abort;
+	std::atomic<bool> thread_abort;
 
 	void resolve_queues() {
 		for (int i = 0; i < IP::RESOLVER_MAX_QUERIES; i++) {
@@ -109,7 +111,7 @@ struct _IP_ResolverPrivate {
 	static void _thread_function(void *self) {
 		_IP_ResolverPrivate *ipr = (_IP_ResolverPrivate *)self;
 
-		while (!ipr->thread_abort) {
+		while (!ipr->thread_abort.load(std::memory_order_acquire)) {
 			ipr->sem.wait();
 			ipr->resolve_queues();
 		}
@@ -347,7 +349,7 @@ IP::IP() {
 }
 
 IP::~IP() {
-	resolver->thread_abort = true;
+	resolver->thread_abort.store(true, std::memory_order_release);
 	resolver->sem.post();
 	resolver->thread.wait_to_finish();
 

--- a/core/os/thread.cpp
+++ b/core/os/thread.cpp
@@ -65,7 +65,11 @@ void Thread::_set_platform_funcs(
 }
 
 void Thread::callback(Thread *p_self, const Settings &p_settings, Callback p_callback, void *p_userdata) {
-	caller_id = _thread_id_hash(p_self->thread.get_id());
+	// Prevent unused parameter warning since p_self is no longer read here.
+	(void)p_self;
+
+	// Safely query the current thread ID without accessing the parent/shared thread object.
+	caller_id = _thread_id_hash(std::this_thread::get_id());
 	caller_id_cached = true;
 
 	if (set_priority_func) {

--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -35,6 +35,7 @@
 
 ScriptLanguage *ScriptServer::_languages[MAX_LANGUAGES];
 int ScriptServer::_language_count = 0;
+Mutex ScriptServer::_mutex;
 
 bool ScriptServer::scripting_enabled = true;
 bool ScriptServer::reload_scripts_on_save = false;
@@ -134,6 +135,8 @@ ScriptLanguage *ScriptServer::get_language(int p_idx) {
 }
 
 void ScriptServer::register_language(ScriptLanguage *p_language) {
+	MutexLock lock(_mutex);
+
 	ERR_FAIL_COND(_language_count >= MAX_LANGUAGES);
 	_languages[_language_count++] = p_language;
 }
@@ -188,6 +191,8 @@ bool ScriptServer::is_reload_scripts_on_save_enabled() {
 }
 
 void ScriptServer::thread_enter() {
+	MutexLock lock(_mutex);
+
 	for (int i = 0; i < _language_count; i++) {
 		_languages[i]->thread_enter();
 	}

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -48,6 +48,7 @@ class ScriptServer {
 
 	static ScriptLanguage *_languages[MAX_LANGUAGES];
 	static int _language_count;
+	static Mutex _mutex;
 	static bool scripting_enabled;
 	static bool reload_scripts_on_save;
 	static bool languages_finished;

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -921,7 +921,7 @@ String OS_X11::get_processor_name() const {
 }
 
 void OS_X11::finalize() {
-	events_thread_done = true;
+	events_thread_done.store(true, std::memory_order_release);
 	events_thread.wait_to_finish();
 
 	if (main_loop) {
@@ -2571,7 +2571,7 @@ bool OS_X11::_wait_for_events() const {
 }
 
 void OS_X11::_poll_events() {
-	while (!events_thread_done) {
+	while (!events_thread_done.load(std::memory_order_acquire)) {
 		_wait_for_events();
 
 		// Process events from the queue.

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -51,6 +51,7 @@
 #include <X11/extensions/XInput2.h>
 #include <X11/extensions/Xrandr.h>
 #include <X11/keysym.h>
+#include <atomic>
 
 #if defined(SPEECHD_ENABLED)
 #include "tts_linux.h"
@@ -172,7 +173,7 @@ class OS_X11 : public OS_Unix {
 
 	mutable Mutex events_mutex;
 	Thread events_thread;
-	bool events_thread_done = false;
+	std::atomic<bool> events_thread_done = false;
 	LocalVector<XEvent> polled_events;
 	static void _poll_events_thread(void *ud);
 	bool _wait_for_events() const;

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -483,7 +483,7 @@ void AudioServer::_driver_process(int p_frames, int32_t *p_buffer) {
 	}
 
 #ifdef DEBUG_ENABLED
-	prof_time += OS::get_singleton()->get_ticks_usec() - prof_ticks;
+	prof_time.fetch_add(OS::get_singleton()->get_ticks_usec() - prof_ticks, std::memory_order_relaxed);
 #endif
 }
 
@@ -1163,7 +1163,7 @@ void AudioServer::update() {
 		// Driver time includes server time + effects times
 		// Server time includes effects times
 		uint64_t driver_time = AudioDriver::get_singleton()->get_profiling_time();
-		uint64_t server_time = prof_time;
+		uint64_t server_time = prof_time.load(std::memory_order_relaxed);
 
 		// Subtract the server time from the driver time
 		if (driver_time > server_time) {
@@ -1221,7 +1221,7 @@ void AudioServer::update() {
 	}
 
 	AudioDriver::get_singleton()->reset_profiling_time();
-	prof_time = 0;
+	prof_time.store(0, std::memory_order_relaxed);
 #endif
 
 	// Give audio driver option to turn off to throttle CPU.

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -37,6 +37,8 @@
 #include "core/variant.h"
 #include "servers/audio/audio_effect.h"
 
+#include <atomic>
+
 class AudioDriverDummy;
 class AudioStream;
 class AudioStreamSample;
@@ -47,8 +49,8 @@ class AudioDriver {
 	uint64_t _last_mix_frames;
 
 #ifdef DEBUG_ENABLED
-	uint64_t prof_ticks;
-	uint64_t prof_time;
+	std::atomic<uint64_t> prof_ticks;
+	std::atomic<uint64_t> prof_time;
 #endif
 
 protected:
@@ -62,8 +64,10 @@ protected:
 	void input_buffer_write(int32_t sample);
 
 #ifdef DEBUG_ENABLED
-	_FORCE_INLINE_ void start_counting_ticks() { prof_ticks = OS::get_singleton()->get_ticks_usec(); }
-	_FORCE_INLINE_ void stop_counting_ticks() { prof_time += OS::get_singleton()->get_ticks_usec() - prof_ticks; }
+	_FORCE_INLINE_ void start_counting_ticks() { prof_ticks.store(OS::get_singleton()->get_ticks_usec(), std::memory_order_relaxed); }
+	_FORCE_INLINE_ void stop_counting_ticks() {
+		prof_time.fetch_add(OS::get_singleton()->get_ticks_usec() - prof_ticks.load(std::memory_order_relaxed), std::memory_order_relaxed);
+	}
 #else
 	_FORCE_INLINE_ void start_counting_ticks() {}
 	_FORCE_INLINE_ void stop_counting_ticks() {}
@@ -112,8 +116,8 @@ public:
 	unsigned int get_input_size() { return input_size; }
 
 #ifdef DEBUG_ENABLED
-	uint64_t get_profiling_time() const { return prof_time; }
-	void reset_profiling_time() { prof_time = 0; }
+	uint64_t get_profiling_time() const { return prof_time.load(std::memory_order_relaxed); }
+	void reset_profiling_time() { prof_time.store(0, std::memory_order_relaxed); }
 #endif
 
 	AudioDriver();
@@ -208,7 +212,7 @@ private:
 	uint64_t mix_count;
 	uint64_t mix_frames;
 #ifdef DEBUG_ENABLED
-	uint64_t prof_time;
+	std::atomic<uint64_t> prof_time;
 #endif
 
 	float channel_disable_threshold_db;


### PR DESCRIPTION
Fixes a number of `tsan` bugs from running a simple project (on Linux).

### `Thread` callback
Was previously accessing `p_self->thread.get_id()` before it was ready.
Instead of protecting this, we can access the thread id directly using `std::this_thread`, avoiding the problem altogether.

### Script Language
Adds a mutex to protect against `register_language` and `thread_enter` happening at the same time.

### Audio Server
Profiling times were subject to data races. These are fixed by switching to atomics. These are `DEBUG` only, so no cost in final release.
Using e.g. a mutex in audio callbacks is not a good idea.

### Various thread bools needing atomics
* IP (thread_abort)
* os_x11 (events_thread_done)

## Notes
* This closes all tsan bugs on running a simple project for me on Linux. All others are GPU driver reports which are likely false positives.
* It's possible that the profiling info in `AudioEffects` would also benefit from being atomic, but I don't have an MRP currently so will leave be.
