### PR TITLE
Fix `AHashMap::erase` for non-trivially-copyable types

### DIFF
--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -338,16 +338,32 @@ public:
 		}
 
 		_metadata[meta_idx].hash = EMPTY_HASH;
-		_elements[element_idx].key.~TKey();
-		_elements[element_idx].value.~TValue();
+		if constexpr (!std::is_trivially_destructible_v<TKey>) {
+			_elements[element_idx].key.~TKey();
+		}
+		if constexpr (!std::is_trivially_destructible_v<TValue>) {
+			_elements[element_idx].value.~TValue();
+		}
 		_size--;
 
 		if (element_idx < _size) {
-			memcpy((void *)&_elements[element_idx], (const void *)&_elements[_size], sizeof(MapKeyValue));
 			uint32_t moved_element_idx = 0;
 			uint32_t moved_meta_idx = 0;
 			_lookup_idx(_elements[_size].key, moved_element_idx, moved_meta_idx);
 			_metadata[moved_meta_idx].element_idx = element_idx;
+
+			if constexpr (std::is_trivially_copyable_v<TKey> && std::is_trivially_copyable_v<TValue>) {
+				memcpy((void *)&_elements[element_idx], (const void *)&_elements[_size], sizeof(MapKeyValue));
+			} else {
+				memnew_placement(&_elements[element_idx], MapKeyValue(std::move(_elements[_size])));
+			}
+
+			if constexpr (!std::is_trivially_destructible_v<TKey>) {
+				_elements[_size].key.~TKey();
+			}
+			if constexpr (!std::is_trivially_destructible_v<TValue>) {
+				_elements[_size].value.~TValue();
+			}
 		}
 
 		return true;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Fixes a potential footgun in `AHashMap::erase` that assumes both the key and value types are trivially copyable.

## Additional information

To keep the dense element array, `AHashMap::erase` moves the last element to the spot of the deleted element. Since the element array type is `KeyValue` which cannot be assigned, the old element has to be destructed and a new one copy constructed. 

The current implementation simply uses `memcpy` but this assumes that both key value types are trivially copyable. Additionally, the old last element was not destructed. These two mistakes accidentally cancelled out in the case of ref counted types. 

The fix uses the move constructor and destructs the last elements. I also added guards for the destructor calls earlier on in the same method since I was here.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
