### PR TITLE
Add Windows Arm64 COFF headers to `ResourceImporterOBJ`

### DIFF
--- a/editor/import/3d/resource_importer_obj.cpp
+++ b/editor/import/3d/resource_importer_obj.cpp
@@ -228,10 +228,16 @@ static Error _parse_obj(const String &p_path, List<Ref<ImporterMesh>> &r_meshes,
 	const int first_bytes = f->get_16();
 	static const Vector<int> coff_header_machines{
 		0x0, // IMAGE_FILE_MACHINE_UNKNOWN
-		0x8664, // IMAGE_FILE_MACHINE_AMD64
-		0x1c0, // IMAGE_FILE_MACHINE_ARM
-		0x14c, // IMAGE_FILE_MACHINE_I386
-		0x200, // IMAGE_FILE_MACHINE_IA64
+		0x8664, // IMAGE_FILE_MACHINE_AMD64 (x86_64)
+		0x1c0, // IMAGE_FILE_MACHINE_ARM (old arm32)
+		0x1c4, // IMAGE_FILE_MACHINE_ARMNT (new arm32)
+		0x14c, // IMAGE_FILE_MACHINE_I386 (x86_32)
+		0x200, // IMAGE_FILE_MACHINE_IA64 (Itanium)
+		0x5064, // IMAGE_FILE_MACHINE_RISCV64 (rv64)
+		0x5128, // IMAGE_FILE_MACHINE_RISCV128 (rv128)
+		0xa641, // IMAGE_FILE_MACHINE_ARM64EC (arm64ec)
+		0xa64e, // IMAGE_FILE_MACHINE_ARM64X (hybrid: both arm64 and arm64ec)
+		0xaa64, // IMAGE_FILE_MACHINE_ARM64 (arm64)
 	};
 	ERR_FAIL_COND_V_MSG(coff_header_machines.has(first_bytes), ERR_FILE_CORRUPT, vformat("Couldn't read OBJ file '%s', it seems to be binary, corrupted, or empty.", p_path));
 	f->seek(0);


### PR DESCRIPTION
## What problem(s) does this PR solve?

When opening a Godot project with GDExtension compilation artifacts in it, Godot has dedicated code in the OBJ importer to skip Windows COFF `.obj` files. This uses a hard-coded list of file header prefixes.

However, Windows Arm64 was missing from this list, so opening this project on Windows for Arm took an hour, as the editor showed these messages for significant fractions of a minute, while the console spammed with errors:

<img width="518" height="137" alt="Screenshot 2026-08-20 at 2 20 10 PM" src="https://github.com/user-attachments/assets/f5164534-bc78-48c1-ac10-70d00cb564e2" />

This PR fixes the problem by adding Arm64(/ec/x) to the list. I also threw in an alternate Arm32 prefix, and RISC-V. The full list provided by Microsoft has many more, but I don't think we ever expect Godot to support most of those.

## Additional information

I used AI to search through the code and find the COFF header code. After that, all the code edits were done manually.

This PR should be cherry-picked to all supported branches.