### PR TITLE
[macOS/CI] Disable `fatal_warnings` linker flag for x86-64 macOS build.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1002,7 +1002,11 @@ else:  # GCC, Clang
 
     if env["werror"]:
         env.AppendUnique(CCFLAGS=["-Werror"])
-        env.AppendUnique(LINKFLAGS=["-Wl,--fatal-warnings" if env["platform"] != "macos" else "-Wl,-fatal_warnings"])
+        if env["platform"] != "macos":
+            env.AppendUnique(LINKFLAGS=["-Wl,--fatal-warnings"])
+        elif env["arch"] != "x86_64":
+            # Disabled for x86-64 macOS build due to MoltenVK min. target version mismatch.
+            env.AppendUnique(LINKFLAGS=["-Wl,-fatal_warnings"])
 
 if hasattr(detect, "get_program_suffix"):
     suffix = "." + detect.get_program_suffix()

--- a/misc/dist/macos/editor_info_plist.template
+++ b/misc/dist/macos/editor_info_plist.template
@@ -40,12 +40,12 @@
 	<string>NSApplication</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
-	<key>LSMinimumSystemVersion</key>
-	<string>10.12</string>
 	<key>LSMinimumSystemVersionByArchitecture</key>
 	<dict>
+		<key>arm64</key>
+		<string>13.0</string>
 		<key>x86_64</key>
-		<string>10.12</string>
+		<string>11.0</string>
 	</dict>
 	<key>NSHighResolutionCapable</key>
 	<true/>


### PR DESCRIPTION
## What problem(s) does this PR solve?

- CI build fails, since MoltenVK bumped min. version to 12.0.

## Additional information

Also updates versions in the `editor_info_plist.template` (used by bundle generator) to match editor template.