### PR TITLE
[4.7] Allow compiling with warnings with min macOS version up to 14

### DIFF
--- a/drivers/coreaudio/audio_driver_coreaudio.mm
+++ b/drivers/coreaudio/audio_driver_coreaudio.mm
@@ -127,7 +127,11 @@ Error AudioDriverCoreAudio::init() {
 	AudioDeviceID device_id;
 	UInt32 dev_id_size = sizeof(AudioDeviceID);
 
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 	AudioObjectPropertyAddress property_dev_id = { kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMaster };
+#else
+	AudioObjectPropertyAddress property_dev_id = { kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain };
+#endif
 	result = AudioObjectGetPropertyData(kAudioObjectSystemObject, &property_dev_id, 0, nullptr, &dev_id_size, &device_id);
 	ERR_FAIL_COND_V(result != noErr, FAILED);
 

--- a/modules/camera/camera_apple.mm
+++ b/modules/camera/camera_apple.mm
@@ -491,12 +491,16 @@ void CameraApple::update_feeds() {
 		if (@available(macOS 14.0, *)) {
 			session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternal, AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeContinuityCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
 		} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 			session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternalUnknown, AVCaptureDeviceTypeBuiltInWideAngleCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
+#endif
 		}
 		devices = session.devices;
 #if defined(__x86_64__)
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 101500
 		devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+#endif
 	}
 #endif // __x86_64__
 #endif // APPLE_EMBEDDED_ENABLED

--- a/platform/macos/display_server_macos_base.mm
+++ b/platform/macos/display_server_macos_base.mm
@@ -408,10 +408,12 @@ Color DisplayServerMacOSBase::get_accent_color() const {
 				color = [[NSColor controlAccentColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
 			}
 		} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 			NSAppearance *saved_appearance = [NSAppearance currentAppearance];
 			[NSAppearance setCurrentAppearance:[NSApp effectiveAppearance]];
 			color = [[NSColor controlAccentColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
 			[NSAppearance setCurrentAppearance:saved_appearance];
+#endif
 		}
 		if (color) {
 			CGFloat components[4];
@@ -436,10 +438,12 @@ Color DisplayServerMacOSBase::get_base_color() const {
 				color = [[NSColor controlColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
 			}
 		} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 			NSAppearance *saved_appearance = [NSAppearance currentAppearance];
 			[NSAppearance setCurrentAppearance:[NSApp effectiveAppearance]];
 			color = [[NSColor controlColor] colorUsingColorSpace:[NSColorSpace genericRGBColorSpace]];
 			[NSAppearance setCurrentAppearance:saved_appearance];
+#endif
 		}
 		if (color) {
 			CGFloat components[4];

--- a/platform/macos/godot_application.mm
+++ b/platform/macos/godot_application.mm
@@ -169,6 +169,11 @@ GodotApplication *GodotApp = nil;
 	}
 }
 
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
+// This option was deprecated in macOS 14.0, replace it with 0 (no options) when min version is 14.0 or higher.
+#define NSApplicationActivateIgnoringOtherApps 0
+#endif
+
 - (void)forceUnbundledWindowActivationHackStep1 {
 	// Step 1: Switch focus to macOS SystemUIServer process.
 	// Required to perform step 2, TransformProcessType will fail if app is already the in focus.
@@ -192,5 +197,9 @@ GodotApplication *GodotApp = nil;
 	// Step 3: Switch focus back to app window.
 	[[NSRunningApplication currentApplication] activateWithOptions:NSApplicationActivateIgnoringOtherApps];
 }
+
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
+#undef NSApplicationActivateIgnoringOtherApps
+#endif
 
 @end

--- a/platform/macos/godot_open_save_delegate.mm
+++ b/platform/macos/godot_open_save_delegate.mm
@@ -245,6 +245,7 @@
 				[p_panel setAllowedContentTypes:type_filters];
 			}
 		} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 			if (type_filters && [type_filters count] == 1 && [[type_filters objectAtIndex:0] isEqualToString:@"*"]) {
 				[p_panel setAllowedFileTypes:nil];
 				[p_panel setAllowsOtherFileTypes:true];
@@ -252,12 +253,15 @@
 				[p_panel setAllowsOtherFileTypes:false];
 				[p_panel setAllowedFileTypes:type_filters];
 			}
