### PR TITLE
Allow making a node scene-unique with % anywhere in name when renaming

### DIFF
--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -1626,11 +1626,11 @@ void SceneTreeEditor::rename_node(Node *p_node, const String &p_name, TreeItem *
 		item = _find(tree->get_root(), p_node->get_path());
 	}
 	ERR_FAIL_NULL(item);
-	bool check_for_unique_name_token = !p_name.is_empty() && p_name[0] == '%';
+	bool check_for_unique_name_token = !p_name.is_empty() && p_name.contains_char('%');
 	String substr_name = p_name;
 
 	if (check_for_unique_name_token) {
-		substr_name = p_name.substr(1);
+		substr_name = p_name.remove_char('%');
 
 		// No need to do anything else with this if already unique.
 		if (p_node->is_unique_name_in_owner()) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/15399

## Additional information

This PR implements the behavior in the above proposal. Including a `%` anywhere in a node's new name when renaming it in the editor makes the node scene-unique (previously, the `%` had to be the first character).

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
