### PR TITLE
Fix GDScript inner class editor navigation and scene serialization

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1210,33 +1210,35 @@ Ref<Texture2D> EditorData::get_script_icon(const String &p_script_path) {
 		}
 	}
 
-	Ref<Script> base_scr = ResourceLoader::load(p_script_path, "Script");
-	while (base_scr.is_valid()) {
-		// Check for scripted classes.
-		String icon_path;
-		StringName base_class_name = script_class_get_name(base_scr->get_path());
-		if (base_scr->is_built_in() || base_class_name == StringName()) {
-			icon_path = base_scr->get_class_icon_path();
-		} else {
-			icon_path = script_class_get_icon_path(base_class_name);
-		}
+	if (!p_script_path.is_empty()) {
+		Ref<Script> base_scr = ResourceLoader::load(p_script_path, "Script");
+		while (base_scr.is_valid()) {
+			// Check for scripted classes.
+			String icon_path;
+			StringName base_class_name = script_class_get_name(base_scr->get_path());
+			if (base_scr->is_built_in() || base_class_name == StringName()) {
+				icon_path = base_scr->get_class_icon_path();
+			} else {
+				icon_path = script_class_get_icon_path(base_class_name);
+			}
 
-		Ref<Texture2D> icon = _load_script_icon(icon_path);
-		if (icon.is_valid()) {
-			_script_icon_cache[p_script_path] = icon;
-			return icon;
-		}
+			Ref<Texture2D> icon = _load_script_icon(icon_path);
+			if (icon.is_valid()) {
+				_script_icon_cache[p_script_path] = icon;
+				return icon;
+			}
 
-		// Check for legacy custom classes defined by plugins.
-		// TODO: Should probably be deprecated in 4.x
-		const EditorData::CustomType *ctype = get_custom_type_by_path(base_scr->get_path());
-		if (ctype && ctype->icon.is_valid()) {
-			_script_icon_cache[p_script_path] = ctype->icon;
-			return ctype->icon;
-		}
+			// Check for legacy custom classes defined by plugins.
+			// TODO: Should probably be deprecated in 4.x
+			const EditorData::CustomType *ctype = get_custom_type_by_path(base_scr->get_path());
+			if (ctype && ctype->icon.is_valid()) {
+				_script_icon_cache[p_script_path] = ctype->icon;
+				return ctype->icon;
+			}
 
-		// Move to the base class.
-		base_scr = base_scr->get_base_script();
+			// Move to the base class.
+			base_scr = base_scr->get_base_script();
+		}
 	}
 
 	// Check if the base type is an extension-defined type.

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -68,6 +68,12 @@
 #include "servers/display/display_server.h"
 #include "servers/rendering/rendering_server.h"
 
+#include "modules/modules_enabled.gen.h" // for gdscript
+
+#ifdef MODULE_GDSCRIPT_ENABLED
+#include "modules/gdscript/gdscript.h"
+#endif // MODULE_GDSCRIPT_ENABLED
+
 void EditorInspectorActionButton::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
@@ -5453,6 +5459,14 @@ void EditorInspector::edit(Object *p_object) {
 	per_array_page.clear();
 
 	object = p_object;
+
+	// For inner classes, edit the owner instead, as they don't have their own file.
+#ifdef MODULE_GDSCRIPT_ENABLED
+	Ref<GDScript> gdscript = Object::cast_to<GDScript>(object);
+	if (gdscript.is_valid() && gdscript->is_built_in() && gdscript->has_owner()) {
+		object = gdscript->get_owner();
+	}
+#endif // MODULE_GDSCRIPT_ENABLED
 
 	if (object) {
 		update_scroll_request = 0; //reset

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -58,6 +58,12 @@
 #include "servers/audio/audio_server.h"
 #include "servers/rendering/rendering_server.h"
 
+#include "modules/modules_enabled.gen.h" // for gdscript
+
+#ifdef MODULE_GDSCRIPT_ENABLED
+#include "modules/gdscript/gdscript.h"
+#endif // MODULE_GDSCRIPT_ENABLED
+
 static bool _has_sub_resources(const Ref<Resource> &p_res) {
 	List<PropertyInfo> property_list;
 	p_res->get_property_list(&property_list);
@@ -189,6 +195,16 @@ void EditorResourcePicker::_update_resource_preview(const String &p_path, const 
 	}
 
 	if (preview_rect) {
+		// For inner classes, show the owner's preview instead, as they don't have their own preview.
+#ifdef MODULE_GDSCRIPT_ENABLED
+		Ref<GDScript> gdscript = edited_resource;
+		if (gdscript.is_valid() && gdscript->is_built_in() && gdscript->has_owner()) {
+			Ref<GDScript> owner_script = gdscript->get_owner();
+			assign_button->set_text(owner_script->get_path().get_file());
+			return;
+		}
+#endif // MODULE_GDSCRIPT_ENABLED
+
 		Ref<Script> scr = edited_resource;
 		if (scr.is_valid()) {
 			assign_button->set_text(scr->get_path().get_file());

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -85,6 +85,12 @@
 #include "scene/main/window.h"
 #include "servers/display/display_server.h"
 
+#include "modules/modules_enabled.gen.h" // for gdscript
+
+#ifdef MODULE_GDSCRIPT_ENABLED
+#include "modules/gdscript/gdscript.h"
+#endif // MODULE_GDSCRIPT_ENABLED
+
 void ScriptEditorQuickOpen::popup_dialog(const Vector<String> &p_functions, bool p_dontclear) {
 	popup_centered_ratio(0.6);
 	if (p_dontclear) {
@@ -2508,6 +2514,16 @@ bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, 
 	if (p_resource.is_null()) {
 		return false;
 	}
+
+	// Ignore inner classes for the purpose of opening in the editor, as they are not separate resources.
+#ifdef MODULE_GDSCRIPT_ENABLED
+	Ref<GDScript> gdscript = p_resource;
+	if (gdscript.is_valid() && gdscript->is_built_in() && gdscript->has_owner()) {
+		Ref<GDScript> owner_script = gdscript->get_owner();
+		int inner_line = owner_script->get_member_line(gdscript->get_local_name());
+		return edit(owner_script, inner_line - 1, p_col, p_grab_focus);
+	}
+#endif // MODULE_GDSCRIPT_ENABLED
 
 	Ref<Script> scr = p_resource;
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -296,6 +296,9 @@ public:
 	String get_script_path() const;
 	Error load_source_code(const String &p_path);
 
+	bool has_owner() const { return _owner != nullptr && _owner->is_script_valid(); }
+	GDScript *get_owner() const { return _owner; }
+
 	void set_binary_tokens_source(const Vector<uint8_t> &p_binary_tokens);
 	const Vector<uint8_t> &get_binary_tokens_source() const;
 	Vector<uint8_t> get_as_binary_tokens() const;

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -45,6 +45,12 @@
 #include "scene/main/missing_node.h"
 #include "scene/property_utils.h"
 
+#include "modules/modules_enabled.gen.h" // for gdscript
+
+#ifdef MODULE_GDSCRIPT_ENABLED
+#include "modules/gdscript/gdscript.h"
+#endif // MODULE_GDSCRIPT_ENABLED
+
 #ifndef _2D_DISABLED
 #include "scene/2d/node_2d.h"
 #endif // _2D_DISABLED
@@ -971,6 +977,13 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Has
 			if (value.get_type() != Variant::NODE_PATH) {
 				continue; //was never set, ignore.
 			}
+		} else if (E.type == Variant::OBJECT && name == CoreStringName(script)) {
+#ifdef MODULE_GDSCRIPT_ENABLED
+			Ref<GDScript> script = value;
+			if (script.is_valid() && script->is_built_in() && script->has_owner()) {
+				continue; // ignore inneer classes.
+			}
+#endif // MODULE_GDSCRIPT_ENABLED
 		} else if (E.type == Variant::OBJECT && missing_resource_properties.has(E.name)) {
 			// Was this missing resource overridden? If so do not save the old value.
 			Ref<Resource> ures = value;


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes the long-term issue with the inner class and `@tool` script in the editor
The previous attempt: 
* https://github.com/godotengine/godot/pull/116576

## Additional information

This PR changes how GDScript inner class navigation works in the editor.
Clicking the script icon in the scene tree for a GDScript inner class now opens the owner class (navigation to inner class) instead of an empty class.
Clicking the node script property in the inspector opens the owner class (navigation to inner class) instead of an empty class.
Saving the scene now doesn't save GDScript inner class refrences/created nodes in the editor

```gdscript
@tool
extends Node

func _ready() -> void:
    var node := TestNode.new()
    add_child(node)
    node.owner = self


class TestNode extends Node: pass
```
```gdscript
@tool
extends Node

@onready var node: TestNode = %TestNode

func _enter_tree() -> void:
    %TestNode.set_script(TestNode)


class TestNode extends Node: pass
```

N/AI