+#endif
 		}
 	} else {
 		if (@available(macOS 11, *)) {
 			[p_panel setAllowedContentTypes:@[ UTTypeData ]];
 		} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 			[p_panel setAllowedFileTypes:nil];
+#endif
 		}
 		[p_panel setAllowsOtherFileTypes:true];
 	}
@@ -331,6 +335,7 @@
 					[dialog setAllowedContentTypes:type_filters];
 				}
 			} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 				if (type_filters && [type_filters count] == 1 && [[type_filters objectAtIndex:0] isEqualToString:@"*"]) {
 					[dialog setAllowedFileTypes:nil];
 					[dialog setAllowsOtherFileTypes:true];
@@ -338,13 +343,16 @@
 					[dialog setAllowsOtherFileTypes:false];
 					[dialog setAllowedFileTypes:type_filters];
 				}
+#endif
 			}
 			cur_index = index;
 		} else {
 			if (@available(macOS 11, *)) {
 				[dialog setAllowedContentTypes:@[ UTTypeData ]];
 			} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 				[dialog setAllowedFileTypes:nil];
+#endif
 			}
 			[dialog setAllowsOtherFileTypes:true];
 			cur_index = -1;

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -849,6 +849,7 @@ Error OS_MacOS::create_process(const String &p_path, const List<String> &p_argum
 #if defined(__x86_64__)
 		} else {
 			Error err = ERR_TIMEOUT;
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 110000
 			NSError *error = nullptr;
 			NSDictionary *config = @{
 				NSWorkspaceLaunchConfigurationArguments : arguments,
@@ -864,6 +865,7 @@ Error OS_MacOS::create_process(const String &p_path, const List<String> &p_argum
 				}
 				err = OK;
 			}
+#endif
 			return err;
 		}
 #endif
@@ -950,11 +952,13 @@ Error OS_MacOS::open_with_program(const String &p_program_path, const List<Strin
 		return err;
 #if defined(__x86_64__)
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 110000
 		NSError *error = nullptr;
 		[[NSWorkspace sharedWorkspace] openURLs:urls_to_open withApplicationAtURL:app_url options:NSWorkspaceLaunchDefault configuration:@{} error:&error];
 		if (error) {
 			return ERR_CANT_FORK;
 		}
+#endif
 		return OK;
 	}
 #endif
@@ -973,7 +977,11 @@ String OS_MacOS::get_unique_id() const {
 	static String serial_number;
 
 	if (serial_number.is_empty()) {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 		io_service_t platform_expert = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("IOPlatformExpertDevice"));
+#else
+		io_service_t platform_expert = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("IOPlatformExpertDevice"));
+#endif
 		CFStringRef serial_number_cf_string = nullptr;
 		if (platform_expert) {
 			serial_number_cf_string = (CFStringRef)IORegistryEntryCreateCFProperty(platform_expert, CFSTR(kIOPlatformSerialNumberKey), kCFAllocatorDefault, 0);

--- a/platform/macos/tts_macos.mm
+++ b/platform/macos/tts_macos.mm
@@ -45,9 +45,11 @@
 		[self->synth setDelegate:self];
 		print_verbose("Text-to-Speech: AVSpeechSynthesizer initialized.");
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 		self->synth = [[NSSpeechSynthesizer alloc] init];
 		[self->synth setDelegate:self];
 		print_verbose("Text-to-Speech: NSSpeechSynthesizer initialized.");
+#endif
 	}
 	return self;
 }
@@ -90,6 +92,8 @@
 
 // NSSpeechSynthesizer callback (macOS 10.4+)
 
