### PR TITLE
visionOS XR: Scale a copy of origin_from_head in `get_camera_transform()`

### DIFF
--- a/modules/visionos_xr/visionos_xr_interface.mm
+++ b/modules/visionos_xr/visionos_xr_interface.mm
@@ -318,8 +318,8 @@ Transform3D VisionOSXRInterface::RenderThread::get_camera_transform() {
 	ERR_FAIL_NULL_V(xr_server, camera_transform);
 	// scale our origin point of our transform
 	float world_scale = xr_server->get_world_scale();
-	origin_from_head.origin *= world_scale;
 	camera_transform = origin_from_head;
+	camera_transform.origin *= world_scale;
 	return camera_transform;
 }
 


### PR DESCRIPTION
Dear Godot community,

This is a small fix on https://github.com/godotengine/godot/pull/109975.

`origin_from_head` is a member set once per frame by `pre_render()`. Scaling it in place could accumulate world scale if `get_camera_transform()` is called multiple times.

Thanks to @BastiaanOlij for spotting this issue!