### PR TITLE
Fix "invalid FFT frame size" guard rejecting correct buffer sizes.

### DIFF
--- a/servers/audio/effects/audio_effect_pitch_shift.cpp
+++ b/servers/audio/effects/audio_effect_pitch_shift.cpp
@@ -162,7 +162,7 @@ void SMBPitchShift::PitchShift(float pitchShift, long numSampsToProcess, long ff
 			/* ***************** PROCESSING ******************* */
 			/* this does the actual pitch shifting */
 			size_t fftBufferSize = static_cast<size_t>(fftFrameSize) * sizeof(float);
-			if (unlikely(fftBufferSize > MAX_FRAME_LENGTH)) {
+			if (unlikely(static_cast<size_t>(fftFrameSize) > static_cast<size_t>(MAX_FRAME_LENGTH) * sizeof(float))) {
 				ERR_PRINT_ONCE("Invalid FFT frame size for PitchShift. This is a bug, please report.");
 				return;
 			}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes a regression from https://github.com/godotengine/godot/pull/105744/
- Fixes and supersedes https://github.com/godotengine/godot/pull/122571

The buffer length is fine; the guard is broken because it compares an element count with a byte count.

## Additional information

Opted to multiply by element count for the offchance of negative buffer sizes or overflows.