### PR TITLE
Add in support for completion tooltip for enum item declarations

### DIFF
--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -591,6 +591,13 @@ void GDScriptDocGen::_generate_docs(GDScript *p_script, const GDP::ClassNode *p_
 
 	// Add doc to the outer-most class.
 	p_script->_add_doc(doc);
+	// Named enums will be attempting to look up their docs based on their full name
+	// So we need to add docs for those names as well
+	for (const auto &enum_doc_entry : doc.enums) {
+		DocData::ClassDoc enum_class_doc = doc;
+		enum_class_doc.name = enum_class_doc.name + "." + enum_doc_entry.key;
+		p_script->_add_doc(enum_class_doc);
+	}
 }
 
 void GDScriptDocGen::generate_docs(GDScript *p_script, const GDP::ClassNode *p_class) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3474,6 +3474,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 
 	switch (completion_context.type) {
 		case GDScriptParser::COMPLETION_NONE:
+		case GDScriptParser::COMPLETION_NAMED_ENUM_ITEM_DECLARATION:
 		case GDScriptParser::COMPLETION_DECLARATION:
 			break;
 		case GDScriptParser::COMPLETION_ANNOTATION: {
@@ -4628,6 +4629,19 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				r_result.type = LookupResult::Type::CLASS_ANNOTATION;
 				r_result.class_name = "@GDScript";
 				r_result.class_member = annotation_symbol;
+				return OK;
+			}
+		} break;
+		case GDScriptParser::COMPLETION_NAMED_ENUM_ITEM_DECLARATION: {
+			if (context.node->type != GDScriptParser::Node::ENUM) {
+				break;
+			}
+			const GDScriptParser::EnumNode *enum_node = static_cast<const GDScriptParser::EnumNode *>(context.node);
+			if (!enum_node->identifier) {
+				break;
+			}
+
+			if (_lookup_symbol_from_base(enum_node->enum_type, p_symbol, r_result) == OK) {
 				return OK;
 			}
 		} break;

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1648,6 +1648,12 @@ GDScriptParser::EnumNode *GDScriptParser::parse_enum(bool p_is_static) {
 
 			elements[item.identifier->name] = item.line;
 
+			if (named) {
+				make_completion_context(COMPLETION_NAMED_ENUM_ITEM_DECLARATION, enum_node);
+			} else {
+				make_completion_context(COMPLETION_IDENTIFIER, item.identifier);
+			}
+
 			if (match(GDScriptTokenizer::Token::EQUAL)) {
 				ExpressionNode *value = parse_expression(false);
 				if (value == nullptr) {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1328,6 +1328,7 @@ public:
 		COMPLETION_BUILT_IN_TYPE_CONSTANT_OR_STATIC_METHOD, // Constants inside a built-in type (e.g. Color.BLUE) or static methods (e.g. Color.html).
 		COMPLETION_CALL_ARGUMENTS, // Complete with nodes, input actions, enum values (or usual expressions).
 		COMPLETION_DECLARATION, // Potential declaration (var, const, class, etc.).
+		COMPLETION_NAMED_ENUM_ITEM_DECLARATION, // Declaration of an item in a named enum
 		COMPLETION_GET_NODE, // Get node with $ notation.
 		COMPLETION_IDENTIFIER, // List available identifiers in scope.
 		COMPLETION_INHERIT_TYPE, // Type after extends. Exclude non-viable types (built-ins, enums, void). Includes subtypes using the argument index.


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?
Missing tool tip for enum declarations and missing doc strings on enum tool tips.

- Closes #122584 

## Additional information
The tool tip for anonymous enum item declarations was just a missing call to `make_completion_context`.
For named enum item declarations, a new completion type was added since to find the correct declaration you need to go inside the named enum. The new completion type was only added to the show tool tip logic and not the auto complete logic.

I also discovered that doc strings weren't appearing correctly for named enum items. This was because the class for the named enum item passed through to `EditorHelpBit::_get_constant_help_data` was a full path to the named enum like "\"test.gd\".AnEnum". Since this isn't a class no doc was generated for that name. The least intrusive change I could find to fix this was to update `GDScriptDocGen::_generate_docs` so that at the end after adding the main class doc, it will add a copy of the doc under the names of all named enums inside the class. There may be a better way to do this, if so let me know.

No AI was used.
