### PR TITLE
Fix area monitoring order

### DIFF
--- a/modules/godot_physics_2d/godot_area_2d.cpp
+++ b/modules/godot_physics_2d/godot_area_2d.cpp
@@ -211,32 +211,36 @@ void GodotArea2D::call_queries() {
 				resptr[i] = &res[i];
 			}
 
-			for (HashMap<BodyKey, BodyState, BodyKey>::Iterator E = monitored_bodies.begin(); E;) {
-				if (E->value.state == 0) { // Nothing happened
-					HashMap<BodyKey, BodyState, BodyKey>::Iterator next = E;
-					++next;
+			// The first pass issues `AREA_BODY_ADDED`, while the second pass issues `AREA_BODY_REMOVED`.
+			// This execution order ensures that the callback doesn't incorrectly issue a body_exit signal.
+			bool first_pass = true;
+			for (HashMap<BodyKey, BodyState, BodyKey>::Iterator next = monitored_bodies.begin(), E = next; E; E = next) {
+				++next;
+
+				if ((E->value.state > 0) || !first_pass) {
+					res[0] = E->value.state > 0 ? PS2DE::AREA_BODY_ADDED : PS2DE::AREA_BODY_REMOVED;
+					res[1] = E->key.rid;
+					res[2] = E->key.instance_id;
+					res[3] = E->key.body_shape;
+					res[4] = E->key.area_shape;
+
 					monitored_bodies.remove(E);
-					E = next;
-					continue;
+
+					Callable::CallError ce;
+					Variant ret;
+					monitor_callback.callp((const Variant **)resptr, 5, ret, ce);
+
+					if (ce.error != Callable::CallError::CALL_OK) {
+						ERR_PRINT_ONCE("Error calling event callback method " + Variant::get_callable_error_text(monitor_callback, (const Variant **)resptr, 5, ce));
+					}
+				} else if (E->value.state == 0) { // Nothing happened.
+					monitored_bodies.remove(E);
 				}
 
-				res[0] = E->value.state > 0 ? PS2DE::AREA_BODY_ADDED : PS2DE::AREA_BODY_REMOVED;
-				res[1] = E->key.rid;
-				res[2] = E->key.instance_id;
-				res[3] = E->key.body_shape;
-				res[4] = E->key.area_shape;
-
-				HashMap<BodyKey, BodyState, BodyKey>::Iterator next = E;
-				++next;
-				monitored_bodies.remove(E);
-				E = next;
-
-				Callable::CallError ce;
-				Variant ret;
-				monitor_callback.callp((const Variant **)resptr, 5, ret, ce);
-
-				if (ce.error != Callable::CallError::CALL_OK) {
-					ERR_PRINT_ONCE("Error calling event callback method " + Variant::get_callable_error_text(monitor_callback, (const Variant **)resptr, 5, ce));
+				if (!next && first_pass) {
+					// Start the second pass.
+					first_pass = false;
+					next = monitored_bodies.begin();
 				}
 			}
 		} else {
@@ -253,32 +257,34 @@ void GodotArea2D::call_queries() {
 				resptr[i] = &res[i];
 			}
 
-			for (HashMap<BodyKey, BodyState, BodyKey>::Iterator E = monitored_areas.begin(); E;) {
-				if (E->value.state == 0) { // Nothing happened
-					HashMap<BodyKey, BodyState, BodyKey>::Iterator next = E;
-					++next;
+			bool first_pass = true;
+			for (HashMap<BodyKey, BodyState, BodyKey>::Iterator next = monitored_areas.begin(), E = next; E; E = next) {
+				++next;
+
+				if ((E->value.state > 0) || !first_pass) {
+					res[0] = E->value.state > 0 ? PS2DE::AREA_BODY_ADDED : PS2DE::AREA_BODY_REMOVED;
+					res[1] = E->key.rid;
+					res[2] = E->key.instance_id;
+					res[3] = E->key.body_shape;
+					res[4] = E->key.area_shape;
+
 					monitored_areas.remove(E);
-					E = next;
-					continue;
+
+					Callable::CallError ce;
+					Variant ret;
+					area_monitor_callback.callp((const Variant **)resptr, 5, ret, ce);
+
+					if (ce.error != Callable::CallError::CALL_OK) {
+						ERR_PRINT_ONCE("Error calling event callback method " + Variant::get_callable_error_text(area_monitor_callback, (const Variant **)resptr, 5, ce));
+					}
+				} else if (E->value.state == 0) { // Nothing happened.
+					monitored_areas.remove(E);
 				}
 
-				res[0] = E->value.state > 0 ? PS2DE::AREA_BODY_ADDED : PS2DE::AREA_BODY_REMOVED;
-				res[1] = E->key.rid;
-				res[2] = E->key.instance_id;
-				res[3] = E->key.body_shape;
-				res[4] = E->key.area_shape;
-
-				HashMap<BodyKey, BodyState, BodyKey>::Iterator next = E;
-				++next;
-				monitored_areas.remove(E);
-				E = next;
-
-				Callable::CallError ce;
-				Variant ret;
-				area_monitor_callback.callp((const Variant **)resptr, 5, ret, ce);
-
-				if (ce.error != Callable::CallError::CALL_OK) {
-					ERR_PRINT_ONCE("Error calling event callback method " + Variant::get_callable_error_text(area_monitor_callback, (const Variant **)resptr, 5, ce));
+				if (!next && first_pass) {
+					// Start the second pass.
+					first_pass = false;
+					next = monitored_areas.begin();
 				}
 			}
 		} else {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #86640
- Alternative to #120966

## Additional information
[Sort monitored_bodies in area2d queries - #120966](https://github.com/godotengine/godot/pull/120966) finds and fixes #86640 by sorting overlap detection records before notifying callbacks of the overlaps. 

I think this is an important fix, but the merge sort does more work than necessary. It only needs to make sure that ENTERED signals are issued before EXIT signals. 

This PR offers an alternative which uses the loop that is already there and issues the callbacks in two passes, one for ENTERED, and the next pass for EXIT. 