### PR TITLE
CI: Bump minimum Python version (3.9 → 3.10)

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -154,7 +154,7 @@ jobs:
         uses: ./.github/actions/godot-deps
         with:
           # Sync with Ensure*Version in SConstruct.
-          python-version: 3.9
+          python-version: "3.10"
           scons-version: 4.4
 
       - name: Force remove preinstalled .NET SDKs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
         stages: [manual]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.20
+    rev: v0.16.3
     hooks:
       - id: ruff-check
         args: [--color=always]
@@ -58,7 +58,7 @@ repos:
         types_or: [text]
 
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.19.1
+    rev: v2.3.1
     hooks:
       - id: mypy
         files: \.py$

--- a/SConstruct
+++ b/SConstruct
@@ -2,7 +2,7 @@
 from misc.utility.scons_hints import *
 
 EnsureSConsVersion(4, 4)
-EnsurePythonVersion(3, 9)
+EnsurePythonVersion(3, 10)
 
 # System
 import glob

--- a/core/profiling/SCsub
+++ b/core/profiling/SCsub
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-from __future__ import annotations
 
 from misc.utility.scons_hints import *
 

--- a/doc/tools/doc_status.py
+++ b/doc/tools/doc_status.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import annotations
-
 import fnmatch
 import math
 import os
@@ -138,7 +136,7 @@ class ClassStatusProgress:
         self.described: int = described
         self.total: int = total
 
-    def __add__(self, other: ClassStatusProgress):
+    def __add__(self, other: "ClassStatusProgress"):
         return ClassStatusProgress(self.described + other.described, self.total + other.total)
 
     def increment(self, described: bool):
@@ -189,7 +187,7 @@ class ClassStatus:
             "constructors": ClassStatusProgress(),
         }
 
-    def __add__(self, other: ClassStatus):
+    def __add__(self, other: "ClassStatus"):
         new_status = ClassStatus()
         new_status.name = self.name
         new_status.has_brief_description = self.has_brief_description and other.has_brief_description

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 
 # This script makes RST files from the XML class reference for use with the online docs.
-from __future__ import annotations
-
 import argparse
 import os
 import re
@@ -424,7 +422,7 @@ class State:
 
         self.current_class = ""
 
-    def parse_params(self, root: ET.Element, context: str) -> list[ParameterDef]:
+    def parse_params(self, root: ET.Element, context: str) -> list["ParameterDef"]:
         param_elements = root.findall("param")
         params: Any = [None] * len(param_elements)
 
@@ -474,7 +472,7 @@ class TypeName:
             return make_type(self.type_name, state)
 
     @classmethod
-    def from_element(cls, element: ET.Element) -> TypeName:
+    def from_element(cls, element: ET.Element) -> "TypeName":
         return cls(element.attrib["type"], element.get("enum"), element.get("is_bitfield") == "true")
 
 

--- a/methods.py
+++ b/methods.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import atexit
 import contextlib
 import glob
@@ -24,7 +22,7 @@ compiler_version_cache = None
 
 # Listing all the folders we have converted
 # for SCU in scu_builders.py
-_scu_folders = set()
+_scu_folders = set[str]()
 
 
 def set_scu_folders(scu_folders):

--- a/misc/scripts/char_range_fetch.py
+++ b/misc/scripts/char_range_fetch.py
@@ -4,8 +4,6 @@
 # the Unicode Character Database to the `char_range.cpp` file.
 # NOTE: This script is deliberately not integrated into the build system;
 # you should run it manually whenever you want to update the data.
-from __future__ import annotations
-
 import os
 import sys
 from typing import Final

--- a/misc/scripts/ucaps_fetch.py
+++ b/misc/scripts/ucaps_fetch.py
@@ -4,8 +4,6 @@
 # the Unicode Character Database to the `ucaps.h` file.
 # NOTE: This script is deliberately not integrated into the build system;
 # you should run it manually whenever you want to update the data.
-from __future__ import annotations
-
 import os
 import sys
 from typing import Final

--- a/misc/scripts/unicode_ranges_fetch.py
+++ b/misc/scripts/unicode_ranges_fetch.py
@@ -4,8 +4,6 @@
 # the Unicode Character Database to the `unicode_ranges.inc` file.
 # NOTE: This script is deliberately not integrated into the build system;
 # you should run it manually whenever you want to update the data.
-from __future__ import annotations
-
 import os
 import sys
 from typing import Final

--- a/misc/utility/color.py
+++ b/misc/utility/color.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import os
 import re
 import sys

--- a/modules/mono/build_scripts/build_assemblies.py
+++ b/modules/mono/build_scripts/build_assemblies.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import annotations
-
 import os
 import os.path
 import shlex

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,12 @@ warn_redundant_casts = true
 warn_return_any = true
 warn_unreachable = true
 exclude = ["thirdparty/"]
-python_version = "3.9"
+python_version = "3.10"
 
 [tool.ruff]
 extend-exclude = ["thirdparty"]
 extend-include = ["*SConstruct", "*SCsub"]
-target-version = "py39"
+target-version = "py310"
 line-length = 120
 preview = true
 fix = true

--- a/scu_builders.py
+++ b/scu_builders.py
@@ -10,7 +10,7 @@ from methods import print_error
 base_folder_path = str(Path(__file__).parent) + "/"
 base_folder_only = os.path.basename(os.path.normpath(base_folder_path))
 _verbose = False  # Set manually for debug prints
-_scu_folders = set()
+_scu_folders = set[str]()
 _max_includes_per_scu = 1024
 
 

--- a/tests/compatibility_test/run_compatibility_test.py
+++ b/tests/compatibility_test/run_compatibility_test.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-from __future__ import annotations
 
 import itertools
 import json

--- a/tests/python_build/validate_builders.py
+++ b/tests/python_build/validate_builders.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-from __future__ import annotations
-
 if __name__ != "__main__":
     raise ImportError(f"{__name__} should not be used as a module.")
 


### PR DESCRIPTION
- Related: #122412

## What problem(s) does this PR solve?

As the above PR notes in point 7, Emscripten now requires a minimum of Python 3.10, up from our current default of 3.9. While this only applies to web builds, I believe there's a discussion to be had on making this our overall minimum version as well. Most pertinently: 3.10 will be reaching EOL later this year[^1], with 3.9 being EOL for a year by that point.

As noted in #116550, Locking our minimum to 3.9 would be closer to what SCons will eventually be doing. However, SCons has been taking longer than expected to bump versions, so this ruleset we originally intended to adopt hasn't been put in practice, so I wouldn't say we're beholden to it. We'd still be fairly behind the curve overall by making an EOL a minimum, but it'd keep us *somewhat* synced with other Python tooling, such as mypy which can finally use its latest version once more.

A 3.10 minimum means we can safely retire the `from __future__ import annotations` imports, as all the typing syntax goodies that came with it are now natively available. The other changes brought by this import are no longer the direction the python team is pursuing, instead opting for deferred resolution of imports[^2]. While we're a long ways off from that import being deprecated, there's no harm in making the that transition as smooth as possible by nipping it in the bud thanks to a 3.10 minimum.

## Additional information

Prek hook version bumps:
- mypy (1.19.1 → 2.3.1)
- ruff (0.15.20 → 0.16.3)

[^1]: https://devguide.python.org/versions/
[^2]: https://peps.python.org/pep-0749/