### PR TITLE
[4.2] Allow compiling with warnings with min macOS version up to 14

### DIFF
--- a/drivers/coreaudio/audio_driver_coreaudio.cpp
+++ b/drivers/coreaudio/audio_driver_coreaudio.cpp
@@ -38,6 +38,10 @@
 #define kOutputBus 0
 #define kInputBus 1
 
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 120000
+#define kAudioObjectPropertyElementMaster kAudioObjectPropertyElementMain
+#endif
+
 #ifdef MACOS_ENABLED
 OSStatus AudioDriverCoreAudio::input_device_address_cb(AudioObjectID inObjectID,
 		UInt32 inNumberAddresses, const AudioObjectPropertyAddress *inAddresses,
@@ -674,5 +678,7 @@ void AudioDriverCoreAudio::set_input_device(const String &p_name) {
 AudioDriverCoreAudio::AudioDriverCoreAudio() {
 	samples_in.clear();
 }
+
+#undef kAudioObjectPropertyElementMaster
 
 #endif // COREAUDIO_ENABLED

--- a/modules/camera/camera_macos.mm
+++ b/modules/camera/camera_macos.mm
@@ -308,7 +308,13 @@ MyDeviceNotifications *device_notifications = nil;
 
 void CameraMacOS::update_feeds() {
 #if MAC_OS_X_VERSION_MIN_REQUIRED >= 101500
-	AVCaptureDeviceDiscoverySession *session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternalUnknown, AVCaptureDeviceTypeBuiltInWideAngleCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
+	AVCaptureDeviceDiscoverySession *session;
+#if MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
+	// Avoid deprecated warning if the minimum SDK is 14.0.
+	session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternal, AVCaptureDeviceTypeBuiltInWideAngleCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
+#else
+	session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternalUnknown, AVCaptureDeviceTypeBuiltInWideAngleCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
+#endif
 	NSArray *devices = session.devices;
 #else
 	NSArray *devices = [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -253,6 +253,8 @@ def configure(env: "Environment"):
             "QuartzCore",
             "-framework",
             "Security",
+            "-framework",
+            "UniformTypeIdentifiers",
         ]
     )
     env.Append(LIBS=["pthread", "z"])

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -630,6 +630,7 @@ Error OS_MacOS::create_process(const String &p_path, const List<String> &p_argum
 			return err;
 		} else {
 			Error err = ERR_TIMEOUT;
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 110000
 			NSError *error = nullptr;
 			NSRunningApplication *app = [[NSWorkspace sharedWorkspace] launchApplicationAtURL:url options:NSWorkspaceLaunchNewInstance configuration:[NSDictionary dictionaryWithObject:arguments forKey:NSWorkspaceLaunchConfigurationArguments] error:&error];
 			if (error) {
@@ -641,6 +642,7 @@ Error OS_MacOS::create_process(const String &p_path, const List<String> &p_argum
 				}
 				err = OK;
 			}
+#endif
 			return err;
 		}
 	} else {
@@ -664,7 +666,11 @@ String OS_MacOS::get_unique_id() const {
 	static String serial_number;
 
 	if (serial_number.is_empty()) {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 		io_service_t platform_expert = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("IOPlatformExpertDevice"));
+#else
+		io_service_t platform_expert = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("IOPlatformExpertDevice"));
+#endif
 		CFStringRef serial_number_cf_string = nullptr;
 		if (platform_expert) {
 			serial_number_cf_string = (CFStringRef)IORegistryEntryCreateCFProperty(platform_expert, CFSTR(kIOPlatformSerialNumberKey), kCFAllocatorDefault, 0);

--- a/platform/macos/tts_macos.mm
+++ b/platform/macos/tts_macos.mm
@@ -43,9 +43,11 @@
 		[self->synth setDelegate:self];
 		print_verbose("Text-to-Speech: AVSpeechSynthesizer initialized.");
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 		self->synth = [[NSSpeechSynthesizer alloc] init];
 		[self->synth setDelegate:self];
 		print_verbose("Text-to-Speech: NSSpeechSynthesizer initialized.");
+#endif
 	}
 	return self;
 }
@@ -88,6 +90,8 @@
 
 // NSSpeechSynthesizer callback (macOS 10.4+)
 
+// Deprecated in macOS 14.0, needs to be removed when compiling with min macOS 14.0.
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 - (void)speechSynthesizer:(NSSpeechSynthesizer *)ns_synth willSpeakWord:(NSRange)characterRange ofString:(NSString *)string {
 	if (!paused && have_utterance) {
 		// Convert from UTF-16 to UTF-32 position.
@@ -116,6 +120,7 @@
 	speaking = false;
 	[self update];
 }
+#endif
 
 - (void)update {
 	if (!speaking && queue.size() > 0) {
@@ -136,6 +141,7 @@
 			ids[new_utterance] = message.id;
 			[av_synth speakUtterance:new_utterance];
 		} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 			NSSpeechSynthesizer *ns_synth = synth;
 			[ns_synth setObject:nil forProperty:NSSpeechResetProperty error:nil];
 			[ns_synth setVoice:[NSString stringWithUTF8String:message.voice.utf8().get_data()]];
@@ -147,6 +153,7 @@
 			last_utterance = message.id;
 			have_utterance = true;
 			[ns_synth startSpeakingString:[NSString stringWithUTF8String:message.text.utf8().get_data()]];
+#endif
 		}
 		queue.pop_front();
 
@@ -160,8 +167,10 @@
 		AVSpeechSynthesizer *av_synth = synth;
 		[av_synth pauseSpeakingAtBoundary:AVSpeechBoundaryImmediate];
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 		NSSpeechSynthesizer *ns_synth = synth;
 		[ns_synth pauseSpeakingAtBoundary:NSSpeechImmediateBoundary];
+#endif
 	}
 	paused = true;
 }
