### PR TITLE
Fixes engine crash when node is missing a name field in a tscn file and has a type

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -201,6 +201,11 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 
 			if (next_tag.fields.has("name")) {
 				name = packed_scene->get_state()->add_name(next_tag.fields["name"]);
+			} else {
+				error = ERR_FILE_CORRUPT;
+				error_text = "Missing 'name' field from node tag";
+				_printerr();
+				return Ref<PackedScene>();
 			}
 
 			if (next_tag.fields.has("parent")) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #122522

## Additional information

`SceneState.names` is expected to always be in pairs, when the node is missing the name field, nothing gets added to it, except the type. Type although is a type, is inserted into names. Together with the actual name.

It's confusing.

But since it is no longer a pair, and just a type, it makes the indexes of `NodeData` go highwire and out of bounds when trying to get the name by the index in the array names.

Modified the PR to just error.

Godot does not crash when type is missing because there's a check here:
https://github.com/godotengine/godot/blob/944a3c6cbbbb88284feebcb0603464cb175fa18e/scene/resources/packed_scene.cpp#L295