### PR TITLE
Fix main scene errors on first scan

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -4183,6 +4183,11 @@ void FileSystemDock::_feature_profile_changed() {
 }
 
 void FileSystemDock::_project_settings_changed() {
+	// First scan not finished, so main scene UID may be inaccessible.
+	if (!EditorNode::get_singleton()->is_editor_ready()) {
+		EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &FileSystemDock::_project_settings_changed), CONNECT_ONE_SHOT | CONNECT_REFERENCE_COUNTED);
+		return;
+	}
 	assigned_folder_colors = ProjectSettings::get_singleton()->get_setting("file_customization/folder_colors");
 
 	const String &current_main_scene_path = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -298,6 +298,11 @@ void EditorSceneTabs::update_scene_tabs() {
 }
 
 void EditorSceneTabs::_update_tab_titles() {
+	// First scan not finished, so main scene UID may be inaccessible.
+	if (!EditorNode::get_singleton()->is_editor_ready()) {
+		return;
+	}
+
 	bool show_rb = EDITOR_GET("interface/scene_tabs/show_script_button");
 	const String main_scene_path = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Fixes the main scene errors in #117362

## Additional information

The problem came from EditorPlugin script that changed a setting at launch, triggering `settings_changed` signal, which made scene tabs and FileSystem update and fetch main scene, while the file system was still scanning (so UID was not available).
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
