### PR TITLE
visionOS: Do not show boot logo in immersive mode

### DIFF
--- a/drivers/apple_embedded/godot_renderer.h
+++ b/drivers/apple_embedded/godot_renderer.h
@@ -45,5 +45,6 @@ inline void safeDispatchSyncToMain(void (^block)(void)) {
 @property(assign, readonly, nonatomic) BOOL hasFinishedSetup;
 
 - (BOOL)setUp;
+- (void)setUpProjectDataShowingBootLogo:(BOOL)p_show_boot_logo;
 
 @end

--- a/drivers/apple_embedded/godot_renderer.mm
+++ b/drivers/apple_embedded/godot_renderer.mm
@@ -55,7 +55,7 @@
 	}
 
 	if (!self.hasCalledProjectDataSetUp) {
-		[self setUpProjectData];
+		[self setUpProjectDataShowingBootLogo:YES];
 	}
 
 	if (!self.hasStartedMain) {
@@ -67,10 +67,10 @@
 	return NO;
 }
 
-- (void)setUpProjectData {
+- (void)setUpProjectDataShowingBootLogo:(BOOL)p_show_boot_logo {
 	self.hasCalledProjectDataSetUp = YES;
 	safeDispatchSyncToMain(^{
-		Main::setup2();
+		Main::setup2(p_show_boot_logo);
 
 		// this might be necessary before here
 		NSDictionary *dict = [[NSBundle mainBundle] infoDictionary];

--- a/platform/visionos/godot_compositor_services_renderer.mm
+++ b/platform/visionos/godot_compositor_services_renderer.mm
@@ -58,6 +58,12 @@ extern void apple_embedded_finish();
 	return self;
 }
 
+// On visionOS Compositor Services mode (used by the visionOS XR module),
+// there's no way to easily show the boot logo on a simple quad.
+- (void)setUpProjectDataShowingBootLogo:(BOOL)p_show_boot_logo {
+	[super setUpProjectDataShowingBootLogo:NO];
+}
+
 - (void)updateXRInterface {
 	Ref<VisionOSXRInterface> visionos_xr_interface = VisionOSXRInterface::find_interface();
 	if (visionos_xr_interface.is_valid()) {


### PR DESCRIPTION
Dear Godot Community,

We contributed visionOS support in https://github.com/godotengine/godot/pull/109975. This follow-up avoids showing the boot logo on visionOS in immersive mode, to avoid rendering errors on the first frame (there's no texture to render it to).

We're aware that not displaying anything while a visionOS XR level is loading is not ideal, we have explored several options and we have not found an acceptable solution due to different issues. We'll continue investigating ways of adding a loading screen in the future.

cc @BastiaanOlij @stuartcarnie 