### PR TITLE
Add Lossless compression mode to editor Detect 3D functionality

### DIFF
--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -136,6 +136,9 @@ void ResourceImporterTexture::update_imports() {
 			} else if (compress_to == 2) {
 				cf->set_value("params", "compress/mode", COMPRESS_BASIS_UNIVERSAL);
 				compress_string = "Basis Universal";
+			} else if (compress_to == 100) {
+				cf->set_value("params", "compress/mode", COMPRESS_LOSSLESS);
+				compress_string = "Lossless";
 			}
 
 			print_line(
@@ -262,7 +265,7 @@ void ResourceImporterTexture::get_import_options(const String &p_path, List<Impo
 	// Maximum bound is the highest allowed value for lossy compression (the lowest common denominator).
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "process/size_limit", PROPERTY_HINT_RANGE, "0,16383,1"), 0));
 
-	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "detect_3d/compress_to", PROPERTY_HINT_ENUM, "Disabled,VRAM Compressed,Basis Universal"), (p_preset == PRESET_DETECT) ? 1 : 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "detect_3d/compress_to", PROPERTY_HINT_ENUM, "Disabled:0,Lossless:100,VRAM Compressed:1,Basis Universal:2"), (p_preset == PRESET_DETECT) ? 1 : 0));
 
 	// Do path based customization only if a path was passed.
 	if (p_path.is_empty() || p_path.get_extension() == "svg") {


### PR DESCRIPTION
- Follow-up to github.com/godotengine/godot/pull/122615
(can be merged independently).

This is intended to be used for 3D projects with a pixel art style, where VRAM compression should be avoided as it visibly degrades textures. However, we still want automatic mipmap generation to engage to avoid grainy textures in the distance.

Existing values are unchanged for compatibility. The new value is introduced at value `100` in case we decide to add other VRAM compression methods in the future, but we could choose to keep it at its usual ordering (which would make it `3` instead).

**Testing project:** [test_detect_3d_compress.zip](https://github.com/user-attachments/files/31242158/test_detect_3d_compress.zip)

## Preview

*The new option is the second one starting from the left. Notice how the texture isn't grainy at a distance (unlike the first option with Detect 3D disabled), yet it retains the original quality as intended by the artist (unlike the last two examples on the right).*

*The quality difference is especially noticeable on the bookshelf and mossy cobblestone textures at the bottom.*

<img width="1152" height="676" alt="Screenshot_20260820_001502" src="https://github.com/user-attachments/assets/9b9ad37f-a1e4-4e1b-889c-d12298bfaf10" />
