### PR TITLE
Fix multiple visual inconsistencies/nitpicks within the editor

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -236,12 +236,6 @@ void EditorDebuggerNode::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("breakpoints_cleared_in_tree", PropertyInfo(Variant::INT, "debugger")));
 }
 
-void EditorDebuggerNode::update_layout(EditorDock::DockLayout p_layout, int p_slot) {
-	_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
-		dbg->update_layout(p_layout, p_slot);
-	});
-}
-
 void EditorDebuggerNode::register_undo_redo(UndoRedo *p_undo_redo) {
 	p_undo_redo->set_method_notify_callback(_methods_changed, this);
 	p_undo_redo->set_property_notify_callback(_properties_changed, this);

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -163,8 +163,6 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	virtual void update_layout(EditorDock::DockLayout p_layout, int p_slot) override;
-
 public:
 	static EditorDebuggerNode *get_singleton() { return singleton; }
 	void register_undo_redo(UndoRedo *p_undo_redo);

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -81,6 +81,7 @@ void EditorVisualProfiler::add_frame_metric(const Metric &p_metric) {
 
 	updating_frame = true;
 	clear_button->set_disabled(false);
+	cursor_metric_edit->set_editable(true);
 	cursor_metric_edit->set_max(frame_metrics[last_metric].frame_number);
 	cursor_metric_edit->set_min(MAX(int64_t(frame_metrics[last_metric].frame_number) - frame_metrics.size(), 0));
 
@@ -122,6 +123,7 @@ void EditorVisualProfiler::clear() {
 	cursor_metric_edit->set_min(0);
 	cursor_metric_edit->set_max(0);
 	cursor_metric_edit->set_value(0);
+	cursor_metric_edit->set_editable(false);
 	updating_frame = false;
 	hover_metric = -1;
 	seeking = false;
@@ -848,6 +850,7 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	cursor_metric_edit = memnew(SpinBox);
 	cursor_metric_edit->set_accessibility_name(TTRC("Frame #:"));
 	cursor_metric_edit->set_h_size_flags(SIZE_FILL);
+	cursor_metric_edit->set_editable(false);
 	hb_frame->add_child(cursor_metric_edit);
 	cursor_metric_edit->connect(SceneStringName(value_changed), callable_mp(this, &EditorVisualProfiler::_cursor_metric_changed));
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -2115,16 +2115,6 @@ void ScriptEditorDebugger::toggle_profiler(const String &p_profiler, bool p_enab
 	_put_msg("profiler:" + p_profiler, msg_data);
 }
 
-void ScriptEditorDebugger::update_layout(EditorDock::DockLayout p_layout, int p_slot) {
-	if (p_slot != EditorDock::DOCK_SLOT_BOTTOM) {
-		vmem_mc->set_theme_type_variation("NoBorderHorizontalBottom");
-		vmem_tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_DISABLED);
-	} else {
-		vmem_mc->set_theme_type_variation("NoBorderHorizontal");
-		vmem_tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTTOM);
-	}
-}
-
 ScriptEditorDebugger::ScriptEditorDebugger() {
 	if (unlikely(parse_message_handlers.is_empty())) {
 		_init_parse_message_handlers();
@@ -2427,14 +2417,13 @@ Instead, use the monitors tab to obtain more precise VRAM usage.
 		vmem_hb->add_child(vmem_refresh);
 		vmem_export = memnew(Button);
 		vmem_export->set_theme_type_variation(SceneStringName(FlatButton));
-		vmem_export->set_tooltip_text(TTRC("Export list to a CSV file"));
+		vmem_export->set_tooltip_text(TTRC("Export List to a CSV File"));
 		vmem_hb->add_child(vmem_export);
 		vmem_vb->add_child(vmem_hb);
 		vmem_refresh->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::_video_mem_request));
 		vmem_export->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::_video_mem_export));
 
 		vmem_mc = memnew(MarginContainer);
-		vmem_mc->set_theme_type_variation("NoBorderHorizontal");
 		vmem_mc->set_v_size_flags(SIZE_EXPAND_FILL);
 		vmem_vb->add_child(vmem_mc);
 
