### PR TITLE
Fix inspector object selector min size

### DIFF
--- a/editor/gui/editor_object_selector.cpp
+++ b/editor/gui/editor_object_selector.cpp
@@ -38,9 +38,7 @@
 #include "scene/gui/margin_container.h"
 
 Size2 EditorObjectSelector::get_minimum_size() const {
-	Ref<Font> font = get_theme_font(SceneStringName(font));
-	int font_size = get_theme_font_size(SceneStringName(font_size));
-	return Button::get_minimum_size() + Size2(0, font->get_height(font_size));
+	return main_mc->get_minimum_size();
 }
 
 void EditorObjectSelector::_add_children_to_popup(Object *p_obj, int p_depth) {
@@ -209,7 +207,7 @@ void EditorObjectSelector::_notification(int p_what) {
 EditorObjectSelector::EditorObjectSelector(EditorSelectionHistory *p_history) {
 	history = p_history;
 
-	MarginContainer *main_mc = memnew(MarginContainer);
+	main_mc = memnew(MarginContainer);
 	main_mc->set_theme_type_variation("ObjectSelectorMargin");
 	main_mc->set_anchors_and_offsets_preset(PRESET_FULL_RECT);
 	add_child(main_mc);

--- a/editor/gui/editor_object_selector.h
+++ b/editor/gui/editor_object_selector.h
@@ -36,12 +36,14 @@
 #include "scene/gui/texture_rect.h"
 
 class EditorSelectionHistory;
+class MarginContainer;
 
 class EditorObjectSelector : public Button {
 	GDCLASS(EditorObjectSelector, Button);
 
 	EditorSelectionHistory *history = nullptr;
 
+	MarginContainer *main_mc = nullptr;
 	TextureRect *current_object_icon = nullptr;
 	Label *current_object_label = nullptr;
 	TextureRect *sub_objects_icon = nullptr;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/122490

## Additional information

After fix:

[Screencast_20260817_183343.webm](https://github.com/user-attachments/assets/5d052d5b-5a47-4bc8-939a-329cdbdebedf)

This does introduce a bit of a jump if you switch between a resource and a node:

[Screencast_20260817_183411.webm](https://github.com/user-attachments/assets/f5f995c6-5ba8-498f-a52b-807abfb3a586)
