### PR TITLE
Fix ambiguous `PHYSICS_INTERPOLATION_WARNING` parameter

### DIFF
--- a/core/error/error_macros.h
+++ b/core/error/error_macros.h
@@ -874,4 +874,4 @@ void _physics_interpolation_warning(const char *p_function, const char *p_file, 
 	_physics_interpolation_warning(FUNCTION_STR, __FILE__, __LINE__, m_object_id, m_string)
 
 #define PHYSICS_INTERPOLATION_WARNING(m_string) \
-	_physics_interpolation_warning(FUNCTION_STR, __FILE__, __LINE__, ObjectID(UINT64_MAX), m_string)
+	_physics_interpolation_warning(FUNCTION_STR, __FILE__, __LINE__, ObjectID((uint64_t)UINT64_MAX), m_string)


### PR DESCRIPTION
Fixes warning reported by @akien-mga in wasm64 build:
```
servers/rendering/storage/mesh_storage.cpp:107:4: error: ambiguous conversion for functional-style cast from 'unsigned long' to 'ObjectID'
  107 |                         PHYSICS_INTERPOLATION_WARNING("MultiMesh interpolation is being triggered from outside physics process, this might lead to issues");
      |                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
./core/error/error_macros.h:877:67: note: expanded from macro 'PHYSICS_INTERPOLATION_WARNING'
  877 |         _physics_interpolation_warning(FUNCTION_STR, __FILE__, __LINE__, ObjectID(UINT64_MAX), m_string)
      |                                                                          ^~~~~~~~~~~~~~~~~~~~
./core/object/object_id.h:61:27: note: candidate constructor
   61 |         _ALWAYS_INLINE_ explicit ObjectID(const uint64_t p_id) { id = p_id; }
      |                                  ^
./core/object/object_id.h:62:27: note: candidate constructor
   62 |         _ALWAYS_INLINE_ explicit ObjectID(const int64_t p_id) { id = p_id; }
      |                                  ^
```

Afaik it's due to there being two constructors:
```
explicit ObjectID(const uint64_t p_id)
explicit ObjectID(const int64_t p_id)
```
and compiler not knowing which to choose. (they both should produce identical result, but the ambiguity is right to flag here)