### PR TITLE
Move compatibility methods maps from `ClassDB` to `GDType`

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1019,7 +1019,7 @@ void ClassDB::get_method_list_with_compatibility(const StringName &p_class, List
 			p_methods->push_back(pair);
 		}
 #endif
-		for (const KeyValue<StringName, LocalVector<MethodBind *, unsigned int, false, false>> &E : type->method_map_compatibility) {
+		for (const KeyValue<StringName, LocalVector<MethodBind *, unsigned int, false, false>> &E : type->gdtype->get_self_compatibility_method_map()) {
 			LocalVector<MethodBind *> compat(E.value);
 			for (MethodBind *method : compat) {
 				MethodInfo minfo = info_from_bind(method);
@@ -1104,8 +1104,8 @@ Vector<uint32_t> ClassDB::get_method_compatibility_hashes(const StringName &p_cl
 	ClassInfo *type = classes.getptr(p_class);
 
 	while (type) {
-		if (type->method_map_compatibility.has(p_name)) {
-			LocalVector<MethodBind *> *c = type->method_map_compatibility.getptr(p_name);
+		if (type->gdtype->get_self_compatibility_method_map().has(p_name)) {
+			const LocalVector<MethodBind *> *c = type->gdtype->get_self_compatibility_method_map().getptr(p_name);
 			Vector<uint32_t> ret;
 			for (uint32_t i = 0; i < c->size(); i++) {
 				ret.push_back((*c)[i]->get_hash());
@@ -1133,7 +1133,7 @@ const MethodBind *ClassDB::get_method_with_compatibility(const StringName &p_cla
 			}
 		}
 
-		LocalVector<MethodBind *> *compat = type->method_map_compatibility.getptr(p_name);
+		const LocalVector<MethodBind *> *compat = type->gdtype->get_self_compatibility_method_map().getptr(p_name);
 		if (compat) {
 			if (r_method_exists) {
 				*r_method_exists = true;
@@ -1601,13 +1601,6 @@ void ClassDB::bind_compatibility_method_custom(const StringName &p_class, Method
 	_bind_method_custom(p_class, p_method, true);
 }
 
-void ClassDB::_bind_compatibility(ClassInfo *r_type, MethodBind *p_method) {
-	if (!r_type->method_map_compatibility.has(p_method->get_name())) {
-		r_type->method_map_compatibility.insert(p_method->get_name(), LocalVector<MethodBind *>());
-	}
-	r_type->method_map_compatibility[p_method->get_name()].push_back(p_method);
-}
-
 void ClassDB::_bind_method_custom(const StringName &p_class, MethodBind *p_method, bool p_compatibility, bool p_take_ownership) {
 	Locker::Lock lock(Locker::STATE_WRITE);
 
@@ -1620,11 +1613,10 @@ void ClassDB::_bind_method_custom(const StringName &p_class, MethodBind *p_metho
 	}
 
 	if (p_compatibility) {
-		_bind_compatibility(type, p_method);
-		return;
+		type->gdtype->bind_compatibility_method(p_method);
+	} else {
+		type->gdtype->bind_method(p_method, p_take_ownership);
 	}
-
-	type->gdtype->bind_method(p_method, p_take_ownership);
 }
 
 MethodBind *ClassDB::_bind_vararg_method(MethodBind *p_bind, const StringName &p_name, const Vector<Variant> &p_default_args, bool p_compatibility) {
@@ -1641,11 +1633,10 @@ MethodBind *ClassDB::_bind_vararg_method(MethodBind *p_bind, const StringName &p
 	}
 
 	if (p_compatibility) {
-		_bind_compatibility(type, bind);
-		return bind;
+		return type->gdtype->bind_compatibility_method(bind) ? bind : nullptr;
+	} else {
+		return type->gdtype->bind_method(bind) ? bind : nullptr;
 	}
-
-	return type->gdtype->bind_method(bind) ? bind : nullptr;
 }
 
 #ifdef DEBUG_ENABLED
@@ -1689,7 +1680,9 @@ MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, bool p_
 #endif // DEBUG_ENABLED
 
 	if (p_compatibility) {
-		_bind_compatibility(type, p_bind);
+		if (!type->gdtype->bind_compatibility_method(p_bind)) {
+			return nullptr;
+		}
 	} else {
 		if (!type->gdtype->bind_method(p_bind)) {
 			return nullptr;
@@ -2095,14 +2088,6 @@ void ClassDB::cleanup() {
 	//OBJTYPE_LOCK; hah not here
 
 	for (KeyValue<StringName, ClassInfo> &E : classes) {
-		ClassInfo &ti = E.value;
-
-		for (KeyValue<StringName, LocalVector<MethodBind *>> &F : ti.method_map_compatibility) {
-			for (uint32_t i = 0; i < F.value.size(); i++) {
-				memdelete(F.value[i]);
-			}
-		}
-
 		if (E.value.gdextension) {
 			WARN_PRINT(vformat("Extension class '%s' is still registered at exit; its GDExtension did not unregister it.", E.key));
 			gdtype_leaked_autorelease_pool.push_back(E.value.gdtype); // We created it; we need to clear it.

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -116,8 +116,6 @@ public:
 
 		ObjectGDExtension *gdextension = nullptr;
 
-		HashMap<StringName, LocalVector<MethodBind *>> method_map_compatibility;
-
 #ifdef DEBUG_ENABLED
 		List<MethodInfo> virtual_methods;
 		HashMap<StringName, MethodInfo> virtual_methods_map;
@@ -215,7 +213,6 @@ private:
 	// Non-locking variants of get_parent_class and is_parent_class.
 	static StringName _get_parent_class(const StringName &p_class);
 	static bool _is_parent_class(const StringName &p_class, const StringName &p_inherits);
-	static void _bind_compatibility(ClassInfo *r_type, MethodBind *p_method);
 	static MethodBind *_bind_vararg_method(MethodBind *p_bind, const StringName &p_name, const Vector<Variant> &p_default_args, bool p_compatibility);
 	static void _bind_method_custom(const StringName &p_class, MethodBind *p_method, bool p_compatibility, bool p_take_ownership = true);
 

--- a/core/object/gdtype.cpp
+++ b/core/object/gdtype.cpp
@@ -55,6 +55,11 @@ GDType::~GDType() {
 	for (MethodBind *bind : owned_method_map) {
 		memdelete(bind);
 	}
+	for (const KeyValue<StringName, LocalVector<MethodBind *>> &kv : self_compatibility_method_map) {
+		for (MethodBind *bind : kv.value) {
+			memdelete(bind);
+		}
+	}
 	for (const PropertyInfo *property : ordered_self_properties) {
 		memdelete(const_cast<PropertyInfo *>(property));
 	}
@@ -170,6 +175,17 @@ void GDType::set_method_flags(const StringName &p_method, int p_flags) {
 	ERR_FAIL_NULL(method);
 
 	const_cast<MethodBind *>(*method)->set_hint_flags(p_flags);
+}
+
+bool GDType::bind_compatibility_method(MethodBind *p_method) {
+	ERR_FAIL_COND_V(!Thread::is_main_thread(), false);
+	ERR_FAIL_COND_V(init_state != InitState::MUTABLE, false);
+
+	if (!self_compatibility_method_map.has(p_method->get_name())) {
+		self_compatibility_method_map.insert(p_method->get_name(), LocalVector<MethodBind *>());
+	}
+	self_compatibility_method_map[p_method->get_name()].push_back(p_method);
+	return true;
 }
 
 void GDType::add_property(const PropertyInfo &p_pinfo, const StringName &p_setter, const StringName &p_getter,

--- a/core/object/gdtype.h
+++ b/core/object/gdtype.h
@@ -110,6 +110,8 @@ protected:
 	// bind_method supports binding non-owned methods.
 	LocalVector<MethodBind *> owned_method_map;
 
+	AHashMap<StringName, LocalVector<MethodBind *>> self_compatibility_method_map;
+
 	/// Contains all properties that can be obtained or set with `object.property`.
 	AHashMap<StringName, Property> property_map;
 	AHashMap<StringName, Property> self_property_map;
@@ -141,6 +143,9 @@ public:
 	bool bind_method(MethodBind *p_method, bool p_take_ownership = true);
 	void set_method_flags(const StringName &p_method, int p_flags);
 	const AHashMap<StringName, const MethodBind *> &get_method_map(bool p_no_inheritance = false) const { return p_no_inheritance ? self_method_map : method_map; }
+
+	bool bind_compatibility_method(MethodBind *p_method);
+	const AHashMap<StringName, LocalVector<MethodBind *>> &get_self_compatibility_method_map() const { return self_compatibility_method_map; }
 
 	void add_property(const PropertyInfo &p_pinfo, const StringName &p_setter, const StringName &p_getter, int p_index);
 	void add_to_ordered_properties(const PropertyInfo &p_pinfo);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Follow-up to #117599 
- Work towards https://github.com/godotengine/godot-proposals/issues/12323

Moves compatibility `MethodBind` maps from `ClassDB` to `GDType`, similarly to what was done for standard method maps.

## Additional information

Unlike its predecessor, these changes were pretty trivial as compatibility methods are an internal only system.