### PR TITLE
Fix grid snapping overriding surface placement height

### DIFF
--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -3814,7 +3814,10 @@ void Node3DEditorViewport::_notification(int p_what) {
 						set_message(vformat(TTR("Translating: %s"), vformat("%.*v", snap_step_decimals, selected_node->get_global_position())));
 					}
 
-					selected_node->set_global_position(spatial_editor->snap_point(_get_instance_position(_edit.mouse_pos, selected_node)));
+					const Vector3 surface_pos = _get_instance_position(_edit.mouse_pos, selected_node);
+					Vector3 snapped_pos = spatial_editor->snap_point(surface_pos);
+					snapped_pos.y = surface_pos.y; // Preserve the surface placement height after grid snapping.
+					selected_node->set_global_position(snapped_pos);
 
 					if (ruler->is_inside_tree() && !ruler_start_point->is_visible()) {
 						ruler_end_point->set_global_position(ruler_start_point->get_global_position());
@@ -3832,7 +3835,9 @@ void Node3DEditorViewport::_notification(int p_what) {
 				return;
 			}
 			if (preview_node->is_inside_tree()) {
-				preview_node_pos = spatial_editor->snap_point(_get_instance_position(preview_node_viewport_pos, preview_node));
+				const Vector3 surface_pos = _get_instance_position(preview_node_viewport_pos, preview_node);
+				preview_node_pos = spatial_editor->snap_point(surface_pos);
+				preview_node_pos.y = surface_pos.y; // Preserve the surface placement height after grid snapping.
 				double snap = EDITOR_GET("interface/inspector/default_float_step");
 				int snap_step_decimals = Math::range_step_decimals(snap);
 				set_message(vformat(TTR("Instantiating: %s"), vformat("%.*v", snap_step_decimals, preview_node_pos)));


### PR DESCRIPTION
## What problem(s) does this PR solve?

When grid snapping is enabled, dragging a 3D scene onto a surface with collision can cause the placed object to sink into or float above the surface.

The collision-aware placement calculation correctly determines the surface contact position, but `snap_point()` subsequently snaps all three axes, including the vertical axis. This overwrites the precise surface-contact height.

This PR preserves the Y coordinate calculated by `_get_instance_position()` while still applying grid snapping to the horizontal axes.

The same issue also affects collision repositioning of an existing selected node, so the same behaviour is applied there for consistency.

- Closes #122552

## Additional information

Tested in a Windows developer build.

Tested with:
- Dragging 3D scenes onto flat collision surfaces.
- Dragging onto surfaces at different heights.
- Dragging onto sloped collision surfaces.
- Grid snapping enabled.
- Collision repositioning of existing nodes.
- Placement through an editor plugin using the standard 3D viewport drag-and-drop behaviour.

Objects retain their upright orientation when placed on slopes, as expected, while their lowest bounds remain correctly positioned against the collision surface.

I used AI to help finding the issue, source-code navigation, discussion of the proposed fix, and preparation of the pull request. I have manually reviewed the source changes, compiled the modified engine, and tested the resulting build.