@@ -171,8 +180,10 @@
 		AVSpeechSynthesizer *av_synth = synth;
 		[av_synth continueSpeaking];
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 		NSSpeechSynthesizer *ns_synth = synth;
 		[ns_synth continueSpeaking];
+#endif
 	}
 	paused = false;
 }
@@ -186,11 +197,13 @@
 		AVSpeechSynthesizer *av_synth = synth;
 		[av_synth stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 		NSSpeechSynthesizer *ns_synth = synth;
 		if (have_utterance) {
 			DisplayServer::get_singleton()->tts_post_utterance_event(DisplayServer::TTS_UTTERANCE_CANCELED, last_utterance);
 		}
 		[ns_synth stopSpeaking];
+#endif
 	}
 	have_utterance = false;
 	speaking = false;
@@ -250,6 +263,7 @@
 			list.push_back(voice_d);
 		}
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 		for (NSString *voiceIdentifierString in [NSSpeechSynthesizer availableVoices]) {
 			NSString *voiceLocaleIdentifier = [[NSSpeechSynthesizer attributesForVoice:voiceIdentifierString] objectForKey:NSVoiceLocaleIdentifier];
 			NSString *voiceName = [[NSSpeechSynthesizer attributesForVoice:voiceIdentifierString] objectForKey:NSVoiceName];
@@ -259,6 +273,7 @@
 			voice_d["language"] = String([voiceLocaleIdentifier UTF8String]);
 			list.push_back(voice_d);
 		}
+#endif
 	}
 	return list;
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR fixes Godot 4.2's Objective-C++ code to allow compiling with newer minimum macOS versions, up to macOS 14.0.

Justification: We should give users the flexibility to customize the minimum macOS version if they need to, such as if a dependency requires a newer minimum macOS version. This adds longevity to the 4.2 branch for macOS.

## Additional information

No AI was used to make this PR.

This PR can be automatically cherry-picked to the 4.1 branch, but a dedicated PR is required for 4.0 and earlier due to conflicts (only minor conflicts exist between 4.0 and 4.1).

The version numbers after `#if MAC_OS_X_VERSION_MIN_REQUIRED` correspond to exactly the version in which those features become deprecated and therefore stop compiling when warnings are enabled.

I tested with up to macOS 26.5, and the only remaining problem with going that far is `CGWindowListCreateImageFromArray` which is deprecated as of macOS 15.0. This will require migration to `ScreenCaptureKit`.

This PR can be considered a further backport of PR #122564.