### PR TITLE
[Core]: Remove extra reference to `this` in `Object::emit_signalp`

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1195,16 +1195,11 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 
 	OBJ_DEBUG_LOCK
 
-	// If this is a ref-counted object, prevent it from being destroyed during signal
-	// emission, which is needed in certain edge cases; e.g., GH-73889 and GH-109471.
-	// Moreover, since signals can be emitted from constructors (classic example being
-	// notify_property_list_changed), we must be careful not to do the ref init ourselves,
-	// which would lead to the object being destroyed at the end of this function.
-	bool pending_unref = Object::cast_to<RefCounted>(this) ? ((RefCounted *)this)->reference() : false;
-
 	Error err = OK;
 
-	Vector<const Variant *> append_source_mem;
+	LocalVector<const Variant *> append_source_mem;
+	// If this is a ref-counted object, `source` also prevents it from being destroyed during
+	// signal emission, which is needed in certain edge cases; e.g., GH-73889 and GH-109471.
 	Variant source = this;
 
 	for (uint32_t i = 0; i < slot_count; ++i) {
@@ -1225,7 +1220,7 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 			int source_index = p_argcount - callable.get_unbound_arguments_count();
 			if (source_index >= 0) {
 				append_source_mem.resize(p_argcount + 1);
-				const Variant **args_mem = append_source_mem.ptrw();
+				const Variant **args_mem = append_source_mem.ptr();
 
 				for (int j = 0; j < source_index; j++) {
 					args_mem[j] = p_args[j];
@@ -1283,14 +1278,7 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 		memfree(slot_flags);
 	}
 
-	if (pending_unref) {
-		// We have to do the same Ref<T> would do. We can't just use Ref<T>
-		// because it would do the init ref logic, which is something this function
-		// shouldn't do, as explained above.
-		if (((RefCounted *)this)->unreference()) {
-			memdelete(this);
-		}
-	}
+	(void)source; // Ensure it's scoped to the function so it lives up to the end.
 
 	return err;
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

Makes the code easier to read. Also 1 less extra reference call.
While I was at it, I also changed `Vector` to `LocalVector`, because it's only used here and not being copied anywhere (well I guess it can be said to be copied, but it's not copied as `Vector`).

## Additional information

The `source` variant is already doing the ref init in the same place, so it also keeps it alive. Now we had 2 things that kept `this` alive, which is 1 too many.

After reading https://github.com/godotengine/godot/pull/109770#issuecomment-3201478331 and doing some tests to understand why we can ref init `this` normally through `Variant`, I arrived at conclusion: 

We can ref init in this place, because it is placed after trying to find the signal with `signal_map.getptr` and returning early if we couldn't find the signal data. Returning early is the important part. Because the signal map is lazily populated, the signal data is only created when the first connection to the signal is made. Because of that we only need to worry about the ref init potentially destroying `this` if we connect the callable and call `emit_signalp` on the same signal inside the constructor of the ref counted type.

If we need to support such situation, I think we can use `alloca` and `VariantInternal::object_assign_without_ref_unsafe` on `source` I guess? But it will need more code, and also will need a branch in case `reference()` failed (someone could emit signal in predelete in a native type for example). Do we need to support such situation?

Sidenote, it was really strange reading such a long comment about why we need to avoid the ref init and then just seeing ref init being used a couple of lines later.