### PR TITLE
[macOS] Set embedded process activation policy to background and launch it as headless.

### DIFF
--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -86,6 +86,7 @@ public:
 		"--help",
 		"/?",
 		"--version",
+		"--embedded",
 		"--dump-gdextension-interface",
 		"--dump-extension-api",
 		"--dump-gdextension-interface-json",

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -1308,6 +1308,9 @@ void OS_MacOS_Embedded::run() {
 OS_MacOS_Embedded::OS_MacOS_Embedded(const char *p_execpath, int p_argc, char **p_argv) :
 		OS_MacOS(p_execpath, p_argc, p_argv) {
 	DisplayServerMacOSEmbedded::register_embedded_driver();
+
+	[GodotApplication sharedApplication];
+	[NSApp setActivationPolicy:NSApplicationActivationPolicyProhibited];
 }
 
 #endif


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/122489
