### PR TITLE
Fix Bezier editor track ordering

### DIFF
--- a/editor/animation/animation_bezier_editor.cpp
+++ b/editor/animation/animation_bezier_editor.cpp
@@ -406,6 +406,10 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 				track_indices[base_path] = indices;
 			}
 
+			if (editor->is_sorting_alphabetically()) {
+				track_order.sort();
+			}
+
 			const Color dc = get_theme_color(SNAME("font_disabled_color"), EditorStringName(Editor));
 
 			Ref<Texture2D> remove = get_editor_theme_icon(SNAME("Remove"));

--- a/editor/animation/animation_bezier_editor.cpp
+++ b/editor/animation/animation_bezier_editor.cpp
@@ -383,7 +383,7 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 			}
 
 			RBMap<String, Vector<int>> track_indices;
-			Vector<String> track_order;
+			LocalVector<String> track_order;
 
 			int track_count = animation->get_track_count();
 			for (int i = 0; i < track_count; ++i) {

--- a/editor/animation/animation_bezier_editor.cpp
+++ b/editor/animation/animation_bezier_editor.cpp
@@ -383,6 +383,8 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 			}
 
 			RBMap<String, Vector<int>> track_indices;
+			Vector<String> track_order;
+
 			int track_count = animation->get_track_count();
 			for (int i = 0; i < track_count; ++i) {
 				if (!_is_track_displayed(i)) {
@@ -394,6 +396,11 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 				if (end != -1) {
 					base_path = base_path.substr(0, end + 1);
 				}
+
+				if (!track_indices.has(base_path)) {
+					track_order.push_back(base_path);
+				}
+
 				Vector<int> indices = track_indices.has(base_path) ? track_indices[base_path] : Vector<int>();
 				indices.push_back(i);
 				track_indices[base_path] = indices;
@@ -408,10 +415,8 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 			Ref<Texture2D> unlock = get_editor_theme_icon(SNAME("Unlock"));
 			Ref<Texture2D> solo = get_editor_theme_icon(SNAME("AudioBusSolo"));
 
-			for (const KeyValue<String, Vector<int>> &E : track_indices) {
-				String base_path = E.key;
-
-				Vector<int> tracks = E.value;
+			for (const String &base_path : track_order) {
+				Vector<int> tracks = track_indices[base_path];
 
 				// Names and icon.
 				{

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -5435,6 +5435,9 @@ void AnimationTrackEditor::_update_tracks() {
 	if (selected_track_edit != nullptr) {
 		selected_track_edit->grab_focus();
 	}
+	if (bezier_edit) {
+		bezier_edit->queue_redraw();
+	}
 }
 
 void AnimationTrackEditor::_redraw_tracks() {


### PR DESCRIPTION
### Issue

The track order in the Bezier Curve Editor could differ from the
Animation Track Editor when switching between the two views.

The Bezier editor used an RBMap to group tracks by base path. Since
RBMap orders its keys, this could change the display order.

### Fix

Preserve the order in which track paths are encountered using a
separate Vector<String>, while keeping RBMap for grouping the tracks.

This keeps the Bezier Curve Editor track order consistent when switching
between the Animation Track Editor and Bezier Curve Editor.

### Testing

Tested with the minimal reproduction project.

Before:
- Animation Track Editor and Bezier Curve Editor could show different orders.

After:
- Both editors preserve the same track order when switching between them.

AI assistance was used to help investigate the issue and discuss the
implementation. I reviewed and tested the submitted change.

Fixes #122537