### PR TITLE
SCons: Fix build with `disable_physics_3d` and disabled navigation

### DIFF
--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -154,13 +154,13 @@ public:
 
 	void set_collision_priority(real_t p_priority);
 	real_t get_collision_priority() const;
+#endif // PHYSICS_3D_DISABLED
 
 	void set_autosmooth(bool p_smooth);
 	bool is_autosmooth() const;
 
 	void set_smoothing_angle(const float p_angle);
 	float get_smoothing_angle() const;
-#endif // PHYSICS_3D_DISABLED
 
 #ifndef DISABLE_DEPRECATED
 	void set_snap(float p_snap);

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -817,7 +817,9 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 		return true;
 	}
 
+#ifndef PHYSICS_3D_DISABLED
 	Vector<Vector3> col_debug;
+#endif
 
 	/*
 	 * foreach item in this octant,

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1530,10 +1530,9 @@ void DisplayServerWayland::window_start_resize(DisplayServerEnums::WindowResizeE
 }
 
 void DisplayServerWayland::_window_update_hdr_state(WindowData &p_window) {
-	DisplayServerEnums::WindowID window_id = p_window.id;
-
 #if defined(RD_ENABLED)
 	if (rendering_context) {
+		DisplayServerEnums::WindowID window_id = p_window.id;
 		// The `display/window/hdr/request_hdr_output` project setting makes the main window "request" HDR.
 		// On Windows, this means enable HDR for the main window if it is on an HDR screen.
 		// Since all screens support HDR on Wayland, we use whether the window "prefers" HDR or not instead.

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -176,7 +176,7 @@ struct GodotTestCaseListener : public doctest::IReporter {
 		reinitialize();
 
 		String name = String(p_in.m_name);
-		String suite_name = String(p_in.m_test_suite);
+		[[maybe_unused]] String suite_name = String(p_in.m_test_suite);
 
 		if (name.contains("[SceneTree]") || name.contains("[Editor]")) {
 			memnew(Input);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes up #120127 which didn't fully fix the compilation for various combinations of `disable_physics_3d`/`2d` and `disable_navigation_3d`/`2d`.
- Fixes #122628.

## Additional information

- Relevant fixes included in the 4.7 cherry-pick #122593.