### PR TITLE
Update editor recursion detection to function for scenes

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5669,7 +5669,7 @@ void EditorNode::add_io_warning(const String &p_warning) {
 	}
 }
 
-bool EditorNode::find_recursive_resources(const Variant &p_variant, HashSet<Resource *> &r_resources_found, const String &p_root_scene_path) {
+bool EditorNode::find_recursive_resources(const Variant &p_variant, HashSet<Resource *> &r_resources_found, const String &p_root_scene_path, Ref<Resource> *r_recursive_resource) {
 	switch (p_variant.get_type()) {
 		case Variant::ARRAY: {
 			Array a = p_variant;
@@ -5678,7 +5678,7 @@ bool EditorNode::find_recursive_resources(const Variant &p_variant, HashSet<Reso
 				if (v2.get_type() != Variant::ARRAY && v2.get_type() != Variant::DICTIONARY && v2.get_type() != Variant::OBJECT) {
 					continue;
 				}
-				if (find_recursive_resources(v2, r_resources_found, p_root_scene_path)) {
+				if (find_recursive_resources(v2, r_resources_found, p_root_scene_path, r_recursive_resource)) {
 					return true;
 				}
 			}
@@ -5689,12 +5689,12 @@ bool EditorNode::find_recursive_resources(const Variant &p_variant, HashSet<Reso
 				const Variant &k = kv.key;
 				const Variant &v2 = kv.value;
 				if (k.get_type() == Variant::ARRAY || k.get_type() == Variant::DICTIONARY || k.get_type() == Variant::OBJECT) {
-					if (find_recursive_resources(k, r_resources_found, p_root_scene_path)) {
+					if (find_recursive_resources(k, r_resources_found, p_root_scene_path, r_recursive_resource)) {
 						return true;
 					}
 				}
 				if (v2.get_type() == Variant::ARRAY || v2.get_type() == Variant::DICTIONARY || v2.get_type() == Variant::OBJECT) {
-					if (find_recursive_resources(v2, r_resources_found, p_root_scene_path)) {
+					if (find_recursive_resources(v2, r_resources_found, p_root_scene_path, r_recursive_resource)) {
 						return true;
 					}
 				}
@@ -5708,6 +5708,9 @@ bool EditorNode::find_recursive_resources(const Variant &p_variant, HashSet<Reso
 			}
 
 			if (r_resources_found.has(r.ptr())) {
+				if (r_recursive_resource) {
+					*r_recursive_resource = Ref<Resource>(r);
+				}
 				return true;
 			}
 
@@ -5715,6 +5718,9 @@ bool EditorNode::find_recursive_resources(const Variant &p_variant, HashSet<Reso
 				Ref<PackedScene> ps = r;
 				if (ps.is_valid()) {
 					if (ps->get_path() == p_root_scene_path) {
+						if (r_recursive_resource) {
+							*r_recursive_resource = Ref<Resource>(r);
+						}
 						return true;
 					}
 				}
@@ -5732,7 +5738,7 @@ bool EditorNode::find_recursive_resources(const Variant &p_variant, HashSet<Reso
 				if (pinfo.type != Variant::ARRAY && pinfo.type != Variant::DICTIONARY && pinfo.type != Variant::OBJECT) {
 					continue;
 				}
-				if (find_recursive_resources(r->get(pinfo.name), r_resources_found, p_root_scene_path)) {
+				if (find_recursive_resources(r->get(pinfo.name), r_resources_found, p_root_scene_path, r_recursive_resource)) {
 					return true;
 				}
 			}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5669,7 +5669,7 @@ void EditorNode::add_io_warning(const String &p_warning) {
 	}
 }
 
-bool EditorNode::find_recursive_resources(const Variant &p_variant, HashSet<Resource *> &r_resources_found) {
+bool EditorNode::find_recursive_resources(const Variant &p_variant, HashSet<Resource *> &r_resources_found, const String &p_root_scene_path) {
 	switch (p_variant.get_type()) {
 		case Variant::ARRAY: {
 			Array a = p_variant;
@@ -5678,7 +5678,7 @@ bool EditorNode::find_recursive_resources(const Variant &p_variant, HashSet<Reso
 				if (v2.get_type() != Variant::ARRAY && v2.get_type() != Variant::DICTIONARY && v2.get_type() != Variant::OBJECT) {
 					continue;
 				}
-				if (find_recursive_resources(v2, r_resources_found)) {
+				if (find_recursive_resources(v2, r_resources_found, p_root_scene_path)) {
 					return true;
 				}
 			}
@@ -5689,12 +5689,12 @@ bool EditorNode::find_recursive_resources(const Variant &p_variant, HashSet<Reso
 				const Variant &k = kv.key;
 				const Variant &v2 = kv.value;
 				if (k.get_type() == Variant::ARRAY || k.get_type() == Variant::DICTIONARY || k.get_type() == Variant::OBJECT) {
-					if (find_recursive_resources(k, r_resources_found)) {
+					if (find_recursive_resources(k, r_resources_found, p_root_scene_path)) {
 						return true;
 					}
 				}
 				if (v2.get_type() == Variant::ARRAY || v2.get_type() == Variant::DICTIONARY || v2.get_type() == Variant::OBJECT) {
-					if (find_recursive_resources(v2, r_resources_found)) {
+					if (find_recursive_resources(v2, r_resources_found, p_root_scene_path)) {
 						return true;
 					}
 				}
@@ -5711,6 +5711,15 @@ bool EditorNode::find_recursive_resources(const Variant &p_variant, HashSet<Reso
 				return true;
 			}
 
+			if (!p_root_scene_path.is_empty()) {
+				Ref<PackedScene> ps = r;
+				if (ps.is_valid()) {
+					if (ps->get_path() == p_root_scene_path) {
+						return true;
+					}
+				}
+			}
+
 			r_resources_found.insert(r.ptr());
 
 			List<PropertyInfo> plist;
@@ -5723,7 +5732,7 @@ bool EditorNode::find_recursive_resources(const Variant &p_variant, HashSet<Reso
 				if (pinfo.type != Variant::ARRAY && pinfo.type != Variant::DICTIONARY && pinfo.type != Variant::OBJECT) {
 					continue;
 				}
-				if (find_recursive_resources(r->get(pinfo.name), r_resources_found)) {
+				if (find_recursive_resources(r->get(pinfo.name), r_resources_found, p_root_scene_path)) {
 					return true;
 				}
 			}

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -775,7 +775,7 @@ public:
 	static void disambiguate_filenames(const Vector<String> p_full_paths, Vector<String> &r_filenames);
 	static void add_io_error(const String &p_error);
 	static void add_io_warning(const String &p_warning);
-	static bool find_recursive_resources(const Variant &p_variant, HashSet<Resource *> &r_resources_found, const String &p_root_scene_path = "");
+	static bool find_recursive_resources(const Variant &p_variant, HashSet<Resource *> &r_resources_found, const String &p_root_scene_path = "", Ref<Resource> *r_recursive_resource = nullptr);
 
 	static void progress_add_task(const String &p_task, const String &p_label, int p_steps, bool p_can_cancel = false);
 	static bool progress_task_step(const String &p_task, const String &p_state, int p_step = -1, bool p_force_refresh = true);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -775,7 +775,7 @@ public:
 	static void disambiguate_filenames(const Vector<String> p_full_paths, Vector<String> &r_filenames);
 	static void add_io_error(const String &p_error);
 	static void add_io_warning(const String &p_warning);
-	static bool find_recursive_resources(const Variant &p_variant, HashSet<Resource *> &r_resources_found);
+	static bool find_recursive_resources(const Variant &p_variant, HashSet<Resource *> &r_resources_found, const String &p_root_scene_path = "");
 
 	static void progress_add_task(const String &p_task, const String &p_label, int p_steps, bool p_can_cancel = false);
 	static bool progress_task_step(const String &p_task, const String &p_state, int p_step = -1, bool p_force_refresh = true);

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3449,7 +3449,7 @@ void EditorPropertyResource::_resource_changed(const Ref<Resource> &p_resource) 
 	Ref<Resource> recursive_resource;
 	bool found = EditorNode::find_recursive_resources(p_resource, resources_found, root_scene_path, &recursive_resource);
 	if (found) {
-		callable_mp(EditorNode::get_singleton(), &EditorNode::show_warning).call_deferred(TTR("Recursion detected on resource '" + recursive_resource->get_path() + "', unable to assign resource to property."), TTR("Warning!"));
+		callable_mp(EditorNode::get_singleton(), &EditorNode::show_warning).call_deferred(vformat(TTR("Recursion detected on resource '%s', unable to assign resource to property."), recursive_resource->get_path()), TTR("Warning!"));
 		emit_changed(get_edited_property(), Ref<Resource>());
 		update_property();
 		return;

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3446,9 +3446,10 @@ void EditorPropertyResource::_resource_changed(const Ref<Resource> &p_resource) 
 	}
 
 	// Check for recursive setting of resource
-	bool found = EditorNode::find_recursive_resources(p_resource, resources_found, root_scene_path);
+	Ref<Resource> recursive_resource;
+	bool found = EditorNode::find_recursive_resources(p_resource, resources_found, root_scene_path, &recursive_resource);
 	if (found) {
-		callable_mp(EditorNode::get_singleton(), &EditorNode::show_warning).call_deferred(TTR("Recursion detected, unable to assign resource to property."), TTR("Warning!"));
+		callable_mp(EditorNode::get_singleton(), &EditorNode::show_warning).call_deferred(TTR("Recursion detected on resource '" + recursive_resource->get_path() + "', unable to assign resource to property."), TTR("Warning!"));
 		emit_changed(get_edited_property(), Ref<Resource>());
 		update_property();
 		return;

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -65,6 +65,7 @@
 #include "scene/main/window.h"
 #include "scene/resources/font.h"
 #include "scene/resources/mesh.h"
+#include "scene/resources/packed_scene.h"
 #include "scene/resources/sky.h"
 #include "servers/display/display_server.h"
 
@@ -3433,18 +3434,24 @@ void EditorPropertyResource::_select_resource(const Ref<Resource> &p_resource, b
 }
 
 void EditorPropertyResource::_resource_changed(const Ref<Resource> &p_resource) {
+	HashSet<Resource *> resources_found;
 	Resource *r = Object::cast_to<Resource>(get_edited_object());
+	String root_scene_path;
 	if (r) {
-		// Check for recursive setting of resource
-		HashSet<Resource *> resources_found;
 		resources_found.insert(r);
-		bool found = EditorNode::find_recursive_resources(p_resource, resources_found);
-		if (found) {
-			callable_mp(EditorNode::get_singleton(), &EditorNode::show_warning).call_deferred(TTR("Recursion detected, unable to assign resource to property."), TTR("Warning!"));
-			emit_changed(get_edited_property(), Ref<Resource>());
-			update_property();
-			return;
-		}
+	}
+	Node *n = Object::cast_to<Node>(get_edited_object());
+	if (n) {
+		root_scene_path = n->get_scene_file_path();
+	}
+
+	// Check for recursive setting of resource
+	bool found = EditorNode::find_recursive_resources(p_resource, resources_found, root_scene_path);
+	if (found) {
+		callable_mp(EditorNode::get_singleton(), &EditorNode::show_warning).call_deferred(TTR("Recursion detected, unable to assign resource to property."), TTR("Warning!"));
+		emit_changed(get_edited_property(), Ref<Resource>());
+		update_property();
+		return;
 	}
 
 	if (p_resource.is_valid() && p_resource->is_local_to_scene()) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #104769

## Additional information

AI was not used in any way during this development. All code was authored completely by me.

This change enhances the existing resource recursion detection in the editor. Previously, the recursion detection would only run if the object being updated was itself a `Resource` - meaning no recursion detection was happening when updating properties on nodes. This allows that recursion detection to occur for nodes, and allows them to detect if the scene they are in is referenced recursively. Attempts to assign a resource a value that would create a cyclic dependency will be rejected with an error message. The error message now also includes the path of the resource that was detected in the recursion.

Admittedly, this differs somewhat from the discussion on the issue itself, particularly in the segment of code that I've updated. While the issue was focused on updating the code responsible for writing `PackedScene` files, this update prioritizes detecting and rejecting them in the editor.

The recursion detection references the `PackedScene` files that are _on disk_ at the time, meaning it's possible to make a cyclic reference between two scenes, then save each independently, and create a cyclic dependency without prompting the warning message. This would be solved by adding or moving this detection to the code that writes `PackedScene` files. This pull request will catch the issue earlier, but has potential to miss this edge case (though should work the majority of the time) - a fix in the writer would catch them always, but not until the scene is saved. It could be worth implementing both.

Additionally, I'm questioning my use of the scene path to track the root scene. It was the easiest option available - but perhaps there's a more proper solution. I'd happily accept feedback from more experienced contributors. I'm also sorry if it's bad practice to submit code for a team that the original issue does not belong to.