@@ -2454,11 +2443,11 @@ Instead, use the monitors tab to obtain more precise VRAM usage.
 		vmem_tree->set_column_title(3, TTRC("Usage"));
 		vmem_tree->set_column_custom_minimum_width(3, 80 * EDSCALE);
 		vmem_tree->set_hide_root(true);
-		vmem_tree->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTTOM);
 		vmem_mc->add_child(vmem_tree);
 		vmem_tree->set_allow_rmb_select(true);
 		vmem_tree->connect("item_activated", callable_mp(this, &ScriptEditorDebugger::_vmem_item_activated));
 		vmem_tree->connect("item_mouse_selected", callable_mp(this, &ScriptEditorDebugger::_vmem_tree_rmb_selected));
+		vmem_tree->set_theme_type_variation("TreeSecondary");
 		tabs->add_child(vmem_vb);
 
 		vmem_item_menu = memnew(PopupMenu);

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -397,8 +397,6 @@ public:
 	void send_message(const String &p_message, const Array &p_args);
 	void toggle_profiler(const String &p_profiler, bool p_enable, const Array &p_data);
 
-	void update_layout(EditorDock::DockLayout p_layout, int p_slot);
-
 	ScriptEditorDebugger();
 	~ScriptEditorDebugger();
 };

--- a/editor/docks/import_dock.cpp
+++ b/editor/docks/import_dock.cpp
@@ -45,6 +45,7 @@
 #include "editor/themes/editor_scale.h"
 #include "editor/themes/editor_theme_manager.h"
 #include "scene/gui/box_container.h"
