### PR TITLE
[4.5] Allow compiling with warnings with min macOS version up to 14

### DIFF
--- a/drivers/coreaudio/audio_driver_coreaudio.mm
+++ b/drivers/coreaudio/audio_driver_coreaudio.mm
@@ -125,7 +125,11 @@ Error AudioDriverCoreAudio::init() {
 	AudioDeviceID device_id;
 	UInt32 dev_id_size = sizeof(AudioDeviceID);
 
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 	AudioObjectPropertyAddress property_dev_id = { kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMaster };
+#else
+	AudioObjectPropertyAddress property_dev_id = { kAudioHardwarePropertyDefaultOutputDevice, kAudioObjectPropertyScopeGlobal, kAudioObjectPropertyElementMain };
+#endif
 	result = AudioObjectGetPropertyData(kAudioObjectSystemObject, &property_dev_id, 0, nullptr, &dev_id_size, &device_id);
 	ERR_FAIL_COND_V(result != noErr, FAILED);
 

--- a/drivers/metal/pixel_formats.mm
+++ b/drivers/metal/pixel_formats.mm
@@ -118,6 +118,7 @@ bool PixelFormats::isPVRTCFormat(MTLPixelFormat p_format) {
 	return false;
 #else
 	switch (p_format) {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 150000
 		case MTLPixelFormatPVRTC_RGBA_2BPP:
 		case MTLPixelFormatPVRTC_RGBA_2BPP_sRGB:
 		case MTLPixelFormatPVRTC_RGBA_4BPP:
@@ -127,6 +128,7 @@ bool PixelFormats::isPVRTCFormat(MTLPixelFormat p_format) {
 		case MTLPixelFormatPVRTC_RGB_4BPP:
 		case MTLPixelFormatPVRTC_RGB_4BPP_sRGB:
 			return true;
+#endif
 		default:
 			return false;
 	}
@@ -672,7 +674,7 @@ void PixelFormats::initMTLPixelFormatCapabilities() {
 	addMTLPixelFormatDesc(RGBA32Sint, Color128, RWC);
 	addMTLPixelFormatDesc(RGBA32Float, Color128, All);
 
-#if !defined(VISIONOS_ENABLED)
+#if !defined(VISIONOS_ENABLED) && MAC_OS_X_VERSION_MIN_REQUIRED < 150000
 	// Compressed pixel formats
 	addMTLPixelFormatDesc(PVRTC_RGBA_2BPP, PVRTC_RGBA_2BPP, RF);
 	addMTLPixelFormatDescSRGB(PVRTC_RGBA_2BPP_sRGB, PVRTC_RGBA_2BPP, RF, PVRTC_RGBA_2BPP);

--- a/drivers/metal/rendering_device_driver_metal.mm
+++ b/drivers/metal/rendering_device_driver_metal.mm
@@ -292,7 +292,7 @@ RDD::TextureID RenderingDeviceDriverMetal::texture_create(const TextureFormat &p
 	// Usage.
 
 	MTLResourceOptions options = 0;
-#if defined(VISIONOS_ENABLED)
+#if defined(VISIONOS_ENABLED) || MAC_OS_X_VERSION_MIN_REQUIRED >= 130000
 	const bool supports_memoryless = true;
 #else
 	const bool supports_memoryless = (*device_properties).features.highestFamily >= MTLGPUFamilyApple2 && (*device_properties).features.highestFamily < MTLGPUFamilyMac1;
@@ -1198,7 +1198,7 @@ RDD::ShaderID RenderingDeviceDriverMetal::shader_create_from_container(const Ref
 													 data:binary];
 		} else {
 			options.preserveInvariance = shader_data.is_position_invariant;
-#if defined(VISIONOS_ENABLED)
+#if defined(VISIONOS_ENABLED) || MAC_OS_X_VERSION_MIN_REQUIRED >= 150000
 			options.mathMode = MTLMathModeFast;
 #else
 			options.fastMathEnabled = YES;

--- a/modules/camera/camera_macos.mm
+++ b/modules/camera/camera_macos.mm
@@ -317,12 +317,16 @@ void CameraMacOS::update_feeds() {
 		if (@available(macOS 14.0, *)) {
 			session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternal, AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeContinuityCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
 		} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 			session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternalUnknown, AVCaptureDeviceTypeBuiltInWideAngleCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
+#endif
 		}
 		devices = session.devices;
 #if defined(__x86_64__)
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 101500
 		devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
+#endif
 	}
 #endif
 

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -54,17 +54,15 @@
 #import <mach-o/getsect.h>
 
 static uint64_t load_address() {
-	const struct segment_command_64 *cmd = getsegbyname("__TEXT");
 	char full_path[1024];
 	uint32_t size = sizeof(full_path);
 
-	if (cmd && !_NSGetExecutablePath(full_path, &size)) {
-		uint32_t dyld_count = _dyld_image_count();
-		for (uint32_t i = 0; i < dyld_count; i++) {
-			const char *image_name = _dyld_get_image_name(i);
-			if (image_name && strncmp(image_name, full_path, 1024) == 0) {
-				return cmd->vmaddr + _dyld_get_image_vmaddr_slide(i);
-			}
+	if (!_NSGetExecutablePath(full_path, &size)) {
+		void *handle = dlopen(full_path, RTLD_LAZY | RTLD_NOLOAD);
+		void *addr = dlsym(handle, "main");
+		Dl_info info;
+		if (dladdr(addr, &info)) {
+			return (uint64_t)info.dli_fbase;
 		}
 	}
 

--- a/platform/macos/godot_application.mm
+++ b/platform/macos/godot_application.mm
@@ -169,6 +169,11 @@ GodotApplication *GodotApp = nil;
 	}
 }
 
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
+// This option was deprecated in macOS 14.0, replace it with 0 (no options) when min version is 14.0 or higher.
+#define NSApplicationActivateIgnoringOtherApps 0
+#endif
+
 - (void)forceUnbundledWindowActivationHackStep1 {
 	// Step 1: Switch focus to macOS SystemUIServer process.
 	// Required to perform step 2, TransformProcessType will fail if app is already the in focus.
@@ -192,5 +197,9 @@ GodotApplication *GodotApp = nil;
 	// Step 3: Switch focus back to app window.
 	[[NSRunningApplication currentApplication] activateWithOptions:NSApplicationActivateIgnoringOtherApps];
 }
+
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
+#undef NSApplicationActivateIgnoringOtherApps
+#endif
 
 @end

--- a/platform/macos/godot_open_save_delegate.mm
+++ b/platform/macos/godot_open_save_delegate.mm
@@ -236,6 +236,7 @@
 				[p_panel setAllowedContentTypes:type_filters];
 			}
 		} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 			if (type_filters && [type_filters count] == 1 && [[type_filters objectAtIndex:0] isEqualToString:@"*"]) {
 				[p_panel setAllowedFileTypes:nil];
 				[p_panel setAllowsOtherFileTypes:true];
@@ -243,12 +244,15 @@
 				[p_panel setAllowsOtherFileTypes:false];
 				[p_panel setAllowedFileTypes:type_filters];
 			}
+#endif
 		}
 	} else {
 		if (@available(macOS 11, *)) {
 			[p_panel setAllowedContentTypes:@[ UTTypeData ]];
 		} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 			[p_panel setAllowedFileTypes:nil];
+#endif
 		}
 		[p_panel setAllowsOtherFileTypes:true];
 	}
