### PR TITLE
Fix RigidBody2D sync with moving parent

### DIFF
--- a/scene/2d/physics/rigid_body_2d.cpp
+++ b/scene/2d/physics/rigid_body_2d.cpp
@@ -151,7 +151,9 @@ struct _RigidBody2DInOut {
 
 void RigidBody2D::_sync_body_state(PhysicsDirectBodyState2D *p_state) {
 	Transform2D new_transform = p_state->get_transform();
-	if (likely(new_transform != get_global_transform())) {
+	// Parent changes can require recomputing the local transform even when global transforms match.
+	bool inherits_parent_transform = get_parent_item() && !is_set_as_top_level();
+	if (likely(inherits_parent_transform || new_transform != get_global_transform())) {
 		set_block_transform_notify(true);
 		set_global_transform(new_transform);
 		set_block_transform_notify(false);


### PR DESCRIPTION
Fixes #122480

4.6.1:
<img width="50%" height="1080" alt="2026-08-18 21-48-35" src="https://github.com/user-attachments/assets/9d135336-713a-4676-b15d-929e9ed6edc0" />

4.7.1:
<img width="50%" height="1080" alt="2026-08-18 22-06-19 (online-video-cutter com)" src="https://github.com/user-attachments/assets/216b5d28-e58d-43e0-bba2-44129e6a892e" />

this PR:
<img width="50%" height="1080" alt="2026-08-18 21-49-19" src="https://github.com/user-attachments/assets/dbdd3a11-2df1-42b8-b1cd-fd45d5eb91a5" />
