### PR TITLE
Fix crash on quit with CanvasTexture leaks

### DIFF
--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -3399,7 +3399,10 @@ RendererCanvasRenderRD::~RendererCanvasRenderRD() {
 
 	state.instance_buffers.uninit();
 
-	// Disable the callback, as we're tearing everything down
+	// Disable the callback for all canvas textures, as we're tearing everything down
+	for (const KeyValue<RID, TightLocalVector<RID>> &E : canvas_texture_to_uniform_set) {
+		texture_storage->canvas_texture_set_invalidation_callback(E.key, nullptr, nullptr);
+	}
 	texture_storage->canvas_texture_set_invalidation_callback(default_canvas_texture, nullptr, nullptr);
 	texture_storage->canvas_texture_free(default_canvas_texture);
 	//pipelines don't need freeing, they are all gone after shaders are gone


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #122648

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

RendererCanvasRenderRD registers an invalidation callback on every CanvasTexture it batches but it only clears it for default_canvas_texture, so a leaked CanvasTexture that has been drawn results in a null pointer dereference on exit.

I used Claude Code for the diagnosis of this issue, it assisted with investigating the crash reports and locating the source of the issue. I wrote and tested the change required to fix it, based on the existing callback clean up.