### PR TITLE
Revert "SCons: Enable `wasm64` support on web builds"

### DIFF
--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -20,16 +20,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Template w/ threads, 64-bit (target=template_release, threads=yes, arch=wasm64)
+          - name: Template w/ threads (target=template_release, threads=yes)
             cache-name: web-template
             target: template_release
-            scons-flags: threads=yes arch=wasm64
+            scons-flags: threads=yes
             artifact: true
 
-          - name: Template w/o threads, 32-bit (target=template_release, threads=no, arch=wasm32)
+          - name: Template w/o threads (target=template_release, threads=no)
             cache-name: web-nothreads-template
             target: template_release
-            scons-flags: threads=no arch=wasm32
+            scons-flags: threads=no
             artifact: true
 
     steps:

--- a/platform/web/detect.py
+++ b/platform/web/detect.py
@@ -124,7 +124,7 @@ def configure(env: "SConsEnvironment"):
     env["EXPORTED_RUNTIME_METHODS"] = []
 
     # Validate arch.
-    supported_arches = ["wasm32", "wasm64"]
+    supported_arches = ["wasm32"]
     validate_arch(env["arch"], get_name(), supported_arches)
 
     try:
@@ -300,8 +300,6 @@ def configure(env: "SConsEnvironment"):
         env.extra_suffix = ".dlink" + env.extra_suffix
 
     env.Append(LINKFLAGS=["-sWASM_BIGINT"])
-    env.Append(CCFLAGS=[f"-sMEMORY64={0 if env['arch'] == 'wasm32' else 1}"])
-    env.Append(LINKFLAGS=[f"-sMEMORY64={0 if env['arch'] == 'wasm32' else 1}"])
 
     # Run the main application in a web worker
     if env["proxy_to_pthread"]:

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -17,7 +17,7 @@ compatibility_platform_aliases = {
 }
 
 # CPU architecture options.
-architectures = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc64", "wasm32", "wasm64", "loongarch64"]
+architectures = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc64", "wasm32", "loongarch64"]
 architecture_aliases = {
     "x86": "x86_32",
     "x64": "x86_64",


### PR DESCRIPTION
This reverts commit c5bf809d160bec1dfb81ec58b48ee5acedcf9193 / #102378.

Unlike what it sounded like, this commit only implemented support for _compiling_ to target `wasm64`, but the resulting binaries are not usable. So it's misleading users and contributors into thinking this is a supported architecture, when it is very much not so. And it made us spend CI resources on a configuration that's unusable, while removing an important config (wasm32 with threads) from the build matrix.

See #122412 for an example of two maintainers (mihe and I) wasting time testing `arch=wasm64` and assuming we broke it because we weren't aware that it wasn't actually usable.

Whoever takes on the work of implementing actual support for wasm64 can re-apply these changes and then modify the web platform code to be functional.