### PR TITLE
[3.x] Add internal `get_entropy()` function for web build

### DIFF
--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -32,6 +32,7 @@
 #define BVH_ABB_H
 
 #include <float.h>
+#include <cmath>
 
 // special optimized version of axis aligned bounding box
 template <class BOUNDS = AABB, class POINT = Vector3>

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -65,12 +65,44 @@ void OS_JavaScript::request_quit_callback() {
 	}
 }
 
+int OS_JavaScript::_internal_getentropy(void *buffer, size_t length) const {
+	if (length > 256) {
+		errno = EIO;
+		return -1;
+	}
+
+	FILE *f = fopen("/dev/urandom", "rb");
+	if (!f) {
+		errno = ENOSYS;
+		return -1;
+	}
+
+	size_t bytes_read = fread(buffer, 1, length, f);
+	fclose(f);
+
+	if (bytes_read != length) {
+		errno = EIO;
+		return -1;
+	}
+	return 0;
+}
+
 Error OS_JavaScript::get_entropy(uint8_t *r_buffer, int p_bytes) {
 	int left = p_bytes;
 	int ofs = 0;
 	do {
 		int chunk = MIN(left, 256);
+#ifdef __EMSCRIPTEN__
+// Check if the version is older than or equal to 1.39.9
+#include <emscripten/version.h>
+#if (__EMSCRIPTEN_major__ < 1 || (__EMSCRIPTEN_major__ == 1 && __EMSCRIPTEN_minor__ < 40))
+		ERR_FAIL_COND_V(_internal_getentropy(r_buffer + ofs, chunk), FAILED);
+#else
 		ERR_FAIL_COND_V(getentropy(r_buffer + ofs, chunk), FAILED);
+#endif
+#else
+		ERR_FAIL_COND_V(getentropy(r_buffer + ofs, chunk), FAILED);
+#endif
 		left -= chunk;
 		ofs += chunk;
 	} while (left > 0);

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -127,6 +127,8 @@ private:
 	static void ime_callback(int p_type, const char *p_text);
 	static void update_voices_callback(int p_size, const char **p_voice);
 
+	int _internal_getentropy(void *buffer, size_t length) const;
+
 protected:
 	void resume_audio();
 


### PR DESCRIPTION
Add internal function to get around the lack of `entropy` in the current Emscripten version.

## Notes
* Needs testing on the specific version used in our builds
* May not be as efficient as it has overheads of virtual filesystem, but should be as secure