+// Deprecated in macOS 14.0, needs to be removed when compiling with min macOS 14.0.
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 - (void)speechSynthesizer:(NSSpeechSynthesizer *)ns_synth willSpeakWord:(NSRange)characterRange ofString:(NSString *)string {
 	if (!paused && have_utterance) {
 		// Convert from UTF-16 to UTF-32 position.
@@ -118,6 +122,7 @@
 	speaking = false;
 	[self update];
 }
+#endif
 
 - (void)update {
 	if (!speaking && queue.size() > 0) {
@@ -138,6 +143,7 @@
 			ids[new_utterance] = message.id;
 			[av_synth speakUtterance:new_utterance];
 		} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 			NSSpeechSynthesizer *ns_synth = synth;
 			[ns_synth setObject:nil forProperty:NSSpeechResetProperty error:nil];
 			[ns_synth setVoice:[NSString stringWithUTF8String:message.voice.utf8().get_data()]];
@@ -149,6 +155,7 @@
 			last_utterance = message.id;
 			have_utterance = true;
 			[ns_synth startSpeakingString:[NSString stringWithUTF8String:message.text.utf8().get_data()]];
+#endif
 		}
 		DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServerEnums::TTS_UTTERANCE_STARTED, message.id);
 		queue.pop_front();
@@ -162,8 +169,10 @@
 		AVSpeechSynthesizer *av_synth = synth;
 		[av_synth pauseSpeakingAtBoundary:AVSpeechBoundaryImmediate];
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 		NSSpeechSynthesizer *ns_synth = synth;
 		[ns_synth pauseSpeakingAtBoundary:NSSpeechImmediateBoundary];
+#endif
 	}
 	paused = true;
 }
@@ -173,8 +182,10 @@
 		AVSpeechSynthesizer *av_synth = synth;
 		[av_synth continueSpeaking];
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 		NSSpeechSynthesizer *ns_synth = synth;
 		[ns_synth continueSpeaking];
+#endif
 	}
 	paused = false;
 }
@@ -188,11 +199,13 @@
 		AVSpeechSynthesizer *av_synth = synth;
 		[av_synth stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 		NSSpeechSynthesizer *ns_synth = synth;
 		if (have_utterance) {
 			DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServerEnums::TTS_UTTERANCE_CANCELED, last_utterance);
 		}
 		[ns_synth stopSpeaking];
+#endif
 	}
 	have_utterance = false;
 	speaking = false;
@@ -252,6 +265,7 @@
 			list.push_back(voice_d);
 		}
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 		for (NSString *voiceIdentifierString in [NSSpeechSynthesizer availableVoices]) {
 			NSString *voiceLocaleIdentifier = [[NSSpeechSynthesizer attributesForVoice:voiceIdentifierString] objectForKey:NSVoiceLocaleIdentifier];
 			NSString *voiceName = [[NSSpeechSynthesizer attributesForVoice:voiceIdentifierString] objectForKey:NSVoiceName];
@@ -261,6 +275,7 @@
 			voice_d["language"] = String([voiceLocaleIdentifier UTF8String]);
 			list.push_back(voice_d);
 		}
+#endif
 	}
 	return list;
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR fixes Godot 4.7's Objective-C++ code to allow compiling with newer minimum macOS versions, up to macOS 14.0.

Justification: We should give users the flexibility to customize the minimum macOS version if they need to, such as if a dependency requires a newer minimum macOS version. This adds longevity to the 4.7 branch for macOS.

## Additional information

No AI was used to make this PR.

This PR can be automatically cherry-picked to the 4.6 branch, but a dedicated PR is required for 4.5 and earlier due to conflicts.

The version numbers after `#if MAC_OS_X_VERSION_MIN_REQUIRED` correspond to exactly the version in which those features become deprecated and therefore stop compiling when warnings are enabled.

I tested with up to macOS 26.5, and the only remaining problem with going that far is `CGWindowListCreateImageFromArray` which is deprecated as of macOS 15.0. This will require migration to `ScreenCaptureKit`.

This PR can be kinda considered a backport of PR #122524 and #121030. However, this PR does not bump the min version in the build system, does not remove old code, and does not remove support for old macOS versions, just improve the support for compiling for new macOS versions.