### PR TITLE
[Core] Add `get_method_info` to Callable

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -47,6 +47,7 @@
 #include "core/os/process_id.h"
 #include "core/os/thread_safe.h"
 #include "core/variant/typed_array.h"
+#include "core/variant/variant.h"
 
 namespace CoreBind {
 
@@ -1718,6 +1719,17 @@ int ClassDB::class_get_method_argument_count(const StringName &p_class, const St
 	return ::ClassDB::get_method_argument_count(p_class, p_method, nullptr, p_no_inheritance);
 }
 
+TypedArray<Dictionary> ClassDB::class_get_method_arguments(const StringName &p_class, const StringName &p_method, bool p_no_inheritance) const {
+	// TODO: This code will change when going from get_arguments -> get_method_info,
+	//       but for now... this's fine
+	TypedArray<Dictionary> ret;
+	Vector<Variant> arguments_as_variant = ::ClassDB::get_method_arguments(p_class, p_method, nullptr, p_no_inheritance);
+	for (const Variant &E : arguments_as_variant) {
+		ret.push_back(E.operator Dictionary());
+	}
+	return ret;
+}
+
 TypedArray<Dictionary> ClassDB::class_get_method_list(const StringName &p_class, bool p_no_inheritance) const {
 	List<MethodInfo> methods;
 	::ClassDB::get_method_list(p_class, &methods, p_no_inheritance);
@@ -1872,6 +1884,7 @@ void ClassDB::_bind_methods() {
 	::ClassDB::bind_method(D_METHOD("class_has_method", "class", "method", "no_inheritance"), &ClassDB::class_has_method, DEFVAL(false));
 
 	::ClassDB::bind_method(D_METHOD("class_get_method_argument_count", "class", "method", "no_inheritance"), &ClassDB::class_get_method_argument_count, DEFVAL(false));
+	::ClassDB::bind_method(D_METHOD("class_get_method_arguments", "class", "method", "no_inheritance"), &ClassDB::class_get_method_arguments, DEFVAL(false));
 
 	::ClassDB::bind_method(D_METHOD("class_get_method_list", "class", "no_inheritance"), &ClassDB::class_get_method_list, DEFVAL(false));
 

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1719,15 +1719,13 @@ int ClassDB::class_get_method_argument_count(const StringName &p_class, const St
 	return ::ClassDB::get_method_argument_count(p_class, p_method, nullptr, p_no_inheritance);
 }
 
-TypedArray<Dictionary> ClassDB::class_get_method_arguments(const StringName &p_class, const StringName &p_method, bool p_no_inheritance) const {
-	// TODO: This code will change when going from get_arguments -> get_method_info,
-	//       but for now... this's fine
-	TypedArray<Dictionary> ret;
-	Vector<Variant> arguments_as_variant = ::ClassDB::get_method_arguments(p_class, p_method, nullptr, p_no_inheritance);
-	for (const Variant &E : arguments_as_variant) {
-		ret.push_back(E.operator Dictionary());
+Dictionary ClassDB::class_get_method_info(const StringName &p_class, const StringName &p_method, bool p_no_inheritance) const {
+	MethodInfo mi;
+	bool is_method_found = ::ClassDB::get_method_info(p_class, p_method, &mi, p_no_inheritance);
+	if (is_method_found) {
+		return mi.operator Dictionary();
 	}
-	return ret;
+	return Dictionary();
 }
 
 TypedArray<Dictionary> ClassDB::class_get_method_list(const StringName &p_class, bool p_no_inheritance) const {
@@ -1884,7 +1882,7 @@ void ClassDB::_bind_methods() {
 	::ClassDB::bind_method(D_METHOD("class_has_method", "class", "method", "no_inheritance"), &ClassDB::class_has_method, DEFVAL(false));
 
 	::ClassDB::bind_method(D_METHOD("class_get_method_argument_count", "class", "method", "no_inheritance"), &ClassDB::class_get_method_argument_count, DEFVAL(false));
-	::ClassDB::bind_method(D_METHOD("class_get_method_arguments", "class", "method", "no_inheritance"), &ClassDB::class_get_method_arguments, DEFVAL(false));
+	::ClassDB::bind_method(D_METHOD("class_get_method_info", "class", "method", "no_inheritance"), &ClassDB::class_get_method_info, DEFVAL(false));
 
 	::ClassDB::bind_method(D_METHOD("class_get_method_list", "class", "no_inheritance"), &ClassDB::class_get_method_list, DEFVAL(false));
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -545,6 +545,7 @@ public:
 	bool class_has_method(const StringName &p_class, const StringName &p_method, bool p_no_inheritance = false) const;
 
 	int class_get_method_argument_count(const StringName &p_class, const StringName &p_method, bool p_no_inheritance = false) const;
+	TypedArray<Dictionary> class_get_method_arguments(const StringName &p_class, const StringName &p_method, bool p_no_inheritance = false) const;
 
 	TypedArray<Dictionary> class_get_method_list(const StringName &p_class, bool p_no_inheritance = false) const;
 	Variant class_call_static(const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -545,7 +545,7 @@ public:
 	bool class_has_method(const StringName &p_class, const StringName &p_method, bool p_no_inheritance = false) const;
 
 	int class_get_method_argument_count(const StringName &p_class, const StringName &p_method, bool p_no_inheritance = false) const;
-	TypedArray<Dictionary> class_get_method_arguments(const StringName &p_class, const StringName &p_method, bool p_no_inheritance = false) const;
+	Dictionary class_get_method_info(const StringName &p_class, const StringName &p_method, bool p_no_inheritance = false) const;
 
 	TypedArray<Dictionary> class_get_method_list(const StringName &p_class, bool p_no_inheritance = false) const;
 	Variant class_call_static(const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error);

--- a/core/object/callable_mp.h
+++ b/core/object/callable_mp.h
@@ -30,10 +30,12 @@
 
 #pragma once
 
+#include "core/error/error_macros.h"
 #include "core/object/object.h"
 #include "core/variant/binder_common.h"
 #include "core/variant/callable.h"
 
+#include <cstdint>
 #include <type_traits>
 
 class CallableCustomMethodPointerBase : public CallableCustom {
@@ -95,6 +97,39 @@ public:
 	virtual int get_argument_count(bool &r_is_valid) const {
 		r_is_valid = true;
 		return sizeof...(P);
+	}
+
+	virtual void get_arguments(Vector<Variant> &r_arguments) const {
+		print_line("CallableCustomMethodPointer::get_arguments is called!");
+		r_arguments.clear();
+
+#ifndef DEBUG_ENABLED
+		for (uint32_t i = 0; i < sizeof...(P); ++i) {
+			PropertyInfo arg;
+			call_get_argument_type_info<P...>(i, arg);
+			r_arguments.push_back(arg.operator Dictionary());
+		}
+#else
+		StringName method_name = get_method();
+		ERR_FAIL_COND(method_name.is_empty());
+		method_name = StringName(method_name.string().split("::")[1]); // Hack.
+
+		ObjectID obj_id = get_object();
+		ERR_FAIL_COND_MSG(!obj_id.is_valid(),
+				vformat("Failed to get the ObjectID of '" + uitos(data.object_id) + "' in CallableCustomMethodPointer, method name: \"%s\"", method_name));
+
+		List<MethodInfo> method_info_list;
+		ObjectDB::get_instance(obj_id)->get_method_list(&method_info_list);
+
+		for (const MethodInfo &E : method_info_list) {
+			if (E.name == method_name) {
+				print_line("Found our method!!");
+				for (const PropertyInfo &F : E.arguments) {
+					r_arguments.push_back(F.operator Dictionary());
+				}
+			}
+		}
+#endif
 	}
 
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
@@ -164,6 +199,17 @@ public:
 	virtual int get_argument_count(bool &r_is_valid) const override {
 		r_is_valid = true;
 		return sizeof...(P);
+	}
+
+	virtual void get_arguments(Vector<Variant> &r_arguments) const override {
+		print_line("CallableCustomMethodPointerC::get_arguments is called!");
+		r_arguments.clear();
+
+		for (uint32_t i = 0; i < sizeof...(P); ++i) {
+			PropertyInfo arg;
+			call_get_argument_type_info<P...>(i, arg);
+			r_arguments.push_back(arg.operator Dictionary());
+		}
 	}
 
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override {
@@ -238,6 +284,17 @@ public:
 	virtual int get_argument_count(bool &r_is_valid) const override {
 		r_is_valid = true;
 		return sizeof...(P);
+	}
+
+	virtual void get_arguments(Vector<Variant> &r_arguments) const override {
+		print_line("CallableCustomStaticMethodPointer::get_arguments is called!");
+		r_arguments.clear();
+
+		for (uint32_t i = 0; i < sizeof...(P); ++i) {
+			PropertyInfo arg;
+			call_get_argument_type_info<P...>(i, arg);
+			r_arguments.push_back(arg.operator Dictionary());
+		}
 	}
 
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override {

--- a/core/object/callable_mp.h
+++ b/core/object/callable_mp.h
@@ -103,15 +103,16 @@ public:
 		print_line("CallableCustomMethodPointer::get_arguments is called!");
 #ifndef DEBUG_ENABLED
 		MethodInfo mi;
-		PropertyInfo arg;
 
 		for (uint32_t i = 0; i < sizeof...(P); ++i) {
+			PropertyInfo arg;
 			call_get_argument_type_info<P...>(i, arg);
 			mi.arguments.push_back(arg);
 		}
 
-		call_get_argument_type_info<P...>(-1, arg);
-		mi.return_val = arg;
+		if constexpr (!std::is_same<R, void>::value) {
+			mi.return_val = GetTypeInfo<R>::get_class_info();
+		}
 
 		r_method_info = mi;
 #else
@@ -123,14 +124,9 @@ public:
 		ERR_FAIL_COND_MSG(!obj_id.is_valid(),
 				vformat("Failed to get the ObjectID of '" + uitos(data.object_id) + "' in CallableCustomMethodPointer, method name: \"%s\"", method_name));
 
-		List<MethodInfo> method_info_list;
-		ObjectDB::get_instance(obj_id)->get_method_list(&method_info_list);
-
-		for (const MethodInfo &E : method_info_list) {
-			if (E.name == method_name) {
-				r_method_info = E;
-			}
-		}
+		Object *obj = ObjectDB::get_instance(obj_id);
+		ERR_FAIL_NULL(obj);
+		r_method_info = obj->get_method_info(method_name);
 #endif
 	}
 
@@ -206,15 +202,18 @@ public:
 	virtual void get_method_info(MethodInfo &r_method_info) const override {
 		print_line("CallableCustomMethodPointerC::get_arguments is called!");
 		MethodInfo mi;
-		PropertyInfo arg;
 
 		for (uint32_t i = 0; i < sizeof...(P); ++i) {
+			PropertyInfo arg;
 			call_get_argument_type_info<P...>(i, arg);
 			mi.arguments.push_back(arg);
 		}
 
-		call_get_argument_type_info<P...>(-1, arg);
-		mi.return_val = arg;
+		if constexpr (!std::is_same<R, void>::value) {
+			mi.return_val = GetTypeInfo<R>::get_class_info();
+		}
+
+		mi.flags |= METHOD_FLAGS_DEFAULT | METHOD_FLAG_CONST;
 
 		r_method_info = mi;
 	}
@@ -296,15 +295,18 @@ public:
 	virtual void get_method_info(MethodInfo &r_method_info) const override {
 		print_line("CallableCustomStaticMethodPointer::get_arguments is called!");
 		MethodInfo mi;
-		PropertyInfo arg;
 
 		for (uint32_t i = 0; i < sizeof...(P); ++i) {
+			PropertyInfo arg;
 			call_get_argument_type_info<P...>(i, arg);
 			mi.arguments.push_back(arg);
 		}
 
-		call_get_argument_type_info<P...>(-1, arg);
-		mi.return_val = arg;
+		if constexpr (!std::is_same<R, void>::value) {
+			mi.return_val = GetTypeInfo<R>::get_class_info();
+		}
+
+		mi.flags |= METHOD_FLAGS_DEFAULT | METHOD_FLAG_STATIC;
 
 		r_method_info = mi;
 	}

--- a/core/object/callable_mp.h
+++ b/core/object/callable_mp.h
@@ -99,16 +99,21 @@ public:
 		return sizeof...(P);
 	}
 
-	virtual void get_arguments(Vector<Variant> &r_arguments) const {
+	virtual void get_method_info(MethodInfo &r_method_info) const {
 		print_line("CallableCustomMethodPointer::get_arguments is called!");
-		r_arguments.clear();
-
 #ifndef DEBUG_ENABLED
+		MethodInfo mi;
+		PropertyInfo arg;
+
 		for (uint32_t i = 0; i < sizeof...(P); ++i) {
-			PropertyInfo arg;
 			call_get_argument_type_info<P...>(i, arg);
-			r_arguments.push_back(arg.operator Dictionary());
+			mi.arguments.push_back(arg);
 		}
+
+		call_get_argument_type_info<P...>(-1, arg);
+		mi.return_val = arg;
+
+		r_method_info = mi;
 #else
 		StringName method_name = get_method();
 		ERR_FAIL_COND(method_name.is_empty());
@@ -123,10 +128,7 @@ public:
 
 		for (const MethodInfo &E : method_info_list) {
 			if (E.name == method_name) {
-				print_line("Found our method!!");
-				for (const PropertyInfo &F : E.arguments) {
-					r_arguments.push_back(F.operator Dictionary());
-				}
+				r_method_info = E;
 			}
 		}
 #endif
@@ -201,15 +203,20 @@ public:
 		return sizeof...(P);
 	}
 
-	virtual void get_arguments(Vector<Variant> &r_arguments) const override {
+	virtual void get_method_info(MethodInfo &r_method_info) const override {
 		print_line("CallableCustomMethodPointerC::get_arguments is called!");
-		r_arguments.clear();
+		MethodInfo mi;
+		PropertyInfo arg;
 
 		for (uint32_t i = 0; i < sizeof...(P); ++i) {
-			PropertyInfo arg;
 			call_get_argument_type_info<P...>(i, arg);
-			r_arguments.push_back(arg.operator Dictionary());
+			mi.arguments.push_back(arg);
 		}
+
+		call_get_argument_type_info<P...>(-1, arg);
+		mi.return_val = arg;
+
+		r_method_info = mi;
 	}
 
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override {
@@ -286,15 +293,20 @@ public:
 		return sizeof...(P);
 	}
 
-	virtual void get_arguments(Vector<Variant> &r_arguments) const override {
+	virtual void get_method_info(MethodInfo &r_method_info) const override {
 		print_line("CallableCustomStaticMethodPointer::get_arguments is called!");
-		r_arguments.clear();
+		MethodInfo mi;
+		PropertyInfo arg;
 
 		for (uint32_t i = 0; i < sizeof...(P); ++i) {
-			PropertyInfo arg;
 			call_get_argument_type_info<P...>(i, arg);
-			r_arguments.push_back(arg.operator Dictionary());
+			mi.arguments.push_back(arg);
 		}
+
+		call_get_argument_type_info<P...>(-1, arg);
+		mi.return_val = arg;
+
+		r_method_info = mi;
 	}
 
 	virtual void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override {

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1596,6 +1596,33 @@ int ClassDB::get_method_argument_count(const StringName &p_class, const StringNa
 	return 0;
 }
 
+Vector<Variant> ClassDB::get_method_arguments(const StringName &p_class, const StringName &p_method, bool *r_is_valid, bool p_no_inheritance) {
+	Locker::Lock lock(Locker::STATE_READ);
+	Vector<Variant> ret;
+
+	ClassInfo *type = classes.getptr(p_class);
+	if (type) {
+		const GDType::Member *member = type->gdtype->members(p_no_inheritance).getptr(p_method);
+		if (member && member->type == GDType::Member::Type::METHOD) {
+			if (r_is_valid) {
+				*r_is_valid = true;
+			}
+
+			const MethodBind *const method = member->payload.method;
+			for (int i = 0; i < method->get_argument_count(); ++i) {
+				ret.push_back(method->get_argument_info(i).operator Dictionary());
+			}
+			return ret;
+		}
+	}
+
+	if (r_is_valid) {
+		*r_is_valid = false;
+	}
+
+	return ret;
+}
+
 void ClassDB::bind_method_custom(const StringName &p_class, MethodBind *p_method, bool p_take_ownership) {
 	_bind_method_custom(p_class, p_method, false, p_take_ownership);
 }

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1596,33 +1596,6 @@ int ClassDB::get_method_argument_count(const StringName &p_class, const StringNa
 	return 0;
 }
 
-Vector<Variant> ClassDB::get_method_arguments(const StringName &p_class, const StringName &p_method, bool *r_is_valid, bool p_no_inheritance) {
-	Locker::Lock lock(Locker::STATE_READ);
-	Vector<Variant> ret;
-
-	ClassInfo *type = classes.getptr(p_class);
-	if (type) {
-		const GDType::Member *member = type->gdtype->members(p_no_inheritance).getptr(p_method);
-		if (member && member->type == GDType::Member::Type::METHOD) {
-			if (r_is_valid) {
-				*r_is_valid = true;
-			}
-
-			const MethodBind *const method = member->payload.method;
-			for (int i = 0; i < method->get_argument_count(); ++i) {
-				ret.push_back(method->get_argument_info(i).operator Dictionary());
-			}
-			return ret;
-		}
-	}
-
-	if (r_is_valid) {
-		*r_is_valid = false;
-	}
-
-	return ret;
-}
-
 void ClassDB::bind_method_custom(const StringName &p_class, MethodBind *p_method, bool p_take_ownership) {
 	_bind_method_custom(p_class, p_method, false, p_take_ownership);
 }

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -468,6 +468,7 @@ public:
 	static void get_method_list_with_compatibility(const StringName &p_class, List<Pair<MethodInfo, uint32_t>> *p_methods_with_hash, bool p_no_inheritance = false);
 	static bool get_method_info(const StringName &p_class, const StringName &p_method, MethodInfo *r_info, bool p_no_inheritance = false);
 	static int get_method_argument_count(const StringName &p_class, const StringName &p_method, bool *r_is_valid = nullptr, bool p_no_inheritance = false);
+	static Vector<Variant> get_method_arguments(const StringName &p_class, const StringName &p_method, bool *r_is_valid = nullptr, bool p_no_inheritance = false);
 	static const MethodBind *get_method(const StringName &p_class, const StringName &p_name);
 	static const MethodBind *get_method_with_compatibility(const StringName &p_class, const StringName &p_name, uint64_t p_hash, bool *r_method_exists = nullptr, bool *r_is_deprecated = nullptr);
 	static Vector<uint32_t> get_method_compatibility_hashes(const StringName &p_class, const StringName &p_name);

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -468,7 +468,6 @@ public:
 	static void get_method_list_with_compatibility(const StringName &p_class, List<Pair<MethodInfo, uint32_t>> *p_methods_with_hash, bool p_no_inheritance = false);
 	static bool get_method_info(const StringName &p_class, const StringName &p_method, MethodInfo *r_info, bool p_no_inheritance = false);
 	static int get_method_argument_count(const StringName &p_class, const StringName &p_method, bool *r_is_valid = nullptr, bool p_no_inheritance = false);
-	static Vector<Variant> get_method_arguments(const StringName &p_class, const StringName &p_method, bool *r_is_valid = nullptr, bool p_no_inheritance = false);
 	static const MethodBind *get_method(const StringName &p_class, const StringName &p_name);
 	static const MethodBind *get_method_with_compatibility(const StringName &p_class, const StringName &p_name, uint64_t p_hash, bool *r_method_exists = nullptr, bool *r_is_deprecated = nullptr);
 	static Vector<uint32_t> get_method_compatibility_hashes(const StringName &p_class, const StringName &p_name);

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -810,6 +810,67 @@ int Object::get_method_argument_count(const StringName &p_method, bool *r_is_val
 	return 0;
 }
 
+TypedArray<Dictionary> Object::_get_method_arguments_bind(const StringName &p_method) const {
+	// TODO: This code will change when going from get_arguments -> get_method_info,
+	//       but for now... this's fine
+	Vector<Variant> arguments_as_variants = get_method_arguments(p_method);
+	TypedArray<Dictionary> ret;
+	for (const Variant &E : arguments_as_variants) {
+		ret.push_back(E.operator Dictionary());
+	}
+	return ret;
+}
+
+Vector<Variant> Object::get_method_arguments(const StringName &p_method, bool *r_is_valid) const {
+	Vector<Variant> ret;
+	if (p_method == CoreStringName(free_)) {
+		if (r_is_valid) {
+			*r_is_valid = true;
+		}
+		return ret;
+	}
+
+	if (script_instance) {
+		bool valid = false;
+		ret = script_instance->get_method_arguments(p_method, &valid);
+		if (valid) {
+			if (r_is_valid) {
+				*r_is_valid = true;
+			}
+			return ret;
+		}
+	}
+
+	{
+		bool valid = false;
+		ret = ClassDB::get_method_arguments(get_class_name(), p_method, &valid);
+		if (valid) {
+			if (r_is_valid) {
+				*r_is_valid = true;
+			}
+			return ret;
+		}
+	}
+
+	const Script *scr = Object::cast_to<Script>(this);
+	while (scr != nullptr) {
+		bool valid = false;
+		ret = scr->get_script_method_arguments(p_method, &valid);
+		if (valid) {
+			if (r_is_valid) {
+				*r_is_valid = true;
+			}
+			return ret;
+		}
+		scr = scr->get_base_script().ptr();
+	}
+
+	if (r_is_valid) {
+		*r_is_valid = false;
+	}
+	return ret;
+}
+
 Variant Object::getvar(const Variant &p_key, bool *r_valid) const {
 	if (r_valid) {
 		*r_valid = false;
@@ -1962,6 +2023,7 @@ void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_method", "method"), &Object::has_method);
 
 	ClassDB::bind_method(D_METHOD("get_method_argument_count", "method"), &Object::_get_method_argument_count_bind);
+	ClassDB::bind_method(D_METHOD("get_method_arguments", "method"), &Object::_get_method_arguments_bind);
 
 	ClassDB::bind_method(D_METHOD("has_signal", "signal"), &Object::has_signal);
 	ClassDB::bind_method(D_METHOD("get_signal_list"), &Object::_get_signal_list);

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -828,8 +828,8 @@ MethodInfo Object::get_method_info(const StringName &p_method) const {
 	}
 
 	{
-		ClassDB::get_method_info(get_class_name(), p_method, &mi);
-		if (!(mi == MethodInfo())) {
+		bool valid = ClassDB::get_method_info(get_class_name(), p_method, &mi);
+		if (valid) {
 			return mi;
 		}
 	}

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -810,65 +810,37 @@ int Object::get_method_argument_count(const StringName &p_method, bool *r_is_val
 	return 0;
 }
 
-TypedArray<Dictionary> Object::_get_method_arguments_bind(const StringName &p_method) const {
-	// TODO: This code will change when going from get_arguments -> get_method_info,
-	//       but for now... this's fine
-	Vector<Variant> arguments_as_variants = get_method_arguments(p_method);
-	TypedArray<Dictionary> ret;
-	for (const Variant &E : arguments_as_variants) {
-		ret.push_back(E.operator Dictionary());
-	}
-	return ret;
+Dictionary Object::_get_method_info_bind(const StringName &p_name) const {
+	return get_method_info(p_name).operator Dictionary();
 }
 
-Vector<Variant> Object::get_method_arguments(const StringName &p_method, bool *r_is_valid) const {
-	Vector<Variant> ret;
+MethodInfo Object::get_method_info(const StringName &p_method) const {
+	MethodInfo mi;
 	if (p_method == CoreStringName(free_)) {
-		if (r_is_valid) {
-			*r_is_valid = true;
-		}
-		return ret;
+		return mi;
 	}
 
 	if (script_instance) {
-		bool valid = false;
-		ret = script_instance->get_method_arguments(p_method, &valid);
-		if (valid) {
-			if (r_is_valid) {
-				*r_is_valid = true;
-			}
-			return ret;
-		}
+		return script_instance->get_method_info(p_method);
 	}
 
 	{
-		bool valid = false;
-		ret = ClassDB::get_method_arguments(get_class_name(), p_method, &valid);
-		if (valid) {
-			if (r_is_valid) {
-				*r_is_valid = true;
-			}
-			return ret;
+		ClassDB::get_method_info(get_class_name(), p_method, &mi);
+		if (!(mi == MethodInfo())) {
+			return mi;
 		}
 	}
 
 	const Script *scr = Object::cast_to<Script>(this);
 	while (scr != nullptr) {
-		bool valid = false;
-		ret = scr->get_script_method_arguments(p_method, &valid);
-		if (valid) {
-			if (r_is_valid) {
-				*r_is_valid = true;
-			}
-			return ret;
+		mi = scr->get_method_info(p_method);
+		if (!(mi == MethodInfo())) {
+			return mi;
 		}
 		scr = scr->get_base_script().ptr();
 	}
 
-	if (r_is_valid) {
-		*r_is_valid = false;
-	}
-	return ret;
+	return mi;
 }
 
 Variant Object::getvar(const Variant &p_key, bool *r_valid) const {
@@ -2023,7 +1995,7 @@ void Object::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_method", "method"), &Object::has_method);
 
 	ClassDB::bind_method(D_METHOD("get_method_argument_count", "method"), &Object::_get_method_argument_count_bind);
-	ClassDB::bind_method(D_METHOD("get_method_arguments", "method"), &Object::_get_method_arguments_bind);
+	ClassDB::bind_method(D_METHOD("get_method_info", "method"), &Object::_get_method_info_bind);
 
 	ClassDB::bind_method(D_METHOD("has_signal", "signal"), &Object::has_signal);
 	ClassDB::bind_method(D_METHOD("get_signal_list"), &Object::_get_signal_list);

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -821,7 +821,10 @@ MethodInfo Object::get_method_info(const StringName &p_method) const {
 	}
 
 	if (script_instance) {
-		return script_instance->get_method_info(p_method);
+		mi = script_instance->get_method_info(p_method);
+		if (!(mi == MethodInfo())) {
+			return mi;
+		}
 	}
 
 	{

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -484,6 +484,7 @@ private:
 	void _set_indexed_bind(const NodePath &p_name, const Variant &p_value);
 	Variant _get_indexed_bind(const NodePath &p_name) const;
 	int _get_method_argument_count_bind(const StringName &p_name) const;
+	TypedArray<Dictionary> _get_method_arguments_bind(const StringName &p_name) const;
 
 	_FORCE_INLINE_ void _construct_object(bool p_reference);
 
@@ -704,6 +705,7 @@ public:
 
 	bool has_method(const StringName &p_method) const;
 	int get_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const;
+	Vector<Variant> get_method_arguments(const StringName &p_method, bool *r_is_valid = nullptr) const;
 	void get_method_list(List<MethodInfo> *p_list) const;
 	Variant callv(const StringName &p_method, const Array &p_args);
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error);

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -484,7 +484,7 @@ private:
 	void _set_indexed_bind(const NodePath &p_name, const Variant &p_value);
 	Variant _get_indexed_bind(const NodePath &p_name) const;
 	int _get_method_argument_count_bind(const StringName &p_name) const;
-	TypedArray<Dictionary> _get_method_arguments_bind(const StringName &p_name) const;
+	Dictionary _get_method_info_bind(const StringName &p_name) const;
 
 	_FORCE_INLINE_ void _construct_object(bool p_reference);
 
@@ -705,7 +705,7 @@ public:
 
 	bool has_method(const StringName &p_method) const;
 	int get_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const;
-	Vector<Variant> get_method_arguments(const StringName &p_method, bool *r_is_valid = nullptr) const;
+	MethodInfo get_method_info(const StringName &p_method) const;
 	void get_method_list(List<MethodInfo> *p_list) const;
 	Variant callv(const StringName &p_method, const Array &p_args);
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error);

--- a/core/object/script_instance.cpp
+++ b/core/object/script_instance.cpp
@@ -54,6 +54,29 @@ int ScriptInstance::get_method_argument_count(const StringName &p_method, bool *
 	return 0;
 }
 
+Vector<Variant> ScriptInstance::get_method_arguments(const StringName &p_method, bool *r_is_valid) const {
+	// Default implementation simply traverses hierarchy.
+	Vector<Variant> ret;
+
+	Ref<Script> script = get_script();
+	while (script.is_valid()) {
+		bool valid = false;
+		ret = script->get_script_method_arguments(p_method, &valid);
+		if (valid) {
+			if (r_is_valid) {
+				*r_is_valid = true;
+			}
+			return ret;
+		}
+		script = script->get_base_script();
+	}
+
+	if (r_is_valid) {
+		*r_is_valid = false;
+	}
+	return ret;
+}
+
 Variant ScriptInstance::call_const(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	return callp(p_method, p_args, p_argcount, r_error);
 }

--- a/core/object/script_instance.cpp
+++ b/core/object/script_instance.cpp
@@ -54,27 +54,19 @@ int ScriptInstance::get_method_argument_count(const StringName &p_method, bool *
 	return 0;
 }
 
-Vector<Variant> ScriptInstance::get_method_arguments(const StringName &p_method, bool *r_is_valid) const {
+MethodInfo ScriptInstance::get_method_info(const StringName &p_method) const {
 	// Default implementation simply traverses hierarchy.
-	Vector<Variant> ret;
+	MethodInfo mi;
 
 	Ref<Script> script = get_script();
 	while (script.is_valid()) {
-		bool valid = false;
-		ret = script->get_script_method_arguments(p_method, &valid);
-		if (valid) {
-			if (r_is_valid) {
-				*r_is_valid = true;
-			}
-			return ret;
+		mi = script->get_method_info(p_method);
+		if (!(mi == MethodInfo())) {
+			return mi;
 		}
 		script = script->get_base_script();
 	}
-
-	if (r_is_valid) {
-		*r_is_valid = false;
-	}
-	return ret;
+	return mi;
 }
 
 Variant ScriptInstance::call_const(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {

--- a/core/object/script_instance.h
+++ b/core/object/script_instance.h
@@ -53,6 +53,7 @@ public:
 	virtual bool has_method(const StringName &p_method) const = 0;
 
 	virtual int get_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const;
+	virtual Vector<Variant> get_method_arguments(const StringName &p_method, bool *r_is_valid = nullptr) const;
 
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) = 0;
 

--- a/core/object/script_instance.h
+++ b/core/object/script_instance.h
@@ -53,7 +53,7 @@ public:
 	virtual bool has_method(const StringName &p_method) const = 0;
 
 	virtual int get_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const;
-	virtual Vector<Variant> get_method_arguments(const StringName &p_method, bool *r_is_valid = nullptr) const;
+	virtual MethodInfo get_method_info(const StringName &p_method) const;
 
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) = 0;
 

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -37,7 +37,9 @@
 #include "core/debugger/script_debugger.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "core/object/property_info.h"
 #include "core/templates/sort_array.h"
+#include "core/templates/vector.h"
 
 ScriptLanguage *ScriptServer::_languages[MAX_LANGUAGES];
 int ScriptServer::_language_count = 0;
@@ -133,6 +135,28 @@ int Script::get_script_method_argument_count(const StringName &p_method, bool *r
 		*r_is_valid = true;
 	}
 	return mi.arguments.size();
+}
+
+Vector<Variant> Script::get_script_method_arguments(const StringName &p_method, bool *r_is_valid) const {
+	MethodInfo mi = get_method_info(p_method);
+	Vector<Variant> ret;
+
+	if (mi == MethodInfo()) {
+		if (r_is_valid) {
+			*r_is_valid = false;
+		}
+		return ret;
+	}
+
+	for (const PropertyInfo &E : mi.arguments) {
+		ret.push_back(E.operator Dictionary());
+	}
+
+	if (r_is_valid) {
+		*r_is_valid = true;
+	}
+
+	return ret;
 }
 
 #ifdef TOOLS_ENABLED
@@ -705,6 +729,34 @@ bool PlaceHolderScriptInstance::has_method(const StringName &p_method) const {
 		}
 	}
 	return false;
+}
+
+Vector<Variant> PlaceHolderScriptInstance::get_method_arguments(const StringName &p_method, bool *r_is_valid) const {
+	Vector<Variant> ret;
+	if (script->is_placeholder_fallback_enabled()) {
+		if (r_is_valid) {
+			*r_is_valid = false;
+		}
+		return ret;
+	}
+
+	Ref<Script> scr = script;
+	while (scr.is_valid()) {
+		bool valid = false;
+		ret = scr->get_script_method_arguments(p_method, &valid);
+		if (valid) {
+			if (r_is_valid) {
+				*r_is_valid = true;
+			}
+			return ret;
+		}
+		scr = scr->get_base_script();
+	}
+
+	if (r_is_valid) {
+		*r_is_valid = false;
+	}
+	return ret;
 }
 
 Variant PlaceHolderScriptInstance::callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -137,28 +137,6 @@ int Script::get_script_method_argument_count(const StringName &p_method, bool *r
 	return mi.arguments.size();
 }
 
-Vector<Variant> Script::get_script_method_arguments(const StringName &p_method, bool *r_is_valid) const {
-	MethodInfo mi = get_method_info(p_method);
-	Vector<Variant> ret;
-
-	if (mi == MethodInfo()) {
-		if (r_is_valid) {
-			*r_is_valid = false;
-		}
-		return ret;
-	}
-
-	for (const PropertyInfo &E : mi.arguments) {
-		ret.push_back(E.operator Dictionary());
-	}
-
-	if (r_is_valid) {
-		*r_is_valid = true;
-	}
-
-	return ret;
-}
-
 #ifdef TOOLS_ENABLED
 
 PropertyInfo Script::get_class_category() const {
@@ -730,31 +708,19 @@ bool PlaceHolderScriptInstance::has_method(const StringName &p_method) const {
 	}
 	return false;
 }
-
-Vector<Variant> PlaceHolderScriptInstance::get_method_arguments(const StringName &p_method, bool *r_is_valid) const {
-	Vector<Variant> ret;
+MethodInfo PlaceHolderScriptInstance::get_method_info(const StringName &p_method) const {
+	MethodInfo ret;
 	if (script->is_placeholder_fallback_enabled()) {
-		if (r_is_valid) {
-			*r_is_valid = false;
-		}
 		return ret;
 	}
 
 	Ref<Script> scr = script;
 	while (scr.is_valid()) {
-		bool valid = false;
-		ret = scr->get_script_method_arguments(p_method, &valid);
-		if (valid) {
-			if (r_is_valid) {
-				*r_is_valid = true;
-			}
+		ret = scr->get_method_info(p_method);
+		if (!(ret == MethodInfo())) {
 			return ret;
 		}
 		scr = scr->get_base_script();
-	}
-
-	if (r_is_valid) {
-		*r_is_valid = false;
 	}
 	return ret;
 }

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -173,6 +173,7 @@ public:
 	virtual bool has_static_method(const StringName &p_method) const { return false; }
 
 	virtual int get_script_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const;
+	virtual Vector<Variant> get_script_method_arguments(const StringName &p_method, bool *r_is_valid = nullptr) const;
 
 	virtual MethodInfo get_method_info(const StringName &p_method) const = 0;
 
@@ -369,6 +370,7 @@ public:
 		return 0;
 	}
 
+	virtual Vector<Variant> get_method_arguments(const StringName &p_method, bool *r_is_valid = nullptr) const override;
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;
 	virtual void notification(int p_notification, bool p_reversed = false) override {}
 

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -173,7 +173,6 @@ public:
 	virtual bool has_static_method(const StringName &p_method) const { return false; }
 
 	virtual int get_script_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const;
-	virtual Vector<Variant> get_script_method_arguments(const StringName &p_method, bool *r_is_valid = nullptr) const;
 
 	virtual MethodInfo get_method_info(const StringName &p_method) const = 0;
 
@@ -370,7 +369,7 @@ public:
 		return 0;
 	}
 
-	virtual Vector<Variant> get_method_arguments(const StringName &p_method, bool *r_is_valid = nullptr) const override;
+	virtual MethodInfo get_method_info(const StringName &p_method) const override;
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;
 	virtual void notification(int p_notification, bool p_reversed = false) override {}
 

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -37,6 +37,9 @@
 #include "core/variant/callable_bind.h"
 #include "core/variant/variant_callable.h"
 
+#include <core/string/print_string.h>
+#include <core/variant/dictionary.h>
+
 void Callable::call_deferredp(const Variant **p_arguments, int p_argcount) const {
 	MessageQueue::get_singleton()->push_callablep(*this, p_arguments, p_argcount, true);
 }
@@ -216,6 +219,28 @@ void Callable::get_bound_arguments_ref(Vector<Variant> &r_arguments) const {
 Array Callable::get_bound_arguments() const {
 	Vector<Variant> arr;
 	get_bound_arguments_ref(arr);
+	Array ret;
+	ret.resize(arr.size());
+	for (int i = 0; i < arr.size(); i++) {
+		ret[i] = arr[i];
+	}
+	return ret;
+}
+
+void Callable::get_arguments_ref(Vector<Variant> &r_arguments) const {
+	if (is_custom()) {
+		custom->get_arguments(r_arguments);
+	} else if (is_valid()) {
+		r_arguments = get_object()->get_method_arguments(method);
+	} else {
+		r_arguments.clear();
+	}
+}
+
+Array Callable::get_arguments() const {
+	print_line("Callable::get_arguments called!");
+	Vector<Variant> arr;
+	get_arguments_ref(arr);
 	Array ret;
 	ret.resize(arr.size());
 	for (int i = 0; i < arr.size(); i++) {
@@ -467,6 +492,11 @@ const Callable *CallableCustom::get_base_comparator() const {
 int CallableCustom::get_argument_count(bool &r_is_valid) const {
 	r_is_valid = false;
 	return 0;
+}
+
+void CallableCustom::get_arguments(Vector<Variant> &r_arguments) const {
+	print_line("CallableCustom::get_arguments is called!");
+	r_arguments.clear();
 }
 
 int CallableCustom::get_bound_arguments_count() const {

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -227,26 +227,24 @@ Array Callable::get_bound_arguments() const {
 	return ret;
 }
 
-void Callable::get_arguments_ref(Vector<Variant> &r_arguments) const {
+void Callable::get_method_info_ref(MethodInfo &r_method_info) const {
 	if (is_custom()) {
-		custom->get_arguments(r_arguments);
+		custom->get_method_info(r_method_info);
 	} else if (is_valid()) {
-		r_arguments = get_object()->get_method_arguments(method);
+		r_method_info = get_object()->get_method_info(method);
 	} else {
-		r_arguments.clear();
+		r_method_info = MethodInfo();
 	}
 }
 
-Array Callable::get_arguments() const {
+Dictionary Callable::get_method_info() const {
 	print_line("Callable::get_arguments called!");
-	Vector<Variant> arr;
-	get_arguments_ref(arr);
-	Array ret;
-	ret.resize(arr.size());
-	for (int i = 0; i < arr.size(); i++) {
-		ret[i] = arr[i];
+	MethodInfo mi;
+	get_method_info_ref(mi);
+	if (mi == MethodInfo()) {
+		return Dictionary();
 	}
-	return ret;
+	return mi.operator Dictionary();
 }
 
 int Callable::get_unbound_arguments_count() const {
@@ -494,9 +492,9 @@ int CallableCustom::get_argument_count(bool &r_is_valid) const {
 	return 0;
 }
 
-void CallableCustom::get_arguments(Vector<Variant> &r_arguments) const {
+void CallableCustom::get_method_info(MethodInfo &r_method_info) const {
 	print_line("CallableCustom::get_arguments is called!");
-	r_arguments.clear();
+	r_method_info = MethodInfo();
 }
 
 int CallableCustom::get_bound_arguments_count() const {

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -241,9 +241,6 @@ Dictionary Callable::get_method_info() const {
 	print_line("Callable::get_arguments called!");
 	MethodInfo mi;
 	get_method_info_ref(mi);
-	if (mi == MethodInfo()) {
-		return Dictionary();
-	}
 	return mi.operator Dictionary();
 }
 

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -112,6 +112,8 @@ public:
 	int get_bound_arguments_count() const;
 	void get_bound_arguments_ref(Vector<Variant> &r_arguments) const; // Internal engine use, the exposed one is below.
 	Array get_bound_arguments() const;
+	void get_arguments_ref(Vector<Variant> &r_arguments) const; // Internal engine use, the exposed one is below.
+	Array get_arguments() const;
 	int get_unbound_arguments_count() const;
 
 	uint32_t hash() const;
@@ -163,6 +165,7 @@ public:
 	virtual int get_argument_count(bool &r_is_valid) const;
 	virtual int get_bound_arguments_count() const;
 	virtual void get_bound_arguments(Vector<Variant> &r_arguments) const;
+	virtual void get_arguments(Vector<Variant> &r_arguments) const;
 	virtual int get_unbound_arguments_count() const;
 
 	CallableCustom();

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -32,7 +32,9 @@
 
 #include "core/object/object_id.h"
 #include "core/string/string_name.h"
+#include "core/variant/dictionary.h"
 
+struct MethodInfo;
 class Array;
 class Object;
 class Variant;
@@ -112,8 +114,8 @@ public:
 	int get_bound_arguments_count() const;
 	void get_bound_arguments_ref(Vector<Variant> &r_arguments) const; // Internal engine use, the exposed one is below.
 	Array get_bound_arguments() const;
-	void get_arguments_ref(Vector<Variant> &r_arguments) const; // Internal engine use, the exposed one is below.
-	Array get_arguments() const;
+	void get_method_info_ref(MethodInfo &r_method_info) const; // Internal engine use, the exposed one is below.
+	Dictionary get_method_info() const;
 	int get_unbound_arguments_count() const;
 
 	uint32_t hash() const;
@@ -165,7 +167,7 @@ public:
 	virtual int get_argument_count(bool &r_is_valid) const;
 	virtual int get_bound_arguments_count() const;
 	virtual void get_bound_arguments(Vector<Variant> &r_arguments) const;
-	virtual void get_arguments(Vector<Variant> &r_arguments) const;
+	virtual void get_method_info(MethodInfo &r_method_info) const;
 	virtual int get_unbound_arguments_count() const;
 
 	CallableCustom();

--- a/core/variant/callable_bind.cpp
+++ b/core/variant/callable_bind.cpp
@@ -99,6 +99,11 @@ int CallableCustomBind::get_argument_count(bool &r_is_valid) const {
 	return 0;
 }
 
+void CallableCustomBind::get_arguments(Vector<Variant> &r_arguments) const {
+	print_line("CallableCustomBind::get_arguments is called!");
+	callable.get_arguments_ref(r_arguments);
+}
+
 int CallableCustomBind::get_bound_arguments_count() const {
 	return callable.get_bound_arguments_count() + MAX(0, binds.size() - callable.get_unbound_arguments_count());
 }
@@ -234,6 +239,11 @@ int CallableCustomUnbind::get_argument_count(bool &r_is_valid) const {
 		return ret + argcount;
 	}
 	return 0;
+}
+
+void CallableCustomUnbind::get_arguments(Vector<Variant> &r_arguments) const {
+	print_line("CallableCustomUnbind::get_arguments is called!");
+	callable.get_arguments_ref(r_arguments);
 }
 
 int CallableCustomUnbind::get_bound_arguments_count() const {

--- a/core/variant/callable_bind.cpp
+++ b/core/variant/callable_bind.cpp
@@ -98,10 +98,9 @@ int CallableCustomBind::get_argument_count(bool &r_is_valid) const {
 	}
 	return 0;
 }
-
-void CallableCustomBind::get_arguments(Vector<Variant> &r_arguments) const {
+void CallableCustomBind::get_method_info(MethodInfo &r_method_info) const {
 	print_line("CallableCustomBind::get_arguments is called!");
-	callable.get_arguments_ref(r_arguments);
+	callable.get_method_info_ref(r_method_info);
 }
 
 int CallableCustomBind::get_bound_arguments_count() const {
@@ -241,9 +240,9 @@ int CallableCustomUnbind::get_argument_count(bool &r_is_valid) const {
 	return 0;
 }
 
-void CallableCustomUnbind::get_arguments(Vector<Variant> &r_arguments) const {
+void CallableCustomUnbind::get_method_info(MethodInfo &r_method_info) const {
 	print_line("CallableCustomUnbind::get_arguments is called!");
-	callable.get_arguments_ref(r_arguments);
+	callable.get_method_info_ref(r_method_info);
 }
 
 int CallableCustomUnbind::get_bound_arguments_count() const {

--- a/core/variant/callable_bind.h
+++ b/core/variant/callable_bind.h
@@ -53,6 +53,7 @@ public:
 	virtual Error rpc(int p_peer_id, const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) const override;
 	virtual const Callable *get_base_comparator() const override;
 	virtual int get_argument_count(bool &r_is_valid) const override;
+	virtual void get_arguments(Vector<Variant> &r_arguments) const override;
 	virtual int get_bound_arguments_count() const override;
 	virtual void get_bound_arguments(Vector<Variant> &r_arguments) const override;
 	virtual int get_unbound_arguments_count() const override;
@@ -82,6 +83,7 @@ public:
 	virtual Error rpc(int p_peer_id, const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) const override;
 	virtual const Callable *get_base_comparator() const override;
 	virtual int get_argument_count(bool &r_is_valid) const override;
+	virtual void get_arguments(Vector<Variant> &r_arguments) const override;
 	virtual int get_bound_arguments_count() const override;
 	virtual void get_bound_arguments(Vector<Variant> &r_arguments) const override;
 	virtual int get_unbound_arguments_count() const override;

--- a/core/variant/callable_bind.h
+++ b/core/variant/callable_bind.h
@@ -53,7 +53,7 @@ public:
 	virtual Error rpc(int p_peer_id, const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) const override;
 	virtual const Callable *get_base_comparator() const override;
 	virtual int get_argument_count(bool &r_is_valid) const override;
-	virtual void get_arguments(Vector<Variant> &r_arguments) const override;
+	virtual void get_method_info(MethodInfo &r_method_info) const override;
 	virtual int get_bound_arguments_count() const override;
 	virtual void get_bound_arguments(Vector<Variant> &r_arguments) const override;
 	virtual int get_unbound_arguments_count() const override;
@@ -83,7 +83,7 @@ public:
 	virtual Error rpc(int p_peer_id, const Variant **p_arguments, int p_argcount, Callable::CallError &r_call_error) const override;
 	virtual const Callable *get_base_comparator() const override;
 	virtual int get_argument_count(bool &r_is_valid) const override;
-	virtual void get_arguments(Vector<Variant> &r_arguments) const override;
+	virtual void get_method_info(MethodInfo &r_method_info) const override;
 	virtual int get_bound_arguments_count() const override;
 	virtual void get_bound_arguments(Vector<Variant> &r_arguments) const override;
 	virtual int get_unbound_arguments_count() const override;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2437,6 +2437,7 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(Callable, get_object_id, sarray(), varray());
 	bind_method(Callable, get_method, sarray(), varray());
 	bind_function(Callable, get_argument_count, _VariantCall::func_Callable_get_argument_count, sarray(), varray());
+	bind_method(Callable, get_arguments, sarray(), varray());
 	bind_method(Callable, get_bound_arguments_count, sarray(), varray());
 	bind_method(Callable, get_bound_arguments, sarray(), varray());
 	bind_method(Callable, get_unbound_arguments_count, sarray(), varray());

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2437,7 +2437,7 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(Callable, get_object_id, sarray(), varray());
 	bind_method(Callable, get_method, sarray(), varray());
 	bind_function(Callable, get_argument_count, _VariantCall::func_Callable_get_argument_count, sarray(), varray());
-	bind_method(Callable, get_arguments, sarray(), varray());
+	bind_method(Callable, get_method_info, sarray(), varray());
 	bind_method(Callable, get_bound_arguments_count, sarray(), varray());
 	bind_method(Callable, get_bound_arguments, sarray(), varray());
 	bind_method(Callable, get_unbound_arguments_count, sarray(), varray());

--- a/core/variant/variant_callable.cpp
+++ b/core/variant/variant_callable.cpp
@@ -32,6 +32,11 @@
 
 #include "core/templates/hashfuncs.h"
 
+#include <core/error/error_macros.h>
+#include <core/object/method_info.h>
+#include <core/templates/vector.h>
+#include <core/variant/variant.h>
+
 bool VariantCallable::compare_equal(const CallableCustom *p_a, const CallableCustom *p_b) {
 	return p_a->hash() == p_b->hash();
 }
@@ -69,12 +74,26 @@ ObjectID VariantCallable::get_object() const {
 }
 
 int VariantCallable::get_argument_count(bool &r_is_valid) const {
-	if (!Variant::has_builtin_method(variant.get_type(), method)) {
+	if (!is_valid()) {
 		r_is_valid = false;
 		return 0;
 	}
 	r_is_valid = true;
 	return Variant::get_builtin_method_argument_count(variant.get_type(), method);
+}
+
+void VariantCallable::get_arguments(Vector<Variant> &r_arguments) const {
+	print_line("VariantCallable::get_arguments called!");
+	r_arguments.clear();
+	if (!is_valid()) {
+		return;
+	}
+	MethodInfo method_info = Variant::get_builtin_method_info(variant.get_type(), method);
+	ERR_FAIL_COND_MSG(method_info == MethodInfo(), vformat("Couldn't get method info of \"%s\"", method));
+	Vector<PropertyInfo> arguments = method_info.arguments;
+	for (PropertyInfo E : arguments) {
+		r_arguments.push_back(E.operator Dictionary());
+	}
 }
 
 void VariantCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {

--- a/core/variant/variant_callable.cpp
+++ b/core/variant/variant_callable.cpp
@@ -82,18 +82,12 @@ int VariantCallable::get_argument_count(bool &r_is_valid) const {
 	return Variant::get_builtin_method_argument_count(variant.get_type(), method);
 }
 
-void VariantCallable::get_arguments(Vector<Variant> &r_arguments) const {
+void VariantCallable::get_method_info(MethodInfo &r_method_info) const {
 	print_line("VariantCallable::get_arguments called!");
-	r_arguments.clear();
 	if (!is_valid()) {
 		return;
 	}
-	MethodInfo method_info = Variant::get_builtin_method_info(variant.get_type(), method);
-	ERR_FAIL_COND_MSG(method_info == MethodInfo(), vformat("Couldn't get method info of \"%s\"", method));
-	Vector<PropertyInfo> arguments = method_info.arguments;
-	for (PropertyInfo E : arguments) {
-		r_arguments.push_back(E.operator Dictionary());
-	}
+	r_method_info = Variant::get_builtin_method_info(variant.get_type(), method);
 }
 
 void VariantCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {

--- a/core/variant/variant_callable.h
+++ b/core/variant/variant_callable.h
@@ -50,6 +50,7 @@ public:
 	StringName get_method() const override;
 	ObjectID get_object() const override;
 	int get_argument_count(bool &r_is_valid) const override;
+	void get_arguments(Vector<Variant> &r_arguments) const override;
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
 	VariantCallable(const Variant &p_variant, const StringName &p_method);

--- a/core/variant/variant_callable.h
+++ b/core/variant/variant_callable.h
@@ -50,7 +50,7 @@ public:
 	StringName get_method() const override;
 	ObjectID get_object() const override;
 	int get_argument_count(bool &r_is_valid) const override;
-	void get_arguments(Vector<Variant> &r_arguments) const override;
+	void get_method_info(MethodInfo &r_method_info) const override;
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
 	VariantCallable(const Variant &p_variant, const StringName &p_method);

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -179,6 +179,13 @@
 				Returns the name of the method represented by this [Callable]. If the callable is a GDScript lambda function, returns the function's name or [code]"&lt;anonymous lambda&gt;"[/code].
 			</description>
 		</method>
+		<method name="get_method_info" qualifiers="const">
+			<return type="Dictionary" />
+			<description>
+				Returns signature of the method represented by this [Callable] as [Dictionary].
+				[b]Note:[/b] Due to the implementation, the [Dictionary] is formatted very similarly to the returned values of [method Object.get_method_list].
+			</description>
+		</method>
 		<method name="get_object" qualifiers="const">
 			<return type="Object" />
 			<description>

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -90,6 +90,16 @@
 				Returns the number of arguments of the method [param method] of [param class] or its ancestry if [param no_inheritance] is [code]false[/code].
 			</description>
 		</method>
+		<method name="class_get_method_info" qualifiers="const">
+			<return type="Dictionary" />
+			<param index="0" name="class" type="StringName" />
+			<param index="1" name="method" type="StringName" />
+			<param index="2" name="no_inheritance" type="bool" default="false" />
+			<description>
+				Returns a [Dictionary] of [param method] in [param class] or its ancestry if [param no_inheritance] is [code]false[/code]. Returned [Dictionary] has the following keys: [code]args[/code], [code]default_args[/code], [code]flags[/code], [code]id[/code], [code]name[/code], [code]return: (class_name, hint, hint_string, name, type, usage)[/code].
+				[b]Note:[/b] In exported release builds the debug info is not available, so the returned dictionaries will contain only method names.
+			</description>
+		</method>
 		<method name="class_get_method_list" qualifiers="const">
 			<return type="Dictionary[]" />
 			<param index="0" name="class" type="StringName" />

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -663,6 +663,14 @@
 				[b]Note:[/b] In C#, [param method] must be in snake_case when referring to built-in Godot methods. Prefer using the names exposed in the [code]MethodName[/code] class to avoid allocating a new [StringName] on each call.
 			</description>
 		</method>
+		<method name="get_method_info" qualifiers="const">
+			<return type="Dictionary" />
+			<param index="0" name="method" type="StringName" />
+			<description>
+				Returns signature of [param method] as [Dictionary].
+				[b]Note:[/b] Due to the implementation, the [Dictionary] is formatted very similarly to the returned values of [method get_method_list].
+			</description>
+		</method>
 		<method name="get_method_list" qualifiers="const">
 			<return type="Dictionary[]" />
 			<description>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -384,28 +384,6 @@ int GDScript::get_script_method_argument_count(const StringName &p_method, bool 
 	return E->value->get_argument_count();
 }
 
-Vector<Variant> GDScript::get_script_method_arguments(const StringName &p_method, bool *r_is_valid) const {
-	HashMap<StringName, GDScriptFunction *>::ConstIterator E = member_functions.find(p_method);
-	Vector<Variant> ret;
-
-	if (!E) {
-		if (r_is_valid) {
-			*r_is_valid = false;
-		}
-		return ret;
-	}
-
-	for (const PropertyInfo &F : E->value->get_method_info().arguments) {
-		ret.push_back(F.operator Dictionary());
-	}
-
-	if (r_is_valid) {
-		*r_is_valid = true;
-	}
-
-	return ret;
-}
-
 MethodInfo GDScript::get_method_info(const StringName &p_method) const {
 	HashMap<StringName, GDScriptFunction *>::ConstIterator E = member_functions.find(p_method);
 	if (!E) {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -41,6 +41,7 @@
 #include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "core/object/property_info.h"
 #include "core/templates/rb_set.h"
 
 #ifdef TOOLS_ENABLED
@@ -381,6 +382,28 @@ int GDScript::get_script_method_argument_count(const StringName &p_method, bool 
 		*r_is_valid = true;
 	}
 	return E->value->get_argument_count();
+}
+
+Vector<Variant> GDScript::get_script_method_arguments(const StringName &p_method, bool *r_is_valid) const {
+	HashMap<StringName, GDScriptFunction *>::ConstIterator E = member_functions.find(p_method);
+	Vector<Variant> ret;
+
+	if (!E) {
+		if (r_is_valid) {
+			*r_is_valid = false;
+		}
+		return ret;
+	}
+
+	for (const PropertyInfo &F : E->value->get_method_info().arguments) {
+		ret.push_back(F.operator Dictionary());
+	}
+
+	if (r_is_valid) {
+		*r_is_valid = true;
+	}
+
+	return ret;
 }
 
 MethodInfo GDScript::get_method_info(const StringName &p_method) const {
@@ -1941,6 +1964,30 @@ int GDScriptInstance::get_method_argument_count(const StringName &p_method, bool
 		*r_is_valid = false;
 	}
 	return 0;
+}
+Vector<Variant> GDScriptInstance::get_method_arguments(const StringName &p_method, bool *r_is_valid) const {
+	const GDScript *sptr = script.ptr();
+	Vector<Variant> ret;
+
+	while (sptr) {
+		HashMap<StringName, GDScriptFunction *>::ConstIterator E = sptr->member_functions.find(p_method);
+		if (E) {
+			if (r_is_valid) {
+				*r_is_valid = true;
+			}
+			for (const PropertyInfo &F : E->value->get_method_info().arguments) {
+				ret.push_back(F.operator Dictionary());
+			}
+			return ret;
+		}
+		sptr = sptr->base.ptr();
+	}
+
+	if (r_is_valid) {
+		*r_is_valid = false;
+	}
+
+	return ret;
 }
 
 void GDScriptInstance::_call_implicit_ready_recursively(GDScript *p_script) {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1943,30 +1943,6 @@ int GDScriptInstance::get_method_argument_count(const StringName &p_method, bool
 	}
 	return 0;
 }
-Vector<Variant> GDScriptInstance::get_method_arguments(const StringName &p_method, bool *r_is_valid) const {
-	const GDScript *sptr = script.ptr();
-	Vector<Variant> ret;
-
-	while (sptr) {
-		HashMap<StringName, GDScriptFunction *>::ConstIterator E = sptr->member_functions.find(p_method);
-		if (E) {
-			if (r_is_valid) {
-				*r_is_valid = true;
-			}
-			for (const PropertyInfo &F : E->value->get_method_info().arguments) {
-				ret.push_back(F.operator Dictionary());
-			}
-			return ret;
-		}
-		sptr = sptr->base.ptr();
-	}
-
-	if (r_is_valid) {
-		*r_is_valid = false;
-	}
-
-	return ret;
-}
 
 void GDScriptInstance::_call_implicit_ready_recursively(GDScript *p_script) {
 	// Call base class first.

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -307,6 +307,7 @@ public:
 	virtual bool has_static_method(const StringName &p_method) const override;
 
 	virtual int get_script_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const override;
+	virtual Vector<Variant> get_script_method_arguments(const StringName &p_method, bool *r_is_valid = nullptr) const override;
 
 	virtual MethodInfo get_method_info(const StringName &p_method) const override;
 
@@ -373,6 +374,7 @@ public:
 	virtual bool has_method(const StringName &p_method) const;
 
 	virtual int get_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const;
+	virtual Vector<Variant> get_method_arguments(const StringName &p_method, bool *r_is_valid = nullptr) const;
 
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -307,7 +307,6 @@ public:
 	virtual bool has_static_method(const StringName &p_method) const override;
 
 	virtual int get_script_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const override;
-	virtual Vector<Variant> get_script_method_arguments(const StringName &p_method, bool *r_is_valid = nullptr) const override;
 
 	virtual MethodInfo get_method_info(const StringName &p_method) const override;
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -373,7 +373,6 @@ public:
 	virtual bool has_method(const StringName &p_method) const;
 
 	virtual int get_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const;
-	virtual Vector<Variant> get_method_arguments(const StringName &p_method, bool *r_is_valid = nullptr) const;
 
 	virtual Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 

--- a/modules/gdscript/gdscript_lambda_callable.cpp
+++ b/modules/gdscript/gdscript_lambda_callable.cpp
@@ -34,6 +34,11 @@
 
 #include "core/templates/hashfuncs.h"
 
+#include <core/error/error_macros.h>
+#include <core/object/property_info.h>
+#include <core/string/print_string.h>
+#include <core/variant/dictionary.h>
+
 bool GDScriptLambdaCallable::compare_equal(const CallableCustom *p_a, const CallableCustom *p_b) {
 	// Lambda callables are only compared by reference.
 	return p_a == p_b;
@@ -87,6 +92,20 @@ int GDScriptLambdaCallable::get_argument_count(bool &r_is_valid) const {
 	}
 	r_is_valid = true;
 	return function->get_argument_count() - captures.size();
+}
+
+void GDScriptLambdaCallable::get_arguments(Vector<Variant> &r_arguments) const {
+	print_line("GDScriptLambdaCallable::get_arguments was called!");
+	r_arguments.clear();
+	if (function == nullptr) {
+		return;
+	}
+	MethodInfo method_info = function->get_method_info();
+	ERR_FAIL_COND_MSG(method_info == MethodInfo(), vformat("Failed to get method info of \"%s\"", get_method()));
+	Vector<PropertyInfo> arguments = method_info.arguments;
+	for (const PropertyInfo &E : arguments) {
+		r_arguments.push_back(E.operator Dictionary());
+	}
 }
 
 void GDScriptLambdaCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
@@ -211,6 +230,20 @@ int GDScriptLambdaSelfCallable::get_argument_count(bool &r_is_valid) const {
 	}
 	r_is_valid = true;
 	return function->get_argument_count() - captures.size();
+}
+
+void GDScriptLambdaSelfCallable::get_arguments(Vector<Variant> &r_arguments) const {
+	print_line("GDScriptLambdaSelfCallable::get_arguments was called!");
+	r_arguments.clear();
+	if (function == nullptr) {
+		return;
+	}
+	MethodInfo method_info = function->get_method_info();
+	ERR_FAIL_COND_MSG(method_info == MethodInfo(), vformat("Failed to get method info of \"%s\"", get_method()));
+	Vector<PropertyInfo> arguments = method_info.arguments;
+	for (const PropertyInfo &E : arguments) {
+		r_arguments.push_back(E.operator Dictionary());
+	}
 }
 
 void GDScriptLambdaSelfCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {

--- a/modules/gdscript/gdscript_lambda_callable.cpp
+++ b/modules/gdscript/gdscript_lambda_callable.cpp
@@ -94,18 +94,12 @@ int GDScriptLambdaCallable::get_argument_count(bool &r_is_valid) const {
 	return function->get_argument_count() - captures.size();
 }
 
-void GDScriptLambdaCallable::get_arguments(Vector<Variant> &r_arguments) const {
+void GDScriptLambdaCallable::get_method_info(MethodInfo &r_method_info) const {
 	print_line("GDScriptLambdaCallable::get_arguments was called!");
-	r_arguments.clear();
 	if (function == nullptr) {
 		return;
 	}
-	MethodInfo method_info = function->get_method_info();
-	ERR_FAIL_COND_MSG(method_info == MethodInfo(), vformat("Failed to get method info of \"%s\"", get_method()));
-	Vector<PropertyInfo> arguments = method_info.arguments;
-	for (const PropertyInfo &E : arguments) {
-		r_arguments.push_back(E.operator Dictionary());
-	}
+	r_method_info = function->get_method_info();
 }
 
 void GDScriptLambdaCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
@@ -232,18 +226,12 @@ int GDScriptLambdaSelfCallable::get_argument_count(bool &r_is_valid) const {
 	return function->get_argument_count() - captures.size();
 }
 
-void GDScriptLambdaSelfCallable::get_arguments(Vector<Variant> &r_arguments) const {
+void GDScriptLambdaSelfCallable::get_method_info(MethodInfo &r_method_info) const {
 	print_line("GDScriptLambdaSelfCallable::get_arguments was called!");
-	r_arguments.clear();
 	if (function == nullptr) {
 		return;
 	}
-	MethodInfo method_info = function->get_method_info();
-	ERR_FAIL_COND_MSG(method_info == MethodInfo(), vformat("Failed to get method info of \"%s\"", get_method()));
-	Vector<PropertyInfo> arguments = method_info.arguments;
-	for (const PropertyInfo &E : arguments) {
-		r_arguments.push_back(E.operator Dictionary());
-	}
+	r_method_info = function->get_method_info();
 }
 
 void GDScriptLambdaSelfCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {

--- a/modules/gdscript/gdscript_lambda_callable.h
+++ b/modules/gdscript/gdscript_lambda_callable.h
@@ -62,6 +62,7 @@ public:
 	ObjectID get_object() const override;
 	StringName get_method() const override;
 	int get_argument_count(bool &r_is_valid) const override;
+	void get_arguments(Vector<Variant> &r_arguments) const override;
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
 	GDScriptLambdaCallable(GDScriptLambdaCallable &) = delete;
@@ -91,6 +92,7 @@ public:
 	ObjectID get_object() const override;
 	StringName get_method() const override;
 	int get_argument_count(bool &r_is_valid) const override;
+	void get_arguments(Vector<Variant> &r_arguments) const override;
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
 	GDScriptLambdaSelfCallable(GDScriptLambdaSelfCallable &) = delete;

--- a/modules/gdscript/gdscript_lambda_callable.h
+++ b/modules/gdscript/gdscript_lambda_callable.h
@@ -62,7 +62,7 @@ public:
 	ObjectID get_object() const override;
 	StringName get_method() const override;
 	int get_argument_count(bool &r_is_valid) const override;
-	void get_arguments(Vector<Variant> &r_arguments) const override;
+	void get_method_info(MethodInfo &r_method_info) const override;
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
 	GDScriptLambdaCallable(GDScriptLambdaCallable &) = delete;
@@ -92,7 +92,7 @@ public:
 	ObjectID get_object() const override;
 	StringName get_method() const override;
 	int get_argument_count(bool &r_is_valid) const override;
-	void get_arguments(Vector<Variant> &r_arguments) const override;
+	void get_method_info(MethodInfo &r_method_info) const override;
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
 	GDScriptLambdaSelfCallable(GDScriptLambdaSelfCallable &) = delete;

--- a/modules/gdscript/gdscript_utility_callable.cpp
+++ b/modules/gdscript/gdscript_utility_callable.cpp
@@ -30,6 +30,12 @@
 
 #include "gdscript_utility_callable.h"
 
+#include "core/object/method_info.h"
+
+#include <core/error/error_macros.h>
+#include <core/string/print_string.h>
+#include <core/variant/variant.h>
+
 bool GDScriptUtilityCallable::compare_equal(const CallableCustom *p_a, const CallableCustom *p_b) {
 	return p_a->hash() == p_b->hash();
 }
@@ -91,6 +97,28 @@ int GDScriptUtilityCallable::get_argument_count(bool &r_is_valid) const {
 			return GDScriptUtilityFunctions::get_function_argument_count(function_name);
 	}
 	ERR_FAIL_V_MSG(0, "Invalid type.");
+}
+
+void GDScriptUtilityCallable::get_arguments(Vector<Variant> &r_arguments) const {
+	print_line("GDScriptUtilityCallable::get_arguments is called!");
+	r_arguments.clear();
+	MethodInfo method_info = MethodInfo();
+	switch (type) {
+		case TYPE_INVALID:
+			break;
+		case TYPE_GLOBAL:
+			method_info = Variant::get_utility_function_info(function_name);
+			break;
+		case TYPE_GDSCRIPT:
+			method_info = GDScriptUtilityFunctions::get_function_info(function_name);
+			break;
+	}
+
+	ERR_FAIL_COND_MSG(method_info == MethodInfo(), vformat("Failed to get method info of \"%s\"", get_method()));
+	Vector<PropertyInfo> arguments = method_info.arguments;
+	for (PropertyInfo E : arguments) {
+		r_arguments.push_back(E.operator Dictionary());
+	}
 }
 
 void GDScriptUtilityCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {

--- a/modules/gdscript/gdscript_utility_callable.cpp
+++ b/modules/gdscript/gdscript_utility_callable.cpp
@@ -99,25 +99,18 @@ int GDScriptUtilityCallable::get_argument_count(bool &r_is_valid) const {
 	ERR_FAIL_V_MSG(0, "Invalid type.");
 }
 
-void GDScriptUtilityCallable::get_arguments(Vector<Variant> &r_arguments) const {
+void GDScriptUtilityCallable::get_method_info(MethodInfo &r_method_info) const {
 	print_line("GDScriptUtilityCallable::get_arguments is called!");
-	r_arguments.clear();
-	MethodInfo method_info = MethodInfo();
 	switch (type) {
 		case TYPE_INVALID:
+			r_method_info = MethodInfo();
 			break;
 		case TYPE_GLOBAL:
-			method_info = Variant::get_utility_function_info(function_name);
+			r_method_info = Variant::get_utility_function_info(function_name);
 			break;
 		case TYPE_GDSCRIPT:
-			method_info = GDScriptUtilityFunctions::get_function_info(function_name);
+			r_method_info = GDScriptUtilityFunctions::get_function_info(function_name);
 			break;
-	}
-
-	ERR_FAIL_COND_MSG(method_info == MethodInfo(), vformat("Failed to get method info of \"%s\"", get_method()));
-	Vector<PropertyInfo> arguments = method_info.arguments;
-	for (PropertyInfo E : arguments) {
-		r_arguments.push_back(E.operator Dictionary());
 	}
 }
 

--- a/modules/gdscript/gdscript_utility_callable.h
+++ b/modules/gdscript/gdscript_utility_callable.h
@@ -57,6 +57,7 @@ public:
 	StringName get_method() const override;
 	ObjectID get_object() const override;
 	int get_argument_count(bool &r_is_valid) const override;
+	void get_arguments(Vector<Variant> &r_arguments) const override;
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
 	GDScriptUtilityCallable(const StringName &p_function_name);

--- a/modules/gdscript/gdscript_utility_callable.h
+++ b/modules/gdscript/gdscript_utility_callable.h
@@ -57,7 +57,7 @@ public:
 	StringName get_method() const override;
 	ObjectID get_object() const override;
 	int get_argument_count(bool &r_is_valid) const override;
-	void get_arguments(Vector<Variant> &r_arguments) const override;
+	void get_method_info(MethodInfo &r_method_info) const override;
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
 	GDScriptUtilityCallable(const StringName &p_function_name);

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -38,6 +38,9 @@
 #include "utils/naming_utils.h"
 #include "utils/string_utils.h"
 
+#include "core/object/property_info.h"
+#include "core/templates/vector.h"
+
 #ifdef GD_MONO_HOT_RELOAD
 #include "managed_callable.h"
 #include "utils/path_utils.h"
@@ -1691,6 +1694,34 @@ int CSharpInstance::get_method_argument_count(const StringName &p_method, bool *
 	return 0;
 }
 
+Vector<Variant> CSharpInstance::get_method_arguments(const StringName &p_method, bool *r_is_valid) const {
+	Vector<Variant> ret;
+	if (!script->is_script_valid() || !script->valid) {
+		if (r_is_valid) {
+			*r_is_valid = false;
+		}
+		return ret;
+	}
+
+	const CSharpScript *top = script.ptr();
+	while (top != nullptr) {
+		bool valid = false;
+		ret = top->get_script_method_arguments(p_method, &valid);
+		if (valid) {
+			if (r_is_valid) {
+				*r_is_valid = true;
+			}
+			return ret;
+		}
+		top = top->base_script.ptr();
+	}
+
+	if (r_is_valid) {
+		*r_is_valid = false;
+	}
+	return ret;
+}
+
 Variant CSharpInstance::callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	ERR_FAIL_COND_V(script.is_null(), Variant());
 
@@ -2552,6 +2583,33 @@ int CSharpScript::get_script_method_argument_count(const StringName &p_method, b
 		*r_is_valid = false;
 	}
 	return 0;
+}
+
+Vector<Variant> CSharpScript::get_script_method_arguments(const StringName &p_method, bool *r_is_valid) const {
+	Vector<Variant> ret;
+	if (!valid) {
+		if (r_is_valid) {
+			*r_is_valid = false;
+		}
+		return ret;
+	}
+
+	for (const CSharpMethodInfo &E : methods) {
+		if (E.name == p_method) {
+			if (r_is_valid) {
+				*r_is_valid = true;
+			}
+			for (const PropertyInfo &F : E.method_info.arguments) {
+				ret.push_back(F.operator Dictionary());
+			}
+			return ret;
+		}
+	}
+
+	if (r_is_valid) {
+		*r_is_valid = false;
+	}
+	return ret;
 }
 
 MethodInfo CSharpScript::get_method_info(const StringName &p_method) const {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1694,32 +1694,22 @@ int CSharpInstance::get_method_argument_count(const StringName &p_method, bool *
 	return 0;
 }
 
-Vector<Variant> CSharpInstance::get_method_arguments(const StringName &p_method, bool *r_is_valid) const {
-	Vector<Variant> ret;
+MethodInfo CSharpInstance::get_method_info(const StringName &p_method) const {
+	MethodInfo mi;
 	if (!script->is_script_valid() || !script->valid) {
-		if (r_is_valid) {
-			*r_is_valid = false;
-		}
-		return ret;
+		return mi;
 	}
 
 	const CSharpScript *top = script.ptr();
 	while (top != nullptr) {
-		bool valid = false;
-		ret = top->get_script_method_arguments(p_method, &valid);
-		if (valid) {
-			if (r_is_valid) {
-				*r_is_valid = true;
-			}
-			return ret;
+		mi = top->get_method_info(p_method);
+		if (!(mi == MethodInfo())) {
+			return mi;
 		}
 		top = top->base_script.ptr();
 	}
 
-	if (r_is_valid) {
-		*r_is_valid = false;
-	}
-	return ret;
+	return mi;
 }
 
 Variant CSharpInstance::callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
@@ -2583,33 +2573,6 @@ int CSharpScript::get_script_method_argument_count(const StringName &p_method, b
 		*r_is_valid = false;
 	}
 	return 0;
-}
-
-Vector<Variant> CSharpScript::get_script_method_arguments(const StringName &p_method, bool *r_is_valid) const {
-	Vector<Variant> ret;
-	if (!valid) {
-		if (r_is_valid) {
-			*r_is_valid = false;
-		}
-		return ret;
-	}
-
-	for (const CSharpMethodInfo &E : methods) {
-		if (E.name == p_method) {
-			if (r_is_valid) {
-				*r_is_valid = true;
-			}
-			for (const PropertyInfo &F : E.method_info.arguments) {
-				ret.push_back(F.operator Dictionary());
-			}
-			return ret;
-		}
-	}
-
-	if (r_is_valid) {
-		*r_is_valid = false;
-	}
-	return ret;
 }
 
 MethodInfo CSharpScript::get_method_info(const StringName &p_method) const {

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -283,6 +283,7 @@ public:
 	void get_script_method_list(List<MethodInfo> *p_list) const override;
 	bool has_method(const StringName &p_method) const override;
 	virtual int get_script_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const override;
+	virtual Vector<Variant> get_script_method_arguments(const StringName &p_method, bool *r_is_valid = nullptr) const override;
 	MethodInfo get_method_info(const StringName &p_method) const override;
 	Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;
 
@@ -352,6 +353,7 @@ public:
 	void get_method_list(List<MethodInfo> *r_list) const override;
 	bool has_method(const StringName &p_method) const override;
 	virtual int get_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const override;
+	virtual Vector<Variant> get_method_arguments(const StringName &p_method, bool *r_is_valid = nullptr) const override;
 	Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;
 
 	void mono_object_disposed(GCHandleIntPtr p_gchandle_to_free);

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -283,7 +283,6 @@ public:
 	void get_script_method_list(List<MethodInfo> *p_list) const override;
 	bool has_method(const StringName &p_method) const override;
 	virtual int get_script_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const override;
-	virtual Vector<Variant> get_script_method_arguments(const StringName &p_method, bool *r_is_valid = nullptr) const override;
 	MethodInfo get_method_info(const StringName &p_method) const override;
 	Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;
 
@@ -353,7 +352,7 @@ public:
 	void get_method_list(List<MethodInfo> *r_list) const override;
 	bool has_method(const StringName &p_method) const override;
 	virtual int get_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const override;
-	virtual Vector<Variant> get_method_arguments(const StringName &p_method, bool *r_is_valid = nullptr) const override;
+	MethodInfo get_method_info(const StringName &p_method) const override;
 	Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;
 
 	void mono_object_disposed(GCHandleIntPtr p_gchandle_to_free);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
@@ -13,6 +13,7 @@ namespace Godot.Bridge
         public delegate* unmanaged<IntPtr, IntPtr, godot_bool> DelegateUtils_DelegateEquals;
         public delegate* unmanaged<IntPtr, int> DelegateUtils_DelegateHash;
         public delegate* unmanaged<IntPtr, godot_bool*, int> DelegateUtils_GetArgumentCount;
+        public delegate* unmanaged<IntPtr, void*, void> DelegateUtils_GetArguments;
         public delegate* unmanaged<IntPtr, godot_array*, godot_bool> DelegateUtils_TrySerializeDelegateWithGCHandle;
         public delegate* unmanaged<godot_array*, IntPtr*, godot_bool> DelegateUtils_TryDeserializeDelegateWithGCHandle;
         public delegate* unmanaged<void> ScriptManagerBridge_FrameCallback;
@@ -57,6 +58,7 @@ namespace Godot.Bridge
                 DelegateUtils_DelegateEquals = &DelegateUtils.DelegateEquals,
                 DelegateUtils_DelegateHash = &DelegateUtils.DelegateHash,
                 DelegateUtils_GetArgumentCount = &DelegateUtils.GetArgumentCount,
+                DelegateUtils_GetArguments = &DelegateUtils.GetArguments,
                 DelegateUtils_TrySerializeDelegateWithGCHandle = &DelegateUtils.TrySerializeDelegateWithGCHandle,
                 DelegateUtils_TryDeserializeDelegateWithGCHandle = &DelegateUtils.TryDeserializeDelegateWithGCHandle,
                 ScriptManagerBridge_FrameCallback = &ScriptManagerBridge.FrameCallback,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Bridge/ManagedCallbacks.cs
@@ -13,7 +13,7 @@ namespace Godot.Bridge
         public delegate* unmanaged<IntPtr, IntPtr, godot_bool> DelegateUtils_DelegateEquals;
         public delegate* unmanaged<IntPtr, int> DelegateUtils_DelegateHash;
         public delegate* unmanaged<IntPtr, godot_bool*, int> DelegateUtils_GetArgumentCount;
-        public delegate* unmanaged<IntPtr, void*, void> DelegateUtils_GetArguments;
+        public delegate* unmanaged<IntPtr, godot_dictionary*, void> DelegateUtils_GetMethodInfo;
         public delegate* unmanaged<IntPtr, godot_array*, godot_bool> DelegateUtils_TrySerializeDelegateWithGCHandle;
         public delegate* unmanaged<godot_array*, IntPtr*, godot_bool> DelegateUtils_TryDeserializeDelegateWithGCHandle;
         public delegate* unmanaged<void> ScriptManagerBridge_FrameCallback;
@@ -58,7 +58,7 @@ namespace Godot.Bridge
                 DelegateUtils_DelegateEquals = &DelegateUtils.DelegateEquals,
                 DelegateUtils_DelegateHash = &DelegateUtils.DelegateHash,
                 DelegateUtils_GetArgumentCount = &DelegateUtils.GetArgumentCount,
-                DelegateUtils_GetArguments = &DelegateUtils.GetArguments,
+                DelegateUtils_GetMethodInfo = &DelegateUtils.GetMethodInfo,
                 DelegateUtils_TrySerializeDelegateWithGCHandle = &DelegateUtils.TrySerializeDelegateWithGCHandle,
                 DelegateUtils_TryDeserializeDelegateWithGCHandle = &DelegateUtils.TryDeserializeDelegateWithGCHandle,
                 ScriptManagerBridge_FrameCallback = &ScriptManagerBridge.FrameCallback,

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
@@ -69,6 +69,31 @@ namespace Godot
         }
 
         [UnmanagedCallersOnly]
+        internal static unsafe void GetArguments(IntPtr delegateGCHandle, void* r_arguments)
+        {
+            try
+            {
+                var @delegate = (Delegate?)GCHandle.FromIntPtr(delegateGCHandle).Target;
+                ParameterInfo[]? argsArr = @delegate?.Method?.GetParameters();
+                if (argsArr is null)
+                {
+                    return;
+                }
+                foreach (ParameterInfo p in argsArr)
+                {
+                    Console.WriteLine(p);
+                }
+                return;
+                //return argCount.Value;
+            }
+            catch (Exception e)
+            {
+                ExceptionUtils.LogException(e);
+                return;
+            }
+        }
+
+        [UnmanagedCallersOnly]
         internal static unsafe void InvokeWithVariantArgs(IntPtr delegateGCHandle, void* trampoline,
             godot_variant** args, int argc, godot_variant* outRet)
         {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/DelegateUtils.cs
@@ -69,22 +69,60 @@ namespace Godot
         }
 
         [UnmanagedCallersOnly]
-        internal static unsafe void GetArguments(IntPtr delegateGCHandle, void* r_arguments)
+        internal static unsafe void GetMethodInfo(IntPtr delegateGCHandle, godot_dictionary* outMethodInfoDictionary)
         {
             try
             {
+                Console.WriteLine("GetMethodInfo was called!");
                 var @delegate = (Delegate?)GCHandle.FromIntPtr(delegateGCHandle).Target;
-                ParameterInfo[]? argsArr = @delegate?.Method?.GetParameters();
-                if (argsArr is null)
+                var method = @delegate?.Method;
+                if (method is null)
                 {
                     return;
                 }
-                foreach (ParameterInfo p in argsArr)
+
+                var methodInfo = new Collections.Dictionary();
+
+                methodInfo.Add("name", method.Name ?? "");
+
+                var returnVal = new Collections.Dictionary()
                 {
-                    Console.WriteLine(p);
+                    { "name", method.ReturnParameter.Name ?? "" },
+                    { "type", (int)GD.TypeToVariantType(method.ReturnType) }
+                };
+                methodInfo.Add("return_val", returnVal);
+
+                var methodParams = new Collections.Array();
+                var methodDefaultParams = new Collections.Array();
+                var parameters = method.GetParameters();
+                if (parameters.Length != 0)
+                {
+                    foreach (var param in parameters)
+                    {
+                        var pinfo = new Collections.Dictionary()
+                        {
+                            { "name", param.Name ?? "" },
+                            { "type", (int)GD.TypeToVariantType(param.ParameterType) }
+                        };
+
+                        if (param.HasDefaultValue) {
+                            methodDefaultParams.Add(param.RawDefaultValue?.ToString() ?? "null");
+                        }
+
+                        methodParams.Add(pinfo);
+                    }
                 }
-                return;
-                //return argCount.Value;
+                methodInfo.Add("args", methodParams);
+                methodInfo.Add("default_args", methodDefaultParams);
+
+                MethodFlags flags = MethodFlags.Default;
+                flags |= method.IsStatic ? MethodFlags.Static : 0;
+                flags |= method.IsVirtual ? MethodFlags.Virtual : 0;
+                flags |= method.IsAbstract ? MethodFlags.VirtualRequired : 0;
+                methodInfo.Add("flags", (int)flags);
+
+                *outMethodInfoDictionary = NativeFuncs.godotsharp_dictionary_new_copy(
+                    (godot_dictionary)methodInfo.NativeValue);
             }
             catch (Exception e)
             {

--- a/modules/mono/managed_callable.cpp
+++ b/modules/mono/managed_callable.cpp
@@ -33,6 +33,8 @@
 #include "csharp_script.h"
 #include "mono_gd/gd_mono_cache.h"
 
+#include <core/string/print_string.h>
+
 #ifdef GD_MONO_HOT_RELOAD
 SelfList<ManagedCallable>::List ManagedCallable::instances;
 RBMap<ManagedCallable *, Array> ManagedCallable::instances_pending_reload;
@@ -87,6 +89,11 @@ ObjectID ManagedCallable::get_object() const {
 
 int ManagedCallable::get_argument_count(bool &r_is_valid) const {
 	return GDMonoCache::managed_callbacks.DelegateUtils_GetArgumentCount(delegate_handle, &r_is_valid);
+}
+
+void ManagedCallable::get_arguments(Vector<Variant> &r_arguments) const {
+	print_line("ManagedCallable::get_arguments is called!");
+	GDMonoCache::managed_callbacks.DelegateUtils_GetArguments(delegate_handle, &r_arguments);
 }
 
 void ManagedCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {

--- a/modules/mono/managed_callable.cpp
+++ b/modules/mono/managed_callable.cpp
@@ -91,9 +91,11 @@ int ManagedCallable::get_argument_count(bool &r_is_valid) const {
 	return GDMonoCache::managed_callbacks.DelegateUtils_GetArgumentCount(delegate_handle, &r_is_valid);
 }
 
-void ManagedCallable::get_arguments(Vector<Variant> &r_arguments) const {
+void ManagedCallable::get_method_info(MethodInfo &r_method_info) const {
 	print_line("ManagedCallable::get_arguments is called!");
-	GDMonoCache::managed_callbacks.DelegateUtils_GetArguments(delegate_handle, &r_arguments);
+	Dictionary mi_dict;
+	GDMonoCache::managed_callbacks.DelegateUtils_GetMethodInfo(delegate_handle, &mi_dict);
+	r_method_info = MethodInfo::from_dict(mi_dict);
 }
 
 void ManagedCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {

--- a/modules/mono/managed_callable.h
+++ b/modules/mono/managed_callable.h
@@ -60,6 +60,7 @@ public:
 	CompareLessFunc get_compare_less_func() const override;
 	ObjectID get_object() const override;
 	int get_argument_count(bool &r_is_valid) const override;
+	void get_arguments(Vector<Variant> &r_arguments) const override;
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
 	_FORCE_INLINE_ GCHandleIntPtr get_delegate() const { return delegate_handle; }

--- a/modules/mono/managed_callable.h
+++ b/modules/mono/managed_callable.h
@@ -60,7 +60,7 @@ public:
 	CompareLessFunc get_compare_less_func() const override;
 	ObjectID get_object() const override;
 	int get_argument_count(bool &r_is_valid) const override;
-	void get_arguments(Vector<Variant> &r_arguments) const override;
+	void get_method_info(MethodInfo &r_method_info) const override;
 	void call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const override;
 
 	_FORCE_INLINE_ GCHandleIntPtr get_delegate() const { return delegate_handle; }

--- a/modules/mono/mono_gd/gd_mono_cache.cpp
+++ b/modules/mono/mono_gd/gd_mono_cache.cpp
@@ -54,6 +54,7 @@ void update_godot_api_cache(const ManagedCallbacks &p_managed_callbacks) {
 	CHECK_CALLBACK_NOT_NULL(DelegateUtils, DelegateEquals);
 	CHECK_CALLBACK_NOT_NULL(DelegateUtils, DelegateHash);
 	CHECK_CALLBACK_NOT_NULL(DelegateUtils, GetArgumentCount);
+	CHECK_CALLBACK_NOT_NULL(DelegateUtils, GetArguments);
 	CHECK_CALLBACK_NOT_NULL(DelegateUtils, TrySerializeDelegateWithGCHandle);
 	CHECK_CALLBACK_NOT_NULL(DelegateUtils, TryDeserializeDelegateWithGCHandle);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, FrameCallback);

--- a/modules/mono/mono_gd/gd_mono_cache.cpp
+++ b/modules/mono/mono_gd/gd_mono_cache.cpp
@@ -54,7 +54,7 @@ void update_godot_api_cache(const ManagedCallbacks &p_managed_callbacks) {
 	CHECK_CALLBACK_NOT_NULL(DelegateUtils, DelegateEquals);
 	CHECK_CALLBACK_NOT_NULL(DelegateUtils, DelegateHash);
 	CHECK_CALLBACK_NOT_NULL(DelegateUtils, GetArgumentCount);
-	CHECK_CALLBACK_NOT_NULL(DelegateUtils, GetArguments);
+	CHECK_CALLBACK_NOT_NULL(DelegateUtils, GetMethodInfo);
 	CHECK_CALLBACK_NOT_NULL(DelegateUtils, TrySerializeDelegateWithGCHandle);
 	CHECK_CALLBACK_NOT_NULL(DelegateUtils, TryDeserializeDelegateWithGCHandle);
 	CHECK_CALLBACK_NOT_NULL(ScriptManagerBridge, FrameCallback);

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -76,6 +76,7 @@ struct ManagedCallbacks {
 	using FuncDelegateUtils_DelegateEquals = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, GCHandleIntPtr);
 	using FuncDelegateUtils_DelegateHash = int32_t(GD_CLR_STDCALL *)(GCHandleIntPtr);
 	using FuncDelegateUtils_GetArgumentCount = int32_t(GD_CLR_STDCALL *)(GCHandleIntPtr, bool *);
+	using FuncDelegateUtils_GetArguments = void(GD_CLR_STDCALL *)(GCHandleIntPtr, Vector<Variant> *);
 	using FuncDelegateUtils_TrySerializeDelegateWithGCHandle = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, const Array *);
 	using FuncDelegateUtils_TryDeserializeDelegateWithGCHandle = bool(GD_CLR_STDCALL *)(const Array *, GCHandleIntPtr *);
 	using FuncScriptManagerBridge_FrameCallback = void(GD_CLR_STDCALL *)();
@@ -114,6 +115,7 @@ struct ManagedCallbacks {
 	FuncDelegateUtils_DelegateEquals DelegateUtils_DelegateEquals;
 	FuncDelegateUtils_DelegateHash DelegateUtils_DelegateHash;
 	FuncDelegateUtils_GetArgumentCount DelegateUtils_GetArgumentCount;
+	FuncDelegateUtils_GetArguments DelegateUtils_GetArguments;
 	FuncDelegateUtils_TrySerializeDelegateWithGCHandle DelegateUtils_TrySerializeDelegateWithGCHandle;
 	FuncDelegateUtils_TryDeserializeDelegateWithGCHandle DelegateUtils_TryDeserializeDelegateWithGCHandle;
 	FuncScriptManagerBridge_FrameCallback ScriptManagerBridge_FrameCallback;

--- a/modules/mono/mono_gd/gd_mono_cache.h
+++ b/modules/mono/mono_gd/gd_mono_cache.h
@@ -76,7 +76,7 @@ struct ManagedCallbacks {
 	using FuncDelegateUtils_DelegateEquals = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, GCHandleIntPtr);
 	using FuncDelegateUtils_DelegateHash = int32_t(GD_CLR_STDCALL *)(GCHandleIntPtr);
 	using FuncDelegateUtils_GetArgumentCount = int32_t(GD_CLR_STDCALL *)(GCHandleIntPtr, bool *);
-	using FuncDelegateUtils_GetArguments = void(GD_CLR_STDCALL *)(GCHandleIntPtr, Vector<Variant> *);
+	using FuncDelegateUtils_GetMethodInfo = void(GD_CLR_STDCALL *)(GCHandleIntPtr, Dictionary *);
 	using FuncDelegateUtils_TrySerializeDelegateWithGCHandle = bool(GD_CLR_STDCALL *)(GCHandleIntPtr, const Array *);
 	using FuncDelegateUtils_TryDeserializeDelegateWithGCHandle = bool(GD_CLR_STDCALL *)(const Array *, GCHandleIntPtr *);
 	using FuncScriptManagerBridge_FrameCallback = void(GD_CLR_STDCALL *)();
@@ -115,7 +115,7 @@ struct ManagedCallbacks {
 	FuncDelegateUtils_DelegateEquals DelegateUtils_DelegateEquals;
 	FuncDelegateUtils_DelegateHash DelegateUtils_DelegateHash;
 	FuncDelegateUtils_GetArgumentCount DelegateUtils_GetArgumentCount;
-	FuncDelegateUtils_GetArguments DelegateUtils_GetArguments;
+	FuncDelegateUtils_GetMethodInfo DelegateUtils_GetMethodInfo;
 	FuncDelegateUtils_TrySerializeDelegateWithGCHandle DelegateUtils_TrySerializeDelegateWithGCHandle;
 	FuncDelegateUtils_TryDeserializeDelegateWithGCHandle DelegateUtils_TryDeserializeDelegateWithGCHandle;
 	FuncScriptManagerBridge_FrameCallback ScriptManagerBridge_FrameCallback;

--- a/tests/core/variant/test_callable.cpp
+++ b/tests/core/variant/test_callable.cpp
@@ -28,6 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#include "core/object/property_info.h"
 #include "tests/test_macros.h"
 
 TEST_FORCE_LINK(test_callable)
@@ -193,6 +194,163 @@ TEST_CASE("[Callable] Bound and unbound argument count") {
 	CHECK(get_output(test_func.bind(1, 2, 3).unbind(1).unbind(1).unbind(1)) == "3 3 [1, 2, 3] [1, 2, 3] [1, 2, 3]");
 
 	memdelete(test_instance);
+}
+
+class TestGetArguments : public Object {
+	GDCLASS(TestGetArguments, Object);
+
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("test_func_1"), &TestGetArguments::test_func_1);
+		ClassDB::bind_method(D_METHOD("test_func_2", "foo", "bar"), &TestGetArguments::test_func_2);
+		ClassDB::bind_method(D_METHOD("test_func_3", "foo", "bar", "baz"), &TestGetArguments::test_func_3);
+		ClassDB::bind_static_method("TestGetArguments", D_METHOD("test_func_6", "foo", "bar", "baz"), &TestGetArguments::test_func_6);
+		ClassDB::bind_static_method("TestGetArguments", D_METHOD("test_func_7", "foo", "bar", "baz"), &TestGetArguments::test_func_7);
+
+		{
+			MethodInfo mi;
+			mi.name = "test_func_8";
+			mi.arguments.push_back(PropertyInfo(Variant::INT, "foo"));
+			mi.arguments.push_back(PropertyInfo(Variant::INT, "bar"));
+
+			ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "test_func_8", &TestGetArguments::test_func_8, mi, varray(), false);
+		}
+
+		{
+			MethodInfo mi;
+			mi.name = "test_func_9";
+			mi.arguments.push_back(PropertyInfo(Variant::INT, "foo"));
+			mi.arguments.push_back(PropertyInfo(Variant::INT, "bar"));
+			mi.arguments.push_back(PropertyInfo(Variant::INT, "baz"));
+
+			ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "test_func_9", &TestGetArguments::test_func_9, mi, varray(), false);
+		}
+	}
+
+public:
+	void test_func_1() {}
+	void test_func_2(int p_foo, String p_bar) {}
+	void test_func_3(Signal p_foo, Variant p_bar, StringName p_baz) {}
+
+	int test_func_4(int p_foo, int p_bar) const { return 0; }
+	int test_func_5(String p_foo, StringName p_bar, NodePath p_baz) const { return 0; }
+
+	static void test_func_6(Callable p_foo, String p_bar, NodePath p_baz) {}
+	static void test_func_7(Callable p_foo, String p_bar, int p_baz) {}
+
+	void test_func_8(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {}
+	void test_func_9(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {}
+
+	static String get_output(const Array &p_callable_arguments) {
+		String ret = "[";
+		for (int i = 0; i < p_callable_arguments.size(); ++i) {
+			PropertyInfo arg = PropertyInfo::from_dict(p_callable_arguments[i]);
+			ret += vformat(
+					"{ type: %d, name: \"%s\", class_name: \"%s\", hint: %d, hint_string: \"%s\", usage: %d }",
+					arg.type, arg.name, arg.class_name, arg.hint, arg.hint_string, arg.usage);
+			if (i != p_callable_arguments.size() - 1) {
+				ret += ", ";
+			}
+		}
+		ret += "]";
+		return ret;
+	}
+};
+TEST_CASE("[Callable] Arguments") {
+	String (*get_output)(const Array &) = TestGetArguments::get_output;
+	TestGetArguments *my_test = memnew(TestGetArguments);
+
+	// Test simple methods.
+	Callable callable_0 = Callable(my_test, "test_func_1");
+	CHECK(get_output(callable_0.get_arguments()) == "[]");
+
+	// Only in debug builds there'll be argument names
+#ifdef DEBUG_ENABLED
+	Callable callable_1 = Callable(my_test, "test_func_2");
+	CHECK(get_output(callable_1.get_arguments()) == "[{ type: 2, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	Callable callable_2 = Callable(my_test, "test_func_3");
+	CHECK(get_output(callable_2.get_arguments()) == "[{ type: 26, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"baz\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	Callable callable_3 = Callable(my_test, "test_func_6");
+	CHECK(get_output(callable_3.get_arguments()) == "[{ type: 25, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 22, name: \"baz\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	Callable callable_4 = Callable(my_test, "test_func_7");
+	CHECK(get_output(callable_4.get_arguments()) == "[{ type: 25, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 2, name: \"baz\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+#else
+	Callable callable_1 = Callable(my_test, "test_func_2");
+	CHECK(get_output(callable_1.get_arguments()) == "[{ type: 2, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	Callable callable_2 = Callable(my_test, "test_func_3");
+	CHECK(get_output(callable_2.get_arguments()) == "[{ type: 26, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	Callable callable_3 = Callable(my_test, "test_func_6");
+	CHECK(get_output(callable_3.get_arguments()) == "[{ type: 25, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 22, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	Callable callable_4 = Callable(my_test, "test_func_7");
+	CHECK(get_output(callable_4.get_arguments()) == "[{ type: 25, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 2, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+#endif
+
+	// Test vararg methods.
+	Callable callable_vararg_1 = Callable(my_test, "test_func_8");
+	CHECK(get_output(callable_vararg_1.get_arguments()) == "[{ type: 2, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 2, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	Callable callable_vararg_2 = Callable(my_test, "test_func_9");
+	CHECK(get_output(callable_vararg_2.get_arguments()) == "[{ type: 2, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 2, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 2, name: \"baz\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+
+	// Callable MP tests.
+
+	// Test simple methods.
+
+	Callable callable_mp_0 = callable_mp(my_test, &TestGetArguments::test_func_1);
+	CHECK(get_output(callable_0.get_arguments()) == "[]");
+
+	// Only in debug builds there'll be argument names
+#ifdef DEBUG_ENABLED
+	Callable callable_mp_1 = callable_mp(my_test, &TestGetArguments::test_func_2);
+	CHECK(get_output(callable_mp_1.get_arguments()) == "[{ type: 2, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	Callable callable_mp_2 = callable_mp(my_test, &TestGetArguments::test_func_3);
+	CHECK(get_output(callable_mp_2.get_arguments()) == "[{ type: 26, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"baz\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+#else
+	Callable callable_mp_1 = callable_mp(my_test, &TestGetArguments::test_func_2);
+	CHECK(get_output(callable_mp_1.get_arguments()) == "[{ type: 2, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	Callable callable_mp_2 = callable_mp(my_test, &TestGetArguments::test_func_3);
+	CHECK(get_output(callable_mp_2.get_arguments()) == "[{ type: 26, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+#endif
+
+	// Const methods
+	Callable callable_mp_3 = callable_mp(my_test, &TestGetArguments::test_func_4);
+	CHECK(get_output(callable_mp_3.get_arguments()) == "[{ type: 2, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 2, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	Callable callable_mp_4 = callable_mp(my_test, &TestGetArguments::test_func_5);
+	CHECK(get_output(callable_mp_4.get_arguments()) == "[{ type: 4, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 21, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 22, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+
+	// Test static methods.
+	Callable callable_mp_static_1 = callable_mp_static(&TestGetArguments::test_func_6);
+	CHECK(get_output(callable_mp_static_1.get_arguments()) == "[{ type: 25, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 22, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	Callable callable_mp_static_2 = callable_mp_static(&TestGetArguments::test_func_7);
+	CHECK(get_output(callable_mp_static_2.get_arguments()) == "[{ type: 25, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 2, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+
+	// Only in debug builds there'll be argument names
+#ifdef DEBUG_ENABLED
+	// Test bind.
+	Callable callable_mp_bind_1 = callable_mp_2.bind(1);
+	CHECK(get_output(callable_mp_bind_1.get_arguments()) == "[{ type: 26, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"baz\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	Callable callable_mp_bind_2 = callable_mp_2.bind(1, 2);
+	CHECK(get_output(callable_mp_bind_2.get_arguments()) == "[{ type: 26, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"baz\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+
+	// Test unbind.
+	Callable callable_mp_unbind_1 = callable_mp_2.unbind(1);
+	CHECK(get_output(callable_mp_unbind_1.get_arguments()) == "[{ type: 26, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"baz\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	Callable callable_mp_unbind_2 = callable_mp_2.unbind(2);
+	CHECK(get_output(callable_mp_unbind_2.get_arguments()) == "[{ type: 26, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"baz\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+#else
+	// Test bind.
+	Callable callable_mp_bind_1 = callable_mp_2.bind(1);
+	CHECK(get_output(callable_mp_bind_1.get_arguments()) == "[{ type: 26, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	Callable callable_mp_bind_2 = callable_mp_2.bind(1, 2);
+	CHECK(get_output(callable_mp_bind_2.get_arguments()) == "[{ type: 26, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+
+	// Test unbind.
+	Callable callable_mp_unbind_1 = callable_mp_2.unbind(1);
+	CHECK(get_output(callable_mp_unbind_1.get_arguments()) == "[{ type: 26, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	Callable callable_mp_unbind_2 = callable_mp_2.unbind(2);
+	CHECK(get_output(callable_mp_unbind_2.get_arguments()) == "[{ type: 26, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+#endif
+
+	memdelete(my_test);
 }
 
 } // namespace TestCallable

--- a/tests/core/variant/test_callable.cpp
+++ b/tests/core/variant/test_callable.cpp
@@ -241,7 +241,7 @@ public:
 	int test_func_5(String p_foo, StringName p_bar, NodePath p_baz) const { return 0; }
 
 	static void test_func_6(Callable p_foo, String p_bar, NodePath p_baz) {}
-	static void test_func_7(Callable p_foo, String p_bar, int p_baz) {}
+	static NodePath test_func_7(Callable p_foo, String p_bar, int p_baz) { return NodePath(); }
 
 	void test_func_8(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {}
 	void test_func_9(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {}
@@ -275,6 +275,7 @@ public:
 		mi.arguments.push_back(PropertyInfo(Variant::Type::INT, "foo"));
 		mi.arguments.push_back(PropertyInfo(Variant::Type::INT, "bar"));
 		mi.return_val = PropertyInfo(Variant::Type::INT, "");
+		mi.flags = METHOD_FLAGS_DEFAULT | METHOD_FLAG_CONST;
 		methods.insert(mi.name, mi);
 		mi = MethodInfo();
 
@@ -282,7 +283,9 @@ public:
 		mi.name = "test_func_5";
 		mi.arguments.push_back(PropertyInfo(Variant::Type::STRING, "foo"));
 		mi.arguments.push_back(PropertyInfo(Variant::Type::STRING_NAME, "bar"));
+		mi.arguments.push_back(PropertyInfo(Variant::Type::NODE_PATH, "baz"));
 		mi.return_val = PropertyInfo(Variant::Type::INT, "");
+		mi.flags = METHOD_FLAGS_DEFAULT | METHOD_FLAG_CONST;
 		methods.insert(mi.name, mi);
 		mi = MethodInfo();
 
@@ -295,11 +298,12 @@ public:
 		methods.insert(mi.name, mi);
 		mi = MethodInfo();
 
-		//static void test_func_7(Callable p_foo, String p_bar, int p_baz) {}
+		//static NodePath test_func_7(Callable p_foo, String p_bar, int p_baz) { return NodePath(); }
 		mi.name = "test_func_7";
 		mi.arguments.push_back(PropertyInfo(Variant::Type::CALLABLE, "foo"));
 		mi.arguments.push_back(PropertyInfo(Variant::Type::STRING, "bar"));
 		mi.arguments.push_back(PropertyInfo(Variant::Type::INT, "baz"));
+		mi.return_val = PropertyInfo(Variant::Type::NODE_PATH, "");
 		mi.flags = METHOD_FLAGS_DEFAULT | METHOD_FLAG_STATIC;
 		methods.insert(mi.name, mi);
 		mi = MethodInfo();
@@ -331,7 +335,7 @@ public:
 				vformat("Method Name \"%s\" not found in methods hashmap.", p_method_name));
 
 		MethodInfo method = MethodInfo::from_dict(p_callable_method_info_dict);
-		MethodInfo expect_method = methods[method.name];
+		MethodInfo expect_method = methods[p_method_name];
 
 		bool is_arguments_euqal = expect_method.arguments.size() == method.arguments.size();
 		if (is_arguments_euqal) {
@@ -339,9 +343,7 @@ public:
 				PropertyInfo expected_arg = expect_method.arguments[i];
 				PropertyInfo arg = method.arguments[i];
 				if (!((expected_arg.type == arg.type) &&
-#ifdef DEBUG_ENABLED
-							(expected_arg.name == arg.name) &&
-#endif // DEBUG_ENABLED
+							(!arg.name.is_empty() ? (expected_arg.name == arg.name) : true) &&
 							(expected_arg.class_name == arg.class_name) &&
 							(expected_arg.hint == arg.hint) &&
 							(expected_arg.hint_string == arg.hint_string) &&
@@ -382,17 +384,14 @@ public:
 		bool is_valid = is_arguments_euqal &&
 				is_arguments_metadata_equal &&
 				is_default_args_euqal &&
-#ifdef DEBUG_ENABLED
-				expect_method.name == method.name &&
-#endif // DEBUG_ENABLED
+				(!method.name.is_empty() ? (expect_method.name == method.name) : true) &&
 				expect_method.return_val == method.return_val &&
 				expect_method.return_val_metadata == method.return_val_metadata &&
 				expect_method.flags == method.flags;
 
 		if (!is_valid) {
-			String msg = vformat("Invalid method info for \"%s\".\nGot: %s,\nExpected: %s",
-					p_method_name, method.operator Dictionary(), expect_method.operator Dictionary());
-			ERR_PRINT(msg);
+			ERR_PRINT(vformat("Invalid method info for \"%s\".\nGot: %s\nExpected: %s",
+					p_method_name, method.operator Dictionary(), expect_method.operator Dictionary()));
 		}
 
 		return is_valid;

--- a/tests/core/variant/test_callable.cpp
+++ b/tests/core/variant/test_callable.cpp
@@ -28,7 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
+#include "core/object/method_info.h"
 #include "core/object/property_info.h"
+#include "core/variant/dictionary.h"
 #include "tests/test_macros.h"
 
 TEST_FORCE_LINK(test_callable)
@@ -196,16 +198,16 @@ TEST_CASE("[Callable] Bound and unbound argument count") {
 	memdelete(test_instance);
 }
 
-class TestGetArguments : public Object {
-	GDCLASS(TestGetArguments, Object);
+class TestGetMethodInfo : public Object {
+	GDCLASS(TestGetMethodInfo, Object);
 
 protected:
 	static void _bind_methods() {
-		ClassDB::bind_method(D_METHOD("test_func_1"), &TestGetArguments::test_func_1);
-		ClassDB::bind_method(D_METHOD("test_func_2", "foo", "bar"), &TestGetArguments::test_func_2);
-		ClassDB::bind_method(D_METHOD("test_func_3", "foo", "bar", "baz"), &TestGetArguments::test_func_3);
-		ClassDB::bind_static_method("TestGetArguments", D_METHOD("test_func_6", "foo", "bar", "baz"), &TestGetArguments::test_func_6);
-		ClassDB::bind_static_method("TestGetArguments", D_METHOD("test_func_7", "foo", "bar", "baz"), &TestGetArguments::test_func_7);
+		ClassDB::bind_method(D_METHOD("test_func_1"), &TestGetMethodInfo::test_func_1);
+		ClassDB::bind_method(D_METHOD("test_func_2", "foo", "bar"), &TestGetMethodInfo::test_func_2, DEFVAL("bar default str"));
+		ClassDB::bind_method(D_METHOD("test_func_3", "foo", "bar", "baz"), &TestGetMethodInfo::test_func_3);
+		ClassDB::bind_static_method("TestGetMethodInfo", D_METHOD("test_func_6", "foo", "bar", "baz"), &TestGetMethodInfo::test_func_6);
+		ClassDB::bind_static_method("TestGetMethodInfo", D_METHOD("test_func_7", "foo", "bar", "baz"), &TestGetMethodInfo::test_func_7);
 
 		{
 			MethodInfo mi;
@@ -213,7 +215,7 @@ protected:
 			mi.arguments.push_back(PropertyInfo(Variant::INT, "foo"));
 			mi.arguments.push_back(PropertyInfo(Variant::INT, "bar"));
 
-			ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "test_func_8", &TestGetArguments::test_func_8, mi, varray(), false);
+			ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "test_func_8", &TestGetMethodInfo::test_func_8, mi, varray(), false);
 		}
 
 		{
@@ -223,13 +225,16 @@ protected:
 			mi.arguments.push_back(PropertyInfo(Variant::INT, "bar"));
 			mi.arguments.push_back(PropertyInfo(Variant::INT, "baz"));
 
-			ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "test_func_9", &TestGetArguments::test_func_9, mi, varray(), false);
+			ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "test_func_9", &TestGetMethodInfo::test_func_9, mi, varray(), false);
 		}
 	}
 
+private:
+	HashMap<String, MethodInfo> methods;
+
 public:
 	void test_func_1() {}
-	void test_func_2(int p_foo, String p_bar) {}
+	void test_func_2(int p_foo, String p_bar = "bar default str") {}
 	void test_func_3(Signal p_foo, Variant p_bar, StringName p_baz) {}
 
 	int test_func_4(int p_foo, int p_bar) const { return 0; }
@@ -241,114 +246,216 @@ public:
 	void test_func_8(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {}
 	void test_func_9(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {}
 
-	static String get_output(const Array &p_callable_arguments) {
-		String ret = "[";
-		for (int i = 0; i < p_callable_arguments.size(); ++i) {
-			PropertyInfo arg = PropertyInfo::from_dict(p_callable_arguments[i]);
-			ret += vformat(
-					"{ type: %d, name: \"%s\", class_name: \"%s\", hint: %d, hint_string: \"%s\", usage: %d }",
-					arg.type, arg.name, arg.class_name, arg.hint, arg.hint_string, arg.usage);
-			if (i != p_callable_arguments.size() - 1) {
-				ret += ", ";
+	TestGetMethodInfo() {
+		MethodInfo mi;
+
+		//void test_func_1() {}
+		mi.name = "test_func_1";
+		methods.insert("test_func_1", mi);
+		mi = MethodInfo();
+
+		//void test_func_2(int p_foo, String p_bar = "bar default str") {}
+		mi.name = "test_func_2";
+		mi.arguments.push_back(PropertyInfo(Variant::Type::INT, "foo"));
+		mi.arguments.push_back(PropertyInfo(Variant::Type::STRING, "bar"));
+		mi.default_arguments.push_back("bar default str");
+		methods.insert(mi.name, mi);
+		mi = MethodInfo();
+
+		//void test_func_3(Signal p_foo, Variant p_bar, StringName p_baz) {}
+		mi.name = "test_func_3";
+		mi.arguments.push_back(PropertyInfo(Variant::Type::SIGNAL, "foo"));
+		mi.arguments.push_back(PropertyInfo(Variant::Type::NIL, "bar", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT));
+		mi.arguments.push_back(PropertyInfo(Variant::Type::STRING_NAME, "baz"));
+		methods.insert(mi.name, mi);
+		mi = MethodInfo();
+
+		//int test_func_4(int p_foo, int p_bar) const { return 0; }
+		mi.name = "test_func_4";
+		mi.arguments.push_back(PropertyInfo(Variant::Type::INT, "foo"));
+		mi.arguments.push_back(PropertyInfo(Variant::Type::INT, "bar"));
+		mi.return_val = PropertyInfo(Variant::Type::INT, "");
+		methods.insert(mi.name, mi);
+		mi = MethodInfo();
+
+		//int test_func_5(String p_foo, StringName p_bar, NodePath p_baz) const { return 0; }
+		mi.name = "test_func_5";
+		mi.arguments.push_back(PropertyInfo(Variant::Type::STRING, "foo"));
+		mi.arguments.push_back(PropertyInfo(Variant::Type::STRING_NAME, "bar"));
+		mi.return_val = PropertyInfo(Variant::Type::INT, "");
+		methods.insert(mi.name, mi);
+		mi = MethodInfo();
+
+		//static void test_func_6(Callable p_foo, String p_bar, NodePath p_baz) {}
+		mi.name = "test_func_6";
+		mi.arguments.push_back(PropertyInfo(Variant::Type::CALLABLE, "foo"));
+		mi.arguments.push_back(PropertyInfo(Variant::Type::STRING, "bar"));
+		mi.arguments.push_back(PropertyInfo(Variant::Type::NODE_PATH, "baz"));
+		mi.flags = METHOD_FLAGS_DEFAULT | METHOD_FLAG_STATIC;
+		methods.insert(mi.name, mi);
+		mi = MethodInfo();
+
+		//static void test_func_7(Callable p_foo, String p_bar, int p_baz) {}
+		mi.name = "test_func_7";
+		mi.arguments.push_back(PropertyInfo(Variant::Type::CALLABLE, "foo"));
+		mi.arguments.push_back(PropertyInfo(Variant::Type::STRING, "bar"));
+		mi.arguments.push_back(PropertyInfo(Variant::Type::INT, "baz"));
+		mi.flags = METHOD_FLAGS_DEFAULT | METHOD_FLAG_STATIC;
+		methods.insert(mi.name, mi);
+		mi = MethodInfo();
+
+		//void test_func_8(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {}
+		mi.name = "test_func_8";
+		// arguments for vararg functions are defined with ClassDB::bind_vararg_method (see _bind_methods above)
+		mi.arguments.push_back(PropertyInfo(Variant::INT, "foo"));
+		mi.arguments.push_back(PropertyInfo(Variant::INT, "bar"));
+		mi.flags = METHOD_FLAGS_DEFAULT | METHOD_FLAG_VARARG;
+		methods.insert(mi.name, mi);
+		mi = MethodInfo();
+
+		//void test_func_9(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {}
+		mi.name = "test_func_9";
+		// arguments for vararg functions are defined with ClassDB::bind_vararg_method (see _bind_methods above)
+		mi.arguments.push_back(PropertyInfo(Variant::INT, "foo"));
+		mi.arguments.push_back(PropertyInfo(Variant::INT, "bar"));
+		mi.arguments.push_back(PropertyInfo(Variant::INT, "baz"));
+		mi.flags = METHOD_FLAGS_DEFAULT | METHOD_FLAG_VARARG;
+		methods.insert(mi.name, mi);
+		mi = MethodInfo();
+	}
+
+	bool is_valid_mi(const String &p_method_name, const Dictionary &p_callable_method_info_dict) {
+		ERR_FAIL_COND_V_MSG(p_method_name.is_empty(), false,
+				"Method Name cannot be empty.");
+		ERR_FAIL_COND_V_MSG(!methods.has(p_method_name), false,
+				vformat("Method Name \"%s\" not found in methods hashmap.", p_method_name));
+
+		MethodInfo method = MethodInfo::from_dict(p_callable_method_info_dict);
+		MethodInfo expect_method = methods[method.name];
+
+		bool is_arguments_euqal = expect_method.arguments.size() == method.arguments.size();
+		if (is_arguments_euqal) {
+			for (uint32_t i = 0; i < method.arguments.size(); ++i) {
+				PropertyInfo expected_arg = expect_method.arguments[i];
+				PropertyInfo arg = method.arguments[i];
+				if (!((expected_arg.type == arg.type) &&
+#ifdef DEBUG_ENABLED
+							(expected_arg.name == arg.name) &&
+#endif // DEBUG_ENABLED
+							(expected_arg.class_name == arg.class_name) &&
+							(expected_arg.hint == arg.hint) &&
+							(expected_arg.hint_string == arg.hint_string) &&
+							(expected_arg.usage == arg.usage))) {
+					is_arguments_euqal = false;
+					ERR_PRINT(vformat(
+							"arguments[%d] not as expected.\nGot: %s\n, Expected: %s",
+							i, method.arguments[i].operator Dictionary(), expect_method.arguments[i].operator Dictionary()));
+					break;
+				}
 			}
 		}
-		ret += "]";
-		return ret;
+
+		bool is_arguments_metadata_equal = expect_method.arguments_metadata.size() == method.arguments_metadata.size();
+		if (is_arguments_metadata_equal) {
+			for (uint32_t i = 0; i < method.arguments_metadata.size(); ++i) {
+				if (!(expect_method.arguments_metadata[i] == method.arguments_metadata[i])) {
+					is_arguments_metadata_equal = false;
+					ERR_PRINT(vformat("arguments_metadata[%d] not as expected.\nGot: %d,\nExpected: %d",
+							i, method.arguments_metadata[i], expect_method.arguments_metadata[i]));
+					break;
+				}
+			}
+		}
+
+		bool is_default_args_euqal = expect_method.default_arguments.size() == method.default_arguments.size();
+		if (is_default_args_euqal) {
+			for (uint32_t i = 0; i < method.default_arguments.size(); ++i) {
+				if (!(expect_method.default_arguments[i] == method.default_arguments[i])) {
+					is_default_args_euqal = false;
+					ERR_PRINT(vformat("default_arguments[%d] not as expected.\nGot: %s,\nExpected: %s",
+							i, method.default_arguments[i], expect_method.default_arguments[i]));
+					break;
+				}
+			}
+		}
+
+		bool is_valid = is_arguments_euqal &&
+				is_arguments_metadata_equal &&
+				is_default_args_euqal &&
+#ifdef DEBUG_ENABLED
+				expect_method.name == method.name &&
+#endif // DEBUG_ENABLED
+				expect_method.return_val == method.return_val &&
+				expect_method.return_val_metadata == method.return_val_metadata &&
+				expect_method.flags == method.flags;
+
+		if (!is_valid) {
+			String msg = vformat("Invalid method info for \"%s\".\nGot: %s,\nExpected: %s",
+					p_method_name, method.operator Dictionary(), expect_method.operator Dictionary());
+			ERR_PRINT(msg);
+		}
+
+		return is_valid;
 	}
 };
+
 TEST_CASE("[Callable] Arguments") {
-	String (*get_output)(const Array &) = TestGetArguments::get_output;
-	TestGetArguments *my_test = memnew(TestGetArguments);
+	TestGetMethodInfo *my_test = memnew(TestGetMethodInfo);
 
 	// Test simple methods.
-	Callable callable_0 = Callable(my_test, "test_func_1");
-	CHECK(get_output(callable_0.get_arguments()) == "[]");
+	Callable callable_1 = Callable(my_test, "test_func_1");
+	CHECK(my_test->is_valid_mi("test_func_1", callable_1.get_method_info()));
 
-	// Only in debug builds there'll be argument names
-#ifdef DEBUG_ENABLED
-	Callable callable_1 = Callable(my_test, "test_func_2");
-	CHECK(get_output(callable_1.get_arguments()) == "[{ type: 2, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-	Callable callable_2 = Callable(my_test, "test_func_3");
-	CHECK(get_output(callable_2.get_arguments()) == "[{ type: 26, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"baz\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-	Callable callable_3 = Callable(my_test, "test_func_6");
-	CHECK(get_output(callable_3.get_arguments()) == "[{ type: 25, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 22, name: \"baz\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-	Callable callable_4 = Callable(my_test, "test_func_7");
-	CHECK(get_output(callable_4.get_arguments()) == "[{ type: 25, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 2, name: \"baz\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-#else
-	Callable callable_1 = Callable(my_test, "test_func_2");
-	CHECK(get_output(callable_1.get_arguments()) == "[{ type: 2, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-	Callable callable_2 = Callable(my_test, "test_func_3");
-	CHECK(get_output(callable_2.get_arguments()) == "[{ type: 26, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-	Callable callable_3 = Callable(my_test, "test_func_6");
-	CHECK(get_output(callable_3.get_arguments()) == "[{ type: 25, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 22, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-	Callable callable_4 = Callable(my_test, "test_func_7");
-	CHECK(get_output(callable_4.get_arguments()) == "[{ type: 25, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 2, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-#endif
+	Callable callable_2 = Callable(my_test, "test_func_2");
+	CHECK(my_test->is_valid_mi("test_func_2", callable_2.get_method_info()));
+	Callable callable_3 = Callable(my_test, "test_func_3");
+	CHECK(my_test->is_valid_mi("test_func_3", callable_3.get_method_info()));
+	Callable callable_4 = Callable(my_test, "test_func_6");
+	CHECK(my_test->is_valid_mi("test_func_6", callable_4.get_method_info()));
+	Callable callable_5 = Callable(my_test, "test_func_7");
+	CHECK(my_test->is_valid_mi("test_func_7", callable_5.get_method_info()));
 
 	// Test vararg methods.
 	Callable callable_vararg_1 = Callable(my_test, "test_func_8");
-	CHECK(get_output(callable_vararg_1.get_arguments()) == "[{ type: 2, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 2, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	CHECK(my_test->is_valid_mi("test_func_8", callable_vararg_1.get_method_info()));
 	Callable callable_vararg_2 = Callable(my_test, "test_func_9");
-	CHECK(get_output(callable_vararg_2.get_arguments()) == "[{ type: 2, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 2, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 2, name: \"baz\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	CHECK(my_test->is_valid_mi("test_func_9", callable_vararg_2.get_method_info()));
 
 	// Callable MP tests.
 
 	// Test simple methods.
 
-	Callable callable_mp_0 = callable_mp(my_test, &TestGetArguments::test_func_1);
-	CHECK(get_output(callable_0.get_arguments()) == "[]");
+	Callable callable_mp_1 = callable_mp(my_test, &TestGetMethodInfo::test_func_1);
+	CHECK(my_test->is_valid_mi("test_func_1", callable_1.get_method_info()));
 
-	// Only in debug builds there'll be argument names
-#ifdef DEBUG_ENABLED
-	Callable callable_mp_1 = callable_mp(my_test, &TestGetArguments::test_func_2);
-	CHECK(get_output(callable_mp_1.get_arguments()) == "[{ type: 2, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-	Callable callable_mp_2 = callable_mp(my_test, &TestGetArguments::test_func_3);
-	CHECK(get_output(callable_mp_2.get_arguments()) == "[{ type: 26, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"baz\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-#else
-	Callable callable_mp_1 = callable_mp(my_test, &TestGetArguments::test_func_2);
-	CHECK(get_output(callable_mp_1.get_arguments()) == "[{ type: 2, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-	Callable callable_mp_2 = callable_mp(my_test, &TestGetArguments::test_func_3);
-	CHECK(get_output(callable_mp_2.get_arguments()) == "[{ type: 26, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-#endif
+	Callable callable_mp_2 = callable_mp(my_test, &TestGetMethodInfo::test_func_2);
+	CHECK(my_test->is_valid_mi("test_func_2", callable_mp_2.get_method_info()));
+	Callable callable_mp_3 = callable_mp(my_test, &TestGetMethodInfo::test_func_3);
+	CHECK(my_test->is_valid_mi("test_func_3", callable_mp_3.get_method_info()));
 
 	// Const methods
-	Callable callable_mp_3 = callable_mp(my_test, &TestGetArguments::test_func_4);
-	CHECK(get_output(callable_mp_3.get_arguments()) == "[{ type: 2, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 2, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-	Callable callable_mp_4 = callable_mp(my_test, &TestGetArguments::test_func_5);
-	CHECK(get_output(callable_mp_4.get_arguments()) == "[{ type: 4, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 21, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 22, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	Callable callable_mp_4 = callable_mp(my_test, &TestGetMethodInfo::test_func_4);
+	CHECK(my_test->is_valid_mi("test_func_4", callable_mp_4.get_method_info()));
+	Callable callable_mp_5 = callable_mp(my_test, &TestGetMethodInfo::test_func_5);
+	CHECK(my_test->is_valid_mi("test_func_5", callable_mp_5.get_method_info()));
 
 	// Test static methods.
-	Callable callable_mp_static_1 = callable_mp_static(&TestGetArguments::test_func_6);
-	CHECK(get_output(callable_mp_static_1.get_arguments()) == "[{ type: 25, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 22, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-	Callable callable_mp_static_2 = callable_mp_static(&TestGetArguments::test_func_7);
-	CHECK(get_output(callable_mp_static_2.get_arguments()) == "[{ type: 25, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 4, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 2, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	Callable callable_mp_static_1 = callable_mp_static(&TestGetMethodInfo::test_func_6);
+	CHECK(my_test->is_valid_mi("test_func_6", callable_mp_static_1.get_method_info()));
+	Callable callable_mp_static_2 = callable_mp_static(&TestGetMethodInfo::test_func_7);
+	CHECK(my_test->is_valid_mi("test_func_7", callable_mp_static_2.get_method_info()));
 
-	// Only in debug builds there'll be argument names
-#ifdef DEBUG_ENABLED
 	// Test bind.
-	Callable callable_mp_bind_1 = callable_mp_2.bind(1);
-	CHECK(get_output(callable_mp_bind_1.get_arguments()) == "[{ type: 26, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"baz\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-	Callable callable_mp_bind_2 = callable_mp_2.bind(1, 2);
-	CHECK(get_output(callable_mp_bind_2.get_arguments()) == "[{ type: 26, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"baz\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
+	Callable callable_mp_bind_1 = callable_mp_3.bind(1);
+	CHECK(my_test->is_valid_mi("test_func_3", callable_mp_bind_1.get_method_info()));
+	Callable callable_mp_bind_2 = callable_mp_3.bind(1, 2);
+	CHECK(my_test->is_valid_mi("test_func_3", callable_mp_bind_2.get_method_info()));
 
 	// Test unbind.
-	Callable callable_mp_unbind_1 = callable_mp_2.unbind(1);
-	CHECK(get_output(callable_mp_unbind_1.get_arguments()) == "[{ type: 26, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"baz\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-	Callable callable_mp_unbind_2 = callable_mp_2.unbind(2);
-	CHECK(get_output(callable_mp_unbind_2.get_arguments()) == "[{ type: 26, name: \"foo\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"bar\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"baz\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-#else
-	// Test bind.
-	Callable callable_mp_bind_1 = callable_mp_2.bind(1);
-	CHECK(get_output(callable_mp_bind_1.get_arguments()) == "[{ type: 26, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-	Callable callable_mp_bind_2 = callable_mp_2.bind(1, 2);
-	CHECK(get_output(callable_mp_bind_2.get_arguments()) == "[{ type: 26, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-
-	// Test unbind.
-	Callable callable_mp_unbind_1 = callable_mp_2.unbind(1);
-	CHECK(get_output(callable_mp_unbind_1.get_arguments()) == "[{ type: 26, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-	Callable callable_mp_unbind_2 = callable_mp_2.unbind(2);
-	CHECK(get_output(callable_mp_unbind_2.get_arguments()) == "[{ type: 26, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }, { type: 0, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 131078 }, { type: 21, name: \"\", class_name: \"\", hint: 0, hint_string: \"\", usage: 6 }]");
-#endif
+	Callable callable_mp_unbind_1 = callable_mp_3.unbind(1);
+	CHECK(my_test->is_valid_mi("test_func_3", callable_mp_unbind_1.get_method_info()));
+	Callable callable_mp_unbind_2 = callable_mp_3.unbind(2);
+	CHECK(my_test->is_valid_mi("test_func_3", callable_mp_unbind_2.get_method_info()));
 
 	memdelete(my_test);
 }

--- a/tests/core/variant/test_callable.cpp
+++ b/tests/core/variant/test_callable.cpp
@@ -398,65 +398,67 @@ public:
 	}
 };
 
-TEST_CASE("[Callable] Arguments") {
+#define CALLABLE_TEST(class_instance, method_name) \
+	CHECK(class_instance->is_valid_mi(#method_name, \
+			Callable(class_instance, #method_name).get_method_info()));
+
+#define CALLABLE_MP_TEST(class_name, class_instance, method_name) \
+	CHECK(class_instance->is_valid_mi(#method_name, \
+			callable_mp(class_instance, &class_name::method_name).get_method_info()));
+
+#define CALLABLE_MP_BIND_TEST(class_name, class_instance, method_name, ...) \
+	CHECK(class_instance->is_valid_mi(#method_name, \
+			callable_mp(class_instance, &class_name::method_name).bind(__VA_ARGS__).get_method_info()));
+
+#define CALLABLE_MP_UNBIND_TEST(class_name, class_instance, method_name, unbind_amount) \
+	CHECK(class_instance->is_valid_mi(#method_name, \
+			callable_mp(class_instance, &class_name::method_name).unbind(unbind_amount).get_method_info()));
+
+#define CALLABLE_MP_STATIC_TEST(class_name, class_instance, method_name) \
+	CHECK(class_instance->is_valid_mi(#method_name, \
+			callable_mp_static(&class_name::method_name).get_method_info()));
+
+TEST_CASE("[Callable] Method Info") {
 	TestGetMethodInfo *my_test = memnew(TestGetMethodInfo);
 
-	// Test simple methods.
-	Callable callable_1 = Callable(my_test, "test_func_1");
-	CHECK(my_test->is_valid_mi("test_func_1", callable_1.get_method_info()));
-
-	Callable callable_2 = Callable(my_test, "test_func_2");
-	CHECK(my_test->is_valid_mi("test_func_2", callable_2.get_method_info()));
-	Callable callable_3 = Callable(my_test, "test_func_3");
-	CHECK(my_test->is_valid_mi("test_func_3", callable_3.get_method_info()));
-	Callable callable_4 = Callable(my_test, "test_func_6");
-	CHECK(my_test->is_valid_mi("test_func_6", callable_4.get_method_info()));
-	Callable callable_5 = Callable(my_test, "test_func_7");
-	CHECK(my_test->is_valid_mi("test_func_7", callable_5.get_method_info()));
+	CALLABLE_TEST(my_test, test_func_1);
+	CALLABLE_TEST(my_test, test_func_2);
+	CALLABLE_TEST(my_test, test_func_3);
+	CALLABLE_TEST(my_test, test_func_6);
+	CALLABLE_TEST(my_test, test_func_7);
 
 	// Test vararg methods.
-	Callable callable_vararg_1 = Callable(my_test, "test_func_8");
-	CHECK(my_test->is_valid_mi("test_func_8", callable_vararg_1.get_method_info()));
-	Callable callable_vararg_2 = Callable(my_test, "test_func_9");
-	CHECK(my_test->is_valid_mi("test_func_9", callable_vararg_2.get_method_info()));
+	CALLABLE_TEST(my_test, test_func_8);
+	CALLABLE_TEST(my_test, test_func_9);
 
 	// Callable MP tests.
-
-	// Test simple methods.
-
-	Callable callable_mp_1 = callable_mp(my_test, &TestGetMethodInfo::test_func_1);
-	CHECK(my_test->is_valid_mi("test_func_1", callable_1.get_method_info()));
-
-	Callable callable_mp_2 = callable_mp(my_test, &TestGetMethodInfo::test_func_2);
-	CHECK(my_test->is_valid_mi("test_func_2", callable_mp_2.get_method_info()));
-	Callable callable_mp_3 = callable_mp(my_test, &TestGetMethodInfo::test_func_3);
-	CHECK(my_test->is_valid_mi("test_func_3", callable_mp_3.get_method_info()));
+	CALLABLE_MP_TEST(TestGetMethodInfo, my_test, test_func_1);
+	CALLABLE_MP_TEST(TestGetMethodInfo, my_test, test_func_2);
+	CALLABLE_MP_TEST(TestGetMethodInfo, my_test, test_func_3);
 
 	// Const methods
-	Callable callable_mp_4 = callable_mp(my_test, &TestGetMethodInfo::test_func_4);
-	CHECK(my_test->is_valid_mi("test_func_4", callable_mp_4.get_method_info()));
-	Callable callable_mp_5 = callable_mp(my_test, &TestGetMethodInfo::test_func_5);
-	CHECK(my_test->is_valid_mi("test_func_5", callable_mp_5.get_method_info()));
+	CALLABLE_MP_TEST(TestGetMethodInfo, my_test, test_func_4);
+	CALLABLE_MP_TEST(TestGetMethodInfo, my_test, test_func_5);
 
 	// Test static methods.
-	Callable callable_mp_static_1 = callable_mp_static(&TestGetMethodInfo::test_func_6);
-	CHECK(my_test->is_valid_mi("test_func_6", callable_mp_static_1.get_method_info()));
-	Callable callable_mp_static_2 = callable_mp_static(&TestGetMethodInfo::test_func_7);
-	CHECK(my_test->is_valid_mi("test_func_7", callable_mp_static_2.get_method_info()));
+	CALLABLE_MP_STATIC_TEST(TestGetMethodInfo, my_test, test_func_6);
+	CALLABLE_MP_STATIC_TEST(TestGetMethodInfo, my_test, test_func_7);
 
 	// Test bind.
-	Callable callable_mp_bind_1 = callable_mp_3.bind(1);
-	CHECK(my_test->is_valid_mi("test_func_3", callable_mp_bind_1.get_method_info()));
-	Callable callable_mp_bind_2 = callable_mp_3.bind(1, 2);
-	CHECK(my_test->is_valid_mi("test_func_3", callable_mp_bind_2.get_method_info()));
+	CALLABLE_MP_BIND_TEST(TestGetMethodInfo, my_test, test_func_3, 1);
+	CALLABLE_MP_BIND_TEST(TestGetMethodInfo, my_test, test_func_3, 1, 2);
 
 	// Test unbind.
-	Callable callable_mp_unbind_1 = callable_mp_3.unbind(1);
-	CHECK(my_test->is_valid_mi("test_func_3", callable_mp_unbind_1.get_method_info()));
-	Callable callable_mp_unbind_2 = callable_mp_3.unbind(2);
-	CHECK(my_test->is_valid_mi("test_func_3", callable_mp_unbind_2.get_method_info()));
+	CALLABLE_MP_UNBIND_TEST(TestGetMethodInfo, my_test, test_func_3, 1);
+	CALLABLE_MP_UNBIND_TEST(TestGetMethodInfo, my_test, test_func_3, 2);
 
 	memdelete(my_test);
 }
+
+#undef CALLABLE_TEST
+#undef CALLABLE_MP_TEST
+#undef CALLABLE_MP_BIND_TEST
+#undef CALLABLE_MP_UNBIND_TEST
+#undef CALLABLE_MP_STATIC_TEST
 
 } // namespace TestCallable


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/10969
- Works toward adding runtime checks for Callable-Signal upon connecting (see https://github.com/godotengine/godot-proposals/issues/14266 for more info)
  Please note this's not best solution, as we could statically check, which'll be better, but adding runtime checks is better then having no checks at all.

## Additional information
- ~C# implementation wasn't thoroughly tested compared to gdscript/cpp version, due to my inexperience with `mono` module and not fully knowing how each part gets triggered (tried my best to trigger `ManagedCallable` Class... but to no avail)~ Found a way to trigger `ManagedCallable` implementation, by making a C# Script, which makes a Callable from a Delegate (used C# lambda), and getting/using that Callable in a GDScript, which tries to call `.get_method_info()` on it... a bit convoluted if you asked me, but it makes sense from implementation standpoint.
- I've added test cases inside `tests/core/variant/test_callable.cpp`, but I haven't added gdscript tests as I didn't find other methods to be tested (only gdscript module's capabilities, but not Class-specific implementation(s)), for this reason I've attached a gdscript to PR body for anyone interested to test changes out.

> [!IMPORTANT]
> PR _still_ has `print_line()`.. I do realize it's not as good/powerful as using a debugger, but knowing what implementation being called is still useful imo, will remove once review process is finalized.

## Interested for a spin? (Testing changes out)
If you're a user of the Engine, or experienced with code base, you can test these changes by:
1. Downloading the CI builds ([Windows](https://github.com/godotengine/godot/actions/runs/34445669421/artifacts/10139698156), [MacOS](https://github.com/godotengine/godot/actions/runs/34445669421/artifacts/10139674610), _Linux build of Editor is unfortunately unavailable :(_)
2. having any `Callable` in your script, and calling `.get_method_info()`, which returns a Dictionary representing the method (see [struct def](https://github.com/godotengine/godot/blob/a3088fecf1837aa22fcf2bccae413598a2e91766/core/object/method_info.h#L48), and [Dictionary convertion](https://github.com/godotengine/godot/blob/a3088fecf1837aa22fcf2bccae413598a2e91766/core/object/method_info.cpp#L37-L51) for more info). returned Dictionary contains following keys:
  - `name`: name of method (of type `String`)
  - `args`: an array of dictionaries, each one represents an argument (which's a Dictionary representing **PropertyInfo type**, see below)
  - `default_args`: an array of variants representing default values of optional arguments.
  - `flags`: a integer representing what the method is (see [MethodFlags enum](https://github.com/godotengine/godot/blob/a3088fecf1837aa22fcf2bccae413598a2e91766/core/object/method_info.h#L36))
  - `id`: unique identifier (of type `int`)
  - `return`: what the method returns (Dictionary representing **PropertyInfo type**, see below)
 
> **PropertyInfo as Dictionary**:
>   - `name`: name of the argument, which's a `String`
>   - `class_name`: name of argument's class, which's a `StringName`
>   - `type`: type of argument, which's a `Variant::Type`, as an `int` (Enum value), [enum definition here](https://github.com/godotengine/godot/blob/94a23991c683254d8b5ef63f4f5e017b995c4c2f/core/variant/variant.h#L97)
>   - `hint`: a hint useful to know what this argument is, as an `int` (Enum value), [enum definition here](https://github.com/godotengine/godot/blob/a3088fecf1837aa22fcf2bccae413598a2e91766/core/object/property_info.h#L39)
>   - `hint_string`: string representation of `hint`
>   - `usage`: a useful hint on what to do with this argument, as an `int` (Enum value), [enum definition here](https://github.com/godotengine/godot/blob/a3088fecf1837aa22fcf2bccae413598a2e91766/core/object/property_info.h#L88)

### Test Script (examples)
here's a test script which tests all different implementations of this new function, enjoy 😄

<details><summary>The script</summary>
<p>

<pre lang="gdscript">
<code>
extends Node

@rpc
func rpc_func(_rpc_func_arg1: int = 10, _rpc_func_arg2: String = "Hello") -> void:
	pass

func standard_func(_stand_func_arg1: int, _stand_func_arg2: String = "Hello", _stand_func_arg3: String = "Hi") -> void:
	pass

func _init() -> void:
	# Should give empty Dictionary, because GDscript methods are not registered in ClassDB on the base class
	var classdb_stand_func_method_info: Dictionary = ClassDB.class_get_method_info(get_class(), &"standard_func")
	print("method info using classdb.class_get_method_info on standard function:\n" + str(classdb_stand_func_method_info) + "\n")
	var classdb_rpc_func_method_info: Dictionary = ClassDB.class_get_method_info(get_class(), &"rpc_func")
	print("method info using classdb.class_get_method_info on rpc function:\n" + str(classdb_rpc_func_method_info) + "\n")

	print("-".repeat(100))

	# This works for Registered methods on this class, unlike the previous example
	var classdb_func1_method_info: Dictionary = ClassDB.class_get_method_info(get_class(), &"find_child")
	print("method info using classdb.class_get_method_info on 'find_child' function:\n" + str(classdb_func1_method_info) + "\n")
	var classdb_func2_method_info: Dictionary = ClassDB.class_get_method_info(get_class(), &"atr_n")
	print("method info using classdb.class_get_method_info on 'atr_n' function:\n" + str(classdb_func2_method_info) + "\n")
	
	print("-".repeat(100))

	var obj_stand_func_method_info: Dictionary = self.get_method_info(&"standard_func")
	print("method info using object.get_method_info on standard function:\n" + str(obj_stand_func_method_info) + "\n")
	var obj_rpc_func_method_info: Dictionary = self.get_method_info(&"rpc_func")
	print("method info using object.get_method_info on rpc function:\n" + str(obj_rpc_func_method_info) + "\n")

	var unbind_stand_func: Callable = standard_func.unbind(1)
	var unbind_stand_func_method_info: Dictionary = unbind_stand_func.get_method_info()
	print("unbind version of standard function method info:\n" + str(unbind_stand_func_method_info) + "\n")
	
	var bind_unbind_stand_func: Callable = standard_func.bind("Hello").unbind(1)
	var bind_unbind_stand_func_method_info: Dictionary = bind_unbind_stand_func.get_method_info()
	print("bind unbind version of standard function method info:\n" + str(bind_unbind_stand_func_method_info) + "\n")
	
	var bind_unbind_bind_stand_func: Callable = standard_func.bind("Hello").unbind(1).bind("World")
	var bind_unbind_bind_stand_func_method_info: Dictionary = bind_unbind_bind_stand_func.get_method_info()
	print("bind unbind bind version of standard function method info:\n" + str(bind_unbind_bind_stand_func_method_info) + "\n")
	
	print("-".repeat(100))
	
	var stand_func_method_info: Dictionary = standard_func.get_method_info()
	print("standard function method info:\n" + str(stand_func_method_info) + "\n")
	var bind_standard_func_callable: Callable = standard_func.bind(20, "Hello")
	var bind_standard_func_method_info: Dictionary = bind_standard_func_callable.get_method_info()
	print("method info of bound version:\n" + str(bind_standard_func_method_info) + "\n")
	
	print("-".repeat(100))
	
	var rpc_func_method_info: Dictionary = rpc_func.get_method_info()
	print("rpc function method info:\n" + str(rpc_func_method_info) + "\n")
	var bind_rpc_func: Callable = rpc_func.bind(20, "Hello")
	var bind_rpc_func_method_info: Dictionary = bind_rpc_func.get_method_info()
	print("method info of bound version:\n" + str(bind_rpc_func_method_info) + "\n")
	
	print("-".repeat(100))
	
	var myfunc1: Callable = func (_norm_lambda_arg1: int, _norm_lambda_arg2: String) -> void: return
	print(str(myfunc1))
	var myfunc1_method_info: Dictionary = myfunc1.get_method_info()
	print("normal lambda method info:\n" + str(myfunc1_method_info) + "\n")
	var bind_myfunc1_callable: Callable = myfunc1.bind(20, "Hello")
	var bind_myfunc1_method_info: Dictionary = bind_myfunc1_callable.get_method_info()
	print("method info of bound version:\n" + str(bind_myfunc1_method_info) + "\n")
	
	print("-".repeat(100))
	
	var self_lambda: Callable = func (_self_lambda_arg1: int, _self_lambda_arg2: String) -> void: self.standard_func(_self_lambda_arg1, _self_lambda_arg2)
	var self_lambda_method_info: Dictionary = self_lambda.get_method_info()
	print("self lambda method info:\n" + str(self_lambda_method_info) + "\n")
	var bind_self_lambda: Callable = self_lambda.bind(20, "Hello")
	var bind_self_lambda_method_info: Dictionary = bind_self_lambda.get_method_info()
	print("method info of bound version:\n" + str(bind_self_lambda_method_info) + "\n")
	
	print("-".repeat(100))
	
	var myfunc2: Callable = func NamedLambda(_named_lambda_arg1: int, _named_lambda_arg2: String) -> void: return
	print(str(myfunc2))
	var myfunc2_method_info: Dictionary = myfunc2.get_method_info()
	print("Lambda with a name method info:\n" + str(myfunc2_method_info) + "\n")
	var bind_myfunc2_callable: Callable = myfunc2.bind(20, "Hello")
	var bind_myfunc2_method_info: Dictionary = bind_myfunc2_callable.get_method_info()
	print("method info of bound version:\n" + str(bind_myfunc2_method_info) + "\n")
	
	print("-".repeat(100))
	
	var dictionary: Dictionary = { "hello": "world" }
	var dict_get_callable: Callable = Callable.create(dictionary, "get")
	var dict_get_method_info: Dictionary = dict_get_callable.get_method_info()
	print("Variant (Dictionary) method info:\n" + str(dict_get_method_info) + "\n")
	var bind_dict_get_callable: Callable = dict_get_callable.bind("hello", "")
	var bind_dict_get_method_info: Dictionary = bind_dict_get_callable.get_method_info()
	print("method info of bound version:\n" + str(bind_dict_get_method_info) + "\n")
	
	print("-".repeat(100))
	
	# For @GDScript utility methods
	var gd_utility_callable: Callable = Color8
	var gd_utility_method_info: Dictionary = gd_utility_callable.get_method_info()
	print("GD Utility method info:\n" + str(gd_utility_method_info) + "\n")
	var bind_gd_utility_callable: Callable = gd_utility_callable.bind(128, 128, 128, 255)
	var bind_gd_utility_method_info: Dictionary = bind_gd_utility_callable.get_method_info()
	print("method info of bound version:\n" + str(bind_gd_utility_method_info) + "\n")
	
	print("-".repeat(100))
	
	# For @GlobalScope utility methods
	var global_utility_callable: Callable = sqrt
	var global_utility_method_info: Dictionary = global_utility_callable.get_method_info()
	print("Global Utility method info:\n" + str(global_utility_method_info) + "\n")
	var bind_global_utility_callable: Callable = global_utility_callable.bind(9)
	var bind_global_utility_method_info: Dictionary = bind_global_utility_callable.get_method_info()
	print("method info of bound version:\n" + str(bind_global_utility_method_info) + "\n")

</code>
</pre>

</p>
</details>

<details><summary>Expected Output</summary>
<p>

<pre lang="ps1">
<code>
method info using classdb.class_get_method_info on standard function:
{  }

method info using classdb.class_get_method_info on rpc function:
{  }

----------------------------------------------------------------------------------------------------
method info using classdb.class_get_method_info on 'find_child' function:
{ "name": "find_child", "args": [{ "name": "pattern", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 6 }, { "name": "recursive", "class_name": &"", "type": 1, "hint": 0, "hint_string": "", "usage": 6 }, { "name": "owned", "class_name": &"", "type": 1, "hint": 0, "hint_string": "", "usage": 6 }], "default_args": [true, true], "flags": 5, "id": 4675, "return": { "name": "", "class_name": &"Node", "type": 24, "hint": 0, "hint_string": "", "usage": 6 } }

method info using classdb.class_get_method_info on 'atr_n' function:
{ "name": "atr_n", "args": [{ "name": "message", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 6 }, { "name": "plural_message", "class_name": &"", "type": 21, "hint": 0, "hint_string": "", "usage": 6 }, { "name": "n", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 6 }, { "name": "context", "class_name": &"", "type": 21, "hint": 0, "hint_string": "", "usage": 6 }], "default_args": [""], "flags": 5, "id": 4771, "return": { "name": "", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 6 } }

----------------------------------------------------------------------------------------------------
method info using object.get_method_info on standard function:
{ "name": "standard_func", "args": [{ "name": "_stand_func_arg1", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_stand_func_arg2", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_stand_func_arg3", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }], "default_args": ["Hello", "Hi"], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 0 } }

method info using object.get_method_info on rpc function:
{ "name": "rpc_func", "args": [{ "name": "_rpc_func_arg1", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_rpc_func_arg2", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }], "default_args": [10, "Hello"], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 0 } }

Callable::get_arguments called!
CallableCustomUnbind::get_arguments is called!
unbind version of standard function method info:
{ "name": "standard_func", "args": [{ "name": "_stand_func_arg1", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_stand_func_arg2", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_stand_func_arg3", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }], "default_args": ["Hello", "Hi"], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 0 } }

Callable::get_arguments called!
CallableCustomUnbind::get_arguments is called!
CallableCustomBind::get_arguments is called!
bind unbind version of standard function method info:
{ "name": "standard_func", "args": [{ "name": "_stand_func_arg1", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_stand_func_arg2", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_stand_func_arg3", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }], "default_args": ["Hello", "Hi"], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 0 } }

Callable::get_arguments called!
CallableCustomBind::get_arguments is called!
CallableCustomUnbind::get_arguments is called!
CallableCustomBind::get_arguments is called!
bind unbind bind version of standard function method info:
{ "name": "standard_func", "args": [{ "name": "_stand_func_arg1", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_stand_func_arg2", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_stand_func_arg3", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }], "default_args": ["Hello", "Hi"], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 0 } }

----------------------------------------------------------------------------------------------------
Callable::get_arguments called!
standard function method info:
{ "name": "standard_func", "args": [{ "name": "_stand_func_arg1", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_stand_func_arg2", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_stand_func_arg3", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }], "default_args": ["Hello", "Hi"], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 0 } }

Callable::get_arguments called!
CallableCustomBind::get_arguments is called!
method info of bound version:
{ "name": "standard_func", "args": [{ "name": "_stand_func_arg1", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_stand_func_arg2", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_stand_func_arg3", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }], "default_args": ["Hello", "Hi"], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 0 } }

----------------------------------------------------------------------------------------------------
Callable::get_arguments called!
rpc function method info:
{ "name": "rpc_func", "args": [{ "name": "_rpc_func_arg1", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_rpc_func_arg2", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }], "default_args": [10, "Hello"], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 0 } }

Callable::get_arguments called!
CallableCustomBind::get_arguments is called!
method info of bound version:
{ "name": "rpc_func", "args": [{ "name": "_rpc_func_arg1", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_rpc_func_arg2", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }], "default_args": [10, "Hello"], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 0 } }

----------------------------------------------------------------------------------------------------
<anonymous lambda>(lambda)
Callable::get_arguments called!
GDScriptLambdaCallable::get_arguments was called!
normal lambda method info:
{ "name": "&lt;anonymous lambda&gt;", "args": [{ "name": "_norm_lambda_arg1", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_norm_lambda_arg2", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }], "default_args": [], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 0 } }

Callable::get_arguments called!
CallableCustomBind::get_arguments is called!
GDScriptLambdaCallable::get_arguments was called!
method info of bound version:
{ "name": "&lt;anonymous lambda&gt;", "args": [{ "name": "_norm_lambda_arg1", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_norm_lambda_arg2", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }], "default_args": [], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 0 } }

----------------------------------------------------------------------------------------------------
Callable::get_arguments called!
GDScriptLambdaSelfCallable::get_arguments was called!
self lambda method info:
{ "name": "&lt;anonymous lambda&gt;", "args": [{ "name": "_self_lambda_arg1", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_self_lambda_arg2", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }], "default_args": [], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 0 } }

Callable::get_arguments called!
CallableCustomBind::get_arguments is called!
GDScriptLambdaSelfCallable::get_arguments was called!
method info of bound version:
{ "name": "&lt;anonymous lambda&gt;", "args": [{ "name": "_self_lambda_arg1", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_self_lambda_arg2", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }], "default_args": [], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 0 } }

----------------------------------------------------------------------------------------------------
NamedLambda(lambda)
Callable::get_arguments called!
GDScriptLambdaCallable::get_arguments was called!
Lambda with a name method info:
{ "name": "NamedLambda", "args": [{ "name": "_named_lambda_arg1", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_named_lambda_arg2", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }], "default_args": [], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 0 } }

Callable::get_arguments called!
CallableCustomBind::get_arguments is called!
GDScriptLambdaCallable::get_arguments was called!
method info of bound version:
{ "name": "NamedLambda", "args": [{ "name": "_named_lambda_arg1", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 0 }, { "name": "_named_lambda_arg2", "class_name": &"", "type": 4, "hint": 0, "hint_string": "", "usage": 0 }], "default_args": [], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 0 } }

----------------------------------------------------------------------------------------------------
Callable::get_arguments called!
VariantCallable::get_arguments called!
Variant (Dictionary) method info:
{ "name": "get", "args": [{ "name": "key", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 131078 }, { "name": "default", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 131078 }], "default_args": [<null>], "flags": 5, "id": 0, "return": { "name": "", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 131078 } }

Callable::get_arguments called!
CallableCustomBind::get_arguments is called!
VariantCallable::get_arguments called!
method info of bound version:
{ "name": "get", "args": [{ "name": "key", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 131078 }, { "name": "default", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 131078 }], "default_args": [<null>], "flags": 5, "id": 0, "return": { "name": "", "class_name": &"", "type": 0, "hint": 0, "hint_string": "", "usage": 131078 } }

----------------------------------------------------------------------------------------------------
Callable::get_arguments called!
GDScriptUtilityCallable::get_arguments is called!
GD Utility method info:
{ "name": "Color8", "args": [{ "name": "r8", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 6 }, { "name": "g8", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 6 }, { "name": "b8", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 6 }, { "name": "a8", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 6 }], "default_args": [255], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 20, "hint": 0, "hint_string": "", "usage": 6 } }

Callable::get_arguments called!
CallableCustomBind::get_arguments is called!
GDScriptUtilityCallable::get_arguments is called!
method info of bound version:
{ "name": "Color8", "args": [{ "name": "r8", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 6 }, { "name": "g8", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 6 }, { "name": "b8", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 6 }, { "name": "a8", "class_name": &"", "type": 2, "hint": 0, "hint_string": "", "usage": 6 }], "default_args": [255], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 20, "hint": 0, "hint_string": "", "usage": 6 } }

----------------------------------------------------------------------------------------------------
Callable::get_arguments called!
GDScriptUtilityCallable::get_arguments is called!
Global Utility method info:
{ "name": "sqrt", "args": [{ "name": "x", "class_name": &"", "type": 3, "hint": 0, "hint_string": "", "usage": 6 }], "default_args": [], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 3, "hint": 0, "hint_string": "", "usage": 6 } }

Callable::get_arguments called!
CallableCustomBind::get_arguments is called!
GDScriptUtilityCallable::get_arguments is called!
method info of bound version:
{ "name": "sqrt", "args": [{ "name": "x", "class_name": &"", "type": 3, "hint": 0, "hint_string": "", "usage": 6 }], "default_args": [], "flags": 1, "id": 0, "return": { "name": "", "class_name": &"", "type": 3, "hint": 0, "hint_string": "", "usage": 6 } }
</code>
</pre>

</p>
</details>


## Use of AI
No AI was used in the process of making these changes.
