### PR TITLE
Document `OS.get_processor_count()` possibly returning a lower value on Web

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -465,7 +465,8 @@
 		<method name="get_processor_count" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the number of [i]logical[/i] CPU cores available on the host machine. On CPUs with HyperThreading enabled, this number will be greater than the number of [i]physical[/i] CPU cores.
+				Returns the number of [i]logical[/i] CPU cores available on the host machine. On CPUs with HyperThreading or SMT enabled, this number will be greater than the number of [i]physical[/i] CPU cores.
+				[b]Note:[/b] On the Web platform, the value returned by [method get_processor_count] is limited to [code]2[/code] at most.
 			</description>
 		</method>
 		<method name="get_processor_name" qualifiers="const">


### PR DESCRIPTION
On Firefox 153 and Chromium 151 on Linux, `OS.get_processor_count()` returns `2` on a Ryzen 9 9950X3D (16 cores/32 threads), while it returns `32` natively on Linux.

This also adds a mention of SMT in the description (the AMD counterpart to Intel's HyperThreading, which works in a similar fashion).

I noticed this while working on https://github.com/godotengine/godot-demo-projects/pull/1332.
