### PR TITLE
`BVH` - std::signbit optimization

### DIFF
--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -206,45 +206,49 @@ struct BVH_ABB {
 	}
 
 	bool intersects_point(const POINT &p_pt) const {
-		if (_any_lessthan(-p_pt, neg_max)) {
-			return false;
+		POINT diff_max = -p_pt - neg_max;
+		POINT diff_min = p_pt - min;
+		bool result = true;
+		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
+			result &= !std::signbit(diff_max[axis]);
+			result &= !std::signbit(diff_min[axis]);
 		}
-		if (_any_lessthan(p_pt, min)) {
-			return false;
-		}
-		return true;
+		return result;
 	}
 
 	// Very hot in profiling, make sure optimized
 	bool intersects(const BVH_ABB &p_o) const {
-		if (_any_morethan(p_o.min, -neg_max)) {
-			return false;
+		POINT diff_max = -neg_max - p_o.min;
+		POINT diff_min = -p_o.neg_max - min;
+		bool result = true;
+		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
+			result &= !std::signbit(diff_max[axis]);
+			result &= !std::signbit(diff_min[axis]);
 		}
-		if (_any_morethan(min, -p_o.neg_max)) {
-			return false;
-		}
-		return true;
+		return result;
 	}
 
 	// for pre-swizzled tester (this object)
 	bool intersects_swizzled(const BVH_ABB &p_o) const {
-		if (_any_lessthan(min, p_o.min)) {
-			return false;
+		POINT diff_min = min - p_o.min;
+		POINT diff_max = neg_max - p_o.neg_max;
+		bool result = true;
+		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
+			result &= !std::signbit(diff_min[axis]);
+			result &= !std::signbit(diff_max[axis]);
 		}
-		if (_any_lessthan(neg_max, p_o.neg_max)) {
-			return false;
-		}
-		return true;
+		return result;
 	}
 
 	bool is_other_within(const BVH_ABB &p_o) const {
-		if (_any_lessthan(p_o.neg_max, neg_max)) {
-			return false;
+		POINT diff_max = p_o.neg_max - neg_max;
+		POINT diff_min = p_o.min - min;
+		bool result = true;
+		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
+			result &= !std::signbit(diff_max[axis]);
+			result &= !std::signbit(diff_min[axis]);
 		}
-		if (_any_lessthan(p_o.min, min)) {
-			return false;
-		}
-		return true;
+		return result;
 	}
 
 	void grow(const POINT &p_change) {
@@ -271,23 +275,5 @@ struct BVH_ABB {
 			neg_max[axis] = FLT_MAX;
 		}
 		min = neg_max;
-	}
-
-	bool _any_morethan(const POINT &p_a, const POINT &p_b) const {
-		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
-			if (p_a[axis] > p_b[axis]) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	bool _any_lessthan(const POINT &p_a, const POINT &p_b) const {
-		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
-			if (p_a[axis] < p_b[axis]) {
-				return true;
-			}
-		}
-		return false;
 	}
 };


### PR DESCRIPTION
This is a great optimization suggested by @Schnorg .
It makes the hot checks branchless using `std::signbit` instead of `if` branches.

Forward port of #122508

The compiler apparently isn't able to make the old `if` versions branchless by default (although it may be able to be forced to, using fast math flags).

The reason is that:
* original code has a quick exit which introduces control-flow dependency
* with branchless it does every axis, even if one fails (although this seems more expensive, it can work out cheaper because branchless)
* NaN and -0.0 must be treated as special cases for IEEE 754 in the old code
* the "cost heuristic" of doing the early exit is hard for the compiler to know _a priori_
 
## Notes
* The behaviour on the exact border (i.e. +0 and -0) could be different, however in practice the BVH uses margins so this shouldn't matter.
* This doesn't always seem to yield an obvious speedup, but seems to in e.g. physics when a lot of objects are overlapping.