### PR TITLE
Document that physics space state queries use global coordinates

### DIFF
--- a/doc/classes/PhysicsDirectSpaceState2D.xml
+++ b/doc/classes/PhysicsDirectSpaceState2D.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		Provides direct access to a physics space in the [PhysicsServer2D]. It's used mainly to do queries against objects and areas residing in a given space.
-		[b]Note:[/b] This class is not meant to be instantiated directly. Use [member World2D.direct_space_state] to get the world's physics 2D space state.
+		[b]Note:[/b] This class is not meant to be instantiated directly. Use [member World2D.direct_space_state] to get the world's physics 2D space state. All queries in this class use global coordinates, not coordinates local to a node.
 	</description>
 	<tutorials>
 		<link title="Physics introduction">$DOCS_URL/tutorials/physics/physics_introduction.html</link>

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		Provides direct access to a physics space in the [PhysicsServer3D]. It's used mainly to do queries against objects and areas residing in a given space.
-		[b]Note:[/b] This class is not meant to be instantiated directly. Use [member World3D.direct_space_state] to get the world's physics 3D space state.
+		[b]Note:[/b] This class is not meant to be instantiated directly. Use [member World3D.direct_space_state] to get the world's physics 3D space state. All queries in this class use global coordinates, not coordinates local to a node.
 	</description>
 	<tutorials>
 		<link title="Physics introduction">$DOCS_URL/tutorials/physics/physics_introduction.html</link>


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-docs/issues/3299

## What changed

`PhysicsDirectSpaceState2D` (and `PhysicsDirectSpaceState3D`, which had the same omission) did not state which coordinate space the query methods expect. The [Ray-casting tutorial](https://docs.godotengine.org/en/latest/tutorials/physics/ray-casting.html) already documents that queries use **global coordinates** ("use global coordinates, not local to node"), but the class reference did not.

Added to the class description of both classes:

> All queries in this class use global coordinates, not coordinates local to a node.

Doc-only change, no engine code touched.