### PR TITLE
Show a proper error when there is invalid input in `EditorPropertyNodePath`

### DIFF
--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3040,8 +3040,14 @@ void EditorPropertyNodePath::_node_selected(const NodePath &p_path, bool p_absol
 		path = get_tree()->get_edited_scene_root()->get_path_to(to_node);
 	}
 
-	if (p_absolute && base_node) { // for AnimationTrackKeyEdit
-		path = base_node->get_path().rel_path_to(p_path);
+	if (base_node) {
+		if (p_absolute) { // For AnimationTrackKeyEdit.
+			path = base_node->get_path().rel_path_to(p_path);
+		} else {
+			path = p_path;
+		}
+		Node *to_node = base_node->get_node_or_null(path);
+		ERR_FAIL_NULL_EDMSG(to_node, vformat(TTR("Invalid node path \"%s\" (relative to %s)."), path, base_node->get_name()));
 	}
 
 	if (editing_node) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Fixes #121678
- Previous PR (which technically solves something different so it doesn't supersede): #122414

## Additional information

I made this more official by making it an editor message as @YeldhamDev suggested. 

I confirmed that there's no regressions when using the `SceneTreeDialog` (since that uses `p_absolute`). N/AI 

<details><summary>(This is the original text :p )</summary>(only copy-pasted from here to edit:) 

https://github.com/godotengine/godot/blob/6bb944587549fbdf01798555fb0b65669927d21e/editor/scene/scene_tree_editor.cpp#L1641-L1646

Technically unrelated to the functionality, but I noticed that the error dialog for the Scene Tree Editor is unique to it, so it's not universal. (Maybe it's because it's only used in that one function, but still seems a bit overkill just to have it stored for that one feature, I assumed it was used elsewhere too). Therefore, I had to follow similar suite here by adding it as a property to `EditorPropertyNodePath`, too (following the `SceneTreeDialog` precedent here too:) 

https://github.com/godotengine/godot/blob/6bb944587549fbdf01798555fb0b65669927d21e/editor/inspector/editor_properties.cpp#L3075-L3081

If this PR is merged, I think there should be a way to make this `AcceptDialog` global somehow so we don't need multiple `AcceptDialog`s for the same purpose. It's probably not very unperformant, but the principle of using less objects would be there.</details>

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->