@@ -321,6 +325,7 @@
 					[dialog setAllowedContentTypes:type_filters];
 				}
 			} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 				if (type_filters && [type_filters count] == 1 && [[type_filters objectAtIndex:0] isEqualToString:@"*"]) {
 					[dialog setAllowedFileTypes:nil];
 					[dialog setAllowsOtherFileTypes:true];
@@ -328,13 +333,16 @@
 					[dialog setAllowsOtherFileTypes:false];
 					[dialog setAllowedFileTypes:type_filters];
 				}
+#endif
 			}
 			cur_index = index;
 		} else {
 			if (@available(macOS 11, *)) {
 				[dialog setAllowedContentTypes:@[ UTTypeData ]];
 			} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 				[dialog setAllowedFileTypes:nil];
+#endif
 			}
 			[dialog setAllowsOtherFileTypes:true];
 			cur_index = -1;

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -816,6 +816,7 @@ Error OS_MacOS::create_process(const String &p_path, const List<String> &p_argum
 #if defined(__x86_64__)
 		} else {
 			Error err = ERR_TIMEOUT;
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 110000
 			NSError *error = nullptr;
 			NSRunningApplication *app = [[NSWorkspace sharedWorkspace] launchApplicationAtURL:url options:NSWorkspaceLaunchNewInstance configuration:[NSDictionary dictionaryWithObject:arguments forKey:NSWorkspaceLaunchConfigurationArguments] error:&error];
 			if (error) {
@@ -827,6 +828,7 @@ Error OS_MacOS::create_process(const String &p_path, const List<String> &p_argum
 				}
 				err = OK;
 			}
+#endif
 			return err;
 		}
 #endif
@@ -906,11 +908,13 @@ Error OS_MacOS::open_with_program(const String &p_program_path, const List<Strin
 		return err;
 #if defined(__x86_64__)
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 110000
 		NSError *error = nullptr;
 		[[NSWorkspace sharedWorkspace] openURLs:urls_to_open withApplicationAtURL:app_url options:NSWorkspaceLaunchDefault configuration:@{} error:&error];
 		if (error) {
 			return ERR_CANT_FORK;
 		}
+#endif
 		return OK;
 	}
 #endif
