### PR TITLE
Fix AreaLight3D energy in SDFGI when physical light units enable

### DIFF
--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -2004,6 +2004,8 @@ void GI::SDFGI::pre_process_gi(const Transform3D &p_transform, RenderDataRD *p_r
 				// Convert from Luminous Power to Luminous Intensity
 				if (lights[idx].type == RSE::LIGHT_OMNI) {
 					lights[idx].energy *= 1.0 / (Math::PI * 4.0);
+				} else if (lights[idx].type == RSE::LIGHT_AREA) {
+					lights[idx].energy *= 1.0 / (Math::PI * 2.0);
 				} else if (lights[idx].type == RSE::LIGHT_SPOT) {
 					// Spot Lights are not physically accurate, Luminous Intensity should change in relation to the cone angle.
 					// We make this assumption to keep them easy to control.
@@ -2495,6 +2497,8 @@ void GI::SDFGI::render_static_lights(RenderDataRD *p_render_data, Ref<RenderScen
 					// Convert from Luminous Power to Luminous Intensity
 					if (lights[idx].type == RSE::LIGHT_OMNI) {
 						lights[idx].energy *= 1.0 / (Math::PI * 4.0);
+					} else if (lights[idx].type == RSE::LIGHT_AREA) {
+						lights[idx].energy *= 1.0 / (Math::PI * 2.0);
 					} else if (lights[idx].type == RSE::LIGHT_SPOT) {
 						// Spot Lights are not physically accurate, Luminous Intensity should change in relation to the cone angle.
 						// We make this assumption to keep them easy to control.


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #122457.
- AreaLight3D energy was not converted from luminous power to luminous intensity in SDFGI when physical light units were enabled, making indirect lighting `2 * PI` too bright.

## Additional information

Apply the same `1 / (2 * PI)` conversion already used by direct lighting and VoxelGI to both dynamic and static SDFGI light packing paths.

This conversion appears to have been missed when AreaLight3D support was added in #108219. That change added area-light packing to both SDFGI paths, while the equivalent VoxelGI path received the correct `1 / (2 * PI)` conversion.

### Before the fix
<img width="1280" height="720" alt="before-on" src="https://github.com/user-attachments/assets/543a24dd-cb8b-484b-bdac-884e7d408cef" />

### After the fix
<img width="1280" height="720" alt="after-on" src="https://github.com/user-attachments/assets/50f02453-c44c-4175-b2ed-22571598515e" />


## AI disclosure

I used AI to help confirm and understand the root cause of this issue, and to review the proposed fix. I reproduced the issue and verified the fix myself.
