### PR TITLE
[3.x] Add internal `get_entropy()` javascript function for web build

### DIFF
--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -32,6 +32,7 @@
 #define BVH_ABB_H
 
 #include <float.h>
+#include <cmath>
 
 // special optimized version of axis aligned bounding box
 template <class BOUNDS = AABB, class POINT = Vector3>

--- a/platform/javascript/godot_js.h
+++ b/platform/javascript/godot_js.h
@@ -51,6 +51,7 @@ extern void godot_js_os_shell_open(const char *p_uri);
 extern int godot_js_os_hw_concurrency_get();
 extern int godot_js_pwa_cb(void (*p_callback)());
 extern int godot_js_pwa_update();
+extern int godot_js_os_internal_getentropy(void *r_buffer, size_t p_length);
 
 // Input
 extern void godot_js_input_mouse_button_cb(int (*p_callback)(int p_pressed, int p_button, double p_x, double p_y, int p_modifiers));

--- a/platform/javascript/js/libs/library_godot_os.js
+++ b/platform/javascript/js/libs/library_godot_os.js
@@ -324,6 +324,17 @@ const GodotOS = {
 		a.remove();
 		window.URL.revokeObjectURL(url);
 	},
+
+	godot_js_os_internal_getentropy__sig: 'iii',
+	godot_js_os_internal_getentropy: function (buf, bufLen) {
+		try {
+			crypto.getRandomValues(GodotRuntime.heapSub(HEAPU8, buf, bufLen));
+			return 0;
+		} catch (e) {
+			return -1;
+		}
+	},
+
 };
 
 autoAddDeps(GodotOS, '$GodotOS');

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -66,6 +66,12 @@ void OS_JavaScript::request_quit_callback() {
 }
 
 Error OS_JavaScript::get_entropy(uint8_t *r_buffer, int p_bytes) {
+	// `getentropy()` wasn't implemented in Emscripten before 2.0.5.
+#if defined(__EMSCRIPTEN_major__) && (__EMSCRIPTEN_major__ < 2 || (__EMSCRIPTEN_major__ == 2 && __EMSCRIPTEN_minor__ == 0 && __EMSCRIPTEN_tiny__ < 5))
+	int ret = godot_js_os_internal_getentropy(r_buffer, p_bytes);
+	ERR_FAIL_COND_V(ret, FAILED);
+	return OK;
+#else
 	int left = p_bytes;
 	int ofs = 0;
 	do {
@@ -75,6 +81,7 @@ Error OS_JavaScript::get_entropy(uint8_t *r_buffer, int p_bytes) {
 		ofs += chunk;
 	} while (left > 0);
 	return OK;
+#endif
 }
 
 bool OS_JavaScript::tts_is_speaking() const {


### PR DESCRIPTION
Add javascript internal function to get around the lack of `entropy` in the current Emscripten version.

## Notes
* I am not a javascript guy so this will need a good review and test
* Needs testing on the specific version used in our builds
