### PR TITLE
[4.7] Fix template compilation with `disable_physics_3d` and `disable_navigation_3d`

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -37,7 +37,10 @@
 #include "scene/main/scene_tree.h"
 #include "scene/resources/3d/navigation_mesh_source_geometry_data_3d.h"
 #include "scene/resources/navigation_mesh.h"
-#include "servers/rendering/rendering_server.h"
+
+#ifndef PHYSICS_3D_DISABLED
+#include "servers/rendering/rendering_server.h" // Only used for debug collision shapes.
+#endif // PHYSICS_3D_DISABLED
 
 #ifdef DEV_ENABLED
 #include "core/io/json.h"
@@ -205,6 +208,7 @@ void CSGShape3D::set_collision_priority(real_t p_priority) {
 real_t CSGShape3D::get_collision_priority() const {
 	return collision_priority;
 }
+#endif // PHYSICS_3D_DISABLED
 
 void CSGShape3D::set_autosmooth(bool p_smooth) {
 	autosmooth = p_smooth;
@@ -224,8 +228,6 @@ void CSGShape3D::set_smoothing_angle(const float p_angle) {
 float CSGShape3D::get_smoothing_angle() const {
 	return smoothing_angle;
 }
-
-#endif // PHYSICS_3D_DISABLED
 
 bool CSGShape3D::is_root_shape() const {
 	return !parent_shape;

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -145,6 +145,7 @@ public:
 
 	virtual AABB get_aabb() const override;
 
+#ifndef PHYSICS_3D_DISABLED
 	void set_use_collision(bool p_enable);
 	bool is_using_collision() const;
 
@@ -164,6 +165,7 @@ public:
 
 	void set_collision_priority(real_t p_priority);
 	real_t get_collision_priority() const;
+#endif // PHYSICS_3D_DISABLED
 
 	void set_autosmooth(bool p_smooth);
 	bool is_autosmooth() const;

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -430,7 +430,7 @@ void GridMap::set_cell_item(const Vector3i &p_position, int p_item, int p_rot) {
 			PhysicsServer3D::get_singleton()->body_set_param(g->static_body, PhysicsServer3D::BODY_PARAM_FRICTION, physics_material->computed_friction());
 			PhysicsServer3D::get_singleton()->body_set_param(g->static_body, PhysicsServer3D::BODY_PARAM_BOUNCE, physics_material->computed_bounce());
 		}
-#endif // PHYSICS_3D_DISABLED
+
 		bool debug_collisions = false;
 		switch (collision_visibility_mode) {
 			case DEBUG_VISIBILITY_MODE_DEFAULT: {
@@ -449,6 +449,7 @@ void GridMap::set_cell_item(const Vector3i &p_position, int p_item, int p_rot) {
 			g->collision_debug_instance = RS::get_singleton()->instance_create();
 			RS::get_singleton()->instance_set_base(g->collision_debug_instance, g->collision_debug);
 		}
+#endif // PHYSICS_3D_DISABLED
 
 		octant_map[octantkey] = g;
 

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.cpp
@@ -36,10 +36,13 @@
 #include "core/config/project_settings.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
-#include "scene/resources/3d/box_shape_3d.h"
-#include "scene/resources/3d/concave_polygon_shape_3d.h"
 #include "scene/resources/3d/primitive_meshes.h"
 #include "servers/xr/xr_server.h"
+
+#ifndef PHYSICS_3D_DISABLED
+#include "scene/resources/3d/box_shape_3d.h"
+#include "scene/resources/3d/concave_polygon_shape_3d.h"
+#endif
 
 ////////////////////////////////////////////////////////////////////////////
 // OpenXRSpatialCapabilityConfigurationPlaneTracking
@@ -285,7 +288,9 @@ void OpenXRPlaneTracker::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_mesh_offset"), &OpenXRPlaneTracker::get_mesh_offset);
 	ClassDB::bind_method(D_METHOD("get_mesh"), &OpenXRPlaneTracker::get_mesh);
+#ifndef PHYSICS_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("get_shape", "thickness"), &OpenXRPlaneTracker::get_shape, DEFVAL(0.01));
+#endif
 
 	ADD_SIGNAL(MethodInfo("mesh_changed"));
 }
@@ -390,7 +395,9 @@ void OpenXRPlaneTracker::set_mesh_data(const Transform3D &p_origin, const Packed
 
 		if (has_changed) {
 			mesh.mesh.unref();
+#ifndef PHYSICS_3D_DISABLED
 			mesh.shape3d.unref();
+#endif
 
 			emit_signal(SNAME("mesh_changed"));
 		}
@@ -399,7 +406,9 @@ void OpenXRPlaneTracker::set_mesh_data(const Transform3D &p_origin, const Packed
 
 void OpenXRPlaneTracker::clear_mesh_data() {
 	mesh.mesh.unref();
+#ifndef PHYSICS_3D_DISABLED
 	mesh.shape3d.unref();
+#endif
 
 	if (mesh.has_mesh_data) {
 		mesh.has_mesh_data = false;
@@ -479,6 +488,7 @@ Ref<Mesh> OpenXRPlaneTracker::get_mesh() {
 	return mesh.mesh;
 }
 
+#ifndef PHYSICS_3D_DISABLED
 Ref<Shape3D> OpenXRPlaneTracker::get_shape(real_t p_thickness) {
 	// We've already created this? Just return it!
 	if (mesh.shape3d.is_valid()) {
@@ -567,6 +577,7 @@ Ref<Shape3D> OpenXRPlaneTracker::get_shape(real_t p_thickness) {
 
 	return mesh.shape3d;
 }
+#endif // PHYSICS_3D_DISABLED
 
 ////////////////////////////////////////////////////////////////////////////
 // OpenXRSpatialPlaneTrackingCapability

--- a/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.h
+++ b/modules/openxr/extensions/spatial_entities/openxr_spatial_plane_tracking.h
@@ -34,7 +34,9 @@
 #include "../openxr_future_extension.h"
 #include "openxr_spatial_entities.h"
 
+#ifndef PHYSICS_3D_DISABLED
 #include "scene/resources/3d/shape_3d.h"
+#endif
 
 // Plane tracking capability configuration
 class OpenXRSpatialCapabilityConfigurationPlaneTracking : public OpenXRSpatialCapabilityConfigurationBaseHeader {
@@ -166,7 +168,9 @@ public:
 
 	Transform3D get_mesh_offset() const;
 	Ref<Mesh> get_mesh();
+#ifndef PHYSICS_3D_DISABLED
 	Ref<Shape3D> get_shape(real_t p_thickness = 0.01);
+#endif
 
 protected:
 	static void _bind_methods();
@@ -184,7 +188,9 @@ private:
 		PackedInt32Array indices;
 
 		Ref<Mesh> mesh;
+#ifndef PHYSICS_3D_DISABLED
 		Ref<Shape3D> shape3d;
+#endif
 	} mesh;
 
 	struct Edge {

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1516,10 +1516,9 @@ void DisplayServerWayland::window_start_resize(DisplayServerEnums::WindowResizeE
 }
 
 void DisplayServerWayland::_window_update_hdr_state(WindowData &p_window) {
-	DisplayServerEnums::WindowID window_id = p_window.id;
-
 #if defined(RD_ENABLED)
 	if (rendering_context) {
+		DisplayServerEnums::WindowID window_id = p_window.id;
 		// The `display/window/hdr/request_hdr_output` project setting makes the main window "request" HDR.
 		// On Windows, this means enable HDR for the main window if it is on an HDR screen.
 		// Since all screens support HDR on Wayland, we use whether the window "prefers" HDR or not instead.

--- a/scene/2d/tile_map_layer.cpp
+++ b/scene/2d/tile_map_layer.cpp
@@ -40,7 +40,6 @@
 #include "scene/2d/tile_map.h"
 #include "scene/gui/control.h"
 #include "scene/main/scene_tree.h"
-#include "scene/resources/2d/navigation_mesh_source_geometry_data_2d.h"
 #include "scene/resources/material.h"
 #include "scene/resources/world_2d.h"
 #include "servers/rendering/rendering_server.h"
@@ -50,6 +49,7 @@
 #endif // PHYSICS_3D_DISABLED
 
 #ifndef NAVIGATION_2D_DISABLED
+#include "scene/resources/2d/navigation_mesh_source_geometry_data_2d.h"
 #include "servers/navigation_2d/navigation_server_2d.h"
 Callable TileMapLayer::_navmesh_source_geometry_parsing_callback;
 RID TileMapLayer::_navmesh_source_geometry_parser;

--- a/scene/resources/3d/mesh_library.cpp
+++ b/scene/resources/3d/mesh_library.cpp
@@ -83,6 +83,7 @@ bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
 #endif // PHYSICS_3D_DISABLED
 		} else if (what == "preview") {
 			set_item_preview(idx, p_value);
+#ifndef NAVIGATION_3D_DISABLED
 		} else if (what == "navigation_mesh") {
 			set_item_navigation_mesh(idx, p_value);
 		} else if (what == "navigation_mesh_transform") {
@@ -95,6 +96,7 @@ bool MeshLibrary::_set(const StringName &p_name, const Variant &p_value) {
 #endif // DISABLE_DEPRECATED
 		} else if (what == "navigation_layers") {
 			set_item_navigation_layers(idx, p_value);
+#endif // NAVIGATION_3D_DISABLED
 		} else {
 			return false;
 		}
@@ -123,6 +125,7 @@ bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
 	} else if (what == "shapes") {
 		r_ret = _get_item_shapes(idx);
 #endif // PHYSICS_3D_DISABLED
+#ifndef NAVIGATION_3D_DISABLED
 	} else if (what == "navigation_mesh") {
 		r_ret = get_item_navigation_mesh(idx);
 	} else if (what == "navigation_mesh_transform") {
@@ -135,6 +138,7 @@ bool MeshLibrary::_get(const StringName &p_name, Variant &r_ret) const {
 #endif // DISABLE_DEPRECATED
 	} else if (what == "navigation_layers") {
 		r_ret = get_item_navigation_layers(idx);
+#endif // NAVIGATION_3D_DISABLED
 	} else if (what == "preview") {
 		r_ret = get_item_preview(idx);
 	} else {
@@ -152,9 +156,11 @@ void MeshLibrary::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, prop_name + PNAME("mesh_transform"), PROPERTY_HINT_NONE, "suffix:m", PROPERTY_USAGE_NO_EDITOR));
 		p_list->push_back(PropertyInfo(Variant::INT, prop_name + PNAME("mesh_cast_shadow"), PROPERTY_HINT_ENUM, "Off,On,Double-Sided,Shadows Only", PROPERTY_USAGE_NO_EDITOR));
 		p_list->push_back(PropertyInfo(Variant::ARRAY, prop_name + PNAME("shapes"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR));
+#ifndef NAVIGATION_3D_DISABLED
 		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("navigation_mesh"), PROPERTY_HINT_RESOURCE_TYPE, NavigationMesh::get_class_static(), PROPERTY_USAGE_NO_EDITOR));
 		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, prop_name + PNAME("navigation_mesh_transform"), PROPERTY_HINT_NONE, "suffix:m", PROPERTY_USAGE_NO_EDITOR));
 		p_list->push_back(PropertyInfo(Variant::INT, prop_name + PNAME("navigation_layers"), PROPERTY_HINT_LAYERS_3D_NAVIGATION, "", PROPERTY_USAGE_NO_EDITOR));
+#endif
 		p_list->push_back(PropertyInfo(Variant::OBJECT, prop_name + PNAME("preview"), PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static(), PROPERTY_USAGE_NO_EDITOR));
 	}
 }
@@ -200,6 +206,7 @@ void MeshLibrary::set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes)
 }
 #endif // PHYSICS_3D_DISABLED
 
+#ifndef NAVIGATION_3D_DISABLED
 void MeshLibrary::set_item_navigation_mesh(int p_item, const Ref<NavigationMesh> &p_navigation_mesh) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	item_map[p_item].navigation_mesh = p_navigation_mesh;
@@ -217,6 +224,7 @@ void MeshLibrary::set_item_navigation_layers(int p_item, uint32_t p_navigation_l
 	item_map[p_item].navigation_layers = p_navigation_layers;
 	emit_changed();
 }
+#endif // NAVIGATION_3D_DISABLED
 
 void MeshLibrary::set_item_preview(int p_item, const Ref<Texture2D> &p_preview) {
 	ERR_FAIL_COND_MSG(!item_map.has(p_item), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
@@ -251,6 +259,7 @@ Vector<MeshLibrary::ShapeData> MeshLibrary::get_item_shapes(int p_item) const {
 }
 #endif // PHYSICS_3D_DISABLED
 
+#ifndef NAVIGATION_3D_DISABLED
 Ref<NavigationMesh> MeshLibrary::get_item_navigation_mesh(int p_item) const {
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Ref<NavigationMesh>(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	return item_map[p_item].navigation_mesh;
@@ -265,6 +274,7 @@ uint32_t MeshLibrary::get_item_navigation_layers(int p_item) const {
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), 0, "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
 	return item_map[p_item].navigation_layers;
 }
+#endif // NAVIGATION_3D_DISABLED
 
 Ref<Texture2D> MeshLibrary::get_item_preview(int p_item) const {
 	ERR_FAIL_COND_V_MSG(!item_map.has(p_item), Ref<Texture2D>(), "Requested for nonexistent MeshLibrary item '" + itos(p_item) + "'.");
@@ -377,23 +387,33 @@ void MeshLibrary::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_item_mesh", "id", "mesh"), &MeshLibrary::set_item_mesh);
 	ClassDB::bind_method(D_METHOD("set_item_mesh_transform", "id", "mesh_transform"), &MeshLibrary::set_item_mesh_transform);
 	ClassDB::bind_method(D_METHOD("set_item_mesh_cast_shadow", "id", "shadow_casting_setting"), &MeshLibrary::set_item_mesh_cast_shadow);
+
+#ifndef NAVIGATION_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("set_item_navigation_mesh", "id", "navigation_mesh"), &MeshLibrary::set_item_navigation_mesh);
 	ClassDB::bind_method(D_METHOD("set_item_navigation_mesh_transform", "id", "navigation_mesh"), &MeshLibrary::set_item_navigation_mesh_transform);
 	ClassDB::bind_method(D_METHOD("set_item_navigation_layers", "id", "navigation_layers"), &MeshLibrary::set_item_navigation_layers);
+#endif // NAVIGATION_3D_DISABLED
+
 #ifndef PHYSICS_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("set_item_shapes", "id", "shapes"), &MeshLibrary::_set_item_shapes);
 #endif // PHYSICS_3D_DISABLED
+
 	ClassDB::bind_method(D_METHOD("set_item_preview", "id", "texture"), &MeshLibrary::set_item_preview);
 	ClassDB::bind_method(D_METHOD("get_item_name", "id"), &MeshLibrary::get_item_name);
 	ClassDB::bind_method(D_METHOD("get_item_mesh", "id"), &MeshLibrary::get_item_mesh);
 	ClassDB::bind_method(D_METHOD("get_item_mesh_transform", "id"), &MeshLibrary::get_item_mesh_transform);
 	ClassDB::bind_method(D_METHOD("get_item_mesh_cast_shadow", "id"), &MeshLibrary::get_item_mesh_cast_shadow);
+
+#ifndef NAVIGATION_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("get_item_navigation_mesh", "id"), &MeshLibrary::get_item_navigation_mesh);
 	ClassDB::bind_method(D_METHOD("get_item_navigation_mesh_transform", "id"), &MeshLibrary::get_item_navigation_mesh_transform);
 	ClassDB::bind_method(D_METHOD("get_item_navigation_layers", "id"), &MeshLibrary::get_item_navigation_layers);
+#endif // NAVIGATION_3D_DISABLED
+
 #ifndef PHYSICS_3D_DISABLED
 	ClassDB::bind_method(D_METHOD("get_item_shapes", "id"), &MeshLibrary::_get_item_shapes);
 #endif // PHYSICS_3D_DISABLED
+
 	ClassDB::bind_method(D_METHOD("get_item_preview", "id"), &MeshLibrary::get_item_preview);
 	ClassDB::bind_method(D_METHOD("remove_item", "id"), &MeshLibrary::remove_item);
 	ClassDB::bind_method(D_METHOD("find_item_by_name", "name"), &MeshLibrary::find_item_by_name);

--- a/scene/resources/3d/mesh_library.h
+++ b/scene/resources/3d/mesh_library.h
@@ -33,12 +33,15 @@
 #include "core/io/resource.h"
 #include "core/templates/rb_map.h"
 #include "scene/resources/mesh.h"
-#include "scene/resources/navigation_mesh.h"
 #include "servers/rendering/rendering_server_enums.h"
 
 #ifndef PHYSICS_3D_DISABLED
 #include "scene/resources/3d/shape_3d.h"
 #endif // PHYSICS_3D_DISABLED
+
+#ifndef NAVIGATION_3D_DISABLED
+#include "scene/resources/navigation_mesh.h"
+#endif // NAVIGATION_3D_DISABLED
 
 class MeshLibrary : public Resource {
 	GDCLASS(MeshLibrary, Resource);
@@ -60,9 +63,11 @@ public:
 		Vector<ShapeData> shapes;
 #endif // PHYSICS_3D_DISABLED
 		Ref<Texture2D> preview;
+#ifndef NAVIGATION_3D_DISABLED
 		Ref<NavigationMesh> navigation_mesh;
 		Transform3D navigation_mesh_transform;
 		uint32_t navigation_layers = 1;
+#endif // NAVIGATION_3D_DISABLED
 	};
 
 	RBMap<int, Item> item_map;
@@ -86,23 +91,33 @@ public:
 	void set_item_mesh(int p_item, const Ref<Mesh> &p_mesh);
 	void set_item_mesh_transform(int p_item, const Transform3D &p_transform);
 	void set_item_mesh_cast_shadow(int p_item, RSE::ShadowCastingSetting p_shadow_casting_setting);
+
+#ifndef NAVIGATION_3D_DISABLED
 	void set_item_navigation_mesh(int p_item, const Ref<NavigationMesh> &p_navigation_mesh);
 	void set_item_navigation_mesh_transform(int p_item, const Transform3D &p_transform);
 	void set_item_navigation_layers(int p_item, uint32_t p_navigation_layers);
+#endif // NAVIGATION_3D_DISABLED
+
 #ifndef PHYSICS_3D_DISABLED
 	void set_item_shapes(int p_item, const Vector<ShapeData> &p_shapes);
 #endif // PHYSICS_3D_DISABLED
+
 	void set_item_preview(int p_item, const Ref<Texture2D> &p_preview);
 	String get_item_name(int p_item) const;
 	Ref<Mesh> get_item_mesh(int p_item) const;
 	Transform3D get_item_mesh_transform(int p_item) const;
 	RSE::ShadowCastingSetting get_item_mesh_cast_shadow(int p_item) const;
+
+#ifndef NAVIGATION_3D_DISABLED
 	Ref<NavigationMesh> get_item_navigation_mesh(int p_item) const;
 	Transform3D get_item_navigation_mesh_transform(int p_item) const;
 	uint32_t get_item_navigation_layers(int p_item) const;
+#endif // NAVIGATION_3D_DISABLED
+
 #ifndef PHYSICS_3D_DISABLED
 	Vector<ShapeData> get_item_shapes(int p_item) const;
 #endif // PHYSICS_3D_DISABLED
+
 	Ref<Texture2D> get_item_preview(int p_item) const;
 
 	void remove_item(int p_item);

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -171,7 +171,7 @@ struct GodotTestCaseListener : public doctest::IReporter {
 		reinitialize();
 
 		String name = String(p_in.m_name);
-		String suite_name = String(p_in.m_test_suite);
+		[[maybe_unused]] String suite_name = String(p_in.m_test_suite);
 
 		if (name.contains("[SceneTree]") || name.contains("[Editor]")) {
 			memnew(Input);


### PR DESCRIPTION
- Cherry-pick of #120127.
- Fixes #122582.
- Also adds MeshLibrary fixes for `disable_navigation_3d` too. The `master` code changed significantly so the relevant fix there wasn't cherry-pickable.
- Tested `disable_physics_3d`, `disable_physics_2d`, `disable_navigation_3d`, and `disable_navigation_2d` successfully (independently, and all combined) for a Linux `template_release` build.