### PR TITLE
Move property maps from `ClassDB` to `GDType`. Accelerate `Object` property access 1.6x

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -479,33 +479,35 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 			}
 		}
 
-		{ //properties
+		{
+			//properties
 
-			List<StringName> snames;
+			LocalVector<StringName> snames;
 
-			for (const KeyValue<StringName, PropertySetGet> &F : t->property_setget) {
-				snames.push_back(F.key);
+			for (const KeyValue<StringName, GDType::Property> &kv : t->gdtype->get_property_map(true)) {
+				if (kv.value.type == GDType::Property::Type::SETGET) {
+					snames.push_back(kv.key);
+				}
 			}
-
 			snames.sort_custom<StringName::AlphCompare>();
 
 			for (const StringName &F : snames) {
-				PropertySetGet *psg = t->property_setget.getptr(F);
-				ERR_FAIL_NULL_V(psg, 0);
+				const GDType::Property &property = t->gdtype->get_property_map(true)[F];
+				const GDType::Property::SetGet &psg = property.payload.setget;
 
 				hash = hash_murmur3_one_64(F.hash(), hash);
-				hash = hash_murmur3_one_64(psg->setter.hash(), hash);
-				hash = hash_murmur3_one_64(psg->getter.hash(), hash);
+				hash = hash_murmur3_one_64((psg.setter ? psg.setter->get_name() : StringName()).hash(), hash);
+				hash = hash_murmur3_one_64((psg.getter ? psg.getter->get_name() : StringName()).hash(), hash);
 			}
 		}
 
 		//property list
-		for (const PropertyInfo &F : t->property_list) {
-			hash = hash_murmur3_one_64(F.name.hash(), hash);
-			hash = hash_murmur3_one_64(F.type, hash);
-			hash = hash_murmur3_one_64(F.hint, hash);
-			hash = hash_murmur3_one_64(F.hint_string.hash(), hash);
-			hash = hash_murmur3_one_64(F.usage, hash);
+		for (const PropertyInfo *F : t->gdtype->get_ordered_self_properties()) {
+			hash = hash_murmur3_one_64(F->name.hash(), hash);
+			hash = hash_murmur3_one_64(F->type, hash);
+			hash = hash_murmur3_one_64(F->hint, hash);
+			hash = hash_murmur3_one_64(F->hint_string.hash(), hash);
+			hash = hash_murmur3_one_64(F->usage, hash);
 		}
 	}
 
@@ -973,7 +975,7 @@ static MethodInfo info_from_bind(const MethodBind *p_method) {
 	return minfo;
 }
 
-void ClassDB::get_method_list(const StringName &p_class, List<MethodInfo> *p_methods, bool p_no_inheritance, bool p_exclude_from_properties) {
+void ClassDB::get_method_list(const StringName &p_class, List<MethodInfo> *p_methods, bool p_no_inheritance) {
 	Locker::Lock lock(Locker::STATE_READ);
 
 	ClassInfo *type = classes.getptr(p_class);
@@ -981,11 +983,6 @@ void ClassDB::get_method_list(const StringName &p_class, List<MethodInfo> *p_met
 		if (type->disabled) {
 			continue;
 		}
-#ifdef DEBUG_ENABLED
-		if (p_exclude_from_properties && type->methods_in_properties.has(kv.key)) {
-			continue;
-		}
-#endif
 
 		p_methods->push_back(info_from_bind(kv.value));
 	}
@@ -995,7 +992,7 @@ void ClassDB::get_method_list(const StringName &p_class, List<MethodInfo> *p_met
 #endif
 }
 
-void ClassDB::get_method_list_with_compatibility(const StringName &p_class, List<Pair<MethodInfo, uint32_t>> *p_methods, bool p_no_inheritance, bool p_exclude_from_properties) {
+void ClassDB::get_method_list_with_compatibility(const StringName &p_class, List<Pair<MethodInfo, uint32_t>> *p_methods, bool p_no_inheritance) {
 	Locker::Lock lock(Locker::STATE_READ);
 
 	ClassInfo *type = classes.getptr(p_class);
@@ -1003,11 +1000,6 @@ void ClassDB::get_method_list_with_compatibility(const StringName &p_class, List
 		if (type->disabled) {
 			continue;
 		}
-#ifdef DEBUG_ENABLED
-		if (p_exclude_from_properties && type->methods_in_properties.has(kv.key)) {
-			continue;
-		}
-#endif
 
 		p_methods->push_back(Pair(info_from_bind(kv.value), kv.value->get_hash()));
 	}
@@ -1044,7 +1036,7 @@ void ClassDB::get_method_list_with_compatibility(const StringName &p_class, List
 	}
 }
 
-bool ClassDB::get_method_info(const StringName &p_class, const StringName &p_method, MethodInfo *r_info, bool p_no_inheritance, bool p_exclude_from_properties) {
+bool ClassDB::get_method_info(const StringName &p_class, const StringName &p_method, MethodInfo *r_info, bool p_no_inheritance) {
 	Locker::Lock lock(Locker::STATE_READ);
 
 	ClassInfo *type = classes.getptr(p_class);
@@ -1344,7 +1336,7 @@ bool ClassDB::get_signal(const StringName &p_class, const StringName &p_signal, 
 }
 
 void ClassDB::add_property_group(const StringName &p_class, const String &p_name, const String &p_prefix, int p_indent_depth) {
-	Locker::Lock lock(Locker::STATE_WRITE);
+	Locker::Lock lock(Locker::STATE_READ); // Doesn't modify ClassDB stuff.
 	ClassInfo *type = classes.getptr(p_class);
 	ERR_FAIL_NO_CLASS(type, p_class);
 
@@ -1353,11 +1345,11 @@ void ClassDB::add_property_group(const StringName &p_class, const String &p_name
 		prefix = vformat("%s,%d", p_prefix, p_indent_depth);
 	}
 
-	type->property_list.push_back(PropertyInfo(Variant::NIL, p_name, PROPERTY_HINT_NONE, prefix, PROPERTY_USAGE_GROUP));
+	type->gdtype->add_to_ordered_properties(PropertyInfo(Variant::NIL, p_name, PROPERTY_HINT_NONE, prefix, PROPERTY_USAGE_GROUP));
 }
 
 void ClassDB::add_property_subgroup(const StringName &p_class, const String &p_name, const String &p_prefix, int p_indent_depth) {
-	Locker::Lock lock(Locker::STATE_WRITE);
+	Locker::Lock lock(Locker::STATE_READ); // Doesn't modify ClassDB stuff.
 	ClassInfo *type = classes.getptr(p_class);
 	ERR_FAIL_NO_CLASS(type, p_class);
 
@@ -1366,7 +1358,7 @@ void ClassDB::add_property_subgroup(const StringName &p_class, const String &p_n
 		prefix = vformat("%s,%d", p_prefix, p_indent_depth);
 	}
 
-	type->property_list.push_back(PropertyInfo(Variant::NIL, p_name, PROPERTY_HINT_NONE, prefix, PROPERTY_USAGE_SUBGROUP));
+	type->gdtype->add_to_ordered_properties(PropertyInfo(Variant::NIL, p_name, PROPERTY_HINT_NONE, prefix, PROPERTY_USAGE_SUBGROUP));
 }
 
 void ClassDB::add_property_array_count(const StringName &p_class, const String &p_label, const StringName &p_count_property, const StringName &p_count_setter, const StringName &p_count_getter, const String &p_array_element_prefix, uint32_t p_count_usage) {
@@ -1374,71 +1366,20 @@ void ClassDB::add_property_array_count(const StringName &p_class, const String &
 }
 
 void ClassDB::add_property_array(const StringName &p_class, const StringName &p_path, const String &p_array_element_prefix) {
-	Locker::Lock lock(Locker::STATE_WRITE);
+	Locker::Lock lock(Locker::STATE_READ); // Doesn't modify ClassDB stuff.
 	ClassInfo *type = classes.getptr(p_class);
 	ERR_FAIL_NO_CLASS(type, p_class);
 
-	type->property_list.push_back(PropertyInfo(Variant::NIL, p_path, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_ARRAY, p_array_element_prefix));
+	type->gdtype->add_to_ordered_properties(PropertyInfo(Variant::NIL, p_path, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_ARRAY, p_array_element_prefix));
 }
 
 // NOTE: For implementation simplicity reasons, this method doesn't allow setters to have optional arguments at the end.
 void ClassDB::add_property(const StringName &p_class, const PropertyInfo &p_pinfo, const StringName &p_setter, const StringName &p_getter, int p_index) {
-	Locker::Lock lock(Locker::STATE_WRITE);
+	Locker::Lock lock(Locker::STATE_READ); // Doesn't modify ClassDB stuff.
 
 	ClassInfo *type = classes.getptr(p_class);
-
 	ERR_FAIL_NO_CLASS(type, p_class);
-
-	const MethodBind *mb_set = nullptr;
-	if (p_setter) {
-		mb_set = get_method(p_class, p_setter);
-#ifdef DEBUG_ENABLED
-
-		ERR_FAIL_NULL_MSG(mb_set, vformat("Invalid setter '%s::%s' for property '%s'.", p_class, p_setter, p_pinfo.name));
-
-		int exp_args = 1 + (p_index >= 0 ? 1 : 0);
-		ERR_FAIL_COND_MSG(mb_set->get_argument_count() != exp_args, vformat("Invalid function for setter '%s::%s' for property '%s'.", p_class, p_setter, p_pinfo.name));
-#endif // DEBUG_ENABLED
-	}
-
-	const MethodBind *mb_get = nullptr;
-	if (p_getter) {
-		mb_get = get_method(p_class, p_getter);
-#ifdef DEBUG_ENABLED
-
-		ERR_FAIL_NULL_MSG(mb_get, vformat("Invalid getter '%s::%s' for property '%s'.", p_class, p_getter, p_pinfo.name));
-
-		int exp_args = 0 + (p_index >= 0 ? 1 : 0);
-		ERR_FAIL_COND_MSG(mb_get->get_argument_count() != exp_args, vformat("Invalid function for getter '%s::%s' for property '%s'.", p_class, p_getter, p_pinfo.name));
-#endif // DEBUG_ENABLED
-	}
-
-#ifdef DEBUG_ENABLED
-	ERR_FAIL_COND_MSG(type->property_setget.has(p_pinfo.name), vformat("Object '%s' already has property '%s'.", p_class, p_pinfo.name));
-#endif // DEBUG_ENABLED
-
-	type->property_list.push_back(p_pinfo);
-	type->property_map[p_pinfo.name] = p_pinfo;
-#ifdef DEBUG_ENABLED
-	// Used to filter out setters and getters in the editor (e.g. autocomplete) to not clutter menus. We only want to filter methods from properties that are easily available to users.
-	if (p_index == -1 && !(p_pinfo.usage & PropertyUsageFlags::PROPERTY_USAGE_INTERNAL)) {
-		if (mb_get) {
-			type->methods_in_properties.insert(p_getter);
-		}
-		if (mb_set) {
-			type->methods_in_properties.insert(p_setter);
-		}
-	}
-#endif // DEBUG_ENABLED
-	PropertySetGet psg;
-	psg.setter = p_setter;
-	psg.getter = p_getter;
-	psg._setptr = mb_set;
-	psg._getptr = mb_get;
-	psg.index = p_index;
-	psg.type = p_pinfo.type;
-
-	type->property_setget[p_pinfo.name] = psg;
+	type->gdtype->add_property(p_pinfo, p_setter, p_getter, p_index);
 }
 
 void ClassDB::set_property_default_value(const StringName &p_class, const StringName &p_name, const Variant &p_default) {
@@ -1450,12 +1391,17 @@ void ClassDB::set_property_default_value(const StringName &p_class, const String
 
 void ClassDB::add_linked_property(const StringName &p_class, const String &p_property, const String &p_linked_property) {
 #ifdef TOOLS_ENABLED
-	Locker::Lock lock(Locker::STATE_WRITE);
+	Locker::Lock lock(Locker::STATE_READ); // Doesn't modify ClassDB stuff.
 	ClassInfo *type = classes.getptr(p_class);
 	ERR_FAIL_NO_CLASS(type, p_class);
 
-	ERR_FAIL_COND(!type->property_map.has(p_property));
-	ERR_FAIL_COND(!type->property_map.has(p_linked_property));
+	const GDType::Property *property = type->gdtype->get_property_map(true).getptr(p_property);
+	ERR_FAIL_NULL(property);
+	ERR_FAIL_COND(property->type != GDType::Property::Type::SETGET);
+
+	const GDType::Property *linked_property = type->gdtype->get_property_map(true).getptr(p_linked_property);
+	ERR_FAIL_NULL(linked_property);
+	ERR_FAIL_COND(linked_property->type != GDType::Property::Type::SETGET);
 
 	if (!type->linked_properties.has(p_property)) {
 		type->linked_properties.insert(p_property, List<StringName>());
@@ -1466,13 +1412,13 @@ void ClassDB::add_linked_property(const StringName &p_class, const String &p_pro
 }
 
 void ClassDB::get_property_list(const StringName &p_class, List<PropertyInfo> *p_list, bool p_no_inheritance, const Object *p_validator) {
-	Locker::Lock lock(Locker::STATE_READ);
+	Locker::Lock lock(Locker::STATE_READ); // Doesn't modify ClassDB stuff.
 
 	ClassInfo *type = classes.getptr(p_class);
 	ClassInfo *check = type;
 	while (check) {
-		for (const PropertyInfo &pi : check->property_list) {
-			p_list->push_back(pi);
+		for (const PropertyInfo *pi : check->gdtype->get_ordered_self_properties()) {
+			p_list->push_back(*pi);
 			if (p_validator) {
 				p_validator->validate_property(p_list->back()->get());
 			}
@@ -1507,22 +1453,18 @@ void ClassDB::get_linked_properties_info(const StringName &p_class, const String
 bool ClassDB::get_property_info(const StringName &p_class, const StringName &p_property, PropertyInfo *r_info, bool p_no_inheritance, const Object *p_validator) {
 	Locker::Lock lock(Locker::STATE_READ);
 
-	ClassInfo *check = classes.getptr(p_class);
-	while (check) {
-		if (check->property_map.has(p_property)) {
-			PropertyInfo pinfo = check->property_map[p_property];
-			if (p_validator) {
-				p_validator->validate_property(pinfo);
-			}
+	ClassInfo *class_info = classes.getptr(p_class);
+	if (class_info) {
+		const GDType::Property *property = class_info->gdtype->get_property_map(p_no_inheritance).getptr(p_property);
+		if (property && property->type == GDType::Property::Type::SETGET) {
 			if (r_info) {
-				*r_info = pinfo;
+				*r_info = *property->payload.setget.property_info;
+			}
+			if (p_validator) {
+				p_validator->validate_property(*r_info);
 			}
 			return true;
 		}
-		if (p_no_inheritance) {
-			break;
-		}
-		check = check->inherits_ptr;
 	}
 
 	return false;
@@ -1531,126 +1473,29 @@ bool ClassDB::get_property_info(const StringName &p_class, const StringName &p_p
 bool ClassDB::set_property(Object *p_object, const StringName &p_property, const Variant &p_value, bool *r_valid) {
 	ERR_FAIL_NULL_V(p_object, false);
 
-	ClassInfo *type = classes.getptr(p_object->get_class_name());
-	ClassInfo *check = type;
-	while (check) {
-		const PropertySetGet *psg = check->property_setget.getptr(p_property);
-		if (psg) {
-			if (!psg->setter) {
-				if (r_valid) {
-					*r_valid = false;
-				}
-				return true; //return true but do nothing
-			}
-
-			Callable::CallError ce;
-
-			if (psg->index >= 0) {
-				Variant index = psg->index;
-				const Variant *arg[2] = { &index, &p_value };
-				//p_object->call(psg->setter,arg,2,ce);
-				if (psg->_setptr) {
-					psg->_setptr->call(p_object, arg, 2, ce);
-				} else {
-					p_object->callp(psg->setter, arg, 2, ce);
-				}
-
-			} else {
-				const Variant *arg[1] = { &p_value };
-				if (psg->_setptr) {
-					psg->_setptr->call(p_object, arg, 1, ce);
-				} else {
-					p_object->callp(psg->setter, arg, 1, ce);
-				}
-			}
-
-			if (r_valid) {
-				*r_valid = ce.error == Callable::CallError::CALL_OK;
-			}
-
-			return true;
-		}
-
-		check = check->inherits_ptr;
-	}
-
-	return false;
+	return p_object->set_native(p_property, p_value, r_valid);
 }
 
 bool ClassDB::get_property(Object *p_object, const StringName &p_property, Variant &r_value) {
 	ERR_FAIL_NULL_V(p_object, false);
 
-	ClassInfo *type = classes.getptr(p_object->get_class_name());
-	ClassInfo *check = type;
-	while (check) {
-		const PropertySetGet *psg = check->property_setget.getptr(p_property);
-		if (psg) {
-			if (!psg->getter) {
-				return true; //return true but do nothing
-			}
-
-			if (psg->index >= 0) {
-				Variant index = psg->index;
-				const Variant *arg[1] = { &index };
-				Callable::CallError ce;
-				const Variant value = p_object->callp(psg->getter, arg, 1, ce);
-				r_value = (ce.error == Callable::CallError::CALL_OK) ? value : Variant();
-
-			} else {
-				Callable::CallError ce;
-				if (psg->_getptr) {
-					r_value = psg->_getptr->call(p_object, nullptr, 0, ce);
-				} else {
-					const Variant value = p_object->callp(psg->getter, nullptr, 0, ce);
-					r_value = (ce.error == Callable::CallError::CALL_OK) ? value : Variant();
-				}
-			}
-			return true;
-		}
-
-		const int64_t *c = check->gdtype->get_integer_constant_map(true).getptr(p_property); //constants count
-		if (c) {
-			r_value = *c;
-			return true;
-		}
-
-		if (check->gdtype->get_method_map(true).has(p_property)) { //methods count
-			r_value = Callable(p_object, p_property);
-			return true;
-		}
-
-		if (check->gdtype->get_signal_map(true).has(p_property)) { //signals count
-			r_value = Signal(p_object, p_property);
-			return true;
-		}
-
-		check = check->inherits_ptr;
-	}
-
-	// The "free()" method is special, so we assume it exists and return a Callable.
-	if (p_property == CoreStringName(free_)) {
-		r_value = Callable(p_object, p_property);
-		return true;
-	}
-
-	return false;
+	return p_object->get_native(p_property, r_value);
 }
 
 int ClassDB::get_property_index(const StringName &p_class, const StringName &p_property, bool *r_is_valid) {
-	ClassInfo *type = classes.getptr(p_class);
-	ClassInfo *check = type;
-	while (check) {
-		const PropertySetGet *psg = check->property_setget.getptr(p_property);
-		if (psg) {
+	ClassInfo *class_info = classes.getptr(p_class);
+	if (class_info) {
+		const GDType::Property *property = class_info->gdtype->get_property_map().getptr(p_property);
+		if (property && property->type == GDType::Property::Type::SETGET) {
+			const GDType::Property::SetGet &psg = property->payload.setget;
 			if (r_is_valid) {
 				*r_is_valid = true;
 			}
 
-			return psg->index;
+			return psg.index;
 		}
-
-		check = check->inherits_ptr;
 	}
+
 	if (r_is_valid) {
 		*r_is_valid = false;
 	}
@@ -1659,20 +1504,19 @@ int ClassDB::get_property_index(const StringName &p_class, const StringName &p_p
 }
 
 Variant::Type ClassDB::get_property_type(const StringName &p_class, const StringName &p_property, bool *r_is_valid) {
-	ClassInfo *type = classes.getptr(p_class);
-	ClassInfo *check = type;
-	while (check) {
-		const PropertySetGet *psg = check->property_setget.getptr(p_property);
-		if (psg) {
+	ClassInfo *class_info = classes.getptr(p_class);
+	if (class_info) {
+		const GDType::Property *property = class_info->gdtype->get_property_map().getptr(p_property);
+		if (property && property->type == GDType::Property::Type::SETGET) {
+			const GDType::Property::SetGet &psg = property->payload.setget;
 			if (r_is_valid) {
 				*r_is_valid = true;
 			}
 
-			return psg->type;
+			return psg.property_info->type;
 		}
-
-		check = check->inherits_ptr;
 	}
+
 	if (r_is_valid) {
 		*r_is_valid = false;
 	}
@@ -1681,47 +1525,34 @@ Variant::Type ClassDB::get_property_type(const StringName &p_class, const String
 }
 
 StringName ClassDB::get_property_setter(const StringName &p_class, const StringName &p_property) {
-	ClassInfo *type = classes.getptr(p_class);
-	ClassInfo *check = type;
-	while (check) {
-		const PropertySetGet *psg = check->property_setget.getptr(p_property);
-		if (psg) {
-			return psg->setter;
+	ClassInfo *class_info = classes.getptr(p_class);
+	if (class_info) {
+		const GDType::Property *property = class_info->gdtype->get_property_map().getptr(p_property);
+		if (property && property->type == GDType::Property::Type::SETGET) {
+			return property->payload.setget.setter ? property->payload.setget.setter->get_name() : StringName();
 		}
-
-		check = check->inherits_ptr;
 	}
 
 	return StringName();
 }
 
 StringName ClassDB::get_property_getter(const StringName &p_class, const StringName &p_property) {
-	ClassInfo *type = classes.getptr(p_class);
-	ClassInfo *check = type;
-	while (check) {
-		const PropertySetGet *psg = check->property_setget.getptr(p_property);
-		if (psg) {
-			return psg->getter;
+	ClassInfo *class_info = classes.getptr(p_class);
+	if (class_info) {
+		const GDType::Property *property = class_info->gdtype->get_property_map().getptr(p_property);
+		if (property && property->type == GDType::Property::Type::SETGET) {
+			return property->payload.setget.getter ? property->payload.setget.getter->get_name() : StringName();
 		}
-
-		check = check->inherits_ptr;
 	}
 
 	return StringName();
 }
 
 bool ClassDB::has_property(const StringName &p_class, const StringName &p_property, bool p_no_inheritance) {
-	ClassInfo *type = classes.getptr(p_class);
-	ClassInfo *check = type;
-	while (check) {
-		if (check->property_setget.has(p_property)) {
-			return true;
-		}
-
-		if (p_no_inheritance) {
-			break;
-		}
-		check = check->inherits_ptr;
+	ClassInfo *class_info = classes.getptr(p_class);
+	if (class_info) {
+		const GDType::Property *property = class_info->gdtype->get_property_map(p_no_inheritance).getptr(p_property);
+		return property ? property->type == GDType::Property::Type::SETGET : false;
 	}
 
 	return false;

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -108,15 +108,6 @@ public:
 	};
 
 public:
-	struct PropertySetGet {
-		int index;
-		StringName setter;
-		StringName getter;
-		const MethodBind *_setptr = nullptr;
-		const MethodBind *_getptr = nullptr;
-		Variant::Type type;
-	};
-
 	struct ClassInfo {
 		APIType api = API_NONE;
 		ClassInfo *inherits_ptr = nullptr;
@@ -127,11 +118,7 @@ public:
 
 		HashMap<StringName, LocalVector<MethodBind *>> method_map_compatibility;
 
-		List<PropertyInfo> property_list;
-		HashMap<StringName, PropertyInfo> property_map;
-
 #ifdef DEBUG_ENABLED
-		HashSet<StringName> methods_in_properties;
 		List<MethodInfo> virtual_methods;
 		HashMap<StringName, MethodInfo> virtual_methods_map;
 		HashMap<StringName, Vector<Error>> method_error_values;
@@ -142,7 +129,6 @@ public:
 		List<StringName> dependency_list;
 #endif
 
-		AHashMap<StringName, PropertySetGet> property_setget;
 		HashMap<StringName, Vector<uint32_t>> virtual_methods_compat;
 
 		bool disabled = false;
@@ -481,9 +467,9 @@ public:
 	static bool has_method(const StringName &p_class, const StringName &p_method, bool p_no_inheritance = false);
 	static void set_method_flags(const StringName &p_class, const StringName &p_method, int p_flags);
 
-	static void get_method_list(const StringName &p_class, List<MethodInfo> *p_methods, bool p_no_inheritance = false, bool p_exclude_from_properties = false);
-	static void get_method_list_with_compatibility(const StringName &p_class, List<Pair<MethodInfo, uint32_t>> *p_methods_with_hash, bool p_no_inheritance = false, bool p_exclude_from_properties = false);
-	static bool get_method_info(const StringName &p_class, const StringName &p_method, MethodInfo *r_info, bool p_no_inheritance = false, bool p_exclude_from_properties = false);
+	static void get_method_list(const StringName &p_class, List<MethodInfo> *p_methods, bool p_no_inheritance = false);
+	static void get_method_list_with_compatibility(const StringName &p_class, List<Pair<MethodInfo, uint32_t>> *p_methods_with_hash, bool p_no_inheritance = false);
+	static bool get_method_info(const StringName &p_class, const StringName &p_method, MethodInfo *r_info, bool p_no_inheritance = false);
 	static int get_method_argument_count(const StringName &p_class, const StringName &p_method, bool *r_is_valid = nullptr, bool p_no_inheritance = false);
 	static const MethodBind *get_method(const StringName &p_class, const StringName &p_name);
 	static const MethodBind *get_method_with_compatibility(const StringName &p_class, const StringName &p_name, uint64_t p_hash, bool *r_method_exists = nullptr, bool *r_is_deprecated = nullptr);

--- a/core/object/gdtype.cpp
+++ b/core/object/gdtype.cpp
@@ -55,6 +55,9 @@ GDType::~GDType() {
 	for (MethodBind *bind : owned_method_map) {
 		memdelete(bind);
 	}
+	for (const PropertyInfo *property : ordered_self_properties) {
+		memdelete(const_cast<PropertyInfo *>(property));
+	}
 }
 
 void GDType::initialize() {
@@ -71,6 +74,7 @@ void GDType::initialize() {
 		enum_map = super_type->enum_map;
 		signal_map = super_type->signal_map;
 		method_map = super_type->method_map;
+		property_map = super_type->property_map;
 	}
 
 	init_state = InitState::MUTABLE;
@@ -80,9 +84,12 @@ void GDType::bind_integer_constant(const StringName &p_enum, const StringName &p
 	ERR_FAIL_COND(!Thread::is_main_thread());
 	ERR_FAIL_COND(init_state != InitState::MUTABLE);
 	ERR_FAIL_COND_MSG(self_constant_map.has(p_name), vformat("Class '%s' already has constant '%s'.", String(name), String(p_name)));
+	ERR_FAIL_COND_MSG(property_map.has(p_name), vformat("Object '%s' already has property '%s'.", get_name(), p_name));
 
 	constant_map[p_name] = p_constant;
 	self_constant_map[p_name] = p_constant;
+	property_map.insert(p_name, Property(Property::Type::INTEGER_CONSTANT, p_constant));
+	self_property_map.insert(p_name, Property(Property::Type::INTEGER_CONSTANT, p_constant));
 
 	String enum_name = p_enum;
 	if (!enum_name.is_empty()) {
@@ -123,22 +130,25 @@ void GDType::add_signal(MethodInfo p_signal) {
 
 	const StringName signal_name(p_signal.name);
 	ERR_FAIL_COND_MSG(signal_map.has(signal_name), vformat("Class '%s' already has signal '%s'.", String(name), String(signal_name)));
+	ERR_FAIL_COND_MSG(property_map.has(signal_name), vformat("Object '%s' already has property '%s'.", get_name(), signal_name));
 
 	const MethodInfo *ptr = memnew(MethodInfo(std::move(p_signal)));
 
 	signal_map[signal_name] = ptr;
 	self_signal_map[signal_name] = ptr;
+	property_map.insert(ptr->name, Property(Property::Type::SIGNAL));
+	self_property_map.insert(ptr->name, Property(Property::Type::SIGNAL));
 }
 
 bool GDType::bind_method(MethodBind *p_method, bool p_take_ownership) {
 	ERR_FAIL_COND_V(!Thread::is_main_thread(), false);
 	ERR_FAIL_COND_V(init_state != InitState::MUTABLE, false);
 
-	if (self_method_map.has(p_method->get_name())) {
+	if (property_map.has(p_method->get_name())) {
 		if (p_take_ownership) {
 			memdelete(p_method);
 		}
-		ERR_FAIL_V_MSG(false, vformat("Method already bound '%s::%s'.", name, p_method->get_name()));
+		ERR_FAIL_V_MSG(false, vformat("Object '%s' already has property '%s'.", get_name(), p_method->get_name()));
 	}
 
 	method_map[p_method->get_name()] = p_method;
@@ -146,6 +156,9 @@ bool GDType::bind_method(MethodBind *p_method, bool p_take_ownership) {
 	if (p_take_ownership) {
 		owned_method_map.push_back(p_method);
 	}
+	property_map.insert(p_method->get_name(), Property(Property::Type::METHOD));
+	self_property_map.insert(p_method->get_name(), Property(Property::Type::METHOD));
+
 	return true;
 }
 
@@ -157,4 +170,50 @@ void GDType::set_method_flags(const StringName &p_method, int p_flags) {
 	ERR_FAIL_NULL(method);
 
 	const_cast<MethodBind *>(*method)->set_hint_flags(p_flags);
+}
+
+void GDType::add_property(const PropertyInfo &p_pinfo, const StringName &p_setter, const StringName &p_getter,
+		int p_index) {
+	ERR_FAIL_COND(!Thread::is_main_thread());
+	ERR_FAIL_COND(init_state != InitState::MUTABLE);
+
+	ERR_FAIL_COND_MSG(property_map.has(p_pinfo.name), vformat("Object '%s' already has property '%s'.", get_name(), p_pinfo.name));
+
+	const MethodBind *const *mb_set = nullptr;
+	if (p_setter) {
+		mb_set = get_method_map().getptr(p_setter);
+
+		ERR_FAIL_NULL_MSG(mb_set, vformat("Invalid setter '%s::%s' for property '%s'.", get_name(), p_setter, p_pinfo.name));
+		int exp_args = 1 + (p_index >= 0 ? 1 : 0);
+		ERR_FAIL_COND_MSG((*mb_set)->get_argument_count() != exp_args, vformat("Invalid function for setter '%s::%s' for property '%s'.", get_name(), p_setter, p_pinfo.name));
+	}
+
+	const MethodBind *const *mb_get = nullptr;
+	if (p_getter) {
+		mb_get = get_method_map().getptr(p_getter);
+
+		ERR_FAIL_NULL_MSG(mb_get, vformat("Invalid getter '%s::%s' for property '%s'.", get_name(), p_getter, p_pinfo.name));
+		int exp_args = 0 + (p_index >= 0 ? 1 : 0);
+		ERR_FAIL_COND_MSG((*mb_get)->get_argument_count() != exp_args, vformat("Invalid function for getter '%s::%s' for property '%s'.", get_name(), p_getter, p_pinfo.name));
+	}
+
+	PropertyInfo *info = memnew(PropertyInfo(p_pinfo));
+
+	Property::SetGet psg;
+	psg.property_info = info;
+	psg.setter = mb_set ? *mb_set : nullptr;
+	psg.getter = mb_get ? *mb_get : nullptr;
+	psg.index = p_index;
+
+	property_map.insert(p_pinfo.name, Property(Property::Type::SETGET, psg));
+	self_property_map.insert(p_pinfo.name, Property(Property::Type::SETGET, psg));
+	ordered_self_properties.push_back(info);
+}
+
+void GDType::add_to_ordered_properties(const PropertyInfo &p_pinfo) {
+	ERR_FAIL_COND(!Thread::is_main_thread());
+	ERR_FAIL_COND(init_state != InitState::MUTABLE);
+
+	PropertyInfo *info = memnew(PropertyInfo(p_pinfo));
+	ordered_self_properties.push_back(info);
 }

--- a/core/object/gdtype.h
+++ b/core/object/gdtype.h
@@ -51,6 +51,41 @@ public:
 		bool is_bitfield = false;
 	};
 
+	struct Property {
+		enum class Type {
+			SETGET,
+			INTEGER_CONSTANT,
+			METHOD,
+			SIGNAL
+		};
+
+		struct SetGet {
+			const PropertyInfo *property_info;
+			const MethodBind *setter;
+			const MethodBind *getter;
+			int index;
+		};
+
+		union Payload {
+			int64_t integer = 0;
+			SetGet setget;
+		};
+
+		Type type;
+		Payload payload;
+
+		Property &operator=(const Property &p) = default;
+
+		Property(const Property &) = default;
+		Property(Type p_type, const SetGet &p_pointer) : type(p_type) {
+			payload.setget = p_pointer;
+		}
+		Property(Type p_type, int64_t p_int) : type(p_type) {
+			payload.integer = p_int;
+		}
+		Property(Type p_type) : type(p_type) {}
+	};
+
 protected:
 	const GDType *super_type;
 	mutable InitState init_state = InitState::UNINITIALIZED;
@@ -74,6 +109,11 @@ protected:
 	// This is deliberately not the same as self_method_map because
 	// bind_method supports binding non-owned methods.
 	LocalVector<MethodBind *> owned_method_map;
+
+	/// Contains all properties that can be obtained or set with `object.property`.
+	AHashMap<StringName, Property> property_map;
+	AHashMap<StringName, Property> self_property_map;
+	LocalVector<const PropertyInfo *> ordered_self_properties;
 
 public:
 	GDType(const GDType *p_super_type, StringName p_name);
@@ -101,4 +141,9 @@ public:
 	bool bind_method(MethodBind *p_method, bool p_take_ownership = true);
 	void set_method_flags(const StringName &p_method, int p_flags);
 	const AHashMap<StringName, const MethodBind *> &get_method_map(bool p_no_inheritance = false) const { return p_no_inheritance ? self_method_map : method_map; }
+
+	void add_property(const PropertyInfo &p_pinfo, const StringName &p_setter, const StringName &p_getter, int p_index);
+	void add_to_ordered_properties(const PropertyInfo &p_pinfo);
+	const AHashMap<StringName, Property> &get_property_map(bool p_no_inheritance = false) const { return p_no_inheritance ? self_property_map : property_map; }
+	const LocalVector<const PropertyInfo *> &get_ordered_self_properties() const { return ordered_self_properties; }
 };

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -220,10 +220,8 @@ void Object::set(const StringName &p_name, const Variant &p_value, bool *r_valid
 	}
 
 	// Try built-in setter.
-	{
-		if (ClassDB::set_property(this, p_name, p_value, r_valid)) {
-			return;
-		}
+	if (set_native(p_name, p_value, r_valid)) {
+		return;
 	}
 
 	if (p_name == CoreStringName(script)) {
@@ -291,13 +289,8 @@ Variant Object::get(const StringName &p_name, bool *r_valid) const {
 	}
 
 	// Try built-in getter.
-	{
-		if (ClassDB::get_property(const_cast<Object *>(this), p_name, ret)) {
-			if (r_valid) {
-				*r_valid = true;
-			}
-			return ret;
-		}
+	if (Variant value; get_native(p_name, value, r_valid)) {
+		return value;
 	}
 
 	if (p_name == CoreStringName(script)) {
@@ -351,6 +344,122 @@ Variant Object::get(const StringName &p_name, bool *r_valid) const {
 		}
 		return Variant();
 	}
+}
+
+bool Object::set_native(const StringName &p_name, const Variant &p_value, bool *r_valid) {
+	const GDType::Property *property = get_gdtype().get_property_map().getptr(p_name);
+	if (property) {
+		switch (property->type) {
+			case GDType::Property::Type::SETGET: {
+				const GDType::Property::SetGet &psg = property->payload.setget;
+				if (!psg.setter) {
+					if (r_valid) {
+						*r_valid = false;
+					}
+					return true;
+				}
+
+				Callable::CallError ce;
+
+				if (psg.index >= 0) {
+					Variant index = psg.index;
+					const Variant *arg[2] = { &index, &p_value };
+					//p_object->call(psg->setter,arg,2,ce);
+					psg.setter->call(this, arg, 2, ce);
+				} else {
+					const Variant *arg[1] = { &p_value };
+					psg.setter->call(this, arg, 1, ce);
+				}
+
+				if (r_valid) {
+					*r_valid = ce.error == Callable::CallError::CALL_OK;
+				}
+				return true;
+			}
+			default: {
+				// All other properties are unsettable.
+				if (r_valid) {
+					*r_valid = false;
+				}
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+bool Object::get_native(const StringName &p_name, Variant &r_value, bool *r_valid) const {
+	const GDType::Property *property = get_gdtype().get_property_map().getptr(p_name);
+	if (property) {
+		switch (property->type) {
+			case GDType::Property::Type::SETGET: {
+				const GDType::Property::SetGet &psg = property->payload.setget;
+				if (!psg.getter) {
+					if (r_valid) {
+						*r_valid = true; // Set to true for compat reasons.
+					}
+					r_value = Variant();
+					return true;
+				}
+
+				Callable::CallError ce;
+				if (psg.index >= 0) {
+					Variant index = psg.index;
+					const Variant *arg[1] = { &index };
+					r_value = psg.getter->call(const_cast<Object *>(this), arg, 1, ce);
+				} else {
+					r_value = psg.getter->call(const_cast<Object *>(this), nullptr, 0, ce);
+				}
+
+				if (ce.error != Callable::CallError::CALL_OK) {
+					if (r_valid) {
+						*r_valid = false;
+					}
+					r_value = Variant();
+				} else if (r_valid) {
+					*r_valid = true;
+				}
+				return true;
+			}
+			case GDType::Property::Type::INTEGER_CONSTANT: {
+				if (r_valid) {
+					*r_valid = true;
+				}
+				r_value = property->payload.integer;
+				return true;
+			}
+			case GDType::Property::Type::METHOD: {
+				if (r_valid) {
+					*r_valid = true;
+				}
+				r_value = Callable(this, p_name);
+				return true;
+			}
+			case GDType::Property::Type::SIGNAL: {
+				if (r_valid) {
+					*r_valid = true;
+				}
+				r_value = Signal(this, p_name);
+				return true;
+			}
+		}
+	}
+
+	// The "free()" method is special, so we assume it exists and return a Callable.
+	if (p_name == CoreStringName(free_)) {
+		if (r_valid) {
+			*r_valid = true;
+		}
+
+		r_value = Callable(this, p_name);
+		return true;
+	}
+
+	if (r_valid) {
+		*r_valid = false;
+	}
+	return false;
 }
 
 void Object::set_indexed(const Vector<StringName> &p_names, const Variant &p_value, bool *r_valid) {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -690,6 +690,10 @@ public:
 
 	void set(const StringName &p_name, const Variant &p_value, bool *r_valid = nullptr);
 	Variant get(const StringName &p_name, bool *r_valid = nullptr) const;
+	/// Like set/get but only uses the internal path. Used from ClassDB::set_property and for GDScript optimization.
+	bool set_native(const StringName &p_name, const Variant &p_value, bool *r_valid = nullptr);
+	bool get_native(const StringName &p_name, Variant &r_value, bool *r_valid = nullptr) const;
+
 	void set_indexed(const Vector<StringName> &p_names, const Variant &p_value, bool *r_valid = nullptr);
 	Variant get_indexed(const Vector<StringName> &p_names, bool *r_valid = nullptr) const;
 

--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -5182,7 +5182,7 @@ SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selec
 
 	reparent_dialog = memnew(ReparentDialog);
 	add_child(reparent_dialog);
-	reparent_dialog->connect("reparent", callable_mp(this, &SceneTreeDock::_node_reparent));
+	reparent_dialog->connect("reparent_requested", callable_mp(this, &SceneTreeDock::_node_reparent));
 
 	accept = memnew(AcceptDialog);
 	add_child(accept);

--- a/editor/inspector/property_selector.cpp
+++ b/editor/inspector/property_selector.cpp
@@ -188,10 +188,34 @@ void PropertySelector::_update_search() {
 				}
 			}
 
+			// Skip getters and setters of properties because users will usually use the property instead.
+			HashSet<StringName> methods_to_skip;
+			for (const KeyValue<StringName, GDType::Property> &kv : ClassDB::get_gdtype(base_type)->get_property_map()) {
+				if (kv.value.type != GDType::Property::Type::SETGET) {
+					continue; // Not relevant.
+				}
+				const GDType::Property::SetGet &psg = kv.value.payload.setget;
+				if (psg.index != -1 || (psg.property_info->usage & PROPERTY_USAGE_INTERNAL)) {
+					continue; // Not exposed.
+				}
+				if (psg.setter) {
+					methods_to_skip.insert(psg.setter->get_name());
+				}
+				if (psg.getter) {
+					methods_to_skip.insert(psg.getter->get_name());
+				}
+			}
+
 			StringName base = base_type;
 			while (base) {
 				methods.push_back(MethodInfo("*" + String(base)));
-				ClassDB::get_method_list(base, &methods, true, true);
+				List<MethodInfo> class_methods;
+				ClassDB::get_method_list(base, &class_methods, true);
+				for (const MethodInfo &mi : class_methods) {
+					if (!methods_to_skip.has(mi.name)) {
+						methods.push_back(mi);
+					}
+				}
 				base = ClassDB::get_parent_class(base);
 			}
 		}

--- a/editor/scene/reparent_dialog.cpp
+++ b/editor/scene/reparent_dialog.cpp
@@ -54,7 +54,7 @@ void ReparentDialog::_cancel() {
 
 void ReparentDialog::_reparent() {
 	if (tree->get_selected()) {
-		emit_signal(SNAME("reparent"), tree->get_selected()->get_path(), keep_transform->is_pressed());
+		emit_signal(SNAME("reparent_requested"), tree->get_selected()->get_path(), keep_transform->is_pressed());
 		hide();
 	}
 }
@@ -67,7 +67,7 @@ void ReparentDialog::set_current(const HashSet<Node *> &p_selection) {
 void ReparentDialog::_bind_methods() {
 	ClassDB::bind_method("_cancel", &ReparentDialog::_cancel);
 
-	ADD_SIGNAL(MethodInfo("reparent", PropertyInfo(Variant::NODE_PATH, "path"), PropertyInfo(Variant::BOOL, "keep_global_xform")));
+	ADD_SIGNAL(MethodInfo("reparent_requested", PropertyInfo(Variant::NODE_PATH, "path"), PropertyInfo(Variant::BOOL, "keep_global_xform")));
 }
 
 ReparentDialog::ReparentDialog() {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1479,13 +1479,34 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 
 				bool only_static = base_type.is_meta_type && !Engine::get_singleton()->has_singleton(type);
 
+				// Skip getters and setters of properties because users will usually use the property instead.
+				HashSet<StringName> methods_to_skip;
+				for (const KeyValue<StringName, GDType::Property> &kv : ClassDB::get_gdtype(type)->get_property_map()) {
+					if (kv.value.type != GDType::Property::Type::SETGET) {
+						continue; // Not relevant.
+					}
+					const GDType::Property::SetGet &psg = kv.value.payload.setget;
+					if (psg.index != -1 || (psg.property_info->usage & PROPERTY_USAGE_INTERNAL)) {
+						continue; // Not exposed.
+					}
+					if (psg.setter) {
+						methods_to_skip.insert(psg.setter->get_name());
+					}
+					if (psg.getter) {
+						methods_to_skip.insert(psg.getter->get_name());
+					}
+				}
+
 				List<MethodInfo> methods;
-				ClassDB::get_method_list(type, &methods, false, true);
+				ClassDB::get_method_list(type, &methods, false);
 				for (const MethodInfo &E : methods) {
 					if (only_static && (E.flags & METHOD_FLAG_STATIC) == 0) {
 						continue;
 					}
 					if (E.name.begins_with("_")) {
+						continue;
+					}
+					if (methods_to_skip.has(E.name)) {
 						continue;
 					}
 					int location = p_recursion_depth + _get_method_location(type, E.name);

--- a/modules/mono/class_db_api_json.cpp
+++ b/modules/mono/class_db_api_json.cpp
@@ -179,10 +179,11 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 			List<StringName> snames;
 
-			for (const KeyValue<StringName, ClassDB::PropertySetGet> &F : t->property_setget) {
-				snames.push_back(F.key);
+			for (const KeyValue<StringName, GDType::Property> &kv : t->gdtype->get_property_map(true)) {
+				if (kv.value.type == GDType::Property::Type::SETGET) {
+					snames.push_back(kv.key);
+				}
 			}
-
 			snames.sort_custom<StringName::AlphCompare>();
 
 			Array properties;
@@ -191,11 +192,12 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 				Dictionary property_dict;
 				properties.push_back(property_dict);
 
-				ClassDB::PropertySetGet *psg = t->property_setget.getptr(F);
+				const GDType::Property &property = t->gdtype->get_property_map(true)[F];
+				const GDType::Property::SetGet &psg = property.payload.setget;
 
 				property_dict["name"] = F;
-				property_dict["setter"] = psg->setter;
-				property_dict["getter"] = psg->getter;
+				property_dict["setter"] = psg.setter;
+				property_dict["getter"] = psg.getter;
 			}
 
 			if (!properties.is_empty()) {
@@ -206,15 +208,15 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 		Array property_list;
 
 		//property list
-		for (const PropertyInfo &F : t->property_list) {
+		for (const PropertyInfo *F : t->gdtype->get_ordered_self_properties()) {
 			Dictionary property_dict;
 			property_list.push_back(property_dict);
 
-			property_dict["name"] = F.name;
-			property_dict["type"] = F.type;
-			property_dict["hint"] = F.hint;
-			property_dict["hint_string"] = F.hint_string;
-			property_dict["usage"] = F.usage;
+			property_dict["name"] = F->name;
+			property_dict["type"] = F->type;
+			property_dict["hint"] = F->hint;
+			property_dict["hint_string"] = F->hint_string;
+			property_dict["usage"] = F->usage;
 		}
 
 		if (!property_list.is_empty()) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Follow-up of https://github.com/godotengine/godot/pull/113586
- Follow-up of https://github.com/godotengine/godot/pull/117474
- Follow-up of #117599
- Works towards https://github.com/godotengine/godot-proposals/issues/12323
- Supersedes https://github.com/godotengine/godot/pull/106646

Moves property maps from `ClassDB` to `GDType`, to make access more efficient and to consolidate typing.

## Additional information

This turned out pretty straight-forward luckily.

The main changes that are not just refactor are:
- Namespace conflict tests now run in both debug and release; there's no good reason to run them in debug only as release would act weirdly on clashes anyway.
- Namespace conflicts are now tested for across all property types, not just each type within itself.
- Namespace conflicts are now tested across the whole hierarchy. This used to already be the case for methods and signals, but is new for 'setget' properties and constants.
- `methods_in_properties` is removed from the type system. It's an editor concern to hide methods that property accessors, so the type system shouldn't need to build a cache for it. Instead, the two editor users compute it on the fly. If more users emerge, we can add a helper function or reconsider a cache, but it shouldn't live in `GDType` or `ClassDB`.

### Benchmarks

TL;DR: The average get/set call is around twice as fast as before (1.6x from GDScript, matching https://github.com/godotengine/godot/pull/106646).

> AI Disclosure: I used an AI to generate a few benchmarks to run to get wider coverage than I otherwise would have.

<details>

<summary>Full benchmark report</summary>

| Setup | |
|---|---|
| Base | `c382f9c7bb` (worktree `godot-bench-base`) → `bin/godot.macos.editor.arm64.master` |
| Patched | working tree, uncommitted change → `bin/godot.macos.editor.arm64` |
| Build | `scons arch=arm64 vulkan_sdk_path=/Users/lukas/dev/libs/MoltenVK debug_symbols=yes tests=yes [extra_suffix=master]` |
| Machine | macOS 25.5, arm64, 10 cores (8P), idle |

## Throughput — GDScript

| Benchmark | Opcode | Base (ns/op) | Patched (ns/op) | Speedup |
|---|---|---:|---:|---:|
| `self.prop get (deep)` | `GET_MEMBER` | 44.32 | 24.75 | 1.79× |
| `self.prop set (deep)` | `SET_MEMBER` | 34.98 | 28.62 | 1.22× |
| `self.prop get (self class)` | `GET_MEMBER` | 27.19 | 23.76 | 1.14× |
| `obj.prop get` | `GET_NAMED` | 54.62 | 33.35 | 1.64× |
| `obj.prop set` | `SET_NAMED` | 44.63 | 34.89 | 1.28× |
| `obj.signal get` | `GET_NAMED` | 82.65 | 63.80 | 1.30× |
| `obj.method get` | `GET_NAMED` | 78.36 | 63.81 | 1.23× |

## Throughput — C++

| Benchmark | Declared on | Base (ns/op) | Patched (ns/op) | Speedup |
|---|---|---:|---:|---:|
| `get/prop_self` | `Sprite2D` (self) | 17.39 | 13.33 | 1.30× |
| `get/prop_mid` | `CanvasItem` (+2) | 33.72 | 15.60 | 2.16× |
| `get/prop_deep` | `Node` (+3) | 47.88 | 14.63 | 3.27× |
| `set/prop_self` | `Sprite2D` (self) | 14.83 | 12.97 | 1.14× |
| `set/prop_deep` | `Node` (+3) | 34.18 | 18.74 | 1.82× |
| `get/method_as_value` | `Node2D` (+1) | 35.25 | 29.76 | 1.18× |
| `get/signal_as_value` | `Node` (+3) | 53.73 | 29.41 | 1.83× |
| `get/constant` | `Node` (+3) | 37.44 | 7.44 | 5.03× |
| `get/miss` | — | 59.00 | 16.23 | 3.64× |
| `set/miss` | — | 27.77 | 14.07 | 1.97× |
| `get/metadata` | — | 111.68 | 65.92 | 1.69× |
| `classdb/get_property_deep` | `Node` (+3) | 45.26 | 12.07 | 3.75× |
| `classdb/set_property_deep` | `Node` (+3) | 32.50 | 17.87 | 1.82× |
| `classdb/has_property` | `Node` (+3) | 17.32 | 5.29 | 3.27× |
| `classdb/get_property_type` | `Node` (+3) | 17.96 | 5.72 | 3.14× |
| `classdb/get_property_setter` | `Node` (+3) | 23.74 | 14.00 | 1.70× |
| `classdb/get_property_list` | `Sprite2D` chain | 2435.82 | 2370.28 | 1.03× |

## Footprint

Median of 7 alternating runs of `--headless --quit`.

| Metric | Base | Patched | Delta |
|---|---:|---:|---:|
| Peak RSS | 402.9 MB | 428.1 MB | +25.2 MB (+6.3%) |
| Startup (wall) | 0.460 s | 0.460 s | ±0 |

## Map sizes (patched, editor build, 1055 classes)

| Map | Entries | Per-entry | ≈ |
|---|---:|---:|---:|
| `property_map` (merged, all kinds) | 277,748 | 56 B | 15.5 MB |
| — of which methods | 190,870 | | |
| — of which constants | 54,004 | | |
| — of which properties | 24,102 | | |
| — of which signals | 8,772 | | |
| `self_property_map` | 28,091 | 56 B | 1.6 MB |
| `method_map` + `signal_map` + `constant_map` (unchanged, merged) | 253,646 | 24 B | 7.0 MB |

<details>
<summary><code>tests/core/object/test_bench_gdtype_props.cpp</code></summary>

```cpp
/**************************************************************************/
/*  test_bench_gdtype_props.cpp                                           */
/**************************************************************************/
/* Temporary benchmark file — not intended for upstream.                  */
/* Run with: bin/godot.* --test --test-case="*PropBench*" --headless      */
/**************************************************************************/

#include "core/object/class_db.h"
#include "core/object/object.h"
#include "core/variant/variant.h"
#include "scene/2d/sprite_2d.h"

#include "tests/test_macros.h"

TEST_FORCE_LINK(test_bench_gdtype_props)

#include <algorithm>
#include <chrono>
#include <cstdio>
#include <vector>

namespace TestBenchGDTypeProps {

template <typename F>
static void bench(const char *p_name, int64_t p_ops, F p_f) {
	constexpr int REPS = 11;
	std::vector<double> samples;
	// First iteration is warmup and discarded.
	for (int i = 0; i < REPS + 1; i++) {
		const auto t0 = std::chrono::steady_clock::now();
		p_f();
		const auto t1 = std::chrono::steady_clock::now();
		if (i > 0) {
			samples.push_back(std::chrono::duration<double>(t1 - t0).count());
		}
	}
	std::sort(samples.begin(), samples.end());
	const double median = samples[samples.size() / 2];
	const double best = samples.front();
	printf("BENCH|%-32s|%10.2f ns/op median |%10.2f ns/op min\n",
			p_name, median * 1e9 / double(p_ops), best * 1e9 / double(p_ops));
	fflush(stdout);
}

// Keeps the optimizer from discarding the results.
static Variant g_sink;

TEST_CASE("[PropBench] Object::get") {
	static constexpr int N = 3'000'000;
	Sprite2D *obj = memnew(Sprite2D);

	// Property declared on the instance's own class.
	const StringName p_self("centered");
	bench("get/prop_self", N, [&]() {
		for (int i = 0; i < N; i++) {
			g_sink = obj->get(p_self);
		}
	});

	// Property two levels up (CanvasItem).
	const StringName p_mid("visible");
	bench("get/prop_mid", N, [&]() {
		for (int i = 0; i < N; i++) {
			g_sink = obj->get(p_mid);
		}
	});

	// Property three levels up (Node) — the case the old chain walk paid most for.
	const StringName p_deep("editor_description");
	bench("get/prop_deep", N, [&]() {
		for (int i = 0; i < N; i++) {
			g_sink = obj->get(p_deep);
		}
	});

	memdelete(obj);
}

TEST_CASE("[PropBench] Object::set") {
	static constexpr int N = 3'000'000;
	Sprite2D *obj = memnew(Sprite2D);

	const StringName p_self("centered");
	const Variant v_self(true);
	bench("set/prop_self", N, [&]() {
		for (int i = 0; i < N; i++) {
			obj->set(p_self, v_self);
		}
	});

	const StringName p_deep("editor_description");
	const Variant v_deep("benchmark");
	bench("set/prop_deep", N, [&]() {
		for (int i = 0; i < N; i++) {
			obj->set(p_deep, v_deep);
		}
	});

	memdelete(obj);
}

TEST_CASE("[PropBench] Object::get non-property members") {
	static constexpr int N = 2'000'000;
	Sprite2D *obj = memnew(Sprite2D);

	// Method as a value: `obj.get_position` in GDScript.
	const StringName m_name("get_position");
	bench("get/method_as_value", N, [&]() {
		for (int i = 0; i < N; i++) {
			g_sink = obj->get(m_name);
		}
	});

	// Signal as a value: `obj.renamed.connect(...)` (declared on Node, 3 levels up).
	const StringName s_name("renamed");
	bench("get/signal_as_value", N, [&]() {
		for (int i = 0; i < N; i++) {
			g_sink = obj->get(s_name);
		}
	});

	// Integer constant (declared on Node, 3 levels up).
	const StringName c_name("NOTIFICATION_READY");
	bench("get/constant", N, [&]() {
		for (int i = 0; i < N; i++) {
			g_sink = obj->get(c_name);
		}
	});

	memdelete(obj);
}

TEST_CASE("[PropBench] Object miss paths") {
	static constexpr int N = 2'000'000;
	Sprite2D *obj = memnew(Sprite2D);

	// Full miss: walks every map at every level in the old code.
	const StringName miss("zzz_no_such_member");
	bench("get/miss", N, [&]() {
		for (int i = 0; i < N; i++) {
			g_sink = obj->get(miss);
		}
	});

	const Variant v_int(1);
	bench("set/miss", N, [&]() {
		for (int i = 0; i < N; i++) {
			obj->set(miss, v_int);
		}
	});

	// Metadata resolves only after the native lookup fails.
	const StringName meta("metadata/bench");
	obj->set(meta, v_int);
	bench("get/metadata", N, [&]() {
		for (int i = 0; i < N; i++) {
			g_sink = obj->get(meta);
		}
	});

	memdelete(obj);
}

TEST_CASE("[PropBench] ClassDB property access") {
	// The path GDScript's OPCODE_GET_MEMBER / OPCODE_SET_MEMBER takes.
	static constexpr int N = 3'000'000;
	Sprite2D *obj = memnew(Sprite2D);

	const StringName p_deep("editor_description");
	bench("classdb/get_property_deep", N, [&]() {
		Variant ret;
		for (int i = 0; i < N; i++) {
			ClassDB::get_property(obj, p_deep, ret);
		}
		g_sink = ret;
	});

	const Variant v_deep("benchmark");
	bench("classdb/set_property_deep", N, [&]() {
		bool valid = false;
		for (int i = 0; i < N; i++) {
			ClassDB::set_property(obj, p_deep, v_deep, &valid);
		}
	});

	memdelete(obj);
}

TEST_CASE("[PropBench] ClassDB reflective queries") {
	static constexpr int N = 2'000'000;
	const StringName cls("Sprite2D");
	const StringName p_deep("editor_description");

	bench("classdb/has_property", N, [&]() {
		bool acc = false;
		for (int i = 0; i < N; i++) {
			acc = acc != ClassDB::has_property(cls, p_deep);
		}
		g_sink = acc;
	});

	bench("classdb/get_property_type", N, [&]() {
		int acc = 0;
		for (int i = 0; i < N; i++) {
			acc += ClassDB::get_property_type(cls, p_deep);
		}
		g_sink = acc;
	});

	bench("classdb/get_property_setter", N, [&]() {
		uint32_t acc = 0;
		for (int i = 0; i < N; i++) {
			acc += ClassDB::get_property_setter(cls, p_deep).hash();
		}
		g_sink = acc;
	});

	static constexpr int L = 20'000;
	bench("classdb/get_property_list", L, [&]() {
		int acc = 0;
		for (int i = 0; i < L; i++) {
			List<PropertyInfo> list;
			ClassDB::get_property_list(cls, &list);
			acc += list.size();
		}
		g_sink = acc;
	});
}

} // namespace TestBenchGDTypeProps
```

</details>

<details>
<summary>GDScript project — run with <code>bin/godot.* --headless --path gdbench</code></summary>

`project.godot`

```ini
config_version=5

[application]

config/name="gdbench"
run/main_scene="res://main.tscn"

[rendering]

renderer/rendering_method="mobile"
```

`main.tscn`

```ini
[gd_scene load_steps=2 format=3]

[ext_resource type="Script" path="res://main.gd" id="1"]

[node name="Main" type="Camera3D"]
script = ExtResource("1")
```

`main.gd`

```gdscript
extends Camera3D

const REPS := 7

func _bench(name: String, ops: int, f: Callable) -> void:
	var samples: Array[float] = []
	for i in range(REPS + 1):
		var t0 := Time.get_ticks_usec()
		f.call()
		var t1 := Time.get_ticks_usec()
		if i > 0:
			samples.append(float(t1 - t0))
	samples.sort()
	var median: float = samples[samples.size() / 2]
	print("BENCH|%-28s|%8.2f ns/op" % [name, median * 1000.0 / float(ops)])

const N := 3000000

var _sink: Variant
var _other: Camera3D

func _self_get() -> void:
	for i in range(N):
		_sink = editor_description        # OPCODE_GET_MEMBER (Node, +3)

func _self_set() -> void:
	for i in range(N):
		editor_description = "x"          # OPCODE_SET_MEMBER (Node, +3)

func _self_get_shallow() -> void:
	for i in range(N):
		_sink = keep_aspect               # OPCODE_GET_MEMBER (Camera3D, self)

func _other_get() -> void:
	var o := _other
	for i in range(N):
		_sink = o.editor_description      # GET_NAMED on a typed Object

func _other_set() -> void:
	var o := _other
	for i in range(N):
		o.editor_description = "x"        # SET_NAMED on a typed Object

func _signal_get() -> void:
	var o := _other
	for i in range(N):
		_sink = o.renamed                 # signal as a value

func _method_get() -> void:
	var o := _other
	for i in range(N):
		_sink = o.get_name                # method as a value

func _ready() -> void:
	_other = Camera3D.new()
	_bench("self.prop get (deep)", N, _self_get)
	_bench("self.prop set (deep)", N, _self_set)
	_bench("self.prop get (self class)", N, _self_get_shallow)
	_bench("obj.prop get", N, _other_get)
	_bench("obj.prop set", N, _other_set)
	_bench("obj.signal get", N, _signal_get)
	_bench("obj.method get", N, _method_get)
	_other.free()
	get_tree().quit()
```

</details>

<details>
<summary>Map-size measurement (GDScript, run against the patched editor build)</summary>

```gdscript
extends SceneTree

func _init():
	var mask := PROPERTY_USAGE_GROUP | PROPERTY_USAGE_SUBGROUP | PROPERTY_USAGE_CATEGORY | PROPERTY_USAGE_ARRAY
	var m := 0; var s := 0; var k := 0; var p := 0
	for c in ClassDB.get_class_list():
		m += ClassDB.class_get_method_list(c, false).size()
		s += ClassDB.class_get_signal_list(c, false).size()
		k += ClassDB.class_get_integer_constant_list(c, false).size()
		for pi in ClassDB.class_get_property_list(c, false):
			if not (pi.usage & mask):
				p += 1
	print("merged: methods=%d signals=%d constants=%d properties=%d" % [m, s, k, p])
	quit()
```

</details>

</details>

### Follow-ups

The new maps are a tiny bit RAM indulgent (~20mb RAM total in an editor build). I'll consider merging all the property maps into a single map instead (no property self map, and no hierarchy other-maps; only property map aggregated).
This is not urgent though as 20mb is pretty excusable for the type system as a stop gap.