### PR TITLE
Fix area monitoring order and excess allocations

### DIFF
--- a/modules/godot_physics_2d/godot_area_2d.cpp
+++ b/modules/godot_physics_2d/godot_area_2d.cpp
@@ -33,6 +33,8 @@
 #include "godot_body_2d.h"
 #include "godot_space_2d.h"
 
+PagedAllocator<HashMapElement<GodotArea2D::BodyKey, GodotArea2D::BodyState>, false, 2048> GodotArea2D::SharedAllocator::allocator;
+
 GodotArea2D::BodyKey::BodyKey(GodotBody2D *p_body, uint32_t p_body_shape, uint32_t p_area_shape) {
 	rid = p_body->get_self();
 	instance_id = p_body->get_instance_id();
@@ -211,32 +213,36 @@ void GodotArea2D::call_queries() {
 				resptr[i] = &res[i];
 			}
 
-			for (HashMap<BodyKey, BodyState, BodyKey>::Iterator E = monitored_bodies.begin(); E;) {
-				if (E->value.state == 0) { // Nothing happened
-					HashMap<BodyKey, BodyState, BodyKey>::Iterator next = E;
-					++next;
+			// The first pass issues `AREA_BODY_ADDED`, while the second pass issues `AREA_BODY_REMOVED`.
+			// This execution order ensures that the callback doesn't incorrectly issue a body_exit signal.
+			bool first_pass = true;
+			for (HashMap<BodyKey, BodyState, BodyKey, HashMapComparatorDefault<BodyKey>, SharedAllocator>::Iterator next = monitored_bodies.begin(), E = next; E; E = next) {
+				++next;
+
+				if ((E->value.state > 0) || !first_pass) {
+					res[0] = E->value.state > 0 ? PS2DE::AREA_BODY_ADDED : PS2DE::AREA_BODY_REMOVED;
+					res[1] = E->key.rid;
+					res[2] = E->key.instance_id;
+					res[3] = E->key.body_shape;
+					res[4] = E->key.area_shape;
+
 					monitored_bodies.remove(E);
-					E = next;
-					continue;
+
+					Callable::CallError ce;
+					Variant ret;
+					monitor_callback.callp((const Variant **)resptr, 5, ret, ce);
+
+					if (ce.error != Callable::CallError::CALL_OK) {
+						ERR_PRINT_ONCE("Error calling event callback method " + Variant::get_callable_error_text(monitor_callback, (const Variant **)resptr, 5, ce));
+					}
+				} else if (E->value.state == 0) { // Nothing happened.
+					monitored_bodies.remove(E);
 				}
 
-				res[0] = E->value.state > 0 ? PS2DE::AREA_BODY_ADDED : PS2DE::AREA_BODY_REMOVED;
-				res[1] = E->key.rid;
-				res[2] = E->key.instance_id;
-				res[3] = E->key.body_shape;
-				res[4] = E->key.area_shape;
-
-				HashMap<BodyKey, BodyState, BodyKey>::Iterator next = E;
-				++next;
-				monitored_bodies.remove(E);
-				E = next;
-
-				Callable::CallError ce;
-				Variant ret;
-				monitor_callback.callp((const Variant **)resptr, 5, ret, ce);
-
-				if (ce.error != Callable::CallError::CALL_OK) {
-					ERR_PRINT_ONCE("Error calling event callback method " + Variant::get_callable_error_text(monitor_callback, (const Variant **)resptr, 5, ce));
+				if (!next && first_pass) {
+					// Start the second pass.
+					first_pass = false;
+					next = monitored_bodies.begin();
 				}
 			}
 		} else {
@@ -253,32 +259,34 @@ void GodotArea2D::call_queries() {
 				resptr[i] = &res[i];
 			}
 
-			for (HashMap<BodyKey, BodyState, BodyKey>::Iterator E = monitored_areas.begin(); E;) {
-				if (E->value.state == 0) { // Nothing happened
-					HashMap<BodyKey, BodyState, BodyKey>::Iterator next = E;
-					++next;
+			bool first_pass = true;
+			for (HashMap<BodyKey, BodyState, BodyKey, HashMapComparatorDefault<BodyKey>, SharedAllocator>::Iterator next = monitored_areas.begin(), E = next; E; E = next) {
+				++next;
+
+				if ((E->value.state > 0) || !first_pass) {
+					res[0] = E->value.state > 0 ? PS2DE::AREA_BODY_ADDED : PS2DE::AREA_BODY_REMOVED;
+					res[1] = E->key.rid;
+					res[2] = E->key.instance_id;
+					res[3] = E->key.body_shape;
+					res[4] = E->key.area_shape;
+
 					monitored_areas.remove(E);
-					E = next;
-					continue;
+
+					Callable::CallError ce;
+					Variant ret;
+					area_monitor_callback.callp((const Variant **)resptr, 5, ret, ce);
+
+					if (ce.error != Callable::CallError::CALL_OK) {
+						ERR_PRINT_ONCE("Error calling event callback method " + Variant::get_callable_error_text(area_monitor_callback, (const Variant **)resptr, 5, ce));
+					}
+				} else if (E->value.state == 0) { // Nothing happened.
+					monitored_areas.remove(E);
 				}
 
-				res[0] = E->value.state > 0 ? PS2DE::AREA_BODY_ADDED : PS2DE::AREA_BODY_REMOVED;
-				res[1] = E->key.rid;
-				res[2] = E->key.instance_id;
-				res[3] = E->key.body_shape;
-				res[4] = E->key.area_shape;
-
-				HashMap<BodyKey, BodyState, BodyKey>::Iterator next = E;
-				++next;
-				monitored_areas.remove(E);
-				E = next;
-
-				Callable::CallError ce;
-				Variant ret;
-				area_monitor_callback.callp((const Variant **)resptr, 5, ret, ce);
-
-				if (ce.error != Callable::CallError::CALL_OK) {
-					ERR_PRINT_ONCE("Error calling event callback method " + Variant::get_callable_error_text(area_monitor_callback, (const Variant **)resptr, 5, ce));
+				if (!next && first_pass) {
+					// Start the second pass.
+					first_pass = false;
+					next = monitored_areas.begin();
 				}
 			}
 		} else {

--- a/modules/godot_physics_2d/godot_area_2d.h
+++ b/modules/godot_physics_2d/godot_area_2d.h
@@ -33,6 +33,7 @@
 #include "godot_collision_object_2d.h"
 
 #include "core/templates/hash_set.h"
+#include "core/templates/paged_allocator.h"
 #include "core/templates/self_list.h"
 #include "core/variant/callable.h"
 
@@ -89,8 +90,17 @@ class GodotArea2D : public GodotCollisionObject2D {
 		_FORCE_INLINE_ void dec() { state--; }
 	};
 
-	HashMap<BodyKey, BodyState, BodyKey> monitored_bodies;
-	HashMap<BodyKey, BodyState, BodyKey> monitored_areas;
+	// This wraps a global allocator for use by all GodotArea2D objects
+	struct SharedAllocator {
+		static PagedAllocator<HashMapElement<BodyKey, BodyState>, false, 2048> allocator;
+
+		template <typename... Args>
+		HashMapElement<BodyKey, BodyState> *new_allocation(Args &&...p_args) { return allocator.new_allocation(p_args...); }
+		void delete_allocation(HashMapElement<BodyKey, BodyState> *p_mem) { allocator.free(p_mem); }
+	};
+
+	HashMap<BodyKey, BodyState, BodyKey, HashMapComparatorDefault<BodyKey>, SharedAllocator> monitored_bodies;
+	HashMap<BodyKey, BodyState, BodyKey, HashMapComparatorDefault<BodyKey>, SharedAllocator> monitored_areas;
 
 	HashSet<GodotConstraint2D *> constraints;
 

--- a/scene/2d/physics/area_2d.cpp
+++ b/scene/2d/physics/area_2d.cpp
@@ -36,6 +36,9 @@
 #include "servers/audio/audio_server.h"
 #include "servers/physics_2d/physics_server_2d.h"
 
+PagedAllocator<HashMapElement<ObjectID, Area2D::BodyState>, false, 512> Area2D::SharedBodyAllocator::allocator;
+PagedAllocator<HashMapElement<ObjectID, Area2D::AreaState>, false, 512> Area2D::SharedAreaAllocator::allocator;
+
 void Area2D::set_gravity_space_override_mode(SpaceOverride p_mode) {
 	gravity_space_override = p_mode;
 	PhysicsServer2D::get_singleton()->area_set_param(get_rid(), PS2DE::AREA_PARAM_GRAVITY_OVERRIDE_MODE, p_mode);
@@ -140,7 +143,7 @@ void Area2D::_body_enter_tree(ObjectID p_id) {
 	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_NULL(node);
 
-	HashMap<ObjectID, BodyState>::Iterator E = body_map.find(p_id);
+	HashMap<ObjectID, BodyState, HashMapHasherDefault, HashMapComparatorDefault<ObjectID>, SharedBodyAllocator>::Iterator E = body_map.find(p_id);
 	ERR_FAIL_COND(!E);
 	ERR_FAIL_COND(E->value.in_tree);
 
@@ -155,7 +158,7 @@ void Area2D::_body_exit_tree(ObjectID p_id) {
 	Object *obj = ObjectDB::get_instance(p_id);
 	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_NULL(node);
-	HashMap<ObjectID, BodyState>::Iterator E = body_map.find(p_id);
+	HashMap<ObjectID, BodyState, HashMapHasherDefault, HashMapComparatorDefault<ObjectID>, SharedBodyAllocator>::Iterator E = body_map.find(p_id);
 	ERR_FAIL_COND(!E);
 	ERR_FAIL_COND(!E->value.in_tree);
 	E->value.in_tree = false;
@@ -187,7 +190,7 @@ void Area2D::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, i
 	Object *obj = ObjectDB::get_instance(objid);
 	Node *node = Object::cast_to<Node>(obj);
 
-	HashMap<ObjectID, BodyState>::Iterator E = body_map.find(objid);
+	HashMap<ObjectID, BodyState, HashMapHasherDefault, HashMapComparatorDefault<ObjectID>, SharedBodyAllocator>::Iterator E = body_map.find(objid);
 
 	if (!body_in && !E) {
 		return; //does not exist because it was likely removed from the tree
@@ -251,7 +254,7 @@ void Area2D::_area_enter_tree(ObjectID p_id) {
 	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_NULL(node);
 
-	HashMap<ObjectID, AreaState>::Iterator E = area_map.find(p_id);
+	HashMap<ObjectID, AreaState, HashMapHasherDefault, HashMapComparatorDefault<ObjectID>, SharedAreaAllocator>::Iterator E = area_map.find(p_id);
 	ERR_FAIL_COND(!E);
 	ERR_FAIL_COND(E->value.in_tree);
 
@@ -266,7 +269,7 @@ void Area2D::_area_exit_tree(ObjectID p_id) {
 	Object *obj = ObjectDB::get_instance(p_id);
 	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_NULL(node);
-	HashMap<ObjectID, AreaState>::Iterator E = area_map.find(p_id);
+	HashMap<ObjectID, AreaState, HashMapHasherDefault, HashMapComparatorDefault<ObjectID>, SharedAreaAllocator>::Iterator E = area_map.find(p_id);
 	ERR_FAIL_COND(!E);
 	ERR_FAIL_COND(!E->value.in_tree);
 	E->value.in_tree = false;
@@ -298,7 +301,7 @@ void Area2D::_area_inout(int p_status, const RID &p_area, ObjectID p_instance, i
 	Object *obj = ObjectDB::get_instance(objid);
 	Node *node = Object::cast_to<Node>(obj);
 
-	HashMap<ObjectID, AreaState>::Iterator E = area_map.find(objid);
+	HashMap<ObjectID, AreaState, HashMapHasherDefault, HashMapComparatorDefault<ObjectID>, SharedAreaAllocator>::Iterator E = area_map.find(objid);
 
 	if (!area_in && !E) {
 		return; //likely removed from the tree
@@ -361,7 +364,7 @@ void Area2D::_clear_monitoring() {
 	ERR_FAIL_COND_MSG(locked, "This function can't be used during the in/out signal.");
 
 	{
-		HashMap<ObjectID, BodyState> bmcopy(body_map);
+		HashMap<ObjectID, BodyState, HashMapHasherDefault, HashMapComparatorDefault<ObjectID>, SharedBodyAllocator> bmcopy(body_map);
 		body_map.clear();
 		//disconnect all monitored stuff
 
@@ -389,7 +392,7 @@ void Area2D::_clear_monitoring() {
 	}
 
 	{
-		HashMap<ObjectID, AreaState> bmcopy(area_map);
+		HashMap<ObjectID, AreaState, HashMapHasherDefault, HashMapComparatorDefault<ObjectID>, SharedAreaAllocator> bmcopy(area_map);
 		area_map.clear();
 		//disconnect all monitored stuff
 
@@ -507,7 +510,7 @@ bool Area2D::has_overlapping_areas() const {
 
 bool Area2D::overlaps_area(RequiredParam<Node> p_area) const {
 	EXTRACT_PARAM_OR_FAIL_V(check_area, p_area, false);
-	HashMap<ObjectID, AreaState>::ConstIterator E = area_map.find(check_area->get_instance_id());
+	HashMap<ObjectID, AreaState, HashMapHasherDefault, HashMapComparatorDefault<ObjectID>, SharedAreaAllocator>::ConstIterator E = area_map.find(check_area->get_instance_id());
 	if (!E) {
 		return false;
 	}
@@ -516,7 +519,7 @@ bool Area2D::overlaps_area(RequiredParam<Node> p_area) const {
 
 bool Area2D::overlaps_body(RequiredParam<Node> p_body) const {
 	EXTRACT_PARAM_OR_FAIL_V(body, p_body, false);
-	HashMap<ObjectID, BodyState>::ConstIterator E = body_map.find(body->get_instance_id());
+	HashMap<ObjectID, BodyState, HashMapHasherDefault, HashMapComparatorDefault<ObjectID>, SharedBodyAllocator>::ConstIterator E = body_map.find(body->get_instance_id());
 	if (!E) {
 		return false;
 	}

--- a/scene/2d/physics/area_2d.h
+++ b/scene/2d/physics/area_2d.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/paged_allocator.h"
 #include "core/templates/vset.h"
 #include "scene/2d/physics/collision_object_2d.h"
 
@@ -95,7 +96,16 @@ private:
 		VSet<ShapePair> shapes;
 	};
 
-	HashMap<ObjectID, BodyState> body_map;
+	// This wraps a global allocator for use by all Area2D objects
+	struct SharedBodyAllocator {
+		static PagedAllocator<HashMapElement<ObjectID, BodyState>, false, 512> allocator;
+
+		template <typename... Args>
+		HashMapElement<ObjectID, BodyState> *new_allocation(Args &&...p_args) { return allocator.new_allocation(p_args...); }
+		void delete_allocation(HashMapElement<ObjectID, BodyState> *p_mem) { allocator.free(p_mem); }
+	};
+
+	HashMap<ObjectID, BodyState, HashMapHasherDefault, HashMapComparatorDefault<ObjectID>, SharedBodyAllocator> body_map;
 
 	void _area_inout(int p_status, const RID &p_area, ObjectID p_instance, int p_area_shape, int p_self_shape);
 
@@ -127,7 +137,16 @@ private:
 		VSet<AreaShapePair> shapes;
 	};
 
-	HashMap<ObjectID, AreaState> area_map;
+	// This wraps a global allocator for use by all Area2D objects
+	struct SharedAreaAllocator {
+		static PagedAllocator<HashMapElement<ObjectID, AreaState>, false, 512> allocator;
+
+		template <typename... Args>
+		HashMapElement<ObjectID, AreaState> *new_allocation(Args &&...p_args) { return allocator.new_allocation(p_args...); }
+		void delete_allocation(HashMapElement<ObjectID, AreaState> *p_mem) { allocator.free(p_mem); }
+	};
+
+	HashMap<ObjectID, AreaState, HashMapHasherDefault, HashMapComparatorDefault<ObjectID>, SharedAreaAllocator> area_map;
 	void _clear_monitoring();
 
 	bool audio_bus_override = false;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #86640
- Alternative to #120966

## Additional information
[Sort monitored_bodies in area2d queries - #120966](https://github.com/godotengine/godot/pull/120966) finds and fixes #86640 by sorting overlap detection records before notifying callbacks of the overlaps. 

I think this is an important fix, but the merge sort does more work than necessary. It only needs to make sure that ENTERED signals are issued before EXIT signals. 

This PR offers an alternative which uses the loop that is already there and issues the callbacks in two passes, one for ENTERED, and the next pass for EXIT. 

However, there was an even bigger problem impacting this same code, which is that the HashMap was using the default allocator, causing potentially 100's or even 1000's of unnecessary allocations and frees every physics frame.

This PR adds static PagedAllocators to the HashMaps in GodotArea2D and Area2D to eliminate the excess allocation thrashing. The PagedAllocators are shared between object instances (otherwise the total memory allocated for overlap reporting might grow to $n^2$ instead of $n$).
