### PR TITLE
GDScript: Expand `UNREACHABLE_CODE` to all unreachable statements and use LSP to style as faded

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2024,6 +2024,19 @@ GDScriptParser::SuiteNode *GDScriptParser::parse_suite(const String &p_context, 
 
 	} while ((multiline || previous.type == GDScriptTokenizer::Token::SEMICOLON) && !check(GDScriptTokenizer::Token::DEDENT) && !lambda_ended && !is_at_end());
 
+#ifdef DEBUG_ENABLED
+	if (current_suite->unreachable_code_start) {
+		Node *unreachable_start = current_suite->unreachable_code_start;
+		Node *unreachable_end = suite->statements[suite->statements.size() - 1];
+		push_warning(
+				unreachable_start->start_line,
+				unreachable_start->start_column,
+				unreachable_end->end_line,
+				unreachable_end->end_column,
+				GDScriptWarning::UNREACHABLE_CODE,
+				current_function->identifier ? current_function->identifier->name : "<anonymous lambda>");
+	}
+#endif // DEBUG_ENABLED
 	complete_extents(suite);
 
 	if (multiline) {
@@ -2244,7 +2257,12 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 	if (unreachable && result != nullptr) {
 		current_suite->has_unreachable_code = true;
 		if (current_function) {
-			push_warning(result, GDScriptWarning::UNREACHABLE_CODE, current_function->identifier ? current_function->identifier->name : "<anonymous lambda>");
+			// Store where the unreachable code begins for this suite,
+			// but hold off on emitting the warning until we also know where
+			// the unreachable code ends.
+			if (current_suite->unreachable_code_start == nullptr) {
+				current_suite->unreachable_code_start = result;
+			}
 		}
 	}
 #endif

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1202,6 +1202,7 @@ public:
 		FunctionNode *parent_function = nullptr;
 		IfNode *parent_if = nullptr;
 
+		Node *unreachable_code_start = nullptr;
 		bool has_return = false;
 		bool has_continue = false;
 		bool has_unreachable_code = false; // Just so warnings aren't given more than once per block.

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -85,6 +85,10 @@ void ExtendGDScriptParser::update_diagnostics() {
 		diagnostic.source = "gdscript";
 		diagnostic.code = warning.get_name();
 
+		if (warning.code == GDScriptWarning::UNREACHABLE_CODE) {
+			diagnostic.tags.append(LSP::DiagnosticTag::Unnecessary);
+		}
+
 		GodotRange godot_range(
 				GodotPosition(warning.start_line, warning.start_column),
 				GodotPosition(warning.end_line, warning.end_column));

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -732,6 +732,27 @@ static const int Hint = 4;
 }; // namespace DiagnosticSeverity
 
 /**
+ * The diagnostic tags.
+ *
+ * @since 3.15.0
+ */
+namespace DiagnosticTag {
+/**
+ * Unused or unnecessary code.
+ *
+ * Clients are allowed to render diagnostics with this tag faded out
+ * instead of having an error squiggle.
+ */
+static const int Unnecessary = 1;
+/**
+ * Deprecated or obsolete code.
+ *
+ * Clients are allowed to rendered diagnostics with this tag strike through.
+ */
+static const int Deprecated = 2;
+}; // namespace DiagnosticTag
+
+/**
  * Represents a related message and source code location for a diagnostic. This should be
  * used to point to code locations that cause or related to a diagnostics, e.g when duplicating
  * a symbol in a scope.
@@ -788,6 +809,14 @@ struct Diagnostic {
 	String message;
 
 	/**
+	 * Additional metadata about the diagnostic.
+	 *
+	 * @since 3.15.0
+	 */
+	// Note: Uses DiagnosticTag namespace values.
+	Vector<int> tags;
+
+	/**
 	 * An array of related diagnostic information, e.g. when symbol-names within
 	 * a scope collide all definitions can be marked via this property.
 	 */
@@ -807,6 +836,14 @@ struct Diagnostic {
 				arr[i] = relatedInformation[i].to_json();
 			}
 			dict["relatedInformation"] = arr;
+		}
+		if (!tags.is_empty()) {
+			Array arr;
+			arr.resize(tags.size());
+			for (int i = 0; i < tags.size(); i++) {
+				arr[i] = tags[i];
+			}
+			dict["tags"] = arr;
 		}
 		return dict;
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/15393

## Additional information

With this PR, the `UNREACHABLE_CODE` warning in GDScript covers _all_ statements which are deemed unreachable (i.e., after a `return`), not just the first statement. Furthermore, the LSP sends a special indicator for the warning so that external IDEs can mark it as "unnecessary". For example, here in VS Code, the unreachable code is displayed faded out.

| Without PR | With PR |
| ----------- | -------- |
| <img width="566" height="486" alt="Image" src="https://github.com/user-attachments/assets/4a6eef37-adb9-4134-9b01-b8139824bb29" /> | <img width="558" height="485" alt="Image" src="https://github.com/user-attachments/assets/4f206eb7-07fd-4414-9b81-5ea3e46e0e2e" /> |

> [!note]
> I'm not _thrilled_ about the way the warning squiggles look in the "with PR" example.
> Pylance with VS Code displays unreachable code as faded out, but without warning squiggles:
> <img width="417" height="149" alt="CleanShot 2026-08-17 at 18 18 35@2x" src="https://github.com/user-attachments/assets/d442fdc5-e723-4273-85a7-32dc7bdf71bc" />
> However, it does _not_ consider this as a "warning" and display it in the "Problems" list. Overall, I think it would probably be best to keep it the way that the "With PR" version looks.


> [!note]
> The "faded-out code" effect is currently _not_ supported by Godot's built-in script editor. Since the warning range for `UNREACHABLE_CODE` is changed on the analyzer side, that will be visible as regular warning squiggles just like any other warning. I would like to implement the "faded-out code" effect for the built-in editor, but I think that can be done in a separate PR.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
