### PR TITLE
Fix use-after-free by reordering members

### DIFF
--- a/modules/gdscript/gdscript_lambda_callable.h
+++ b/modules/gdscript/gdscript_lambda_callable.h
@@ -41,8 +41,11 @@ class GDScriptFunction;
 class GDScriptInstance;
 
 class GDScriptLambdaCallable : public CallableCustom {
-	GDScript::UpdatableFuncPtr function;
+	// `script` must have a longer lifetime than `function`.
+	// `~UpdatableFuncPtr()` locks the GDScript mutex it points to via a raw pointer.
+	// As members are destroyed in reverse order of declaration, the reference must be declared first.
 	Ref<GDScript> script;
+	GDScript::UpdatableFuncPtr function;
 	uint32_t h;
 
 	Vector<Variant> captures;


### PR DESCRIPTION
Since the `function` holds a raw pointer to `script`, reorder the members so that `function` is freed first to prevent a use-after-free from occurring upon destruction.

## What problem(s) does this PR solve?

- Closes #122532
