### PR TITLE
Remove logic forcing all opaque geometry with "Depth Draw Mode": "Never"/"No Depth Test": "On" into alpha queue.

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -261,7 +261,7 @@ void RasterizerSceneGLES3::_geometry_instance_add_surface_with_material(Geometry
 		flags |= GeometryInstanceSurface::FLAG_USES_STENCIL;
 	}
 
-	if (has_alpha || has_read_screen_alpha || p_material->shader_data->depth_draw == GLES3::SceneShaderData::DEPTH_DRAW_DISABLED || p_material->shader_data->depth_test != GLES3::SceneShaderData::DEPTH_TEST_ENABLED) {
+	if (has_alpha || has_read_screen_alpha) {
 		//material is only meant for alpha pass
 		flags |= GeometryInstanceSurface::FLAG_PASS_ALPHA;
 		if (p_material->shader_data->uses_depth_prepass_alpha && !(p_material->shader_data->depth_draw == GLES3::SceneShaderData::DEPTH_DRAW_DISABLED || p_material->shader_data->depth_test != GLES3::SceneShaderData::DEPTH_TEST_ENABLED)) {
@@ -270,8 +270,11 @@ void RasterizerSceneGLES3::_geometry_instance_add_surface_with_material(Geometry
 		}
 	} else {
 		flags |= GeometryInstanceSurface::FLAG_PASS_OPAQUE;
-		flags |= GeometryInstanceSurface::FLAG_PASS_DEPTH;
-		flags |= GeometryInstanceSurface::FLAG_PASS_SHADOW;
+
+		if (p_material->shader_data->depth_draw != GLES3::SceneShaderData::DEPTH_DRAW_DISABLED) {
+			flags |= GeometryInstanceSurface::FLAG_PASS_DEPTH;
+			flags |= GeometryInstanceSurface::FLAG_PASS_SHADOW;
+		}
 	}
 
 	if (p_material->shader_data->stencil_enabled) {
@@ -3336,7 +3339,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 			should_request_redraw = true;
 		}
 
-		if constexpr (p_pass_mode == PASS_MODE_COLOR_TRANSPARENT) {
+		if constexpr (p_pass_mode == PASS_MODE_COLOR || p_pass_mode == PASS_MODE_COLOR_TRANSPARENT) {
 			scene_state.enable_gl_depth_test(shader->depth_test != GLES3::SceneShaderData::DEPTH_TEST_DISABLED);
 		}
 

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -4242,8 +4242,10 @@ void RenderForwardClustered::_geometry_instance_add_surface_with_material(Geomet
 		}
 	} else {
 		flags |= GeometryInstanceSurfaceDataCache::FLAG_PASS_OPAQUE;
-		flags |= GeometryInstanceSurfaceDataCache::FLAG_PASS_DEPTH;
-		flags |= GeometryInstanceSurfaceDataCache::FLAG_PASS_SHADOW;
+		if (p_material->shader_data->depth_draw != SceneShaderForwardClustered::ShaderData::DEPTH_DRAW_DISABLED) {
+			flags |= GeometryInstanceSurfaceDataCache::FLAG_PASS_DEPTH;
+			flags |= GeometryInstanceSurfaceDataCache::FLAG_PASS_SHADOW;
+		}
 	}
 
 	if (p_material->shader_data->uses_particle_trails) {

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -286,9 +286,7 @@ public:
 			bool has_base_alpha = (uses_alpha && (!uses_alpha_clip || uses_alpha_antialiasing)) || has_read_screen_alpha;
 			bool has_blend_alpha = uses_blend_alpha;
 			bool has_alpha = has_base_alpha || has_blend_alpha;
-			bool no_depth_draw = depth_draw == DEPTH_DRAW_DISABLED;
-			bool no_depth_test = depth_test != DEPTH_TEST_ENABLED;
-			return has_alpha || has_read_screen_alpha || no_depth_draw || no_depth_test;
+			return has_alpha || has_read_screen_alpha;
 		}
 
 		_FORCE_INLINE_ bool uses_depth_in_alpha_pass() const {

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -2948,8 +2948,10 @@ void RenderForwardMobile::_geometry_instance_add_surface_with_material(GeometryI
 		}
 	} else {
 		flags |= GeometryInstanceSurfaceDataCache::FLAG_PASS_OPAQUE;
-		flags |= GeometryInstanceSurfaceDataCache::FLAG_PASS_DEPTH;
-		flags |= GeometryInstanceSurfaceDataCache::FLAG_PASS_SHADOW;
+		if (p_material->shader_data->depth_draw != SceneShaderForwardMobile::ShaderData::DEPTH_DRAW_DISABLED) {
+			flags |= GeometryInstanceSurfaceDataCache::FLAG_PASS_DEPTH;
+			flags |= GeometryInstanceSurfaceDataCache::FLAG_PASS_SHADOW;
+		}
 	}
 
 	if (p_material->shader_data->uses_particle_trails) {

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -287,9 +287,7 @@ public:
 			bool has_base_alpha = (uses_alpha && (!uses_alpha_clip || uses_alpha_antialiasing));
 			bool has_blend_alpha = uses_blend_alpha;
 			bool has_alpha = has_base_alpha || has_blend_alpha;
-			bool no_depth_draw = depth_draw == DEPTH_DRAW_DISABLED;
-			bool no_depth_test = depth_test != DEPTH_TEST_ENABLED;
-			return has_alpha || has_read_screen_alpha || no_depth_draw || no_depth_test;
+			return has_alpha || has_read_screen_alpha;
 		}
 
 		_FORCE_INLINE_ bool uses_depth_in_alpha_pass() const {


### PR DESCRIPTION
There is currently logic which detects that either "Depth Draw Mode" is "Never" or "No Depth Test" is "On" and forces even opaque geometry into the alpha queue.  This PR removes that in all renderers.

While regression testing, I determined that disabling depth test additionally disables depth write in the Forward+ and Mobile renderers.  I think the behaviour in the Compatibility renderer (depth write is disconnected from depth test) is more likely to be correct so aligned Forward+ and Mobile with it.  The existing logic in the D3D12 and Metal renderers seemed to assume that no depth test = no depth write so I've made an attempt to amend that.

[repro.zip](https://github.com/user-attachments/files/31140497/repro.zip)

<img width="1495" height="889" alt="image" src="https://github.com/user-attachments/assets/2b04bba0-32a9-4b7d-94cc-d97fabfd4377" />

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- PART closes [#73158](https://github.com/godotengine/godot/issues/73158) (does not fix Forward+ with depth pre-pass)

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

NOTE: I started from @clayjohn's comment [here](https://github.com/godotengine/godot/issues/73158#issuecomment-1430123182) and continued making changes until the feature seemed to work.  Let me know if there's something I should do my end to attribute this more clearly/correctly.  

NOTE: This is still broken specifically for Forward+ with depth pre-pass enabled.  I can't figure out the correct way to exclude the right surfaces from the depth pre-pass.  But this at least fixes Compatability, Mobile and Forward+ sans depth pre-pass.

I have probably broken something but I'm not familiar enough with the rendering pipeline's internal workings to be sure.  I tried using `blame` to determine if the depth draw/depth test checks were originally added to fix some kind of bug but wasn't able to find anything.

Part of this was spun off into #123147.  I don't expect this to get merged in its current state but it may be helpful to others who are also doing terrible, terrible things with the depth buffer.