### PR TITLE
Keep `RichTextLabel` font cache on `Stylebox` override

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2712,7 +2712,12 @@ void RichTextLabel::_notification(int p_what) {
 			} else {
 				current_fitted_font_size = 0;
 			}
-			main->first_invalid_font_line.store(0);
+			theme_cache_old.normal_style = theme_cache.normal_style;
+			theme_cache_old.focus_style = theme_cache.focus_style;
+			if (theme_cache != theme_cache_old) {
+				main->first_invalid_font_line.store(0);
+			}
+			theme_cache_old = theme_cache;
 			main->first_resized_line.store(0);
 			for (const RID &E : hr_list) {
 				Item *it = items.get_or_null(E);

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -817,7 +817,62 @@ private:
 		Color table_border;
 
 		float base_scale = 1.0;
+
+		bool operator==(const ThemeCache &p_other) const {
+			return normal_style == p_other.normal_style &&
+					focus_style == p_other.focus_style &&
+					progress_bg_style == p_other.progress_bg_style &&
+					progress_fg_style == p_other.progress_fg_style &&
+
+					horizontal_rule == p_other.horizontal_rule &&
+
+					line_separation == p_other.line_separation &&
+					paragraph_separation == p_other.paragraph_separation &&
+
+					normal_font == p_other.normal_font &&
+					normal_font_size == p_other.normal_font_size &&
+
+					default_color == p_other.default_color &&
+					font_selected_color == p_other.font_selected_color &&
+					selection_color == p_other.selection_color &&
+					font_outline_color == p_other.font_outline_color &&
+					font_shadow_color == p_other.font_shadow_color &&
+					shadow_outline_size == p_other.shadow_outline_size &&
+					shadow_offset_x == p_other.shadow_offset_x &&
+					shadow_offset_y == p_other.shadow_offset_y &&
+					outline_size == p_other.outline_size &&
+					outline_color == p_other.outline_color &&
+
+					bold_font == p_other.bold_font &&
+					bold_font_size == p_other.bold_font_size &&
+					bold_italics_font == p_other.bold_italics_font &&
+					bold_italics_font_size == p_other.bold_italics_font_size &&
+					italics_font == p_other.italics_font &&
+					italics_font_size == p_other.italics_font_size &&
+					mono_font == p_other.mono_font &&
+					mono_font_size == p_other.mono_font_size &&
+
+					text_highlight_h_padding == p_other.text_highlight_h_padding &&
+					text_highlight_v_padding == p_other.text_highlight_v_padding &&
+
+					underline_alpha == p_other.underline_alpha &&
+					strikethrough_alpha == p_other.strikethrough_alpha &&
+
+					table_h_separation == p_other.table_h_separation &&
+					table_v_separation == p_other.table_v_separation &&
+					table_odd_row_bg == p_other.table_odd_row_bg &&
+					table_even_row_bg == p_other.table_even_row_bg &&
+					table_border == p_other.table_border &&
+
+					base_scale == p_other.base_scale;
+		}
+
+		bool operator!=(const ThemeCache &p_other) const {
+			return !(*this == p_other);
+		}
 	} theme_cache;
+
+	ThemeCache theme_cache_old = ThemeCache();
 
 public:
 	virtual RID get_focused_accessibility_element() const override;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Partially Fixes (large width) https://github.com/godotengine/godot/issues/122630

## Additional information

When `EditorHelp` is resized above a certain threshold it adds margins to the sides. The margins are added through the  `RichTextLabel`s styleboxes which makes it invalidate it's font cache (happens on theme change). This PR adds a check which excludes changes to the modified styleboxes from invalidating this cache. I feel like the cache comparison adds a lot of code but I couldn't think of a better solution for checking that nothing else in it changed (there is the `default` keyword in C++20 which could replace the large `==` definition https://github.com/godotengine/godot/pull/100749).

https://github.com/godotengine/godot/blob/7a3904e22b90dc79933c7b34f8d0a26ca751e23d/editor/doc/editor_help.cpp#L398-L412

> AI Disclosure: I used Gemini to find relevant code sections. Code and PR are by me