### PR TITLE
Window: Only set `DisplayServer` flag when value has changed

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -573,7 +573,9 @@ void Window::set_flag(Flags p_flag, bool p_enabled) {
 		embedder->_sub_window_update(this);
 	} else if (window_id != DisplayServerEnums::INVALID_WINDOW_ID) {
 		if (!is_in_edited_scene_root()) {
-			DisplayServer::get_singleton()->window_set_flag(DisplayServerEnums::WindowFlags(p_flag), p_enabled, window_id);
+			if (DisplayServer::get_singleton()->window_get_flag(DisplayServerEnums::WindowFlags(p_flag), window_id) != p_enabled) {
+				DisplayServer::get_singleton()->window_set_flag(DisplayServerEnums::WindowFlags(p_flag), p_enabled, window_id);
+			}
 		}
 	}
 }


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #99203
- Closes #120218
- Fixes second example in #115047

Continuation of #122591 which only added a check in `PopupMenu` for the `FLAG_NO_FOCUS` flag. Other flags can cause the same issues, so having this check in `Window::set_flag` is a better solution.

Prevents setting `DisplayServer` flags when the value would be unchanged. On Windows machines some flags would cause the window style to update even when no change occurred, which could for example cause issues in the editors context menu (see #122591 for details).

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

* *Bugsquad edit, fixes: https://github.com/godotengine/godot/issues/123307*