### PR TITLE
Fix selected folder erroneously unfolding in the FileSystem dock

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -817,8 +817,8 @@ void FileSystemDock::_navigate_to_path(const String &p_path, bool p_select_in_fa
 		return;
 	}
 
-	// Unfold all folders along the path.
-	TreeItem *ti = *directory_ptr;
+	// Unfold all folders along the path (minus itself).
+	TreeItem *ti = (*directory_ptr)->get_parent();
 	while (ti) {
 		ti->set_collapsed(false);
 		ti = ti->get_parent();


### PR DESCRIPTION
## What problem(s) does this PR solve?

When the FileSystem dock updated to unfold all folders in order to show a selected item, it also included the item itself. And if the item was a folder, it also unfolded it, ignoring if that was not its original state before. This PR makes so that the item is now ignored.