@@ -929,7 +933,11 @@ String OS_MacOS::get_unique_id() const {
 	static String serial_number;
 
 	if (serial_number.is_empty()) {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 		io_service_t platform_expert = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("IOPlatformExpertDevice"));
+#else
+		io_service_t platform_expert = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("IOPlatformExpertDevice"));
+#endif
 		CFStringRef serial_number_cf_string = nullptr;
 		if (platform_expert) {
 			serial_number_cf_string = (CFStringRef)IORegistryEntryCreateCFProperty(platform_expert, CFSTR(kIOPlatformSerialNumberKey), kCFAllocatorDefault, 0);

--- a/platform/macos/tts_macos.mm
+++ b/platform/macos/tts_macos.mm
@@ -43,9 +43,11 @@
 		[self->synth setDelegate:self];
 		print_verbose("Text-to-Speech: AVSpeechSynthesizer initialized.");
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 		self->synth = [[NSSpeechSynthesizer alloc] init];
 		[self->synth setDelegate:self];
 		print_verbose("Text-to-Speech: NSSpeechSynthesizer initialized.");
+#endif
 	}
 	return self;
 }
@@ -88,6 +90,8 @@
 
 // NSSpeechSynthesizer callback (macOS 10.4+)
 
+// Deprecated in macOS 14.0, needs to be removed when compiling with min macOS 14.0.
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 - (void)speechSynthesizer:(NSSpeechSynthesizer *)ns_synth willSpeakWord:(NSRange)characterRange ofString:(NSString *)string {
 	if (!paused && have_utterance) {
 		// Convert from UTF-16 to UTF-32 position.
@@ -116,6 +120,7 @@
 	speaking = false;
 	[self update];
 }
+#endif
 
 - (void)update {
 	if (!speaking && queue.size() > 0) {
@@ -136,6 +141,7 @@
 			ids[new_utterance] = message.id;
 			[av_synth speakUtterance:new_utterance];
 		} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 			NSSpeechSynthesizer *ns_synth = synth;
 			[ns_synth setObject:nil forProperty:NSSpeechResetProperty error:nil];
 			[ns_synth setVoice:[NSString stringWithUTF8String:message.voice.utf8().get_data()]];
@@ -147,6 +153,7 @@
 			last_utterance = message.id;
 			have_utterance = true;
 			[ns_synth startSpeakingString:[NSString stringWithUTF8String:message.text.utf8().get_data()]];
+#endif
 		}
 		queue.pop_front();
 
@@ -160,8 +167,10 @@
 		AVSpeechSynthesizer *av_synth = synth;
 		[av_synth pauseSpeakingAtBoundary:AVSpeechBoundaryImmediate];
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 		NSSpeechSynthesizer *ns_synth = synth;
 		[ns_synth pauseSpeakingAtBoundary:NSSpeechImmediateBoundary];
+#endif
 	}
 	paused = true;
 }
@@ -171,8 +180,10 @@
 		AVSpeechSynthesizer *av_synth = synth;
 		[av_synth continueSpeaking];
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 		NSSpeechSynthesizer *ns_synth = synth;
 		[ns_synth continueSpeaking];
+#endif
 	}
 	paused = false;
 }
@@ -186,11 +197,13 @@
 		AVSpeechSynthesizer *av_synth = synth;
 		[av_synth stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 		NSSpeechSynthesizer *ns_synth = synth;
 		if (have_utterance) {
 			DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServer::TTS_UTTERANCE_CANCELED, last_utterance);
 		}
 		[ns_synth stopSpeaking];
+#endif
 	}
 	have_utterance = false;
 	speaking = false;
@@ -250,6 +263,7 @@
 			list.push_back(voice_d);
 		}
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 		for (NSString *voiceIdentifierString in [NSSpeechSynthesizer availableVoices]) {
 			NSString *voiceLocaleIdentifier = [[NSSpeechSynthesizer attributesForVoice:voiceIdentifierString] objectForKey:NSVoiceLocaleIdentifier];
 			NSString *voiceName = [[NSSpeechSynthesizer attributesForVoice:voiceIdentifierString] objectForKey:NSVoiceName];
@@ -259,6 +273,7 @@
 			voice_d["language"] = String([voiceLocaleIdentifier UTF8String]);
 			list.push_back(voice_d);
 		}
+#endif
 	}
 	return list;
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR fixes Godot 4.5's Objective-C++ code to allow compiling with newer minimum macOS versions, up to macOS 14.0.

Justification: We should give users the flexibility to customize the minimum macOS version if they need to, such as if a dependency requires a newer minimum macOS version. This adds longevity to the 4.5 branch for macOS.

## Additional information

No AI was used to make this PR.

A dedicated PR is required to backport this to 4.4 and earlier due to conflicts.

The version numbers after `#if MAC_OS_X_VERSION_MIN_REQUIRED` correspond to exactly the version in which those features become deprecated and therefore stop compiling when warnings are enabled.

I tested with up to macOS 26.5, and the only remaining problem with going that far is `CGWindowListCreateImageFromArray` which is deprecated as of macOS 15.0. This will require migration to `ScreenCaptureKit`.

This PR can be considered a further backport of PR #122561. However, I also had to include a piece of PR #111425, because the previous `getsegbyname` API is deprecated on newer macOS versions. The API used by PR #111425 is [present](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/dlopen.3.html) in macOS 10.4 (from 2005), so it will work fine even on very old macOS versions.