### PR TITLE
PopupMenu: Only set FLAG_NO_FOCUS when necessary

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -3688,7 +3688,9 @@ void PopupMenu::_popup_base(const Rect2i &p_bounds) {
 	} else {
 		if (is_inside_tree()) {
 			set_flag(FLAG_POPUP, true);
-			set_flag(FLAG_NO_FOCUS, !is_embedded());
+			if (get_flag(FLAG_NO_FOCUS) != !is_embedded()) {
+				set_flag(FLAG_NO_FOCUS, !is_embedded());
+			}
 		}
 
 		moved = Vector2();
@@ -3797,7 +3799,9 @@ void PopupMenu::set_visible(bool p_visible) {
 	} else {
 		if (p_visible && is_inside_tree()) {
 			set_flag(FLAG_POPUP, true);
-			set_flag(FLAG_NO_FOCUS, !is_embedded());
+			if (get_flag(FLAG_NO_FOCUS) != !is_embedded()) {
+				set_flag(FLAG_NO_FOCUS, !is_embedded());
+			}
 		}
 
 		Popup::set_visible(p_visible);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #99203
- Closes #120218
- Closes (partially?) #115047

The flag was being set every time a `PopupMenu` pops up or changes visibility, even if the value is unchanged. This causes issues on Windows due to the window style being updated whenever this flag is set.

Specifically (on a Windows machine) when a `PopupMenu` pops up but does not change visibility it will become blank and can take on weird shapes. This is reproducible in the editor by quickly right clicking two times.

Before: 

https://github.com/user-attachments/assets/1a73a28c-3389-4eb7-94f4-97a1a0bfbfe2

After:


https://github.com/user-attachments/assets/9369d578-078c-4097-954f-169ef09f224a

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
