### PR TITLE
Fix AudioEffectPitchShift::FFT_SIZE_4096

### DIFF
--- a/servers/audio/effects/audio_effect_pitch_shift.h
+++ b/servers/audio/effects/audio_effect_pitch_shift.h
@@ -34,7 +34,7 @@
 
 class SMBPitchShift {
 	enum {
-		MAX_FRAME_LENGTH = 8192
+		MAX_FRAME_LENGTH = 4096 * sizeof(float),
 	};
 
 	float gInFIFO[MAX_FRAME_LENGTH] = {};


### PR DESCRIPTION
The max frame length was erroneously set to 8192, which was insufficient for the max FFT size of 4096. It has been doubled to 16384 in order to support the max FFT size.

## What problem(s) does this PR solve?
The maximum FFT size is currently broken as the maximum frame length isn’t wide enough to support it.

## Additional information
AI tools neither have nor will be used in the creation of this pull request.
Both the new and existing behavior have only been tested on macOS 15.