+#include "scene/gui/rich_text_label.h"
 
 class ImportDockParameters : public Object {
 	GDCLASS(ImportDockParameters, Object);
@@ -158,7 +159,7 @@ void ImportDock::set_edit_path(const String &p_path) {
 	content->show();
 	select_a_resource->hide();
 
-	imported->set_text(p_path.get_file());
+	_update_imported(p_path.get_file(), p_path);
 }
 
 void ImportDock::_add_keep_import_option(const String &p_importer_name) {
@@ -349,7 +350,7 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 	content->show();
 	select_a_resource->hide();
 
-	imported->set_text(vformat(TTR("%d Files"), p_paths.size()));
+	_update_imported(vformat(TTR("%d Files"), p_paths.size()), p_paths.size() == 1 ? p_paths[0] : String());
 
 	if (params->paths.size() == 1 && params->importer->has_advanced_options()) {
 		advanced->show();
@@ -527,6 +528,19 @@ static bool _find_owners(EditorFileSystemDirectory *efsd, const String &p_path) 
 	}
 
 	return false;
+}
+
+void ImportDock::_update_imported(const String &p_text, const String &p_path) {
+	imported->clear();
+
+	if (!p_path.is_empty()) {
+		String type = EditorFileSystem::get_singleton()->get_file_type(p_path);
+		Ref<Texture2D> icon = has_theme_icon(type, EditorStringName(EditorIcons)) ? get_editor_theme_icon(type) : get_editor_theme_icon(SNAME("File"));
+		imported->add_image(icon);
+		imported->add_text("  ");
+	}
+
+	imported->add_text(p_text);
 }
 
 void ImportDock::_reimport_pressed() {
@@ -761,10 +775,9 @@ ImportDock::ImportDock() {
 	main_vb->add_child(content);
 	content->hide();
 
-	imported = memnew(Label);
+	imported = memnew(RichTextLabel);
 	imported->set_focus_mode(FOCUS_ACCESSIBILITY);
-	imported->add_theme_style_override(CoreStringName(normal), EditorNode::get_singleton()->get_editor_theme()->get_stylebox(CoreStringName(normal), SNAME("LineEdit")));
-	imported->set_clip_text(true);
+	imported->set_fit_content(true);
 	content->add_child(imported);
 	HBoxContainer *hb = memnew(HBoxContainer);
 	content->add_margin_child(TTRC("Import As:"), hb);

--- a/editor/docks/import_dock.h
+++ b/editor/docks/import_dock.h
@@ -40,12 +40,13 @@
 #include "scene/gui/popup_menu.h"
 
 class ImportDockParameters;
+class RichTextLabel;
 class VBoxContainer;
 
 class ImportDock : public EditorDock {
 	GDCLASS(ImportDock, EditorDock);
 
-	Label *imported = nullptr;
+	RichTextLabel *imported = nullptr;
 	OptionButton *import_as = nullptr;
 	MenuButton *preset = nullptr;
 	EditorInspector *import_opts = nullptr;
@@ -69,6 +70,7 @@ class ImportDock : public EditorDock {
 	void _update_options(const String &p_path, const Ref<ConfigFile> &p_config = Ref<ConfigFile>());
 	void _update_preset_menu();
 	void _add_keep_import_option(const String &p_importer_name);
+	void _update_imported(const String &p_text, const String &p_path);
 
 	void _property_edited(const StringName &p_prop);
 	void _property_toggled(const StringName &p_prop, bool p_checked);

--- a/editor/export/project_export.cpp
+++ b/editor/export/project_export.cpp
@@ -128,6 +128,8 @@ void ProjectExportDialog::_notification(int p_what) {
 			export_error->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("error_color"), EditorStringName(Editor)));
 			export_error2->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("error_color"), EditorStringName(Editor)));
 			export_warning->add_theme_color_override(SceneStringName(font_color), EditorNode::get_singleton()->get_editor_theme()->get_color(SNAME("warning_color"), EditorStringName(Editor)));
+
+			add_preset->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 		} break;
 
 		case NOTIFICATION_TRANSLATION_CHANGED: {
@@ -1610,7 +1612,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	preset_vb->add_child(preset_hb);
 
 	add_preset = memnew(MenuButton);
-	add_preset->set_text(TTRC("Add..."));
+	add_preset->set_text(TTRC("Add"));
 	add_preset->get_popup()->connect("index_pressed", callable_mp(this, &ProjectExportDialog::_add_preset));
 	preset_hb->add_child(add_preset);
 	MarginContainer *mc = memnew(MarginContainer);

--- a/editor/gui/editor_object_selector.cpp
+++ b/editor/gui/editor_object_selector.cpp
@@ -215,6 +215,7 @@ EditorObjectSelector::EditorObjectSelector(EditorSelectionHistory *p_history) {
 	add_child(main_mc);
 
 	HBoxContainer *main_hb = memnew(HBoxContainer);
+	main_hb->add_theme_constant_override("separation", 0);
 	main_mc->add_child(main_hb);
 
 	current_object_icon = memnew(TextureRect);

--- a/editor/run/run_instances_dialog.cpp
+++ b/editor/run/run_instances_dialog.cpp
@@ -318,12 +318,14 @@ RunInstancesDialog::RunInstancesDialog() {
 	{
 		Label *l = memnew(Label);
 		l->set_text(TTR("Main Run Args:"));
+		l->set_theme_type_variation("HeaderSmall");
 		main_gc->add_child(l);
 	}
 
 	{
 		Label *l = memnew(Label);
 		l->set_text(TTR("Main Feature Tags:"));
+		l->set_theme_type_variation("HeaderSmall");
 		main_gc->add_child(l);
 	}
 

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -1187,17 +1187,19 @@ void ScriptEditor::_update_recent_scripts() {
 	Array rc = EditorSettings::get_singleton()->get_project_metadata("recent_files", config_section, Array());
 	recent_scripts->clear();
 
-	String path;
-	for (int i = 0; i < rc.size(); i++) {
-		path = rc[i];
-		recent_scripts->add_item(path.replace("res://", ""));
+	if (rc.is_empty()) {
+		recent_scripts->add_item(TTRC("No Recent Documents"), -1);
+		recent_scripts->set_item_disabled(-1, true);
+	} else {
+		for (const String path : rc) {
+			recent_scripts->add_item(path.replace("res://", ""));
+		}
+
+		recent_scripts->add_separator();
+		recent_scripts->add_shortcut(ED_GET_SHORTCUT("script_editor/clear_recent"));
 	}
 
-	recent_scripts->add_separator();
-	recent_scripts->add_shortcut(ED_GET_SHORTCUT("script_editor/clear_recent"));
 	recent_scripts->set_item_auto_translate_mode(-1, AUTO_TRANSLATE_MODE_ALWAYS);
-	recent_scripts->set_item_disabled(-1, rc.is_empty());
-
 	recent_scripts->reset_size();
 }
 

--- a/editor/settings/editor_build_profile.cpp
+++ b/editor/settings/editor_build_profile.cpp
@@ -44,7 +44,6 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/line_edit.h"
-#include "scene/gui/margin_container.h"
 #include "scene/gui/separator.h"
 
 #include "modules/modules_enabled.gen.h" // IWYU pragma: keep. For mono.
@@ -1376,13 +1375,15 @@ EditorBuildProfileManager::EditorBuildProfileManager() {
 	add_child(main_vbc);
 
 	HBoxContainer *path_hbc = memnew(HBoxContainer);
-	profile_label = memnew(Label);
+	profile_label = memnew(LineEdit);
 	path_hbc->add_child(profile_label);
 	profile_label->set_text(TTR("[Unsaved Profile]"));
-	profile_label->set_text_overrun_behavior(TextServer::OVERRUN_TRIM_ELLIPSIS);
+	profile_label->set_accessibility_name(TTRC("Current Profile:"));
+	profile_label->set_text(TTR("(none)"));
+	profile_label->set_editable(false);
+	profile_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	profile_label->set_accessibility_name(TTRC("Profile Path"));
 	profile_label->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
-	profile_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 
 	profile_actions[ACTION_NEW] = memnew(Button(TTRC("New/Unset")));
 	path_hbc->add_child(profile_actions[ACTION_NEW]);
@@ -1424,19 +1425,21 @@ EditorBuildProfileManager::EditorBuildProfileManager() {
 
 	main_vbc->add_margin_child(TTRC("Actions:"), profiles_hbc);
 
+	Label *cecp = memnew(Label(TTRC("Configure Engine Compilation Profile:")));
+	cecp->set_theme_type_variation("HeaderSmall");
+	main_vbc->add_child(cecp);
+
+	// It will be displayed once the user creates or chooses a profile.
 	class_list = memnew(Tree);
 	class_list->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	class_list->set_hide_root(true);
 	class_list->set_edit_checkbox_cell_only_when_checkbox_is_pressed(true);
-	class_list->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTH);
+	class_list->set_theme_type_variation("TreeSecondary");
+	class_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	class_list->connect("cell_selected", callable_mp(this, &EditorBuildProfileManager::_class_list_item_selected));
 	class_list->connect("item_edited", callable_mp(this, &EditorBuildProfileManager::_class_list_item_edited), CONNECT_DEFERRED);
 	class_list->connect("item_collapsed", callable_mp(this, &EditorBuildProfileManager::_class_list_item_collapsed));
-
-	// It will be displayed once the user creates or chooses a profile.
-	MarginContainer *mc = main_vbc->add_margin_child(TTRC("Configure Engine Compilation Profile:"), class_list, true);
-	mc->set_theme_type_variation("NoBorderHorizontalWindow");
-	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	main_vbc->add_child(class_list);
 
 	description_bit = memnew(EditorHelpBit);
 	description_bit->set_content_height_limits(80 * EDSCALE, 80 * EDSCALE);

--- a/editor/settings/editor_build_profile.h
+++ b/editor/settings/editor_build_profile.h
@@ -33,6 +33,7 @@
 #include "core/object/ref_counted.h"
 #include "editor/doc/editor_help.h"
 #include "scene/gui/dialogs.h"
+#include "scene/gui/line_edit.h"
 #include "scene/gui/tree.h"
 
 class EditorBuildProfile : public RefCounted {
@@ -168,7 +169,7 @@ class EditorBuildProfileManager : public AcceptDialog {
 	EditorFileDialog *import_profile = nullptr;
 	EditorFileDialog *export_profile = nullptr;
 
-	Label *profile_label = nullptr;
+	LineEdit *profile_label = nullptr;
 	String profile_path;
 
 	LineEdit *force_detect_classes = nullptr;

--- a/editor/settings/editor_layouts_dialog.cpp
+++ b/editor/settings/editor_layouts_dialog.cpp
@@ -37,7 +37,6 @@
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/item_list.h"
 #include "scene/gui/line_edit.h"
-#include "scene/gui/margin_container.h"
 
 void EditorLayoutsDialog::_validate_name() {
 	const String layout_name = name->get_text().strip_edges();
@@ -150,18 +149,20 @@ EditorLayoutsDialog::EditorLayoutsDialog() {
 	validation->set_accept_button(get_ok_button());
 	validation->set_v_size_flags(0);
 
+	Label *lb = memnew(Label(TTRC("Select Existing Layout:")));
+	lb->set_theme_type_variation("HeaderSmall");
+	makevb->add_child(lb);
+
 	layout_names = memnew(ItemList);
 	layout_names->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
 	layout_names->set_allow_rmb_select(true);
-	layout_names->set_scroll_hint_mode(ItemList::SCROLL_HINT_MODE_BOTH);
+	layout_names->set_theme_type_variation("ItemListSecondary");
+	layout_names->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	layout_names->set_custom_minimum_size(Size2(300 * EDSCALE, 50 * EDSCALE));
 	layout_names->connect(SceneStringName(item_selected), callable_mp(validation, &EditorValidationPanel::update).unbind(1));
 	layout_names->connect("multi_selected", callable_mp(this, &EditorLayoutsDialog::_multi_selected).unbind(2)); // For deletion mode.
 	layout_names->connect("item_activated", callable_mp(this, &EditorLayoutsDialog::_item_activated).unbind(1));
-
-	MarginContainer *mc = makevb->add_margin_child(TTRC("Select Existing Layout:"), layout_names);
-	mc->set_custom_minimum_size(Size2(300 * EDSCALE, 50 * EDSCALE));
-	mc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	mc->set_theme_type_variation("NoBorderHorizontalWindow");
+	makevb->add_child(layout_names);
 
 	name = memnew(LineEdit);
 	makevb->add_child(name);

--- a/editor/translations/localization_editor.cpp
+++ b/editor/translations/localization_editor.cpp
@@ -79,6 +79,13 @@ void LocalizationEditor::_notification(int p_what) {
 				tree->set_drop_mode_flags(Tree::DROP_MODE_DISABLED);
 			}
 		} break;
+
+		case NOTIFICATION_THEME_CHANGED: {
+			translation_button->set_button_icon(get_editor_theme_icon(SNAME("Add")));
+			translation_res_add_button->set_button_icon(get_editor_theme_icon(SNAME("Add")));
+			translation_res_option_add_button->set_button_icon(get_editor_theme_icon(SNAME("Add")));
+			translation_template_gen_button->set_button_icon(get_editor_theme_icon(SNAME("Add")));
+		} break;
 	}
 }
 
@@ -771,7 +778,8 @@ LocalizationEditor::LocalizationEditor() {
 		thb->add_spacer();
 		tvb->add_child(thb);
 
-		Button *addtr = memnew(Button(TTRC("Add...")));
+		Button *addtr = memnew(Button(TTRC("Add")));
+		translation_button = addtr;
 		addtr->connect(SceneStringName(pressed), callable_mp(this, &LocalizationEditor::_translation_file_open));
 		thb->add_child(addtr);
 
@@ -809,8 +817,9 @@ LocalizationEditor::LocalizationEditor() {
 		thb->add_spacer();
 		tvb->add_child(thb);
 
-		Button *addtr = memnew(Button(TTRC("Add...")));
+		Button *addtr = memnew(Button(TTRC("Add")));
 		addtr->connect(SceneStringName(pressed), callable_mp(this, &LocalizationEditor::_translation_res_file_open));
+		translation_res_add_button = addtr;
 		thb->add_child(addtr);
 
 		MarginContainer *mc = memnew(MarginContainer);
@@ -836,7 +845,7 @@ LocalizationEditor::LocalizationEditor() {
 		thb->add_spacer();
 		tvb->add_child(thb);
 
-		addtr = memnew(Button(TTRC("Add...")));
+		addtr = memnew(Button(TTRC("Add")));
 		addtr->connect(SceneStringName(pressed), callable_mp(this, &LocalizationEditor::_translation_res_option_file_open));
 		translation_res_option_add_button = addtr;
 		thb->add_child(addtr);
@@ -882,8 +891,9 @@ LocalizationEditor::LocalizationEditor() {
 		thb->add_spacer();
 		tvb->add_child(thb);
 
-		Button *addtr = memnew(Button(TTRC("Add...")));
+		Button *addtr = memnew(Button(TTRC("Add")));
 		addtr->connect(SceneStringName(pressed), callable_mp(this, &LocalizationEditor::_template_source_file_open));
+		translation_template_gen_button = addtr;
 		thb->add_child(addtr);
 
 		template_generate_button = memnew(Button(TTRC("Generate")));

--- a/editor/translations/localization_editor.h
+++ b/editor/translations/localization_editor.h
@@ -45,7 +45,10 @@ class LocalizationEditor : public VBoxContainer {
 	EditorLocaleDialog *locale_select = nullptr;
 	EditorFileDialog *translation_file_open = nullptr;
 
+	Button *translation_button = nullptr;
+	Button *translation_res_add_button = nullptr;
 	Button *translation_res_option_add_button = nullptr;
+	Button *translation_template_gen_button = nullptr;
 	EditorFileDialog *translation_res_file_open_dialog = nullptr;
 	EditorFileDialog *translation_res_option_file_open_dialog = nullptr;
 	Tree *translation_remap = nullptr;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Fixes multiple visual inconsistencies/nitpicks within the editor.

## Additional information

> [!NOTE]
> This PR is just a big list of changes, and can be separated if wanted. Individual changes can also be rejected, and I will remove them from this PR. Most, if not all, of these are self-contained though.

## Import Dock
- [x] Added icon to import header

| Before | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/dc6baef7-3749-4845-b7c2-3ee0d865c0b1)  | ![image](https://github.com/user-attachments/assets/6e3744f0-f9a1-4de9-a922-b432e1e3f85f) |

## Visual Profiler
- [x] Disable Frame # selector if profiler is not active (_matches Profiler_)

| Before | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/51516919-10be-4a0c-aec3-2212952cd8e9)  | ![image](https://github.com/user-attachments/assets/ebe0b13b-50f0-48b1-a541-5f496e5cf342) |

## Video RAM
- [x] Use `TreeSecondary` styling for Tree

| Before | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/913c48fd-b084-4705-8f40-856870521e77)  | ![image](https://github.com/user-attachments/assets/a14d412d-ec16-46b7-b277-3f190504dc0c) |

## Editor Layout
- [x] Use `ItemListSecondary` styling for ItemList

| Before | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/41ffc351-ba82-465a-bc19-03f2f0ff328b)  | ![image](https://github.com/user-attachments/assets/85d3ab37-11c0-4476-9ad5-c029d0fdbe0f) |

## Script Editor
- [x] Show "No Recent Scripts" instead of separator and redundant clear

| Before | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/906da71e-7ff9-4af9-9af8-50fead0bfe80)  | ![image](https://github.com/user-attachments/assets/2f38dab2-c9ea-4669-b5e9-3b8372e19549) |

## Edit Compilation Configuration Profile
- [x] Change Profile label to use a disabled LineEdit (_similar to `Manage Editor Feature Profiles`_)
- [x] Use `TreeSecondary` styling for Tree

| Before | After |
| ------------- | ------------- |
| ![image](https://github.com/user-attachments/assets/92d57651-eea8-4e3e-a290-8aa55d477354)  | ![image](https://github.com/user-attachments/assets/daa5d31f-8c0a-4e82-a288-dac4e28a85ee) |

## Misc
- [ ] ~Update various headers to add an ":" to the end of the text, reflecting how other headers are displayed~
- [x] Decrease separation width between icon and text in Inspector object selector
- [x] Update "Add..." buttons to be "+ Add" with an icon (_matches other similar buttons_)