### PR TITLE
Replace DefaultAllocator use in area monitoring HashMaps

### DIFF
--- a/modules/godot_physics_2d/godot_area_2d.cpp
+++ b/modules/godot_physics_2d/godot_area_2d.cpp
@@ -33,6 +33,8 @@
 #include "godot_body_2d.h"
 #include "godot_space_2d.h"
 
+PagedAllocator<HashMapElement<GodotArea2D::BodyKey, GodotArea2D::BodyState>, false, 2048> GodotArea2D::SharedAllocator::allocator;
+
 GodotArea2D::BodyKey::BodyKey(GodotBody2D *p_body, uint32_t p_body_shape, uint32_t p_area_shape) {
 	rid = p_body->get_self();
 	instance_id = p_body->get_instance_id();
@@ -211,9 +213,9 @@ void GodotArea2D::call_queries() {
 				resptr[i] = &res[i];
 			}
 
-			for (HashMap<BodyKey, BodyState, BodyKey>::Iterator E = monitored_bodies.begin(); E;) {
+			for (MonitoredHashMap::Iterator E = monitored_bodies.begin(); E;) {
 				if (E->value.state == 0) { // Nothing happened
-					HashMap<BodyKey, BodyState, BodyKey>::Iterator next = E;
+					MonitoredHashMap::Iterator next = E;
 					++next;
 					monitored_bodies.remove(E);
 					E = next;
@@ -226,7 +228,7 @@ void GodotArea2D::call_queries() {
 				res[3] = E->key.body_shape;
 				res[4] = E->key.area_shape;
 
-				HashMap<BodyKey, BodyState, BodyKey>::Iterator next = E;
+				MonitoredHashMap::Iterator next = E;
 				++next;
 				monitored_bodies.remove(E);
 				E = next;
@@ -253,9 +255,9 @@ void GodotArea2D::call_queries() {
 				resptr[i] = &res[i];
 			}
 
-			for (HashMap<BodyKey, BodyState, BodyKey>::Iterator E = monitored_areas.begin(); E;) {
+			for (MonitoredHashMap::Iterator E = monitored_areas.begin(); E;) {
 				if (E->value.state == 0) { // Nothing happened
-					HashMap<BodyKey, BodyState, BodyKey>::Iterator next = E;
+					MonitoredHashMap::Iterator next = E;
 					++next;
 					monitored_areas.remove(E);
 					E = next;
@@ -268,7 +270,7 @@ void GodotArea2D::call_queries() {
 				res[3] = E->key.body_shape;
 				res[4] = E->key.area_shape;
 
-				HashMap<BodyKey, BodyState, BodyKey>::Iterator next = E;
+				MonitoredHashMap::Iterator next = E;
 				++next;
 				monitored_areas.remove(E);
 				E = next;

--- a/modules/godot_physics_2d/godot_area_2d.h
+++ b/modules/godot_physics_2d/godot_area_2d.h
@@ -33,6 +33,7 @@
 #include "godot_collision_object_2d.h"
 
 #include "core/templates/hash_set.h"
+#include "core/templates/paged_allocator.h"
 #include "core/templates/self_list.h"
 #include "core/variant/callable.h"
 
@@ -89,8 +90,18 @@ class GodotArea2D : public GodotCollisionObject2D {
 		_FORCE_INLINE_ void dec() { state--; }
 	};
 
-	HashMap<BodyKey, BodyState, BodyKey> monitored_bodies;
-	HashMap<BodyKey, BodyState, BodyKey> monitored_areas;
+	// This wraps a global allocator for use by all GodotArea2D objects
+	struct SharedAllocator {
+		static PagedAllocator<HashMapElement<BodyKey, BodyState>, false, 2048> allocator;
+
+		template <typename... Args>
+		HashMapElement<BodyKey, BodyState> *new_allocation(Args &&...p_args) { return allocator.new_allocation(p_args...); }
+		void delete_allocation(HashMapElement<BodyKey, BodyState> *p_mem) { allocator.free(p_mem); }
+	};
+
+	using MonitoredHashMap = HashMap<BodyKey, BodyState, BodyKey, HashMapComparatorDefault<BodyKey>, SharedAllocator>;
+	MonitoredHashMap monitored_bodies;
+	MonitoredHashMap monitored_areas;
 
 	HashSet<GodotConstraint2D *> constraints;
 

--- a/scene/2d/physics/area_2d.cpp
+++ b/scene/2d/physics/area_2d.cpp
@@ -36,6 +36,9 @@
 #include "servers/audio/audio_server.h"
 #include "servers/physics_2d/physics_server_2d.h"
 
+PagedAllocator<HashMapElement<ObjectID, Area2D::BodyState>, false, 512> Area2D::SharedBodyAllocator::allocator;
+PagedAllocator<HashMapElement<ObjectID, Area2D::AreaState>, false, 512> Area2D::SharedAreaAllocator::allocator;
+
 void Area2D::set_gravity_space_override_mode(SpaceOverride p_mode) {
 	gravity_space_override = p_mode;
 	PhysicsServer2D::get_singleton()->area_set_param(get_rid(), PS2DE::AREA_PARAM_GRAVITY_OVERRIDE_MODE, p_mode);
@@ -140,7 +143,7 @@ void Area2D::_body_enter_tree(ObjectID p_id) {
 	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_NULL(node);
 
-	HashMap<ObjectID, BodyState>::Iterator E = body_map.find(p_id);
+	MonitoredBodyHashMap::Iterator E = body_map.find(p_id);
 	ERR_FAIL_COND(!E);
 	ERR_FAIL_COND(E->value.in_tree);
 
@@ -155,7 +158,7 @@ void Area2D::_body_exit_tree(ObjectID p_id) {
 	Object *obj = ObjectDB::get_instance(p_id);
 	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_NULL(node);
-	HashMap<ObjectID, BodyState>::Iterator E = body_map.find(p_id);
+	MonitoredBodyHashMap::Iterator E = body_map.find(p_id);
 	ERR_FAIL_COND(!E);
 	ERR_FAIL_COND(!E->value.in_tree);
 	E->value.in_tree = false;
@@ -187,7 +190,7 @@ void Area2D::_body_inout(int p_status, const RID &p_body, ObjectID p_instance, i
 	Object *obj = ObjectDB::get_instance(objid);
 	Node *node = Object::cast_to<Node>(obj);
 
-	HashMap<ObjectID, BodyState>::Iterator E = body_map.find(objid);
+	MonitoredBodyHashMap::Iterator E = body_map.find(objid);
 
 	if (!body_in && !E) {
 		return; //does not exist because it was likely removed from the tree
@@ -251,7 +254,7 @@ void Area2D::_area_enter_tree(ObjectID p_id) {
 	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_NULL(node);
 
-	HashMap<ObjectID, AreaState>::Iterator E = area_map.find(p_id);
+	MonitoredAreaHashMap::Iterator E = area_map.find(p_id);
 	ERR_FAIL_COND(!E);
 	ERR_FAIL_COND(E->value.in_tree);
 
@@ -266,7 +269,7 @@ void Area2D::_area_exit_tree(ObjectID p_id) {
 	Object *obj = ObjectDB::get_instance(p_id);
 	Node *node = Object::cast_to<Node>(obj);
 	ERR_FAIL_NULL(node);
-	HashMap<ObjectID, AreaState>::Iterator E = area_map.find(p_id);
+	MonitoredAreaHashMap::Iterator E = area_map.find(p_id);
 	ERR_FAIL_COND(!E);
 	ERR_FAIL_COND(!E->value.in_tree);
 	E->value.in_tree = false;
@@ -298,7 +301,7 @@ void Area2D::_area_inout(int p_status, const RID &p_area, ObjectID p_instance, i
 	Object *obj = ObjectDB::get_instance(objid);
 	Node *node = Object::cast_to<Node>(obj);
 
-	HashMap<ObjectID, AreaState>::Iterator E = area_map.find(objid);
+	MonitoredAreaHashMap::Iterator E = area_map.find(objid);
 
 	if (!area_in && !E) {
 		return; //likely removed from the tree
@@ -361,7 +364,7 @@ void Area2D::_clear_monitoring() {
 	ERR_FAIL_COND_MSG(locked, "This function can't be used during the in/out signal.");
 
 	{
-		HashMap<ObjectID, BodyState> bmcopy(body_map);
+		MonitoredBodyHashMap bmcopy(body_map);
 		body_map.clear();
 		//disconnect all monitored stuff
 
@@ -389,7 +392,7 @@ void Area2D::_clear_monitoring() {
 	}
 
 	{
-		HashMap<ObjectID, AreaState> bmcopy(area_map);
+		MonitoredAreaHashMap bmcopy(area_map);
 		area_map.clear();
 		//disconnect all monitored stuff
 
@@ -507,7 +510,7 @@ bool Area2D::has_overlapping_areas() const {
 
 bool Area2D::overlaps_area(RequiredParam<Node> p_area) const {
 	EXTRACT_PARAM_OR_FAIL_V(check_area, p_area, false);
-	HashMap<ObjectID, AreaState>::ConstIterator E = area_map.find(check_area->get_instance_id());
+	MonitoredAreaHashMap::ConstIterator E = area_map.find(check_area->get_instance_id());
 	if (!E) {
 		return false;
 	}
@@ -516,7 +519,7 @@ bool Area2D::overlaps_area(RequiredParam<Node> p_area) const {
 
 bool Area2D::overlaps_body(RequiredParam<Node> p_body) const {
 	EXTRACT_PARAM_OR_FAIL_V(body, p_body, false);
-	HashMap<ObjectID, BodyState>::ConstIterator E = body_map.find(body->get_instance_id());
+	MonitoredBodyHashMap::ConstIterator E = body_map.find(body->get_instance_id());
 	if (!E) {
 		return false;
 	}

--- a/scene/2d/physics/area_2d.h
+++ b/scene/2d/physics/area_2d.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/templates/paged_allocator.h"
 #include "core/templates/vset.h"
 #include "scene/2d/physics/collision_object_2d.h"
 
@@ -95,7 +96,17 @@ private:
 		VSet<ShapePair> shapes;
 	};
 
-	HashMap<ObjectID, BodyState> body_map;
+	// This wraps a global allocator for use by all Area2D objects
+	struct SharedBodyAllocator {
+		static PagedAllocator<HashMapElement<ObjectID, BodyState>, false, 512> allocator;
+
+		template <typename... Args>
+		HashMapElement<ObjectID, BodyState> *new_allocation(Args &&...p_args) { return allocator.new_allocation(p_args...); }
+		void delete_allocation(HashMapElement<ObjectID, BodyState> *p_mem) { allocator.free(p_mem); }
+	};
+
+	using MonitoredBodyHashMap = HashMap<ObjectID, BodyState, HashMapHasherDefault, HashMapComparatorDefault<ObjectID>, SharedBodyAllocator>;
+	MonitoredBodyHashMap body_map;
 
 	void _area_inout(int p_status, const RID &p_area, ObjectID p_instance, int p_area_shape, int p_self_shape);
 
@@ -127,7 +138,17 @@ private:
 		VSet<AreaShapePair> shapes;
 	};
 
-	HashMap<ObjectID, AreaState> area_map;
+	// This wraps a global allocator for use by all Area2D objects
+	struct SharedAreaAllocator {
+		static PagedAllocator<HashMapElement<ObjectID, AreaState>, false, 512> allocator;
+
+		template <typename... Args>
+		HashMapElement<ObjectID, AreaState> *new_allocation(Args &&...p_args) { return allocator.new_allocation(p_args...); }
+		void delete_allocation(HashMapElement<ObjectID, AreaState> *p_mem) { allocator.free(p_mem); }
+	};
+
+	using MonitoredAreaHashMap = HashMap<ObjectID, AreaState, HashMapHasherDefault, HashMapComparatorDefault<ObjectID>, SharedAreaAllocator>;
+	MonitoredAreaHashMap area_map;
 	void _clear_monitoring();
 
 	bool audio_bus_override = false;


### PR DESCRIPTION

## What problem(s) does this PR solve?
Area monitoring HashMaps in `GodotArea2D` and `Area2D` were using the DefaultAllocator to allocate and free shape intersection reports many times per physics frame.

## Additional information

This PR adds static PagedAllocators to the HashMaps in `GodotArea2D` and `Area2D` to eliminate potential allocation thrashing. The PagedAllocators are shared between object instances (otherwise the total memory allocated for overlap reporting might grow to $n^2$ instead of $n$).
