### PR TITLE
Bump minimum macOS version to 12

### DIFF
--- a/misc/dist/macos/editor_info_plist.template
+++ b/misc/dist/macos/editor_info_plist.template
@@ -45,7 +45,7 @@
 		<key>arm64</key>
 		<string>13.0</string>
 		<key>x86_64</key>
-		<string>11.0</string>
+		<string>12.0</string>
 	</dict>
 	<key>NSHighResolutionCapable</key>
 	<true/>

--- a/misc/dist/macos_tools.app/Contents/Info.plist
+++ b/misc/dist/macos_tools.app/Contents/Info.plist
@@ -52,7 +52,7 @@
 		<key>arm64</key>
 		<string>13.0</string>
 		<key>x86_64</key>
-		<string>11.0</string>
+		<string>12.0</string>
 	</dict>
 	<key>NSHighResolutionCapable</key>
 	<true/>

--- a/modules/camera/camera_apple.mm
+++ b/modules/camera/camera_apple.mm
@@ -483,7 +483,9 @@ void CameraApple::update_feeds() {
 	if (@available(macOS 14.0, *)) {
 		session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternal, AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeContinuityCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 		session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternalUnknown, AVCaptureDeviceTypeBuiltInWideAngleCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
+#endif
 	}
 	devices = session.devices;
 #endif // APPLE_EMBEDDED_ENABLED

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -120,7 +120,7 @@ def configure(env: "SConsEnvironment"):
             print_error("Building for iOS with 'arch=x86_64' requires 'simulator=yes'.")
             sys.exit(255)
 
-        env["ENV"]["MACOSX_DEPLOYMENT_TARGET"] = "11.0"
+        env["ENV"]["MACOSX_DEPLOYMENT_TARGET"] = "12.0"
         env.Append(
             CCFLAGS=(
                 "-fobjc-arc -arch x86_64"

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -110,10 +110,10 @@ def configure(env: "SConsEnvironment"):
         env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=13.0"])
         env.Append(LINKFLAGS=["-arch", "arm64", "-mmacosx-version-min=13.0"])
     elif env["arch"] == "x86_64":
-        print("Building for macOS 11.0+.")
-        env.Append(ASFLAGS=["-arch", "x86_64", "-mmacosx-version-min=11.0"])
-        env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=11.0"])
-        env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=11.0"])
+        print("Building for macOS 12.0+.")
+        env.Append(ASFLAGS=["-arch", "x86_64", "-mmacosx-version-min=12.0"])
+        env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=12.0"])
+        env.Append(LINKFLAGS=["-arch", "x86_64", "-mmacosx-version-min=12.0"])
 
     env.Append(CCFLAGS=["-ffp-contract=off"])
     env.Append(CCFLAGS=["-fobjc-arc", "-fvisibility=hidden"])

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -490,7 +490,7 @@ void EditorExportPlatformMacOS::get_export_options(List<ExportOption> *r_options
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/version", PROPERTY_HINT_PLACEHOLDER_TEXT, "Leave empty to use project version"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/copyright"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::DICTIONARY, "application/copyright_localized", PROPERTY_HINT_LOCALIZABLE_STRING), Dictionary()));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/min_macos_version_x86_64"), "11.00"));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/min_macos_version_x86_64"), "12.00"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/min_macos_version_arm64"), "13.00"));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/export_angle", PROPERTY_HINT_ENUM, "Auto,Yes,No"), 0, true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "display/high_res"), true));

--- a/platform/macos/godot_application.mm
+++ b/platform/macos/godot_application.mm
@@ -169,6 +169,11 @@ GodotApplication *GodotApp = nil;
 	}
 }
 
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
+// This option was deprecated in macOS 14.0, replace it with 0 (no options) when min version is 14.0 or higher.
+#define NSApplicationActivateIgnoringOtherApps 0
+#endif
+
 - (void)forceUnbundledWindowActivationHackStep1 {
 	// Step 1: Switch focus to macOS SystemUIServer process.
 	// Required to perform step 2, TransformProcessType will fail if app is already the in focus.
@@ -192,5 +197,9 @@ GodotApplication *GodotApp = nil;
 	// Step 3: Switch focus back to app window.
 	[[NSRunningApplication currentApplication] activateWithOptions:NSApplicationActivateIgnoringOtherApps];
 }
+
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
+#undef NSApplicationActivateIgnoringOtherApps
+#endif
 
 @end

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -933,11 +933,7 @@ String OS_MacOS::get_unique_id() const {
 	static String serial_number;
 
 	if (serial_number.is_empty()) {
-#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
-		io_service_t platform_expert = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("IOPlatformExpertDevice"));
-#else
 		io_service_t platform_expert = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("IOPlatformExpertDevice"));
-#endif
 		CFStringRef serial_number_cf_string = nullptr;
 		if (platform_expert) {
 			serial_number_cf_string = (CFStringRef)IORegistryEntryCreateCFProperty(platform_expert, CFSTR(kIOPlatformSerialNumberKey), kCFAllocatorDefault, 0);

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -933,7 +933,7 @@ String OS_MacOS::get_unique_id() const {
 	static String serial_number;
 
 	if (serial_number.is_empty()) {
-#if defined(__x86_64) || defined(__x86_64__)
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 		io_service_t platform_expert = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("IOPlatformExpertDevice"));
 #else
 		io_service_t platform_expert = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("IOPlatformExpertDevice"));


### PR DESCRIPTION

## What problem(s) does this PR solve?

This PR bumps the minimum macOS version to 12, which is required to fix compatibility with the new Vulkan SDK.

This PR fixes `kIOMasterPortDefault`, allowing compiling with the min version set to macOS 12.

I also checked ahead a bit, and included a fix to `NSApplicationActivateIgnoringOtherApps` and a fix to `AVCaptureDeviceTypeExternalUnknown` for compiling with the min version set to macOS 14.

Going further to macOS 15 will be a challenge, due to `CGWindowListCreateImageFromArray` being deprecated without a trivial replacement in macOS 15. This will require migration to `ScreenCaptureKit`.

## Additional information

See PR #122523 for a different fix that disables warnings. I made this commit before that PR was opened.

None of the code is AI generated. I did ask AI to review my work, and it pointed out that `editor_info_plist.template` could also have its version bumped. I decided to include that in this PR.