### PR TITLE
CI: Pass GitHub Action prek diffs via `--from-ref`

### DIFF
--- a/.github/changed_files.yml
+++ b/.github/changed_files.yml
@@ -1,8 +1,3 @@
-# We lack a convenient means of gathering *all* the changes when specializations are passed, so
-#  a catch-all variable is the easiest workaround.
-everything:
-  - "**"
-
 # Determines if build actions should occur after static checks are ran. Broadly speaking, these
 #  files changing would result in SCons rebuilding the engine, or are otherwise pertinent to the
 #  buildsystem itself.

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -39,29 +39,12 @@ jobs:
           skip_initial_fetch: true
           files_yaml_from_source_file: .github/changed_files.yml
 
-      - name: Decide prek file scope (all files or only changed files)
-        id: prek-scope
-        shell: bash
+      - name: Style checks via prek
+        uses: j178/prek-action@v3.0.0
         env:
-          CHANGED_FILES: '"${{ steps.changed-files.outputs.everything_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.
-        run: |
-          CHANGED_FILES_LENGTH=${#CHANGED_FILES}
-          if [ "$CHANGED_FILES_LENGTH" -lt 5 ] || [ "$CHANGED_FILES_LENGTH" -gt 100000 ]; then
-            echo "use_all_files=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "use_all_files=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Style checks via prek (all files)
-        if: steps.prek-scope.outputs.use_all_files == 'true'
-        uses: j178/prek-action@v2
+          FROM_REF: >-
+            ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha
+            || github.event.before != '0000000000000000000000000000000000000000' && github.event.before
+            || 'HEAD~1' }}
         with:
-          extra-args: --all-files
-
-      - name: Style checks via prek (changed files)
-        if: steps.prek-scope.outputs.use_all_files == 'false'
-        uses: j178/prek-action@v2
-        env:
-          CHANGED_FILES: '"${{ steps.changed-files.outputs.everything_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.
-        with:
-          extra-args: --files ${{ env.CHANGED_FILES }}
+          extra-args: --from-ref ${{ env.FROM_REF }}


### PR DESCRIPTION
## What problem(s) does this PR solve?

As seen in this RC thread[^1], the prek action still struggles when it comes to obscenely long line lengths. So instead of trying to address the line length directly, this PR sidesteps the issue entirely by passing the base SHA via `--from-ref` instead. The base SHA is determined by `github.event.pull_request.base.sha` if it's a pull request; failing that, it'll pull from `github.event.before` if a value is detected; otherwise, it'll fallback to `HEAD~1`.

## Additional information

[^1]: https://chat.godotengine.org/channel/buildsystem?msg=ubhc34otgA7o83CJW