### PR TITLE
Prevent too early audio bus save attempt

### DIFF
--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -1441,6 +1441,11 @@ void EditorAudioBuses::_drop_at_index(int p_bus, int p_index) {
 }
 
 void EditorAudioBuses::_server_save() {
+	if (!EditorNode::get_singleton()->is_editor_ready()) {
+		// UIDs might be not initialized before first import, so don't save yet.
+		return;
+	}
+
 	Ref<AudioBusLayout> state = AudioServer::get_singleton()->generate_bus_layout();
 	if (edited_path.is_empty()) {
 		ResourceSaver::save(state, "res://default_bus_layout.tres");


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Fixes #117362, at least based on the latest MRP.

## Additional information

I also can't reproduce the issue in 4.8, however I verified that the fix works on top of 4.7 branch, so I guess it can be merged in 4.8 for good measure, idk.
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
