### PR TITLE
macOS: Fix embedded process responsiveness

### DIFF
--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -1248,7 +1248,9 @@ OS_MacOS_Headless::OS_MacOS_Headless(const char *p_execpath, int p_argc, char **
 #ifdef TOOLS_ENABLED
 
 void OS_MacOS_Embedded::run() {
-	CFRunLoopGetCurrent();
+	// The process is registered with LaunchServices, so it must use the
+	// NSApplication event loop to signal that it has finished launching.
+	[GodotApplication sharedApplication];
 
 	@autoreleasepool {
 		Error err = Main::setup(execpath, argc, argv);
@@ -1275,7 +1277,8 @@ void OS_MacOS_Embedded::run() {
 			main_loop->initialize();
 		}
 
-		while (true) {
+		CFRunLoopObserverRef pre_wait_observer = CFRunLoopObserverCreateWithHandler(kCFAllocatorDefault, kCFRunLoopBeforeWaiting, true, 0, ^(CFRunLoopObserverRef observer, CFRunLoopActivity activity) {
+			bool should_wake = true;
 			@autoreleasepool {
 				@try {
 					GodotProfileFrameMark;
@@ -1289,15 +1292,29 @@ void OS_MacOS_Embedded::run() {
 					}
 #endif
 					if (Main::iteration()) {
-						break;
-					}
+						should_wake = false;
+						CFRunLoopRemoveObserver(CFRunLoopGetCurrent(), observer, kCFRunLoopCommonModes);
+						[NSApp stop:nil];
 
-					CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0, 0);
+						// `stop:` is processed after the next event, but an embedded process
+						// has no window to generate one.
+						NSEvent *stop_event = [NSEvent otherEventWithType:NSEventTypeApplicationDefined location:NSZeroPoint modifierFlags:0 timestamp:0 windowNumber:0 context:nil subtype:0 data1:0 data2:0];
+						[NSApp postEvent:stop_event atStart:YES];
+					}
 				} @catch (NSException *exception) {
 					ERR_PRINT("NSException: " + String::utf8([exception reason].UTF8String));
 				}
 			}
-		}
+			if (should_wake && wait_timer == nil) {
+				CFRunLoopWakeUp(CFRunLoopGetCurrent()); // Prevent main loop from sleeping.
+			}
+		});
+		CFRunLoopAddObserver(CFRunLoopGetCurrent(), pre_wait_observer, kCFRunLoopCommonModes);
+
+		[NSApp run];
+
+		CFRunLoopRemoveObserver(CFRunLoopGetCurrent(), pre_wait_observer, kCFRunLoopCommonModes);
+		CFRelease(pre_wait_observer);
 
 		main_loop->finalize();
 	}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #122489

On macOS, embedded game processes are registered with LaunchServices but use a custom loop that never enters the `NSApplication` run loop. The process therefore never signals that it has finished launching, which causes Activity Monitor to report it as "Not Responding" even though the embedded game remains interactive.

## Additional information

This changes `OS_MacOS_Embedded` to use the `NSApplication` event loop, with Godot's frame iteration driven by a `kCFRunLoopBeforeWaiting` observer in the same way as the regular macOS loop.

When the game exits, the observer is removed, `NSApp` is stopped, and an application-defined event is posted so the run loop returns even when the embedded process has no window-generated events. Run-loop wakeups also respect `wait_timer` so event-aware frame pacing can sleep correctly.

Validation:

- Built the macOS ARM64 development editor and `.app` bundle.
- Reproduced the issue with the Compatibility renderer and confirmed the embedded process no longer appears as "Not Responding" in Activity Monitor.
- Confirmed `LSApplicationHasSignalledItIsReady=true`.
- Verified graceful self-quit through both raw and bundled launch paths.
- Exercised the event-aware frame-delay path.
- Ran `git diff --check`.

## AI disclosure

OpenAI Codex assisted with investigating the issue and drafting the implementation. Claude Code and GPT-5.6 Sol were used for independent code review. I built and manually verified the resulting fix in Activity Monitor.