### PR TITLE
Fix text in print followed by print_rich being interpreted as rich

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -220,7 +220,7 @@ void RemoteDebugger::flush_output() {
 			} else if (output_string.type == MESSAGE_TYPE_LOG_RICH) {
 				if (!joined_log_strings.is_empty()) {
 					strings.push_back(String("\n").join(joined_log_strings));
-					types.push_back(MESSAGE_TYPE_LOG_RICH);
+					types.push_back(MESSAGE_TYPE_LOG);
 					joined_log_strings.clear();
 				}
 				strings.push_back(output_string.message);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Currently, if a user writes the following GDScript code:
```gdscript
func _ready():
    print("[b]This text shouldn't be bold[/b]")
```
and runs the project, he gets:
```
[b]This text shouldn't be bold[/b]
```
in the output.

However, if the user decides to add the following line:
```gdscript
    print_rich("Something")
```
now he gets:
```
This text shouldn't be bold
Something
```
and the first line is **bold**, which means that the first line is now being treated as rich.

Which means the following code blocks are equivalent:
```gdscript
func _ready():
    print("[b]This text shouldn't be bold[/b]")
    print_rich("Something")
```
and
```gdscript
func _ready():
    print_rich("[b]This text shouldn't be bold[/b]")
    print_rich("Something")
```

This PR fixes that and makes the first code block print
```
[b]This text shouldn't be bold[/b]
Something
```
as it should

## Additional information

In the source code `joined_log_strings` is a `Vector` of all plaintext messages (that are **not** rich), however when a rich message is encountered, remote debugger currently pushes one message joined from `joined_log_strings` as a message with type `MESSAGE_TYPE_LOG_RICH`. But those messages in `joined_log_strings` can't be rich, because only non-rich messages are added there, as I mentioned earlier.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
