### PR TITLE
Update `argument_options.tscn` to load `AnimationPlayer` libraries in the most recent format

### DIFF
--- a/modules/gdscript/tests/scripts/completion/argument_options/argument_options.tscn
+++ b/modules/gdscript/tests/scripts/completion/argument_options/argument_options.tscn
@@ -1,16 +1,14 @@
-[gd_scene load_steps=1 format=3 uid="uid://dl28pdkxcjvym"]
+[gd_scene format=3 uid="uid://dl28pdkxcjvym"]
 
 [sub_resource type="Animation" id="Animation_d1pub"]
 resource_name = "bounce"
 
 [sub_resource type="AnimationLibrary" id="AnimationLibrary_gs7mj"]
 _data = {
-"bounce": SubResource("Animation_d1pub")
+&"bounce": SubResource("Animation_d1pub")
 }
 
-[node name="GetNode" type="Node"]
+[node name="GetNode" type="Node" unique_id=876232322]
 
-[node name="AnimationPlayer" type="AnimationPlayer" parent="."]
-libraries = {
-"": SubResource("AnimationLibrary_gs7mj")
-}
+[node name="AnimationPlayer" type="AnimationPlayer" parent="." unique_id=1664998033]
+libraries/ = SubResource("AnimationLibrary_gs7mj")

--- a/modules/gdscript/tests/test_completion.h
+++ b/modules/gdscript/tests/test_completion.h
@@ -208,7 +208,7 @@ static void test_directory(const String &p_dir) {
 				}
 			}
 			CHECK_MESSAGE(contains_excluded.is_empty(), "Autocompletion suggests illegal option '", contains_excluded, "' for '", path.path_join(next), "'.");
-			CHECK(include.is_empty());
+			CHECK_MESSAGE(include.is_empty(), "An autocompletion option is missing for '", path.path_join(next), "'.");
 
 			String expected_call_hint = conf.get_value("output", "call_hint", call_hint);
 			bool expected_forced = conf.get_value("output", "forced", forced);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Solves the 4th issue of #122196

## Additional information

I only took a skim at it when writing the issue, but now that I inspected it deeply, I figured out the cause.

`argument_options.tscn` was last updated 2 years ago in #99277, when `AnimationPlayer` autocompletion was first added as a test. `AnimationPlayer` library serialization was updated to the `libraries/<name>` format in #110502. #114844 covers the loading only when `deprecated=yes`, which is why it doesn't load anything when `deprecated=no` and therefore the test has nothing to show for in the autocompletion. Therefore I remade the `AnimationLibrary` in a `master` branch of Godot and resaved it just to be safe.

(That way, when `5.0` comes out in 2030+, this is one less test that fails. :D )

It also updated the key in the `AnimationLibrary`'s `_data` to use the `&` literal as introduced in #110767, but there were no bugs from the previous behavior due to implicit conversion between `String` and `StringName`.

I also changed 
https://github.com/godotengine/godot/blob/7a3904e22b90dc79933c7b34f8d0a26ca751e23d/modules/gdscript/tests/test_completion.h#L211

to

https://github.com/godotengine/godot/blob/ea4a213e6c78c89b2098c81cb15143b2cdb36378/modules/gdscript/tests/test_completion.h#L211

as it was difficult to figure out the issue at first due to its vagueness, and then when trying to figure out the problem scripts. Maybe this will help someone in the future, if something else about the serialization of `AnimationPlayer`, `AnimationLibrary`, `Animation` etc. gets updated, or even just the format of `PackedScene`s in general. Please suggest if the error message can be improved though. I couldn't include the exact option that would be missing because `include` is a `List<Dictionary>` which idk how to serialize. I think the missing option can be discovered from looking at `argument_options.tscn` or whatever scene it uses anyway.

N/AI (I would've spent a thousand more eons trying to figure this out by using a bot than my own IDE, Godot engine and brain :) )

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
