### PR TITLE
Fix issue with duplicate extracted textures

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -2243,7 +2243,11 @@ void GLTFDocument::_parse_image_save_image(Ref<GLTFState> p_state, const Vector<
 				must_write = !FileAccess::exists(file_path);
 			} else {
 				// Texture data has to be written to the res:// folder and imported.
-				file_path = p_state->get_extract_path().path_join(p_state->get_extract_prefix() + "_" + p_image->get_name());
+				if (p_state->get_extract_prefix().is_empty()) {
+					file_path = p_state->get_extract_path().path_join(p_image->get_name());
+				} else {
+					file_path = p_state->get_extract_path().path_join(p_state->get_extract_prefix() + "_" + p_image->get_name());
+				}
 				file_path += p_file_extension.is_empty() ? ".png" : p_file_extension;
 				if (FileAccess::exists(file_path + ".import")) {
 					Ref<ConfigFile> config;

--- a/modules/gltf/gltf_state.cpp
+++ b/modules/gltf/gltf_state.cpp
@@ -440,9 +440,6 @@ String GLTFState::get_filename() const {
 
 void GLTFState::set_filename(const String &p_filename) {
 	filename = p_filename;
-	if (extract_prefix.is_empty()) {
-		extract_prefix = p_filename.get_basename();
-	}
 }
 
 Variant GLTFState::get_additional_data(const StringName &p_extension_name) const {

--- a/modules/gltf/tests/test_gltf_images.h
+++ b/modules/gltf/tests/test_gltf_images.h
@@ -117,7 +117,7 @@ TEST_CASE("[SceneTree][Node][Editor] Import GLTF from .godot/imported folder wit
 	ERR_PRINT_ON
 
 	// In-editor imports of gltf and texture from .godot/imported folder should end up in res:// if extract_path is defined.
-	CHECK_MESSAGE(texture->get_path() == "res://gltf_placed_in_dot_godot_imported_material_albedo000.png", "Texture not parsed as resource.");
+	CHECK_MESSAGE(texture->get_path() == "res://material_albedo000.png", "Texture not parsed as resource.");
 
 	memdelete(loaded);
 	memdelete(erp);
@@ -144,7 +144,7 @@ TEST_CASE("[SceneTree][Node][Editor] Import GLTF with texture outside of res:// 
 	ERR_PRINT_ON
 
 	// Imports of gltf with texture from outside of res:// folder should end up being copied to res://
-	CHECK_MESSAGE(texture->get_path() == "res://gltf_pointing_to_texture_outside_of_res_folder_material_albedo000.png", "Texture not parsed as resource.");
+	CHECK_MESSAGE(texture->get_path() == "res://material_albedo000.png", "Texture not parsed as resource.");
 
 	memdelete(loaded);
 	memdelete(erp);
@@ -163,7 +163,7 @@ TEST_CASE("[SceneTree][Node][Editor] Import GLTF with embedded texture, check ho
 	ERR_PRINT_ON
 
 	// In-editor imports of texture embedded in file should end up with a resource.
-	CHECK_MESSAGE(texture->get_path() == "res://embedded_texture_material_albedo000.png", "Texture not parsed as resource.");
+	CHECK_MESSAGE(texture->get_path() == "res://material_albedo000.png", "Texture not parsed as resource.");
 
 	memdelete(loaded);
 	memdelete(erp);

--- a/tests/scene/test_gltf_document.cpp
+++ b/tests/scene/test_gltf_document.cpp
@@ -251,6 +251,19 @@ TEST_CASE("[SceneTree][GLTFDocument] Load suzanne.glb") {
 	memdelete(node);
 }
 
+TEST_CASE("[GLTFState] No extraction prefix if not set") {
+	Ref<GLTFState> default_state;
+	default_state.instantiate();
+	default_state->set_filename("scene.gltf");
+	CHECK(default_state->get_extract_prefix().is_empty());
+
+	Ref<GLTFState> custom_prefix_state;
+	custom_prefix_state.instantiate();
+	custom_prefix_state->set_extract_prefix("custom");
+	custom_prefix_state->set_filename("scene.gltf");
+	CHECK(custom_prefix_state->get_extract_prefix() == "custom");
+}
+
 } // namespace TestGLTFDocument
 
 #endif // MODULE_GLTF_ENABLED


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #79040

## Additional information

These changes remove the automatic addition of a prefix to all textures extracted from GLTF files. The extra textures were unreferenced anyway, so this shouldn't break anything.

Used Copilot to review the changes for any side effects and add a new test case in `tests/scene/test_gltf_document.cpp`. All other code changes are my own.