### PR TITLE
Add setting presets to optimize the project for specific use cases

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -8428,6 +8428,8 @@ void EditorNode::notify_settings_overrides_changed() {
 // Keep the list alphabetically sorted.
 HashMap<String, Variant> EditorNode::get_initial_settings() {
 	HashMap<String, Variant> settings;
+	settings["display/window/size/viewport_height"] = 720;
+	settings["display/window/size/viewport_width"] = 1280;
 	settings["display/window/stretch/aspect"] = "expand";
 	settings["display/window/stretch/mode"] = "canvas_items";
 	settings["gui/common/auto_focus_strategy"] = Control::AutoFocusStrategy::STRATEGY_BALLOON;

--- a/editor/project_manager/project_dialog.cpp
+++ b/editor/project_manager/project_dialog.cpp
@@ -40,6 +40,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/gui/editor_file_dialog.h"
 #include "editor/settings/editor_settings.h"
+#include "editor/settings/setting_preset_editor.h"
 #include "editor/themes/editor_icons.h"
 #include "editor/themes/editor_scale.h"
 #include "editor/version_control/editor_vcs_interface.h"
@@ -518,7 +519,7 @@ void ProjectDialog::_renderer_selected() {
 				String::utf8("•  ") + TTR("Supports desktop, mobile + web platforms.") +
 				String::utf8("\n•  ") + TTR("Least advanced 3D graphics.") +
 				String::utf8("\n•  ") + TTR("Intended for low-end/older devices.") +
-				String::utf8("\n•  ") + TTR("Uses OpenGL 3 backend (OpenGL 3.3/ES 3.0/WebGL2).") +
+				String::utf8("\n•  ") + TTR("Uses OpenGL ES 3.0 backend.") +
 				String::utf8("\n•  ") + TTR("Fastest rendering of simple scenes."));
 	} else {
 		WARN_PRINT("Unknown renderer type. Please report this as a bug on GitHub.");
@@ -596,10 +597,17 @@ void ProjectDialog::ok_pressed() {
 		initial_settings["application/config/features"] = project_features;
 		initial_settings["application/config/name"] = project_name->get_text().strip_edges();
 		initial_settings["application/config/icon"] = "res://icon.svg";
-		ProjectSettings::CustomMap extra_settings = EditorNode::get_initial_settings();
+
+		const ProjectSettings::CustomMap extra_settings = EditorNode::get_initial_settings();
 		for (const KeyValue<String, Variant> &extra_setting : extra_settings) {
 			// Merge with other initial settings defined above.
 			initial_settings[extra_setting.key] = extra_setting.value;
+		}
+
+		const ProjectSettings::CustomMap preset_settings = setting_preset_editor->get_setting_preset_values(SettingPresetEditor::SettingPreset(setting_preset_editor->get_selected_preset()));
+		for (const KeyValue<String, Variant> &preset_setting : preset_settings) {
+			// Merge with other initial settings defined above.
+			initial_settings[preset_setting.key] = preset_setting.value;
 		}
 
 		Error err = ProjectSettings::get_singleton()->save_custom(path.path_join("project.godot"), initial_settings, Vector<String>(), false);
@@ -615,8 +623,6 @@ void ProjectDialog::ok_pressed() {
 			return;
 		}
 		fa_icon->store_string(get_default_project_icon());
-
-		EditorVCSInterface::create_vcs_metadata_files(EditorVCSInterface::VCSMetadata(vcs_metadata_selection->get_selected()), path);
 
 		// Ensures external editors and IDEs use UTF-8 encoding.
 		const String editor_config_path = path.path_join(".editorconfig");
@@ -872,7 +878,9 @@ void ProjectDialog::show_dialog(bool p_reset_name, bool p_is_confirmed) {
 		name_container->show();
 		install_path_container->hide();
 		renderer_container->hide();
-		default_files_container->hide();
+		setting_preset_editor->hide();
+		change_later_separator->hide();
+		change_later_label->hide();
 
 		callable_mp((Control *)project_name, &Control::grab_focus).call_deferred(false);
 		callable_mp(project_name, &LineEdit::select_all).call_deferred();
@@ -913,7 +921,9 @@ void ProjectDialog::show_dialog(bool p_reset_name, bool p_is_confirmed) {
 			name_container->hide();
 			install_path_container->hide();
 			renderer_container->hide();
-			default_files_container->hide();
+			setting_preset_editor->hide();
+			change_later_separator->hide();
+			change_later_label->hide();
 			edit_check_box->show();
 
 			// Project path dialog is also opened; no need to change focus.
@@ -941,7 +951,9 @@ void ProjectDialog::show_dialog(bool p_reset_name, bool p_is_confirmed) {
 			name_container->show();
 			install_path_container->hide();
 			renderer_container->show();
-			default_files_container->show();
+			setting_preset_editor->show();
+			change_later_separator->show();
+			change_later_label->show();
 			edit_check_box->hide();
 
 			callable_mp((Control *)project_name, &Control::grab_focus).call_deferred(false);
@@ -955,7 +967,9 @@ void ProjectDialog::show_dialog(bool p_reset_name, bool p_is_confirmed) {
 			name_container->show();
 			install_path_container->hide();
 			renderer_container->hide();
-			default_files_container->hide();
+			setting_preset_editor->hide();
+			change_later_separator->hide();
+			change_later_label->hide();
 			edit_check_box->show();
 
 			callable_mp((Control *)project_path, &Control::grab_focus).call_deferred(false);
@@ -966,7 +980,9 @@ void ProjectDialog::show_dialog(bool p_reset_name, bool p_is_confirmed) {
 			name_container->show();
 			install_path_container->hide();
 			renderer_container->hide();
-			default_files_container->hide();
+			setting_preset_editor->hide();
+			change_later_separator->hide();
+			change_later_label->hide();
 			edit_check_box->set_visible(duplicate_can_edit);
 
 			callable_mp((Control *)project_name, &Control::grab_focus).call_deferred(false);
@@ -1190,38 +1206,30 @@ ProjectDialog::ProjectDialog() {
 	rd_not_supported->set_visible(false);
 	renderer_container->add_child(rd_not_supported);
 
-	l = memnew(Label);
-	l->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
-	l->set_text(TTRC("The renderer can be changed later, but scenes may need to be adjusted."));
-	// Add some extra spacing to separate it from the list above and the buttons below.
-	l->set_custom_minimum_size(Size2(0, 40) * EDSCALE);
-	l->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
-	l->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
-	l->set_modulate(Color(1, 1, 1, 0.7));
-	renderer_container->add_child(l);
-
-	default_files_container = memnew(HBoxContainer);
-	vb->add_child(default_files_container);
-	l = memnew(Label);
-	l->set_text(TTRC("Version Control Metadata:"));
-	default_files_container->add_child(l);
-	vcs_metadata_selection = memnew(OptionButton);
-	vcs_metadata_selection->set_custom_minimum_size(Size2(100, 20));
-	vcs_metadata_selection->add_item(TTRC("None"), (int)EditorVCSInterface::VCSMetadata::NONE);
-	vcs_metadata_selection->add_item(TTRC("Git"), (int)EditorVCSInterface::VCSMetadata::GIT);
-	vcs_metadata_selection->select((int)EditorVCSInterface::VCSMetadata::GIT);
-	vcs_metadata_selection->set_accessibility_name(TTRC("Version Control Metadata:"));
-	default_files_container->add_child(vcs_metadata_selection);
 	Control *spacer = memnew(Control);
 	spacer->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	default_files_container->add_child(spacer);
+	spacer->set_custom_minimum_size(Size2(0, 10) * EDSCALE);
+	vb->add_child(spacer);
+
+	setting_preset_editor = memnew(SettingPresetEditor);
+	vb->add_child(setting_preset_editor);
+
+	change_later_separator = memnew(HSeparator);
+	vb->add_child(change_later_separator);
+
+	change_later_label = memnew(Label);
+	change_later_label->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
+	change_later_label->set_text(TTRC("The renderer and optimization preset can be changed later\nin the Project Settings, but scenes may need to be adjusted."));
+	// Add some extra spacing to separate it from the list above and the buttons below.
+	change_later_label->set_custom_minimum_size(Size2(0, 40) * EDSCALE);
+	change_later_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	change_later_label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
+	change_later_label->set_modulate(Color(1, 1, 1, 0.7));
+	vb->add_child(change_later_label);
+
 	fdialog_install = memnew(EditorFileDialog);
 	fdialog_install->set_access(EditorFileDialog::ACCESS_FILESYSTEM);
 	add_child(fdialog_install);
-
-	Control *spacer2 = memnew(Control);
-	spacer2->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	vb->add_child(spacer2);
 
 	edit_check_box = memnew(CheckBox);
 	edit_check_box->set_text(TTRC("Edit Now"));

--- a/editor/project_manager/project_dialog.h
+++ b/editor/project_manager/project_dialog.h
@@ -36,8 +36,10 @@ class Button;
 class CheckBox;
 class CheckButton;
 class EditorFileDialog;
+class HSeparator;
 class LineEdit;
 class OptionButton;
+class SettingPresetEditor;
 class TextureRect;
 
 class ProjectDialog : public ConfirmationDialog {
@@ -83,7 +85,6 @@ private:
 
 	VBoxContainer *renderer_container = nullptr;
 	Label *renderer_info = nullptr;
-	HBoxContainer *default_files_container = nullptr;
 	Ref<ButtonGroup> renderer_button_group;
 	bool rendering_device_supported = false;
 	bool rendering_device_checked = false;
@@ -96,7 +97,10 @@ private:
 	TextureRect *project_status_rect = nullptr;
 	TextureRect *install_status_rect = nullptr;
 
-	OptionButton *vcs_metadata_selection = nullptr;
+	SettingPresetEditor *setting_preset_editor = nullptr;
+
+	HSeparator *change_later_separator = nullptr;
+	Label *change_later_label = nullptr;
 
 	CheckBox *edit_check_box = nullptr;
 

--- a/editor/settings/project_settings_editor.cpp
+++ b/editor/settings/project_settings_editor.cpp
@@ -38,13 +38,16 @@
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/export/editor_export.h"
+#include "editor/gui/editor_toaster.h"
 #include "editor/gui/editor_variant_type_selectors.h"
 #include "editor/inspector/editor_inspector.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/settings/editor_settings_dialog.h"
 #include "editor/settings/gdextension/project_settings_gdextension.h"
+#include "editor/settings/setting_preset_editor.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/check_button.h"
+#include "scene/gui/separator.h"
 #include "servers/movie_writer/movie_writer.h"
 
 void ProjectSettingsEditor::connect_filesystem_dock_signals(FileSystemDock *p_fs_dock) {
@@ -218,6 +221,29 @@ void ProjectSettingsEditor::_delete_setting() {
 
 	property_box->clear();
 	del_button->release_focus();
+}
+
+void ProjectSettingsEditor::_presets_pressed() {
+	// Same width as the project creation dialog, so that the setting presets dialog looks similar.
+	// The height is set to allow all settings to show without scrolling with all presets.
+	presets_dialog->popup_centered_clamped(Size2(500, 450) * EDSCALE);
+}
+
+void ProjectSettingsEditor::_preset_dialog_confirmed() {
+	if (presets_editor->get_selected_preset() == SettingPresetEditor::SETTING_PRESET_DEFAULT) {
+		// Nothing needs to be changed.
+		return;
+	}
+
+	const HashMap<String, Variant> preset_settings = presets_editor->get_setting_preset_values(presets_editor->get_selected_preset());
+	for (const KeyValue<String, Variant> &preset_setting : preset_settings) {
+		ProjectSettings::get_singleton()->set_setting(preset_setting.key, preset_setting.value);
+	}
+	ProjectSettings::get_singleton()->save();
+
+	EditorToaster::get_singleton()->popup_str(
+			vformat(TTR("Setting preset \"%s\" applied."),
+					presets_editor->get_setting_preset_name(presets_editor->get_selected_preset())));
 }
 
 void ProjectSettingsEditor::_property_box_changed(const String &p_text) {
@@ -651,6 +677,7 @@ void ProjectSettingsEditor::_update_action_map_editor() {
 void ProjectSettingsEditor::_update_theme() {
 	add_button->set_button_icon(get_editor_theme_icon(SNAME("Add")));
 	del_button->set_button_icon(get_editor_theme_icon(SNAME("Remove")));
+	presets_button->set_button_icon(get_editor_theme_icon(SNAME("FileList")));
 	search_box->set_right_icon(get_editor_theme_icon(SNAME("Search")));
 	restart_close_button->set_button_icon(get_editor_theme_icon(SNAME("Close")));
 	restart_container->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SceneStringName(panel), SNAME("Tree")));
@@ -773,6 +800,22 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	del_button->set_disabled(true);
 	del_button->connect(SceneStringName(pressed), callable_mp(this, &ProjectSettingsEditor::_delete_setting));
 	custom_properties->add_child(del_button);
+
+	VSeparator *separator = memnew(VSeparator);
+	custom_properties->add_child(separator);
+
+	presets_button = memnew(Button);
+	presets_button->set_text(TTRC("Presets"));
+	presets_button->connect(SceneStringName(pressed), callable_mp(this, &ProjectSettingsEditor::_presets_pressed));
+	custom_properties->add_child(presets_button);
+
+	presets_dialog = memnew(ConfirmationDialog);
+	presets_dialog->set_title(TTRC("Presets"));
+	add_child(presets_dialog);
+	presets_dialog->connect(SceneStringName(confirmed), callable_mp(this, &ProjectSettingsEditor::_preset_dialog_confirmed));
+
+	presets_editor = memnew(SettingPresetEditor);
+	presets_dialog->add_child(presets_editor);
 
 	general_settings_inspector = memnew(SectionedInspector);
 	general_settings_inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);

--- a/editor/settings/project_settings_editor.h
+++ b/editor/settings/project_settings_editor.h
@@ -47,6 +47,7 @@
 class EditorVariantTypeOptionButton;
 class FileSystemDock;
 class ProjectSettingsGDExtension;
+class SettingPresetEditor;
 
 class ProjectSettingsEditor : public AcceptDialog {
 	GDCLASS(ProjectSettingsEditor, AcceptDialog);
@@ -83,6 +84,10 @@ class ProjectSettingsEditor : public AcceptDialog {
 	EditorVariantTypeOptionButton *type_box = nullptr;
 	Button *add_button = nullptr;
 	Button *del_button = nullptr;
+	Button *presets_button = nullptr;
+
+	ConfirmationDialog *presets_dialog = nullptr;
+	SettingPresetEditor *presets_editor = nullptr;
 
 	Label *restart_label = nullptr;
 	TextureRect *restart_icon = nullptr;
@@ -112,6 +117,8 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _setting_selected(const String &p_path);
 	void _add_setting();
 	void _delete_setting();
+	void _presets_pressed();
+	void _preset_dialog_confirmed();
 
 	void _tabs_tab_changed(int p_tab);
 	void _focus_current_search_box();

--- a/editor/settings/setting_preset_editor.cpp
+++ b/editor/settings/setting_preset_editor.cpp
@@ -1,0 +1,295 @@
+/**************************************************************************/
+/*  setting_preset_editor.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "setting_preset_editor.h"
+
+#include "core/object/callable_mp.h"
+#include "editor/themes/editor_scale.h"
+#include "scene/gui/foldable_container.h"
+#include "scene/gui/label.h"
+#include "scene/gui/option_button.h"
+#include "scene/gui/tree.h"
+#include "scene/main/viewport.h"
+
+String SettingPresetEditor::get_setting_preset_name(SettingPreset p_preset) {
+	switch (p_preset) {
+		case SETTING_PRESET_DEFAULT:
+			return TTRC("Default");
+		case SETTING_PRESET_2D_PIXEL_ART:
+			return vformat("%s - %s", TTRC("2D"), TTRC("Pixel Art"));
+		case SETTING_PRESET_2D_HIGH_DEFINITION:
+			return vformat("%s - %s", TTRC("2D"), TTRC("High Definition"));
+		case SETTING_PRESET_3D_PIXEL_ART:
+			return vformat("%s - %s", TTRC("3D"), TTRC("Pixel Art"));
+		case SETTING_PRESET_3D_STYLIZED:
+			return vformat("%s - %s", TTRC("3D"), TTRC("Stylized"));
+		case SETTING_PRESET_3D_HIGH_END:
+			return vformat("%s - %s", TTRC("3D"), TTRC("High-End"));
+		case SETTING_PRESET_MISC_APPLICATION:
+			return vformat("%s - %s", TTRC("Misc"), TTRC("Application"));
+		case SETTING_PRESET_MAX:
+			// Internal value, skip.
+			return "";
+	};
+
+	return "";
+}
+
+String SettingPresetEditor::get_setting_preset_description(SettingPreset p_preset) {
+	// Some descriptions are wrapped by hand to fit on two lines with good appearance.
+	switch (p_preset) {
+		case SETTING_PRESET_DEFAULT:
+			return TTRC("Use the default project settings, not tailored for a specific use case.");
+		case SETTING_PRESET_2D_PIXEL_ART:
+			return TTRC("Optimize project settings for a 2D pixel art project.");
+		case SETTING_PRESET_2D_HIGH_DEFINITION:
+			return TTRC("Optimize project settings for a high-resolution 2D project.");
+		case SETTING_PRESET_3D_PIXEL_ART:
+			return TTRC("Optimize project settings for a 3D pixel art project.");
+		case SETTING_PRESET_3D_STYLIZED:
+			return TTRC("Optimize project settings for a 3D stylized project\nwith simplified, clean visuals.");
+		case SETTING_PRESET_3D_HIGH_END:
+			return TTRC("Optimize project settings for a 3D project with high-end graphics.\nA dedicated GPU is recommended for this preset.");
+		case SETTING_PRESET_MISC_APPLICATION:
+			return TTRC("Optimize project settings for a non-game application. This aims to improve system integration and reduce power consumption.");
+		case SETTING_PRESET_MAX:
+			// Internal value, skip.
+			return "";
+	};
+
+	return "";
+}
+
+StringName SettingPresetEditor::get_setting_preset_icon_name(SettingPreset p_preset) {
+	// Some descriptions are wrapped by hand to fit on two lines with good appearance.
+	switch (p_preset) {
+		case SETTING_PRESET_DEFAULT:
+			return SNAME("Node");
+		case SETTING_PRESET_2D_PIXEL_ART:
+		case SETTING_PRESET_2D_HIGH_DEFINITION:
+			return SNAME("Node2D");
+		case SETTING_PRESET_3D_PIXEL_ART:
+		case SETTING_PRESET_3D_STYLIZED:
+		case SETTING_PRESET_3D_HIGH_END:
+			return SNAME("Node3D");
+		case SETTING_PRESET_MISC_APPLICATION:
+			return SNAME("Control");
+		case SETTING_PRESET_MAX:
+			// Internal value, skip.
+			return "";
+	};
+
+	return "";
+}
+
+HashMap<String, Variant> SettingPresetEditor::get_setting_preset_values(SettingPreset p_preset) {
+	// Keep lists of settings alphabetically sorted (with the exception of width/height values).
+	HashMap<String, Variant> settings;
+	switch (p_preset) {
+		case SETTING_PRESET_DEFAULT: {
+			// No settings to override.
+			break;
+		}
+
+		case SETTING_PRESET_2D_PIXEL_ART: {
+			settings["display/window/size/viewport_width"] = 640;
+			settings["display/window/size/viewport_height"] = 360;
+			settings["display/window/size/window_width_override"] = 1280;
+			settings["display/window/size/window_height_override"] = 720;
+			settings["display/window/stretch/mode"] = "viewport";
+			settings["display/window/stretch/scale_mode"] = "integer";
+			settings["rendering/2d/snap/snap_2d_transforms_to_pixel"] = true;
+			settings["rendering/textures/canvas_textures/default_texture_filter"] = CanvasItem::TEXTURE_FILTER_NEAREST;
+		} break;
+
+		case SETTING_PRESET_2D_HIGH_DEFINITION: {
+			// Enable high quality VRAM compression in case the user opts into VRAM compression.
+			// Lossless compression is still the default for textures used in 2D, but some HD 2D games
+			// may wish to use VRAM compression for large backgrounds or complex spritesheets.
+			Dictionary dictionary;
+			dictionary[StringName("compress/high_quality")] = true;
+			settings["importer_defaults/texture"] = dictionary;
+		} break;
+
+		case SETTING_PRESET_3D_PIXEL_ART: {
+			settings["display/window/size/viewport_width"] = 640;
+			settings["display/window/size/viewport_height"] = 360;
+			settings["display/window/size/window_width_override"] = 1280;
+			settings["display/window/size/window_height_override"] = 720;
+			settings["display/window/stretch/scale_mode"] = "integer";
+			settings["rendering/2d/snap/snap_2d_transforms_to_pixel"] = true;
+			settings["rendering/textures/canvas_textures/default_texture_filter"] = CanvasItem::TEXTURE_FILTER_NEAREST;
+			settings["rendering/textures/decals/filter"] = RenderingServerEnums::DECAL_FILTER_NEAREST;
+			settings["rendering/textures/light_projectors/filter"] = RenderingServerEnums::LIGHT_PROJECTOR_FILTER_NEAREST;
+
+			// Disable automatic VRAM compression for textures used in 3D, as it looks bad on pixel art.
+			// High quality VRAM compression isn't as bad, but we want a lossless result for pixel art
+			// since it doesn't use much VRAM in the first place.
+			Dictionary dictionary;
+			dictionary[StringName("detect_3d/compress_to")] = 0; // Disabled
+			settings["importer_defaults/texture"] = dictionary;
+		} break;
+
+		case SETTING_PRESET_3D_STYLIZED: {
+			settings["rendering/anti_aliasing/quality/msaa_3d"] = Viewport::MSAA_4X;
+			settings["rendering/anti_aliasing/quality/use_debanding"] = true;
+		} break;
+
+		case SETTING_PRESET_3D_HIGH_END: {
+			// Disable FSR sharpening, as we are using FSR2 at native resolution as a high-quality TAA solution.
+			settings["rendering/scaling_3d/fsr_sharpness"] = 2.0;
+			settings["rendering/scaling_3d/mode"] = Viewport::SCALING_3D_MODE_FSR2;
+			settings["rendering/textures/decals/filter"] = RenderingServerEnums::DECAL_FILTER_LINEAR_MIPMAPS_ANISOTROPIC;
+			settings["rendering/textures/light_projectors/filter"] = RenderingServerEnums::LIGHT_PROJECTOR_FILTER_LINEAR_MIPMAPS_ANISOTROPIC;
+			// Make the project ready for enabling HDR output, without further adjustments needed down the line.
+			settings["rendering/viewport/hdr_2d"] = true;
+
+			// Enable high quality VRAM compression.
+			Dictionary dictionary;
+			dictionary[StringName("compress/high_quality")] = true;
+			settings["importer_defaults/texture"] = dictionary;
+		} break;
+
+		case SETTING_PRESET_MISC_APPLICATION: {
+			settings["application/run/low_processor_mode"] = true;
+			settings["display/window/energy_saving/keep_screen_on"] = false;
+			settings["display/window/ios/hide_home_indicator"] = false;
+			settings["display/window/ios/hide_status_bar"] = false;
+			settings["display/window/ios/suppress_ui_gesture"] = false;
+			settings["display/window/subwindows/embed_subwindows"] = false;
+			// Reduce input lag by disabling V-Sync.
+			// Framerate is still capped by low processor mode to avoid excessive CPU/GPU utilization.
+			settings["display/window/vsync/vsync_mode"] = DisplayServerEnums::VSYNC_DISABLED;
+			settings["input_devices/pointing/android/enable_long_press_as_right_click"] = true;
+			settings["input_devices/pointing/android/enable_pan_and_scale_gestures"] = true;
+		} break;
+
+		case SETTING_PRESET_MAX: {
+			// Internal value, skip.
+			break;
+		}
+	}
+	return settings;
+}
+
+void SettingPresetEditor::_setting_preset_selected(int p_index) {
+	setting_preset_description->set_text(get_setting_preset_description(SettingPreset(setting_preset_selection->get_selected())));
+
+	// Update preview tree.
+	setting_preset_preview->clear();
+	// Create hidden root item (as all items are displayed at the top level).
+	setting_preset_preview->create_item();
+
+	const HashMap<String, Variant> preset_settings = get_setting_preset_values(SettingPreset(p_index));
+	for (const KeyValue<String, Variant> &preset_setting : preset_settings) {
+		TreeItem *item = setting_preset_preview->create_item();
+		// FIXME: EditorPropertyNameProcessor doesn't seem usable here (crashes in the project manager).
+		String key = preset_setting.key.replace("/", " > ").capitalize();
+		item->set_text(0, key);
+		if (preset_setting.value.get_type() == Variant::BOOL) {
+			// Always display "On" text even if unchecked, as the icon determines the actual state.
+			// This is similar to the Project Settings dialog.
+			item->set_text(1, TTRC("On"));
+			item->set_icon(1, get_editor_theme_icon(preset_setting.value ? SNAME("GuiCheckedDisabled") : SNAME("GuiUncheckedDisabled")));
+		} else {
+			item->set_text(1, String(preset_setting.value));
+		}
+	}
+
+	setting_preset_preview_container->set_visible(setting_preset_selection->get_selected() != SettingPreset::SETTING_PRESET_DEFAULT);
+}
+
+SettingPresetEditor::SettingPreset SettingPresetEditor::get_selected_preset() const {
+	return SettingPreset(setting_preset_selection->get_selected());
+}
+
+void SettingPresetEditor::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED: {
+			for (int i = 0; i < SettingPreset::SETTING_PRESET_MAX; i++) {
+				setting_preset_selection->set_item_icon(i, get_editor_theme_icon(get_setting_preset_icon_name(SettingPreset(i))));
+			}
+		} break;
+	}
+}
+
+SettingPresetEditor::SettingPresetEditor() {
+	option_button_container = memnew(HBoxContainer);
+	add_child(option_button_container);
+
+	setting_preset_label = memnew(Label);
+	setting_preset_label->set_text(TTRC("Project Settings:"));
+	option_button_container->add_child(setting_preset_label);
+
+	setting_preset_selection = memnew(OptionButton);
+	setting_preset_selection->set_custom_minimum_size(Size2(100, 20));
+	for (int i = 0; i < SettingPreset::SETTING_PRESET_MAX; i++) {
+		setting_preset_selection->add_item(get_setting_preset_name(SettingPreset(i)), i);
+		setting_preset_selection->set_item_tooltip(i, get_setting_preset_description(SettingPreset(i)));
+	}
+	setting_preset_selection->set_accessibility_name(TTRC("Project Settings:"));
+	option_button_container->add_child(setting_preset_selection);
+
+	setting_preset_description = memnew(Label);
+	setting_preset_description->set_focus_mode(Control::FOCUS_ACCESSIBILITY);
+	setting_preset_description->set_text(get_setting_preset_description(SettingPreset(setting_preset_selection->get_selected())));
+	setting_preset_description->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	// Set minimum height to roughly two lines of text to avoid reflows.
+	setting_preset_description->set_custom_minimum_size(Size2(200, 54) * EDSCALE);
+	setting_preset_description->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
+	setting_preset_description->set_modulate(Color(1, 1, 1, 0.7));
+	setting_preset_description->set_text(get_setting_preset_description(SettingPreset(setting_preset_selection->get_selected())));
+	add_child(setting_preset_description);
+	setting_preset_selection->connect(SceneStringName(item_selected), callable_mp(this, &SettingPresetEditor::_setting_preset_selected));
+
+	setting_preset_preview_container = memnew(FoldableContainer);
+	setting_preset_preview_container->set_title(TTRC("Preset Settings Preview"));
+	setting_preset_preview_container->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	setting_preset_preview_container->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	setting_preset_preview_container->set_folded(true);
+	// Start hidden, and show when a setting preset other than "Default" is selected.
+	setting_preset_preview_container->hide();
+	add_child(setting_preset_preview_container);
+
+	setting_preset_preview = memnew(Tree);
+	setting_preset_preview->set_columns(2);
+	setting_preset_preview->set_column_titles_visible(true);
+	setting_preset_preview->set_hide_root(true);
+	setting_preset_preview->set_column_title(0, TTRC("Setting"));
+	setting_preset_preview->set_column_title(1, TTRC("Value"));
+	setting_preset_preview->set_column_expand_ratio(0, 6);
+	setting_preset_preview->set_column_expand_ratio(1, 1);
+	setting_preset_preview->set_scroll_hint_mode(Tree::SCROLL_HINT_MODE_BOTTOM);
+	setting_preset_preview->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	setting_preset_preview->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	setting_preset_preview->set_custom_minimum_size(Size2(200, 150) * EDSCALE);
+
+	setting_preset_preview_container->add_child(setting_preset_preview);
+}

--- a/editor/settings/setting_preset_editor.h
+++ b/editor/settings/setting_preset_editor.h
@@ -1,0 +1,76 @@
+/**************************************************************************/
+/*  setting_preset_editor.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "scene/gui/box_container.h"
+
+class FoldableContainer;
+class Label;
+class OptionButton;
+class Tree;
+
+class SettingPresetEditor : public VBoxContainer {
+	GDCLASS(SettingPresetEditor, VBoxContainer);
+
+	HBoxContainer *option_button_container = nullptr;
+	Label *setting_preset_label = nullptr;
+	OptionButton *setting_preset_selection = nullptr;
+
+	Label *setting_preset_description = nullptr;
+	FoldableContainer *setting_preset_preview_container = nullptr;
+	Tree *setting_preset_preview = nullptr;
+
+	void _setting_preset_selected(int p_index);
+
+protected:
+	void _notification(int p_what);
+
+public:
+	enum SettingPreset {
+		SETTING_PRESET_DEFAULT,
+		SETTING_PRESET_2D_PIXEL_ART,
+		SETTING_PRESET_2D_HIGH_DEFINITION,
+		SETTING_PRESET_3D_PIXEL_ART,
+		SETTING_PRESET_3D_STYLIZED,
+		SETTING_PRESET_3D_HIGH_END,
+		SETTING_PRESET_MISC_APPLICATION,
+		SETTING_PRESET_MAX,
+	};
+
+	String get_setting_preset_name(SettingPreset p_preset);
+	String get_setting_preset_description(SettingPreset p_preset);
+	StringName get_setting_preset_icon_name(SettingPreset p_preset);
+	HashMap<String, Variant> get_setting_preset_values(SettingPreset p_preset);
+
+	SettingPreset get_selected_preset() const;
+
+	SettingPresetEditor();
+};


### PR DESCRIPTION
This is available in the project creation dialog and the project settings dialog, so you can change the setting preset after creating a project.

This also changes the default window size for new projects to 1280×720, as this is a common trait shared across all presets proposed in https://github.com/godotengine/godot-proposals/issues/15320. Existing projects are **not** affected by this change.

- This closes https://github.com/godotengine/godot-proposals/issues/15320
and closes https://github.com/godotengine/godot-proposals/issues/5658.

## Preview

> [!NOTE]
>
> "Optimize For:" label has been changed to "Project Settings:", but some screenshots haven't been updated yet.

### Project creation dialog

The setting preset dropdown replaces the existing version control metadata dropdown (see [proposal description](https://github.com/godotengine/godot-proposals/issues/15320) for rationale):

No preset chosen | With preset chosen (folded preview) | With preset chosen (expanded preview)
-|-|-
<img width="500" height="597" alt="Screenshot_20260901_171310" src="https://github.com/user-attachments/assets/7bca05fa-8547-463a-ba6a-e6f8d31b3851" /> | <img width="500" height="625" alt="Screenshot_20260901_171259" src="https://github.com/user-attachments/assets/88ac3fcb-6898-4c4b-aadd-65de599c48c2" /> | <img width="500" height="783" alt="Screenshot_20260901_171120" src="https://github.com/user-attachments/assets/93e0f0ce-d5e9-4314-ad5a-f3572d12b59a" />


### Project settings editor

Click the **Presets** button to open the setting presets dialog, with the same interface as the one from the project creation dialog:

<img width="714" height="185" alt="Image" src="https://github.com/user-attachments/assets/e6516363-ee0f-49e1-ab12-2b99afe59fbb" />

Select a setting preset:

<img width="500" height="478" alt="Image" src="https://github.com/user-attachments/assets/fa42c78f-19d3-4952-b452-3ddd2558a851" />

Review the list of changed settings, and confirm (or cancel).

<img width="500" height="478" alt="Image" src="https://github.com/user-attachments/assets/2f47c966-8e70-43ba-b2be-4db42cbe3bcb" />

A toast is displayed when the change is confirmed:

<img width="408" height="50" alt="Image" src="https://github.com/user-attachments/assets/99751db9-f728-4af3-b8db-c771a74d6159" />

## TODO

- [ ] Add settings from other presets to "revert" values to the defaults.
  - For example, if you choose the **Misc - Application** preset then switch to the **2D - Pixel Art** preset later on, it will not revert the value of settings like low-processor mode back to `false`.
    - This can be addressed by turning the list of presets to a table used by all presets, with "unused" values effectively being the project setting's default value.
    - When doing so, unchanged settings wouldn't be shown anymore in the settings preview Tree.
- [ ] Store metadata in `project.godot` to indicate the last setting preset that was chosen, and show this information in the setting preset dialog. This can be useful information to remember later on, especially on shared projects.
- [ ] Open the 2D editor main screen by default when using one of the 2D or Misc presets (currently, it opens on 3D as usual). This could be worth splitting into its own project setting to determine the default main screen.
- [ ] Make use of EditorPropertyNameProcessor to capitalize project setting names in the preview Tree. I originally attempted this, but it caused a crash in the project creation dialog.
- [ ] In the settings preview Tree, display enum values with the actual project setting's property hint instead of numeric values.
- [x] In a separate PR, change **Detect 3D > Compress To** to still run the mipmap generation logic for the **3D - Pixel art** preset. Right now, projects using that preset won't get VRAM compression on textures (as intended), but this also disables mipmap generation. We should keep mipmap genertation enabled in this case to avoid grainy textures in the distance.
  - Done in https://github.com/godotengine/godot/pull/122617.

For future PRs:

- [ ] Add command line support when we get around to introducing an `--init` or `--new` command line argument, to make project scaffolding easier. The argument should be able to accept an optional setting preset name such as `2d_pixel_art` or `misc_application`
  - For example: `godot --path /tmp/new --init 2d_pixel_art` or `godot /tmp/new/project.godot --init 2d_pixel_art`