### PR TITLE
Clarify JetBrains Mono OpenType docs in EditorSettings

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1064,11 +1064,11 @@
 		</member>
 		<member name="interface/editor/fonts/code_font_custom_opentype_features" type="String" setter="" getter="">
 			List of custom OpenType features to use, if supported by the currently configured code font. Not all fonts include support for custom OpenType features. The string should follow the OpenType specification.
-			[b]Note:[/b] The default editor code font ([url=https://www.jetbrains.com/lp/mono/]JetBrains Mono[/url]) has custom OpenType features in its font file, but there is no documented list yet.
+			[b]Note:[/b] This is only used when [member interface/editor/fonts/code_font_contextual_ligatures] is set to [b]Use Custom OpenType Feature Set[/b]. The other options only toggle [code]calt[/code]. The default code font ([url=https://www.jetbrains.com/lp/mono/]JetBrains Mono[/url]) supports features such as [code]calt[/code] and [code]ss01[/code]. See the [url=https://github.com/JetBrains/JetBrainsMono/wiki/OpenType-features]OpenType features list[/url].
 		</member>
 		<member name="interface/editor/fonts/code_font_custom_variations" type="String" setter="" getter="">
 			List of alternative characters to use, if supported by the currently configured code font. Not all fonts include support for custom variations. The string should follow the OpenType specification.
-			[b]Note:[/b] The default editor code font ([url=https://www.jetbrains.com/lp/mono/]JetBrains Mono[/url]) has alternate characters in its font file, but there is no documented list yet.
+			[b]Note:[/b] The bundled JetBrains Mono is not a variable font, so this does nothing for the default code font. It only applies if you set a custom variable code font.
 		</member>
 		<member name="interface/editor/fonts/code_font_size" type="int" setter="" getter="">
 			The size of the font in the script editor. This setting does not impact the font size of the Output panel (see [member run/output/font_size]).


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #122159

## Additional information

The class ref still said JetBrains Mono had no documented list for OpenType features/variations. Updated the two notes per bruvzg's feedback on the issue (wiki link, ligatures setting, bundled font isn't variable). Docs only.

**AI disclosure:** I used Cursor to help draft the note text, then read through it against the issue comments before opening this PR.