### PR TITLE
Make it possible to call methods in `RefCounted` predelete

### DIFF
--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -65,7 +65,17 @@ void Callable::callp(const Variant **p_arguments, int p_argcount, Variant &r_ret
 			r_return_value = Variant();
 			return;
 		}
+		// If this is a ref-counted object, it should be kept alive, but this shouldn't
+		// ref init it. Because if it was called inside the constructor it would lead
+		// to the object being destroyed at the end of this function.
+		bool pending_unref = obj->is_ref_counted() ? (static_cast<RefCounted *>(obj))->reference() : false;
 		r_return_value = obj->callp(method, p_arguments, p_argcount, r_call_error);
+		if (pending_unref) {
+			// We have to do the same Ref<T> would do.
+			if ((static_cast<RefCounted *>(obj))->unreference()) {
+				memdelete(obj);
+			}
+		}
 	}
 }
 

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -251,6 +251,27 @@ static bool _can_use_validate_call(const MethodBind *p_method, const Vector<GDSc
 	return true;
 }
 
+static bool _can_hold_ref_counted(const GDScriptCodeGenerator::Address &address) {
+	if (address.type.kind == GDScriptDataType::VARIANT) {
+		return true;
+	}
+	if (address.type.kind == GDScriptDataType::BUILTIN) {
+		return false;
+	}
+	// Known type, can be checked.
+	StringName class_name;
+	if (address.type.kind == GDScriptDataType::NATIVE) {
+		class_name = address.type.native_type;
+	} else {
+		class_name = address.type.native_type == StringName() ? address.type.script_type->get_instance_base_type() : address.type.native_type;
+	}
+	if (!GDScriptAnalyzer::class_exists(class_name)) {
+		// Class doesn't exists, let's assume it can hold RefCounted.
+		return true;
+	}
+	return class_name == Object::get_class_static() || ClassDB::is_parent_class(class_name, RefCounted::get_class_static());
+}
+
 GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &codegen, Error &r_error, const GDScriptParser::ExpressionNode *p_expression, bool p_root, bool p_initializer) {
 	if (p_expression->is_constant && !(p_expression->type_constraint.is_meta_type && p_expression->type_constraint.kind == GDScriptParser::DataType::CLASS)) {
 		return codegen.add_constant(p_expression->reduced_value);
@@ -620,6 +641,12 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 				if (r_error) {
 					return GDScriptCodeGenerator::Address();
 				}
+				// Always pass `self` as null inside a ref-counted predelete by passing it as a copy.
+				if (arg.mode == GDScriptCodeGenerator::Address::SELF && ClassDB::is_parent_class(codegen.script->native->get_name(), RefCounted::get_class_static())) {
+					GDScriptCodeGenerator::Address temp = codegen.add_temporary(_gdtype_from_datatype(codegen.class_node->self_type, codegen.script));
+					gen->write_assign(temp, arg);
+					arg = temp;
+				}
 				arguments.push_back(arg);
 			}
 
@@ -692,6 +719,12 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 								GDScriptCodeGenerator::Address base = _parse_expression(codegen, r_error, subscript->base);
 								if (r_error) {
 									return GDScriptCodeGenerator::Address();
+								}
+								// If the base could be ref-counted object we need to make sure it will exist for the whole call.
+								if (base.mode == GDScriptCodeGenerator::Address::MEMBER && _can_hold_ref_counted(base)) {
+									GDScriptCodeGenerator::Address temp = codegen.add_temporary(base.type);
+									gen->write_assign(temp, base);
+									base = temp;
 								}
 								if (is_awaited) {
 									gen->write_call_async(result, base, call->function_name, arguments);
@@ -791,6 +824,13 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 			GDScriptCodeGenerator::Address base = _parse_expression(codegen, r_error, subscript->base);
 			if (r_error) {
 				return GDScriptCodeGenerator::Address();
+			}
+
+			// If the base could be ref-counted object with its own getter we need to make sure it will exist for the whole call.
+			if (base.mode == GDScriptCodeGenerator::Address::MEMBER && _can_hold_ref_counted(base)) {
+				GDScriptCodeGenerator::Address temp = codegen.add_temporary(base.type);
+				gen->write_assign(temp, base);
+				base = temp;
 			}
 
 			bool named = subscript->is_attribute;
@@ -1079,10 +1119,13 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 
 				GDScriptCodeGenerator::Address prev_base = base;
 
+				GDScriptCodeGenerator::Address base_temp;
+				// If the base could be ref-counted object with its own setter we need to make sure it will exist for the whole call.
+				bool needs_lifetime_ensured = base.mode == GDScriptCodeGenerator::Address::MEMBER && _can_hold_ref_counted(base);
 				// In case the base has a setter, don't use the address directly, as we want to call that setter.
 				// So use a temp value instead and call the setter at the end.
-				GDScriptCodeGenerator::Address base_temp;
-				if ((!base_known_type || !base_is_shared) && base.mode == GDScriptCodeGenerator::Address::MEMBER && member_property_has_setter && !member_property_is_in_setter) {
+				bool base_has_setter = (!base_known_type || !base_is_shared) && base.mode == GDScriptCodeGenerator::Address::MEMBER && member_property_has_setter && !member_property_is_in_setter;
+				if (needs_lifetime_ensured || base_has_setter) {
 					base_temp = codegen.add_temporary(base.type);
 					gen->write_assign(base_temp, base);
 					prev_base = base_temp;
@@ -1240,8 +1283,10 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					if (!base_known_type) {
 						gen->write_jump_if_shared(base);
 					}
-					// Save the temp value back to the base by calling its setter.
-					gen->write_call(GDScriptCodeGenerator::Address(), base, member_property_setter_function, { assigned });
+					if (base_has_setter) {
+						// Save the temp value back to the base by calling its setter.
+						gen->write_call(GDScriptCodeGenerator::Address(), base, member_property_setter_function, { assigned });
+					}
 					if (!base_known_type) {
 						gen->write_end_jump_if_shared();
 					}

--- a/modules/gdscript/gdscript_lambda_callable.cpp
+++ b/modules/gdscript/gdscript_lambda_callable.cpp
@@ -197,7 +197,7 @@ CallableCustom::CompareLessFunc GDScriptLambdaSelfCallable::get_compare_less_fun
 }
 
 ObjectID GDScriptLambdaSelfCallable::get_object() const {
-	return object->get_instance_id();
+	return object ? object->get_instance_id() : ObjectID();
 }
 
 StringName GDScriptLambdaSelfCallable::get_method() const {
@@ -215,7 +215,7 @@ int GDScriptLambdaSelfCallable::get_argument_count(bool &r_is_valid) const {
 
 void GDScriptLambdaSelfCallable::call(const Variant **p_arguments, int p_argcount, Variant &r_return_value, Callable::CallError &r_call_error) const {
 #ifdef DEBUG_ENABLED
-	if (object->get_script_instance() == nullptr || object->get_script_instance()->get_language() != GDScriptLanguage::get_singleton()) {
+	if (object == nullptr || object->get_script_instance() == nullptr || object->get_script_instance()->get_language() != GDScriptLanguage::get_singleton()) {
 		ERR_PRINT("Trying to call a lambda with an invalid instance.");
 		r_call_error.error = Callable::CallError::CALL_ERROR_INSTANCE_IS_NULL;
 		return;

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -648,19 +648,24 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		}
 	}
 
+#ifdef DEBUG_ENABLED
+	// This is used to catch cases where the instance owner is freed during the call.
+	Ref<RefCounted> instance_owner(p_instance ? p_instance->owner : nullptr);
+#endif
+
+	// We must call a `Variant` constructor here, as accessing an object without doing so is undefined behavior.
+	memnew_placement(&stack[ADDR_STACK_SELF], Variant);
+	memnew_placement(&stack[ADDR_STACK_CLASS], Variant);
+	memnew_placement(&stack[ADDR_STACK_NIL], Variant);
+
 	if (p_instance) {
-		memnew_placement(&stack[ADDR_STACK_SELF], Variant(p_instance->owner));
+		VariantInternal::object_assign_without_ref_unsafe(&stack[ADDR_STACK_SELF], p_instance->owner);
 		script = p_instance->script.ptr();
 	} else {
-		memnew_placement(&stack[ADDR_STACK_SELF], Variant);
 		script = _script;
 	}
 
-	// We must call a `Variant` constructor here, as accessing an object without doing so is undefined behavior.
-	memnew_placement(&stack[ADDR_STACK_CLASS], Variant);
 	VariantInternal::object_assign_without_ref_unsafe(&stack[ADDR_STACK_CLASS], script);
-
-	memnew_placement(&stack[ADDR_STACK_NIL], Variant);
 
 #ifdef DEBUG_ENABLED
 	String err_text;
@@ -3967,6 +3972,11 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 		OPCODES_END
 #ifdef DEBUG_ENABLED
+		if (unlikely(exit_ok && instance_owner.is_valid() && instance_owner->get_reference_count() == 1)) {
+			exit_ok = false;
+			err_text = "Instance was freed during the function call. The caller must guarantee the lifetime of the called instance.";
+		}
+
 		if (exit_ok) {
 			OPCODE_OUT;
 		}
@@ -4022,9 +4032,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 	GDScriptLanguage::get_singleton()->exit_function();
 
-	// We deliberately avoid calling the destructor for `ADDR_STACK_CLASS`, since we initialized it
-	// without incrementing any reference count that it might have.
-	stack[ADDR_STACK_SELF].~Variant();
+	// We deliberately avoid calling the destructors for `ADDR_STACK_CLASS` and `ADDR_STACK_SELF`,
+	// since we initialized them without incrementing any reference count that they might have.
 	stack[ADDR_STACK_NIL].~Variant();
 
 	for (int i = FIXED_ADDRESSES_MAX; i < _stack_size; i++) {

--- a/modules/gdscript/tests/scripts/runtime/features/refcounted_predelete_call.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/refcounted_predelete_call.gd
@@ -1,0 +1,44 @@
+class RefInstance extends RefCounted:
+	signal remove_self_ref()
+	var some_state := 0
+
+	func emit_remove_self_ref_signal() -> void:
+		var before := get_reference_count()
+		remove_self_ref.emit()
+		var diff := before - get_reference_count()
+		prints("Did drop itself?:", diff == 1)
+		some_state += 1
+
+	func _notification(what: int) -> void:
+		if what == NOTIFICATION_PREDELETE:
+			print("===")
+			print("Entered NOTIFICATION_PREDELETE")
+			call_1()
+
+	func call_1() -> void:
+		prints("call_1: ok. Count:", get_reference_count())
+		call_2()
+
+	func call_2() -> void:
+		var self_copy := self
+		prints("call_2:", self_copy, self)
+		prints("self == null:", self == null)
+		prints("self_copy == null:", self_copy == null)
+		prints("self_copy == self:", self_copy == self)
+		prints("Some state:", self.some_state, self["some_state"])
+		call_3(self)
+
+	func call_3(self_arg: RefInstance) -> void:
+		prints("call_3 self arg:", self_arg)
+
+var instance: RefInstance
+
+func test():
+	print("===")
+	instance = RefInstance.new()
+	@warning_ignore("return_value_discarded")
+	instance.remove_self_ref.connect(func ():
+		instance = null
+	)
+	instance.emit_remove_self_ref_signal()
+	print("===")

--- a/modules/gdscript/tests/scripts/runtime/features/refcounted_predelete_call.out
+++ b/modules/gdscript/tests/scripts/runtime/features/refcounted_predelete_call.out
@@ -1,0 +1,13 @@
+GDTEST_OK
+===
+Did drop itself?: true
+===
+Entered NOTIFICATION_PREDELETE
+call_1: ok. Count: 0
+call_2: <Object#null> <Object#null>
+self == null: false
+self_copy == null: true
+self_copy == self: false
+Some state: 1 1
+call_3 self arg: <Object#null>
+===


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Salvages: https://github.com/godotengine/godot/pull/118086
- Salvages: https://github.com/godotengine/godot/pull/86969 (basic code)
- Fixes: https://github.com/godotengine/godot/issues/80834
- Fixes: https://github.com/godotengine/godot/issues/31166
- Fixes: https://github.com/godotengine/godot/issues/122367
- Fixes: https://github.com/godotengine/godot/issues/122362

## Additional information

I noticed that `VariantInternal::object_assign_without_ref_unsafe` is really direct and that it is, indeed, unsafe, as it ignores all the checks that `Variant` usually does when it is being created from `RefCounted`, which allows us to create an "invalid" `Variant` that holds ref counted object with a ref count of 0. Technically it was the only thing that stopped the calls from being made inside the predelete.

I guess the major difference between this and the salvaged PR is that this one also inserts additional references at the possible caller sites. Because of this the only breaking change should be for GDExtension users that depended on the GDScript VM stack to keep the instance alive during the GDScript function call, which shouldn't happen really often.

## Design decisions

### How GDScript now keeps RefCounted alive

It was implemented as suggested here https://github.com/godotengine/godot/pull/117850#issuecomment-4137276180:
> A way to salvage this might actually be to insert the reference at the caller site.
> Like I said, it's illegal to call a function without guaranteeing the lifetime of all objects within to at least the end of the function. Since the caller is currently not doing this, they're violating that contract.
> If the caller was made to adhere to the contract, we could merge this optimization. The GDScript VM would be able to avoid a superfluous refcount increase on call if the caller is guaranteed to outlive the function - which i think should be most cases, except those where a field is used as callee (as seen in your artificial crash).

After some tests I found out that GDScript VM already keeps temporaries alive until the end of the statement, so we don't need to keep temporaries alive, and that it is also very generous with what it considers to be temporary. Like, just getting a value using dot (`obj.value`), by index (`arr[0]`), or by key (`dict["key"]`) already makes it a temporary. We also don't need to keep locals or parameters alive as they are already kept alive by being stored as values locally. So we only need to worry about the direct member access:
```gdscript
var ref_object: RefCounted

func _ready() -> void:
    ref_object.direct_call() # direct call from member
    ref_object.prop_with_setter = 1 # directly setting a value on member with a setter
    print(ref_object.prop_with_getter) # directly getting a value on member with a getter
```
Now it will keep it alive by inserting a temporary copy when it detect the subscript (the dot access, and also `["key"]`) being used and if the member type is a type that can hold a ref-counted object are being used together, the types:
- `Variant`.
- `Object` or extends `RefCounted`.
- Unknown Object type.

As a bonus this will also keep native `RefCounted` alive while before they could be dropped mid call.

### Callable

The `Callable` is a hack, but I'm not sure how else to make it possible to call the callable to itself inside the constructor of a ref-counted type. If we are sure we will never call the callable to itself inside the constructor we can change it to a simple `Ref<RefCounted> keep_alive`.

### Prevent `self` from being passed outside during predelete

In the initial version it was possible to pass `self` to native vararg methods and to validated method calls, while the normal native calls and GDScript calls got null object variant. To keep the behaviour consistent I decided to always pass it as null object variant by making it pass `self` as a copy when it detects `self` being used for a call inside a ref-counted class. This also fully prevents us from passing `self` outside during predelete, which is really desirable as `self` is currently in a technically "invalid" state, so it should be as restricted as possible.

As for setters, we don't need to worry about them as long as they use normal `MethodBind::call`, which uses `VariantCaster<T>::cast` that makes a value copy when passing arguments.

## Possible breaking change?

Native classes now need to be responsible for keeping the GDScript ref-counted instances alive during the calls to their GDscript functions. Basically, in the sense of keeping them alive, they now need to treat the calls to GDScript the same way they treat the calls to other native classes. Now that the stack doesn't keep the instance alive we don't actually can do much for the languages outside of GDScript. Well this PR also salvaged `instance_owner` debug guard to report that the instance was freed during the call that is only relevant here now, which should be enough?

No AI used