### PR TITLE
visionOS XR module: Fix error when using MSAA on visionOS

### DIFF
--- a/modules/visionos_xr/visionos_xr_interface.mm
+++ b/modules/visionos_xr/visionos_xr_interface.mm
@@ -563,7 +563,7 @@ RID VisionOSXRInterface::RenderThread::get_depth_texture() {
 			MTL::texture_type_from_metal(depth_texture.textureType),
 			pixel_formats->getDataFormat((MTL::PixelFormat)depth_texture.pixelFormat),
 			MTL::texture_samples_from_metal(depth_texture.sampleCount),
-			RD::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | RD::TEXTURE_USAGE_SAMPLING_BIT,
+			RD::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_DEPTH_RESOLVE_ATTACHMENT_BIT,
 			(uint64_t)depth_texture,
 			depth_texture.width,
 			depth_texture.height,


### PR DESCRIPTION
## What problem does this PR solve?

This PR fixes an error when using MSAA on Apple Vision Pro.
Before this fix, using MSAA leads to the app rendering black/transparent, and the following error being printed:
```
servers/rendering/rendering_device.cpp:3325:_render_pass_create(): Invalid framebuffer depth resolve format attachment(4), in pass (0), it's marked as depth, but it's not a depth resolve attachment. Condition "!(p_attachments[attachment].usage_flags & TEXTURE_USAGE_DEPTH_RESOLVE_ATTACHMENT_BIT)" is true. Returning: RDD::RenderPassID()
```

## Additional information

This PR is a follow-up to https://github.com/godotengine/godot/pull/120231

I tested it by:
1. cloning one of the XR [godot-demo-projects](https://github.com/godotengine/godot-demo-projects/tree/master/xr) (such as [openxr_origin_centric_movement](https://github.com/godotengine/godot-demo-projects/tree/master/xr/openxr_origin_centric_movement))
2. modifying it to use the "visionOS" XRInterface
3. toggling anti-aliasing in the project settings

Here are the results:
| | Without MSAA | With MSAA |
| - | - | - |
| Project Settings | <img width="914" height="209" alt="Settings no MSAA" src="https://github.com/user-attachments/assets/ae8ad5d1-dcfc-4bc9-85fe-854255e7f017" /> | <img width="914" height="209" alt="Settings with MSAA" src="https://github.com/user-attachments/assets/13684659-92cf-468a-a7fa-53107c7545eb" /> |
| Metal GPU capture | <img width="1113" height="686" alt="GPU Capture no MSAA" src="https://github.com/user-attachments/assets/75e8b5f7-43e2-403a-a34a-803936b31fbc" /> | <img width="1223" height="908" alt="GPU Capture MSAA" src="https://github.com/user-attachments/assets/2e183806-7bed-4e58-bde6-5d037d0b256f" /> |