### PR TITLE
Update older link of town truck to the new version in the asset store.

### DIFF
--- a/doc/classes/Joint3D.xml
+++ b/doc/classes/Joint3D.xml
@@ -7,7 +7,7 @@
 		Abstract base class for all joints in 3D physics. 3D joints bind together two physics bodies ([member node_a] and [member node_b]) and apply a constraint. If only one body is defined, it is attached to a fixed [StaticBody3D] without collision shapes.
 	</description>
 	<tutorials>
-		<link title="3D Truck Town Demo">https://godotengine.org/asset-library/asset/2752</link>
+		<link title="3D Truck Town Demo">https://store.godotengine.org/asset/godot-foundation/truck-town-demo/</link>
 	</tutorials>
 	<methods>
 		<method name="get_rid" qualifiers="const">

--- a/doc/classes/RigidBody3D.xml
+++ b/doc/classes/RigidBody3D.xml
@@ -14,7 +14,7 @@
 	<tutorials>
 		<link title="Physics introduction">$DOCS_URL/tutorials/physics/physics_introduction.html</link>
 		<link title="Troubleshooting physics issues">$DOCS_URL/tutorials/physics/troubleshooting_physics_issues.html</link>
-		<link title="3D Truck Town Demo">https://godotengine.org/asset-library/asset/2752</link>
+		<link title="3D Truck Town Demo">https://store.godotengine.org/asset/godot-foundation/truck-town-demo/</link>
 		<link title="3D Physics Tests Demo">https://godotengine.org/asset-library/asset/2747</link>
 	</tutorials>
 	<methods>

--- a/doc/classes/VehicleBody3D.xml
+++ b/doc/classes/VehicleBody3D.xml
@@ -12,7 +12,7 @@
 	<tutorials>
 		<link title="Physics introduction">$DOCS_URL/tutorials/physics/physics_introduction.html</link>
 		<link title="Troubleshooting physics issues">$DOCS_URL/tutorials/physics/troubleshooting_physics_issues.html</link>
-		<link title="3D Truck Town Demo">https://godotengine.org/asset-library/asset/2752</link>
+		<link title="3D Truck Town Demo">https://store.godotengine.org/asset/godot-foundation/truck-town-demo/</link>
 	</tutorials>
 	<members>
 		<member name="brake" type="float" setter="set_brake" getter="get_brake" default="0.0">

--- a/doc/classes/VehicleWheel3D.xml
+++ b/doc/classes/VehicleWheel3D.xml
@@ -8,7 +8,7 @@
 		[b]Note:[/b] This class has known issues and isn't designed to provide realistic 3D vehicle physics. If you want advanced vehicle physics, you may need to write your own physics integration using another [PhysicsBody3D] class.
 	</description>
 	<tutorials>
-		<link title="3D Truck Town Demo">https://godotengine.org/asset-library/asset/2752</link>
+		<link title="3D Truck Town Demo">https://store.godotengine.org/asset/godot-foundation/truck-town-demo/</link>
 	</tutorials>
 	<methods>
 		<method name="get_contact_body" qualifiers="const">


### PR DESCRIPTION
Pretty much what it says in the tin.

Same thing, but for the docs repo:
https://github.com/godotengine/godot-docs/pull/12288