### PR TITLE
Fix handle mode being dropped for bezier curves in track editor

### DIFF
--- a/editor/animation/animation_bezier_editor.cpp
+++ b/editor/animation/animation_bezier_editor.cpp
@@ -2641,6 +2641,9 @@ void AnimationBezierTrackEdit::paste_keys(real_t p_ofs, bool p_ofs_valid) {
 
 			undo_redo->add_do_method(animation.ptr(), "track_insert_key", selected_track, dst_time, value, key.transition);
 			undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_time", selected_track, dst_time);
+			if (key.track_type == Animation::TYPE_BEZIER) {
+				undo_redo->add_do_method(editor, "_bezier_track_set_key_handle_mode_at_time", animation.ptr(), selected_track, dst_time, key.handle_mode);
+			}
 
 			Pair<int, float> p;
 			p.first = selected_track;

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -6212,6 +6212,7 @@ struct _AnimMoveRestore {
 	float time = 0;
 	Variant key;
 	float transition = 0;
+	Animation::HandleMode handle_mode = Animation::HANDLE_MODE_FREE;
 };
 // Used for undo/redo.
 
@@ -6372,6 +6373,9 @@ void AnimationTrackEditor::_move_selection_commit() {
 		amr.track = E->key().track;
 		amr.time = newtime;
 		amr.transition = animation->track_get_key_transition(E->key().track, idx);
+		if (animation->track_get_type(E->key().track) == Animation::TYPE_BEZIER) {
+			amr.handle_mode = animation->bezier_track_get_key_handle_mode(E->key().track, idx);
+		}
 
 		to_restore.push_back(amr);
 	}
@@ -6380,6 +6384,9 @@ void AnimationTrackEditor::_move_selection_commit() {
 	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 		float newpos = E->get().pos + motion;
 		undo_redo->add_do_method(animation.ptr(), "track_insert_key", E->key().track, newpos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
+		if (animation->track_get_type(E->key().track) == Animation::TYPE_BEZIER) {
+			undo_redo->add_do_method(this, "_bezier_track_set_key_handle_mode", animation.ptr(), E->key().track, E->key().key, animation->bezier_track_get_key_handle_mode(E->key().track, E->key().key));
+		}
 	}
 
 	// 4 - (Undo) Remove inserted keys.
@@ -6391,11 +6398,17 @@ void AnimationTrackEditor::_move_selection_commit() {
 	// 5 - (Undo) Reinsert keys.
 	for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 		undo_redo->add_undo_method(animation.ptr(), "track_insert_key", E->key().track, E->get().pos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
+		if (animation->track_get_type(E->key().track) == Animation::TYPE_BEZIER) {
+			undo_redo->add_undo_method(this, "_bezier_track_set_key_handle_mode", animation.ptr(), E->key().track, E->key().key, animation->bezier_track_get_key_handle_mode(E->key().track, E->key().key));
+		}
 	}
 
 	// 6 - (Undo) Reinsert overlapped keys.
 	for (_AnimMoveRestore &amr : to_restore) {
 		undo_redo->add_undo_method(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, amr.transition);
+		if (animation->track_get_type(amr.track) == Animation::TYPE_BEZIER) {
+			undo_redo->add_undo_method(this, "_bezier_track_set_key_handle_mode_at_time", animation.ptr(), amr.track, amr.time, amr.handle_mode);
+		}
 	}
 
 	undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
@@ -6695,6 +6708,9 @@ void AnimationTrackEditor::_anim_duplicate_keys(float p_ofs, bool p_ofs_valid, i
 
 			undo_redo->add_do_method(animation.ptr(), "track_insert_key", dst_track, dst_time, value, animation->track_get_key_transition(E->key().track, E->key().key));
 			undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_time", dst_track, dst_time);
+			if (key_is_bezier && track_is_bezier) {
+				undo_redo->add_do_method(this, "_bezier_track_set_key_handle_mode_at_time", animation.ptr(), dst_track, dst_time, animation->bezier_track_get_key_handle_mode(sk.track, sk.key));
+			}
 
 			Pair<int, float> p;
 			p.first = dst_track;
@@ -6755,6 +6771,9 @@ void AnimationTrackEditor::_anim_copy_keys(bool p_cut) {
 				float time = E->value().pos;
 				undo_redo->add_do_method(animation.ptr(), "track_remove_key_at_time", track_idx, time);
 				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", track_idx, time, animation->track_get_key_value(track_idx, key_idx), animation->track_get_key_transition(track_idx, key_idx));
+				if (animation->track_get_type(track_idx) == Animation::TYPE_BEZIER) {
+					undo_redo->add_undo_method(this, "_bezier_track_set_key_handle_mode_at_time", animation.ptr(), track_idx, time, animation->bezier_track_get_key_handle_mode(track_idx, key_idx));
+				}
 			}
 			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 				undo_redo->add_undo_method(this, "_select_at_anim", animation, E->key().track, E->value().pos);
@@ -6774,6 +6793,9 @@ void AnimationTrackEditor::_set_key_clipboard(int p_top_track, float p_top_time,
 		k.time = E->value().pos - p_top_time;
 		k.track = E->key().track - p_top_track;
 		k.track_type = animation->track_get_type(E->key().track);
+		if (k.track_type == Animation::TYPE_BEZIER) {
+			k.handle_mode = animation->bezier_track_get_key_handle_mode(E->key().track, E->key().key);
+		}
 
 		key_clipboard.keys.push_back(k);
 	}
@@ -6838,6 +6860,9 @@ void AnimationTrackEditor::_anim_paste_keys(float p_ofs, bool p_ofs_valid, int p
 
 			undo_redo->add_do_method(animation.ptr(), "track_insert_key", dst_track, dst_time, value, key.transition);
 			undo_redo->add_undo_method(animation.ptr(), "track_remove_key_at_time", dst_track, dst_time);
+			if (key_is_bezier && track_is_bezier) {
+				undo_redo->add_do_method(this, "_bezier_track_set_key_handle_mode_at_time", animation.ptr(), dst_track, dst_time, key.handle_mode);
+			}
 
 			Pair<int, float> p;
 			p.first = dst_track;
@@ -7222,6 +7247,9 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 				amr.track = E->key().track;
 				amr.time = newtime;
 				amr.transition = animation->track_get_key_transition(E->key().track, idx);
+				if (animation->track_get_type(E->key().track) == Animation::TYPE_BEZIER) {
+					amr.handle_mode = animation->bezier_track_get_key_handle_mode(E->key().track, idx);
+				}
 
 				to_restore.push_back(amr);
 			}
@@ -7231,6 +7259,9 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 				float newpos = NEW_POS(E->get().pos);
 				undo_redo->add_do_method(animation.ptr(), "track_insert_key", E->key().track, newpos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
+				if (animation->track_get_type(E->key().track) == Animation::TYPE_BEZIER) {
+					undo_redo->add_do_method(this, "_bezier_track_set_key_handle_mode_at_time", animation.ptr(), E->key().track, newpos, animation->bezier_track_get_key_handle_mode(E->key().track, E->key().key));
+				}
 			}
 
 			// 4 - (Undo) Remove inserted keys.
@@ -7242,11 +7273,17 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 			// 5 - (Undo) Reinsert keys.
 			for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", E->key().track, E->get().pos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
+				if (animation->track_get_type(E->key().track) == Animation::TYPE_BEZIER) {
+					undo_redo->add_undo_method(this, "_bezier_track_set_key_handle_mode", animation.ptr(), E->key().track, E->key().key, animation->bezier_track_get_key_handle_mode(E->key().track, E->key().key));
+				}
 			}
 
 			// 6 - (Undo) Reinsert overlapped keys.
 			for (_AnimMoveRestore &amr : to_restore) {
 				undo_redo->add_undo_method(animation.ptr(), "track_insert_key", amr.track, amr.time, amr.key, amr.transition);
+				if (animation->track_get_type(amr.track) == Animation::TYPE_BEZIER) {
+					undo_redo->add_undo_method(this, "_bezier_track_set_key_handle_mode_at_time", animation.ptr(), amr.track, amr.time, amr.handle_mode);
+				}
 			}
 
 			undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
@@ -7530,9 +7567,15 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 
 				undo_redo->add_do_method(reset.ptr(), "track_insert_key", dst_track, 0, animation->track_get_key_value(sk.track, sk.key), animation->track_get_key_transition(sk.track, sk.key));
 				undo_redo->add_undo_method(reset.ptr(), "track_remove_key_at_time", dst_track, 0);
+				if (animation->track_get_type(sk.track) == Animation::TYPE_BEZIER) {
+					undo_redo->add_do_method(this, "_bezier_track_set_key_handle_mode_at_time", reset.ptr(), dst_track, 0, animation->bezier_track_get_key_handle_mode(sk.track, sk.key));
+				}
 
 				if (existing_idx != -1) {
 					undo_redo->add_undo_method(reset.ptr(), "track_insert_key", dst_track, 0, reset->track_get_key_value(dst_track, existing_idx), reset->track_get_key_transition(dst_track, existing_idx));
+					if (animation->track_get_type(sk.track) == Animation::TYPE_BEZIER) {
+						undo_redo->add_undo_method(this, "_bezier_track_set_key_handle_mode_at_time", reset.ptr(), dst_track, 0, reset->bezier_track_get_key_handle_mode(dst_track, existing_idx));
+					}
 				}
 			}
 
@@ -7556,6 +7599,9 @@ void AnimationTrackEditor::_edit_menu_pressed(int p_option) {
 				for (RBMap<SelectedKey, KeyInfo>::Element *E = selection.back(); E; E = E->prev()) {
 					undo_redo->add_do_method(animation.ptr(), "track_remove_key", E->key().track, E->key().key);
 					undo_redo->add_undo_method(animation.ptr(), "track_insert_key", E->key().track, E->get().pos, animation->track_get_key_value(E->key().track, E->key().key), animation->track_get_key_transition(E->key().track, E->key().key));
+					if (animation->track_get_type(E->key().track) == Animation::TYPE_BEZIER) {
+						undo_redo->add_undo_method(this, "_bezier_track_set_key_handle_mode", animation.ptr(), E->key().track, E->key().key, animation->bezier_track_get_key_handle_mode(E->key().track, E->key().key));
+					}
 				}
 				undo_redo->add_do_method(this, "_clear_selection_for_anim", animation);
 				undo_redo->add_undo_method(this, "_clear_selection_for_anim", animation);

--- a/editor/animation/animation_track_editor.h
+++ b/editor/animation/animation_track_editor.h
@@ -891,6 +891,7 @@ class AnimationTrackEditor : public VBoxContainer {
 			float time = 0;
 			float transition = 0;
 			Variant value;
+			Animation::HandleMode handle_mode = Animation::HANDLE_MODE_FREE;
 		};
 		Vector<Key> keys;
 	};


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #122632

Fixes handle mode not being included in various track editor operations.

## Additional information

Adds the handle mode to (hopefully) all Do / Undo actions when track type is Beziere. Also adds it as a property Clipboard and Restore helper classes to enable correct functionality.

<details>
<summary>Verification</summary>

Notice the stable Handle Mode property in the inspector.

https://github.com/user-attachments/assets/5f6c8d3f-4076-4b76-81b3-e5f79d68b192

</details>

While doing this several other issues also arose for the track / beziere editor, seems to be pretty patchy overall.
