### PR TITLE
Fix copy / move node position miscalculation

### DIFF
--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -1053,7 +1053,7 @@ void CanvasItemEditor::_add_node_pressed(int p_result) {
 			for (Node *node : pasted_nodes) {
 				CanvasItem *ci = Object::cast_to<CanvasItem>(node);
 				if (ci) {
-					Transform2D xform = ci->get_global_transform_with_canvas().affine_inverse() * ci->get_transform();
+					Transform2D xform = ci->get_transform() * ci->get_global_transform_with_canvas().affine_inverse();
 					undo_redo->add_do_method(ci, "_edit_set_position", xform.xform(node_create_position));
 					undo_redo->add_undo_method(ci, "_edit_set_position", ci->_edit_get_position());
 				}
@@ -1074,7 +1074,7 @@ void CanvasItemEditor::_add_node_pressed(int p_result) {
 					if (!_is_node_movable(ci, true)) {
 						continue;
 					}
-					Transform2D xform = ci->get_global_transform_with_canvas().affine_inverse() * ci->get_transform();
+					Transform2D xform = ci->get_transform() * ci->get_global_transform_with_canvas().affine_inverse();
 					undo_redo->add_do_method(ci, "_edit_set_position", xform.xform(node_create_position));
 					undo_redo->add_undo_method(ci, "_edit_set_position", ci->_edit_get_position());
 				}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #122622

Fixes a miscalculation in the calculation of the new position when using Move / Paste Node on a child and parent with modified transforms.

## Additional information

The Matrix composition multiplication was done in the wrong order.

<details>
<summary>Verification</summary>

Compared to #122622's description.
Move:

https://github.com/user-attachments/assets/3e8c6349-0e19-4651-a22e-97046fa7cc1f

Paste:

https://github.com/user-attachments/assets/95e9ef50-fecd-4363-ba44-95d00715bc4f

</details>
