### PR TITLE
SoftBody3D Improvements for More Realistic Simulations

### DIFF
--- a/editor/register_editor_types.cpp
+++ b/editor/register_editor_types.cpp
@@ -103,6 +103,7 @@
 #include "editor/scene/3d/particles_3d_editor_plugin.h"
 #include "editor/scene/3d/path_3d_editor_plugin.h"
 #include "editor/scene/3d/physics/physical_bone_3d_editor_plugin.h"
+#include "editor/scene/3d/physics/soft_body_3d_editor_plugin.h"
 #include "editor/scene/3d/polygon_3d_editor_plugin.h"
 #include "editor/scene/3d/skeleton_3d_editor_plugin.h"
 #include "editor/scene/3d/voxel_gi_editor_plugin.h"
@@ -290,6 +291,7 @@ void register_editor_types() {
 	EditorPlugins::add_by_type<VoxelGIEditorPlugin>();
 	// 3D physics editor plugins.
 	EditorPlugins::add_by_type<PhysicalBone3DEditorPlugin>();
+	EditorPlugins::add_by_type<SoftBody3DEditorPlugin>();
 #ifndef DISABLE_DEPRECATED
 	EditorPlugins::add_by_type<SkeletonIK3DEditorPlugin>();
 #endif

--- a/editor/scene/3d/physics/soft_body_3d_editor_plugin.cpp
+++ b/editor/scene/3d/physics/soft_body_3d_editor_plugin.cpp
@@ -1,0 +1,361 @@
+/**************************************************************************/
+/*  soft_body_3d_editor_plugin.cpp                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "soft_body_3d_editor_plugin.h"
+
+#include "core/object/callable_mp.h"
+#include "editor/editor_node.h"
+#include "editor/editor_string_names.h"
+#include "editor/editor_undo_redo_manager.h"
+#include "editor/scene/3d/node_3d_editor_plugin.h"
+#include "scene/gui/label.h"
+
+void SoftBody3DEditor::_menu_option(int p_option) {
+	if (!node) {
+		return;
+	}
+
+	switch (p_option) {
+		case MENU_OPTION_SET_PIN_WEIGHTS_FROM_VERTEX_COLORS: {
+			Ref<Mesh> mesh = node->get_mesh();
+			if (mesh.is_null()) {
+				err_dialog->set_text(TTR("SoftBody3D does not have a mesh assigned."));
+				err_dialog->popup_centered();
+				return;
+			}
+			weight_dialog->popup_centered(Size2i(340, 0));
+		} break;
+		case MENU_OPTION_CLEAR_ALL_PINNED_POINTS: {
+			_clear_all_pinned_points();
+		} break;
+	}
+}
+
+void SoftBody3DEditor::_apply_pin_weights_from_vertex_colors() {
+	if (!node) {
+		return;
+	}
+
+	Ref<Mesh> mesh = node->get_mesh();
+	if (mesh.is_null()) {
+		err_dialog->set_text(TTR("SoftBody3D does not have a mesh assigned."));
+		err_dialog->popup_centered();
+		return;
+	}
+
+	int surface_count = mesh->get_surface_count();
+	if (surface_count == 0) {
+		err_dialog->set_text(TTR("Mesh has no surfaces."));
+		err_dialog->popup_centered();
+		return;
+	}
+
+	bool found_colors = false;
+	for (int s = 0; s < surface_count; s++) {
+		Array arrays = mesh->surface_get_arrays(s);
+		if (arrays.size() > Mesh::ARRAY_COLOR && arrays[Mesh::ARRAY_COLOR].get_type() == Variant::PACKED_COLOR_ARRAY) {
+			PackedColorArray colors = arrays[Mesh::ARRAY_COLOR];
+			if (colors.size() > 0) {
+				found_colors = true;
+				break;
+			}
+		}
+	}
+
+	if (!found_colors) {
+		err_dialog->set_text(TTR("Mesh does not contain vertex colors on any surface."));
+		err_dialog->popup_centered();
+		return;
+	}
+
+	int channel = channel_option->get_selected_id();
+	real_t threshold = (real_t)threshold_spin->get_value();
+	bool invert = invert_check->is_pressed();
+	int mode = mode_option->get_selected_id();
+
+	struct PinData {
+		int point_index = 0;
+		NodePath spatial_attachment_path;
+		Vector3 offset;
+		real_t weight = 1.0;
+	};
+
+	HashMap<int, PinData> target_pins;
+
+	// If mode is merge (1), preload existing pins
+	if (mode == 1) {
+		Array cur_indices = node->get("pinned_points");
+		for (int i = 0; i < cur_indices.size(); i++) {
+			int p_idx = cur_indices[i];
+			String prefix = vformat("attachments/%d/", i);
+			PinData pd;
+			pd.point_index = p_idx;
+			pd.spatial_attachment_path = node->get(prefix + "spatial_attachment_path");
+			pd.offset = node->get(prefix + "offset");
+			pd.weight = node->get(prefix + "weight");
+			target_pins[p_idx] = pd;
+		}
+	}
+
+	int global_vertex_offset = 0;
+	for (int s = 0; s < surface_count; s++) {
+		Array arrays = mesh->surface_get_arrays(s);
+		if (arrays.size() <= Mesh::ARRAY_VERTEX) {
+			continue;
+		}
+		PackedVector3Array vertices = arrays[Mesh::ARRAY_VERTEX];
+		int v_count = vertices.size();
+		PackedColorArray colors;
+		if (arrays.size() > Mesh::ARRAY_COLOR && arrays[Mesh::ARRAY_COLOR].get_type() == Variant::PACKED_COLOR_ARRAY) {
+			colors = arrays[Mesh::ARRAY_COLOR];
+		}
+		bool has_color = (colors.size() == v_count);
+
+		if (!has_color) {
+			global_vertex_offset += v_count;
+			continue;
+		}
+
+		for (int v = 0; v < v_count; v++) {
+			Color c = colors[v];
+			real_t val = 1.0;
+			switch (channel) {
+				case 0: val = c.r; break;
+				case 1: val = c.g; break;
+				case 2: val = c.b; break;
+				case 3: val = c.a; break;
+				case 4: val = c.get_luminance(); break;
+			}
+			if (invert) {
+				val = (real_t)1.0 - val;
+			}
+			val = CLAMP(val, (real_t)0.0, (real_t)1.0);
+
+			int global_idx = global_vertex_offset + v;
+			if (val >= threshold && val > (real_t)0.0) {
+				PinData pd;
+				if (target_pins.has(global_idx)) {
+					pd = target_pins[global_idx];
+				} else {
+					pd.point_index = global_idx;
+				}
+				pd.weight = val;
+				target_pins[global_idx] = pd;
+			} else {
+				// Weight is 0 or below threshold -> remove from target_pins in both replace and merge modes
+				target_pins.erase(global_idx);
+			}
+		}
+		global_vertex_offset += v_count;
+	}
+
+	// Prepare undo state
+	Array prev_indices = node->get("pinned_points");
+	Dictionary prev_props;
+	for (int i = 0; i < prev_indices.size(); i++) {
+		String prefix = vformat("attachments/%d/", i);
+		prev_props[prefix + "point_index"] = node->get(prefix + "point_index");
+		prev_props[prefix + "spatial_attachment_path"] = node->get(prefix + "spatial_attachment_path");
+		prev_props[prefix + "offset"] = node->get(prefix + "offset");
+		prev_props[prefix + "weight"] = node->get(prefix + "weight");
+	}
+
+	// Prepare do state
+	Array new_indices;
+	Dictionary new_props;
+	int pin_idx = 0;
+	for (const KeyValue<int, PinData> &E : target_pins) {
+		if (E.value.point_index < 0 || E.value.weight <= (real_t)0.0) {
+			continue;
+		}
+		new_indices.push_back(E.value.point_index);
+		String prefix = vformat("attachments/%d/", pin_idx);
+		new_props[prefix + "point_index"] = E.value.point_index;
+		new_props[prefix + "spatial_attachment_path"] = E.value.spatial_attachment_path;
+		new_props[prefix + "offset"] = E.value.offset;
+		new_props[prefix + "weight"] = E.value.weight;
+		pin_idx++;
+	}
+
+	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+	ur->create_action(TTR("Set SoftBody3D Pin Weights from Vertex Colors"));
+
+	ur->add_do_property(node, "pinned_points", new_indices);
+	for (const Variant *E = new_props.next(nullptr); E; E = new_props.next(E)) {
+		ur->add_do_property(node, *E, new_props[*E]);
+	}
+
+	ur->add_undo_property(node, "pinned_points", prev_indices);
+	for (const Variant *E = prev_props.next(nullptr); E; E = prev_props.next(E)) {
+		ur->add_undo_property(node, *E, prev_props[*E]);
+	}
+
+	ur->add_do_method(node, "notify_property_list_changed");
+	ur->add_undo_method(node, "notify_property_list_changed");
+	ur->commit_action();
+}
+
+void SoftBody3DEditor::_clear_all_pinned_points() {
+	if (!node) {
+		return;
+	}
+
+	Array prev_indices = node->get("pinned_points");
+	if (prev_indices.is_empty()) {
+		return;
+	}
+
+	Dictionary prev_props;
+	for (int i = 0; i < prev_indices.size(); i++) {
+		String prefix = vformat("attachments/%d/", i);
+		prev_props[prefix + "point_index"] = node->get(prefix + "point_index");
+		prev_props[prefix + "spatial_attachment_path"] = node->get(prefix + "spatial_attachment_path");
+		prev_props[prefix + "offset"] = node->get(prefix + "offset");
+		prev_props[prefix + "weight"] = node->get(prefix + "weight");
+	}
+
+	EditorUndoRedoManager *ur = EditorUndoRedoManager::get_singleton();
+	ur->create_action(TTR("Clear SoftBody3D Pinned Points"));
+
+	ur->add_do_property(node, "pinned_points", Array());
+	ur->add_undo_property(node, "pinned_points", prev_indices);
+	for (const Variant *E = prev_props.next(nullptr); E; E = prev_props.next(E)) {
+		ur->add_undo_property(node, *E, prev_props[*E]);
+	}
+
+	ur->add_do_method(node, "notify_property_list_changed");
+	ur->add_undo_method(node, "notify_property_list_changed");
+	ur->commit_action();
+}
+
+void SoftBody3DEditor::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_ENTER_TREE: {
+			if (options) {
+				options->set_button_icon(EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("SoftBody3D"), EditorStringName(EditorIcons)));
+			}
+		} break;
+	}
+}
+
+void SoftBody3DEditor::edit(SoftBody3D *p_soft_body) {
+	node = p_soft_body;
+}
+
+SoftBody3DEditor::SoftBody3DEditor() {
+	options = memnew(MenuButton);
+	options->set_switch_on_hover(true);
+	options->set_flat(false);
+	options->set_theme_type_variation("FlatMenuButtonNoIconTint");
+	options->set_text(TTR("SoftBody3D"));
+	Node3DEditor::get_singleton()->add_control_to_menu_panel(options);
+
+	options->get_popup()->add_item(TTR("Set Pin Weights from Vertex Colors..."), MENU_OPTION_SET_PIN_WEIGHTS_FROM_VERTEX_COLORS);
+	options->get_popup()->add_separator();
+	options->get_popup()->add_item(TTR("Clear All Pinned Points"), MENU_OPTION_CLEAR_ALL_PINNED_POINTS);
+	options->get_popup()->connect(SceneStringName(id_pressed), callable_mp(this, &SoftBody3DEditor::_menu_option));
+
+	weight_dialog = memnew(ConfirmationDialog);
+	weight_dialog->set_title(TTR("Set Pin Weights from Vertex Colors"));
+	weight_dialog->set_ok_button_text(TTR("Apply"));
+	add_child(weight_dialog);
+	weight_dialog->connect(SceneStringName(confirmed), callable_mp(this, &SoftBody3DEditor::_apply_pin_weights_from_vertex_colors));
+
+	VBoxContainer *vbc = memnew(VBoxContainer);
+	weight_dialog->add_child(vbc);
+
+	Label *lbl_channel = memnew(Label(TTR("Color Channel:")));
+	vbc->add_child(lbl_channel);
+
+	channel_option = memnew(OptionButton);
+	channel_option->add_item(TTR("Red (R)"), 0);
+	channel_option->add_item(TTR("Green (G)"), 1);
+	channel_option->add_item(TTR("Blue (B)"), 2);
+	channel_option->add_item(TTR("Alpha (A)"), 3);
+	channel_option->add_item(TTR("Luminance (Grayscale)"), 4);
+	channel_option->select(0);
+	vbc->add_child(channel_option);
+
+	Label *lbl_thresh = memnew(Label(TTR("Min Weight Threshold:")));
+	vbc->add_child(lbl_thresh);
+
+	threshold_spin = memnew(SpinBox);
+	threshold_spin->set_min(0.0);
+	threshold_spin->set_max(1.0);
+	threshold_spin->set_step(0.001);
+	threshold_spin->set_value(0.01);
+	vbc->add_child(threshold_spin);
+
+	invert_check = memnew(CheckBox(TTR("Invert Weights")));
+	vbc->add_child(invert_check);
+
+	Label *lbl_mode = memnew(Label(TTR("Assignment Mode:")));
+	vbc->add_child(lbl_mode);
+
+	mode_option = memnew(OptionButton);
+	mode_option->add_item(TTR("Replace All Pins"), 0);
+	mode_option->add_item(TTR("Merge / Update Existing Pins"), 1);
+	mode_option->select(0);
+	vbc->add_child(mode_option);
+
+	err_dialog = memnew(AcceptDialog);
+	add_child(err_dialog);
+
+	options->hide();
+}
+
+SoftBody3DEditor::~SoftBody3DEditor() {
+}
+
+void SoftBody3DEditorPlugin::make_visible(bool p_visible) {
+	if (p_visible) {
+		soft_body_editor->options->show();
+	} else {
+		soft_body_editor->options->hide();
+		soft_body_editor->edit(nullptr);
+	}
+}
+
+void SoftBody3DEditorPlugin::edit(Object *p_object) {
+	SoftBody3D *sb = Object::cast_to<SoftBody3D>(p_object);
+	if (sb) {
+		soft_body_editor->edit(sb);
+	}
+}
+
+bool SoftBody3DEditorPlugin::handles(Object *p_object) const {
+	return Object::cast_to<SoftBody3D>(p_object) != nullptr;
+}
+
+SoftBody3DEditorPlugin::SoftBody3DEditorPlugin() {
+	soft_body_editor = memnew(SoftBody3DEditor);
+	EditorNode::get_singleton()->get_gui_base()->add_child(soft_body_editor);
+}

--- a/editor/scene/3d/physics/soft_body_3d_editor_plugin.h
+++ b/editor/scene/3d/physics/soft_body_3d_editor_plugin.h
@@ -1,0 +1,88 @@
+/**************************************************************************/
+/*  soft_body_3d_editor_plugin.h                                         */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "editor/plugins/editor_plugin.h"
+#include "scene/3d/physics/soft_body_3d.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/check_box.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/menu_button.h"
+#include "scene/gui/option_button.h"
+#include "scene/gui/spin_box.h"
+
+class SoftBody3DEditor : public Control {
+	GDCLASS(SoftBody3DEditor, Control);
+
+	enum MenuOption {
+		MENU_OPTION_SET_PIN_WEIGHTS_FROM_VERTEX_COLORS,
+		MENU_OPTION_CLEAR_ALL_PINNED_POINTS,
+	};
+
+	SoftBody3D *node = nullptr;
+
+	MenuButton *options = nullptr;
+	ConfirmationDialog *weight_dialog = nullptr;
+	OptionButton *channel_option = nullptr;
+	SpinBox *threshold_spin = nullptr;
+	CheckBox *invert_check = nullptr;
+	OptionButton *mode_option = nullptr;
+	AcceptDialog *err_dialog = nullptr;
+
+	void _menu_option(int p_option);
+	void _apply_pin_weights_from_vertex_colors();
+	void _clear_all_pinned_points();
+
+	friend class SoftBody3DEditorPlugin;
+
+protected:
+	void _notification(int p_what);
+
+public:
+	void edit(SoftBody3D *p_soft_body);
+
+	SoftBody3DEditor();
+	~SoftBody3DEditor();
+};
+
+class SoftBody3DEditorPlugin : public EditorPlugin {
+	GDCLASS(SoftBody3DEditorPlugin, EditorPlugin);
+
+	SoftBody3DEditor *soft_body_editor = nullptr;
+
+public:
+	virtual String get_plugin_name() const override { return "SoftBody3D"; }
+	virtual void edit(Object *p_object) override;
+	virtual bool handles(Object *p_object) const override;
+	virtual void make_visible(bool p_visible) override;
+
+	SoftBody3DEditorPlugin();
+};

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -1133,6 +1133,34 @@ real_t GodotPhysicsServer3D::soft_body_get_linear_stiffness(RID p_body) const {
 	return soft_body->get_linear_stiffness();
 }
 
+void GodotPhysicsServer3D::soft_body_set_internal_springs(RID p_body, bool p_enabled) {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(soft_body);
+
+	soft_body->set_internal_springs(p_enabled);
+}
+
+bool GodotPhysicsServer3D::soft_body_is_internal_springs_enabled(RID p_body) const {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(soft_body, false);
+
+	return soft_body->is_internal_springs_enabled();
+}
+
+void GodotPhysicsServer3D::soft_body_set_internal_spring_stiffness(RID p_body, real_t p_stiffness) {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(soft_body);
+
+	soft_body->set_internal_spring_stiffness(p_stiffness);
+}
+
+real_t GodotPhysicsServer3D::soft_body_get_internal_spring_stiffness(RID p_body) const {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(soft_body, 0.f);
+
+	return soft_body->get_internal_spring_stiffness();
+}
+
 void GodotPhysicsServer3D::soft_body_set_shrinking_factor(RID p_body, real_t p_shrinking_factor) {
 	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(soft_body);

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -1270,6 +1270,20 @@ bool GodotPhysicsServer3D::soft_body_is_point_pinned(RID p_body, int p_point_ind
 	return soft_body->is_vertex_pinned(p_point_index);
 }
 
+void GodotPhysicsServer3D::soft_body_set_point_weight(RID p_body, int p_point_index, real_t p_weight) {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(soft_body);
+
+	soft_body->set_vertex_weight(p_point_index, p_weight);
+}
+
+real_t GodotPhysicsServer3D::soft_body_get_point_weight(RID p_body, int p_point_index) const {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(soft_body, 1.0);
+
+	return soft_body->get_vertex_weight(p_point_index);
+}
+
 /* JOINT API */
 
 RID GodotPhysicsServer3D::joint_create() {

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -1161,6 +1161,20 @@ real_t GodotPhysicsServer3D::soft_body_get_internal_spring_stiffness(RID p_body)
 	return soft_body->get_internal_spring_stiffness();
 }
 
+void GodotPhysicsServer3D::soft_body_set_internal_spring_damping_coefficient(RID p_body, real_t p_damping_coefficient) {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(soft_body);
+
+	soft_body->set_internal_spring_damping_coefficient(p_damping_coefficient);
+}
+
+real_t GodotPhysicsServer3D::soft_body_get_internal_spring_damping_coefficient(RID p_body) const {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(soft_body, 0.f);
+
+	return soft_body->get_internal_spring_damping_coefficient();
+}
+
 void GodotPhysicsServer3D::soft_body_set_shrinking_factor(RID p_body, real_t p_shrinking_factor) {
 	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(soft_body);
@@ -1201,6 +1215,20 @@ real_t GodotPhysicsServer3D::soft_body_get_damping_coefficient(RID p_body) const
 	ERR_FAIL_NULL_V(soft_body, 0.f);
 
 	return soft_body->get_damping_coefficient();
+}
+
+void GodotPhysicsServer3D::soft_body_set_mesh_damping_coefficient(RID p_body, real_t p_damping_coefficient) {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(soft_body);
+
+	soft_body->set_mesh_damping_coefficient(p_damping_coefficient);
+}
+
+real_t GodotPhysicsServer3D::soft_body_get_mesh_damping_coefficient(RID p_body) const {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(soft_body, 0.f);
+
+	return soft_body->get_mesh_damping_coefficient();
 }
 
 void GodotPhysicsServer3D::soft_body_set_drag_coefficient(RID p_body, real_t p_drag_coefficient) {

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -1119,6 +1119,20 @@ real_t GodotPhysicsServer3D::soft_body_get_total_mass(RID p_body) const {
 	return soft_body->get_total_mass();
 }
 
+void GodotPhysicsServer3D::soft_body_set_gravity_scale(RID p_body, real_t p_gravity_scale) {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(soft_body);
+
+	soft_body->set_gravity_scale(p_gravity_scale);
+}
+
+real_t GodotPhysicsServer3D::soft_body_get_gravity_scale(RID p_body) const {
+	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(soft_body, 0.f);
+
+	return soft_body->get_gravity_scale();
+}
+
 void GodotPhysicsServer3D::soft_body_set_linear_stiffness(RID p_body, real_t p_stiffness) {
 	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(soft_body);

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -294,6 +294,12 @@ public:
 	virtual void soft_body_set_linear_stiffness(RID p_body, real_t p_stiffness) override;
 	virtual real_t soft_body_get_linear_stiffness(RID p_body) const override;
 
+	virtual void soft_body_set_internal_springs(RID p_body, bool p_enabled) override;
+	virtual bool soft_body_is_internal_springs_enabled(RID p_body) const override;
+
+	virtual void soft_body_set_internal_spring_stiffness(RID p_body, real_t p_stiffness) override;
+	virtual real_t soft_body_get_internal_spring_stiffness(RID p_body) const override;
+
 	virtual void soft_body_set_shrinking_factor(RID p_body, real_t p_shrinking_factor) override;
 	virtual real_t soft_body_get_shrinking_factor(RID p_body) const override;
 

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -300,6 +300,9 @@ public:
 	virtual void soft_body_set_internal_spring_stiffness(RID p_body, real_t p_stiffness) override;
 	virtual real_t soft_body_get_internal_spring_stiffness(RID p_body) const override;
 
+	virtual void soft_body_set_internal_spring_damping_coefficient(RID p_body, real_t p_damping_coefficient) override;
+	virtual real_t soft_body_get_internal_spring_damping_coefficient(RID p_body) const override;
+
 	virtual void soft_body_set_shrinking_factor(RID p_body, real_t p_shrinking_factor) override;
 	virtual real_t soft_body_get_shrinking_factor(RID p_body) const override;
 
@@ -308,6 +311,9 @@ public:
 
 	virtual void soft_body_set_damping_coefficient(RID p_body, real_t p_damping_coefficient) override;
 	virtual real_t soft_body_get_damping_coefficient(RID p_body) const override;
+
+	virtual void soft_body_set_mesh_damping_coefficient(RID p_body, real_t p_damping_coefficient) override;
+	virtual real_t soft_body_get_mesh_damping_coefficient(RID p_body) const override;
 
 	virtual void soft_body_set_drag_coefficient(RID p_body, real_t p_drag_coefficient) override;
 	virtual real_t soft_body_get_drag_coefficient(RID p_body) const override;

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -291,6 +291,9 @@ public:
 	virtual void soft_body_set_total_mass(RID p_body, real_t p_total_mass) override;
 	virtual real_t soft_body_get_total_mass(RID p_body) const override;
 
+	virtual void soft_body_set_gravity_scale(RID p_body, real_t p_gravity_scale) override;
+	virtual real_t soft_body_get_gravity_scale(RID p_body) const override;
+
 	virtual void soft_body_set_linear_stiffness(RID p_body, real_t p_stiffness) override;
 	virtual real_t soft_body_get_linear_stiffness(RID p_body) const override;
 

--- a/modules/godot_physics_3d/godot_physics_server_3d.h
+++ b/modules/godot_physics_3d/godot_physics_server_3d.h
@@ -322,6 +322,8 @@ public:
 	virtual void soft_body_remove_all_pinned_points(RID p_body) override;
 	virtual void soft_body_pin_point(RID p_body, int p_point_index, bool p_pin) override;
 	virtual bool soft_body_is_point_pinned(RID p_body, int p_point_index) const override;
+	virtual void soft_body_set_point_weight(RID p_body, int p_point_index, real_t p_weight) override;
+	virtual real_t soft_body_get_point_weight(RID p_body, int p_point_index) const override;
 
 	/* JOINT API */
 

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -1203,6 +1203,10 @@ void GodotSoftBody3D::set_total_mass(real_t p_val) {
 	update_constants();
 }
 
+void GodotSoftBody3D::set_gravity_scale(real_t p_val) {
+	gravity_scale = p_val;
+}
+
 void GodotSoftBody3D::set_collision_margin(real_t p_val) {
 	collision_margin = p_val;
 }
@@ -1363,6 +1367,8 @@ void GodotSoftBody3D::predict_motion(real_t p_delta) {
 		default_area->compute_gravity(get_transform().get_origin(), default_gravity);
 		gravity += default_gravity;
 	}
+
+	gravity *= gravity_scale;
 
 	// Apply forces.
 	add_velocity(gravity * p_delta);

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -324,7 +324,7 @@ void GodotSoftBody3D::set_mesh(RID p_mesh) {
 				int inv_chk = le.v0 * node_count + le.v1;
 				chks[inv_chk] = true;
 
-				append_link(le.v0, le.v1);
+				append_link(le.v0, le.v1, Link::TYPE_INTERNAL_SPRING);
 			}
 		}
 	}
@@ -361,7 +361,7 @@ void GodotSoftBody3D::set_mesh(RID p_mesh) {
 
 				mesh_to_anchor[pinned_vertex] = anchor_idx;
 
-				append_link(node_index, anchor_idx);
+				append_link(node_index, anchor_idx, Link::TYPE_ANCHOR);
 				Link &anchor_link = links[links.size() - 1];
 				anchor_link.rl = 0.0;
 				anchor_link.c1 = 0.0;
@@ -511,8 +511,14 @@ void GodotSoftBody3D::reset_link_rest_lengths() {
 
 void GodotSoftBody3D::update_link_constants() {
 	real_t inv_linear_stiffness = 1.0 / linear_stiffness;
+	real_t inv_internal_stiffness = 1.0 / internal_spring_stiffness;
 	for (Link &link : links) {
-		link.c0 = (link.n[0]->im + link.n[1]->im) * inv_linear_stiffness;
+		if (link.type == Link::TYPE_ANCHOR) {
+			// Anchor link stiffness is calculated from pin weight
+			continue;
+		}
+		real_t inv_stiffness = (link.type == Link::TYPE_INTERNAL_SPRING) ? inv_internal_stiffness : inv_linear_stiffness;
+		link.c0 = (link.n[0]->im + link.n[1]->im) * inv_stiffness;
 	}
 }
 
@@ -1134,7 +1140,7 @@ void GodotSoftBody3D::reoptimize_link_order() {
 	memdelete_arr(link_buffer);
 }
 
-void GodotSoftBody3D::append_link(uint32_t p_node1, uint32_t p_node2) {
+void GodotSoftBody3D::append_link(uint32_t p_node1, uint32_t p_node2, Link::Type p_type) {
 	if (p_node1 == p_node2) {
 		return;
 	}
@@ -1143,6 +1149,7 @@ void GodotSoftBody3D::append_link(uint32_t p_node1, uint32_t p_node2) {
 	Node *node2 = &nodes[p_node2];
 
 	Link link;
+	link.type = p_type;
 	link.n[0] = node1;
 	link.n[1] = node2;
 	link.rl = (node1->x - node2->x).length();
@@ -1218,6 +1225,10 @@ void GodotSoftBody3D::set_internal_spring_stiffness(real_t p_val) {
 	internal_spring_stiffness = CLAMP(p_val, 0.0, 1.0);
 }
 
+void GodotSoftBody3D::set_internal_spring_damping_coefficient(real_t p_val) {
+	internal_spring_damping_coefficient = CLAMP(p_val, 0.0, 1.0);
+}
+
 void GodotSoftBody3D::set_shrinking_factor(real_t p_val) {
 	shrinking_factor = p_val;
 }
@@ -1228,6 +1239,10 @@ void GodotSoftBody3D::set_pressure_coefficient(real_t p_val) {
 
 void GodotSoftBody3D::set_damping_coefficient(real_t p_val) {
 	damping_coefficient = p_val;
+}
+
+void GodotSoftBody3D::set_mesh_damping_coefficient(real_t p_val) {
+	mesh_damping_coefficient = CLAMP(p_val, 0.0, 1.0);
 }
 
 void GodotSoftBody3D::set_drag_coefficient(real_t p_val) {
@@ -1422,7 +1437,53 @@ void GodotSoftBody3D::solve_constraints(real_t p_delta) {
 		node.q = node.x;
 	}
 
+	solve_link_damping();
+
 	update_normals_and_centroids();
+}
+
+void GodotSoftBody3D::solve_link_damping() {
+	if (mesh_damping_coefficient <= CMP_EPSILON && internal_spring_damping_coefficient <= CMP_EPSILON) {
+		return;
+	}
+
+	for (Link &link : links) {
+		real_t damp = 0.0;
+		if (link.type == Link::TYPE_SURFACE) {
+			damp = mesh_damping_coefficient;
+		} else if (link.type == Link::TYPE_INTERNAL_SPRING) {
+			damp = internal_spring_damping_coefficient;
+		} else {
+			// Anchor link
+			// for now, just use the surface damping coefficient
+			damp = mesh_damping_coefficient;
+		}
+
+		if (damp <= CMP_EPSILON) {
+			continue;
+		}
+
+		Node &node_a = *link.n[0];
+		Node &node_b = *link.n[1];
+		real_t w_sum = node_a.im + node_b.im;
+		if (w_sum <= CMP_EPSILON) {
+			continue;
+		}
+
+		Vector3 diff = node_b.x - node_a.x;
+		real_t dist = diff.length();
+		if (dist <= CMP_EPSILON) {
+			continue;
+		}
+
+		Vector3 dir = diff / dist;
+		real_t v_rel_proj = (node_b.v - node_a.v).dot(dir);
+
+		real_t damp_impulse = v_rel_proj * damp;
+
+		node_a.v += dir * (damp_impulse * (node_a.im / w_sum));
+		node_b.v -= dir * (damp_impulse * (node_b.im / w_sum));
+	}
 }
 
 void GodotSoftBody3D::solve_links(real_t kst, real_t ti) {

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -137,22 +137,216 @@ void GodotSoftBody3D::set_mesh(RID p_mesh) {
 		return;
 	}
 
-	// TODO: calling RenderingServer::mesh_surface_get_arrays() from the physics thread
-	// is not safe and can deadlock when physics/3d/run_on_separate_thread is enabled.
-	// This method blocks on the main thread to return data, but the main thread may be
-	// blocked waiting on us in PhysicsServer3D::sync().
-	Array arrays = RenderingServer::get_singleton()->mesh_surface_get_arrays(soft_mesh, 0);
-	ERR_FAIL_COND(arrays.is_empty());
+	if (!internal_springs) {
+		// TODO: calling RenderingServer::mesh_surface_get_arrays() from the physics thread
+		// is not safe and can deadlock when physics/3d/run_on_separate_thread is enabled.
+		// This method blocks on the main thread to return data, but the main thread may be
+		// blocked waiting on us in PhysicsServer3D::sync().
+		Array arrays = RenderingServer::get_singleton()->mesh_surface_get_arrays(soft_mesh, 0);
+		ERR_FAIL_COND(arrays.is_empty());
 
-	const Vector<int> &indices = arrays[RSE::ARRAY_INDEX];
-	const Vector<Vector3> &vertices = arrays[RSE::ARRAY_VERTEX];
-	ERR_FAIL_COND_MSG(indices.is_empty(), "Soft body's mesh needs to have indices");
-	ERR_FAIL_COND_MSG(vertices.is_empty(), "Soft body's mesh needs to have vertices");
+		const Vector<int> &indices = arrays[RSE::ARRAY_INDEX];
+		const Vector<Vector3> &vertices = arrays[RSE::ARRAY_VERTEX];
+		ERR_FAIL_COND_MSG(indices.is_empty(), "Soft body's mesh needs to have indices");
+		ERR_FAIL_COND_MSG(vertices.is_empty(), "Soft body's mesh needs to have vertices");
 
-	bool success = create_from_trimesh(indices, vertices);
-	if (!success) {
-		destroy();
+		bool success = create_from_trimesh(indices, vertices);
+		if (!success) {
+			destroy();
+		}
+		return;
 	}
+
+	// Multi-surface mesh creation with loose edge internal springs
+	RenderingServer *rendering = RenderingServer::get_singleton();
+	int surface_count = rendering->mesh_get_surface_count(soft_mesh);
+	ERR_FAIL_COND(surface_count <= 0);
+
+	uint32_t total_visual_vertices = 0;
+	for (int s = 0; s < surface_count; s++) {
+		Array arrays = rendering->mesh_surface_get_arrays(soft_mesh, s);
+		if (!arrays.is_empty() && arrays.size() > RSE::ARRAY_VERTEX) {
+			const Vector<Vector3> &v = arrays[RSE::ARRAY_VERTEX];
+			total_visual_vertices += v.size();
+		}
+	}
+	ERR_FAIL_COND(total_visual_vertices == 0);
+
+	LocalVector<Vector3> unique_vertices;
+	HashMap<Vector3, uint32_t> unique_vertex_map;
+	map_visual_to_physics.resize(total_visual_vertices);
+
+	struct LooseEdge {
+		uint32_t v0;
+		uint32_t v1;
+	};
+	LocalVector<LooseEdge> loose_edges;
+	LocalVector<int> triangles;
+
+	uint32_t vertex_id_counter = 0;
+	uint32_t global_v_offset = 0;
+
+	for (int s = 0; s < surface_count; s++) {
+		Array arrays = rendering->mesh_surface_get_arrays(soft_mesh, s);
+		if (arrays.is_empty() || arrays.size() <= RSE::ARRAY_VERTEX) {
+			continue;
+		}
+
+		const Vector<Vector3> &mesh_vertices = arrays[RSE::ARRAY_VERTEX];
+		Vector<int> mesh_indices;
+		if (arrays.size() > RSE::ARRAY_INDEX) {
+			mesh_indices = arrays[RSE::ARRAY_INDEX];
+		}
+		const int mesh_vertex_count = mesh_vertices.size();
+		const int mesh_index_count = mesh_indices.size();
+
+		RenderingServerTypes::SurfaceData surface_data = rendering->mesh_get_surface(soft_mesh, s);
+		RSE::PrimitiveType prim_type = surface_data.primitive;
+
+		for (int v = 0; v < mesh_vertex_count; ++v) {
+			const Vector3 &vertex = mesh_vertices[v];
+			HashMap<Vector3, uint32_t>::Iterator e = unique_vertex_map.find(vertex);
+			uint32_t vertex_id;
+			if (e) {
+				vertex_id = e->value;
+			} else {
+				vertex_id = vertex_id_counter++;
+				unique_vertex_map[vertex] = vertex_id;
+				unique_vertices.push_back(vertex);
+			}
+			map_visual_to_physics[global_v_offset + v] = vertex_id;
+		}
+
+		if (prim_type == RSE::PRIMITIVE_TRIANGLES) {
+			if (!mesh_indices.is_empty()) {
+				for (int i = 0; i < mesh_index_count; i += 3) {
+					for (int j = 0; j < 3; ++j) {
+						int visual_idx = global_v_offset + mesh_indices[i + j];
+						triangles.push_back(map_visual_to_physics[visual_idx]);
+					}
+				}
+			} else {
+				for (int i = 0; i + 2 < mesh_vertex_count; i += 3) {
+					for (int j = 0; j < 3; ++j) {
+						int visual_idx = global_v_offset + i + j;
+						triangles.push_back(map_visual_to_physics[visual_idx]);
+					}
+				}
+			}
+		} else if (prim_type == RSE::PRIMITIVE_LINES) {
+			if (!mesh_indices.is_empty()) {
+				for (int i = 0; i + 1 < mesh_index_count; i += 2) {
+					uint32_t p0 = map_visual_to_physics[global_v_offset + mesh_indices[i]];
+					uint32_t p1 = map_visual_to_physics[global_v_offset + mesh_indices[i + 1]];
+					if (p0 != p1) {
+						loose_edges.push_back({ p0, p1 });
+					}
+				}
+			} else {
+				for (int i = 0; i + 1 < mesh_vertex_count; i += 2) {
+					uint32_t p0 = map_visual_to_physics[global_v_offset + i];
+					uint32_t p1 = map_visual_to_physics[global_v_offset + i + 1];
+					if (p0 != p1) {
+						loose_edges.push_back({ p0, p1 });
+					}
+				}
+			}
+		} else if (prim_type == RSE::PRIMITIVE_LINE_STRIP) {
+			if (!mesh_indices.is_empty()) {
+				for (int i = 0; i + 1 < mesh_index_count; ++i) {
+					uint32_t p0 = map_visual_to_physics[global_v_offset + mesh_indices[i]];
+					uint32_t p1 = map_visual_to_physics[global_v_offset + mesh_indices[i + 1]];
+					if (p0 != p1) {
+						loose_edges.push_back({ p0, p1 });
+					}
+				}
+			} else {
+				for (int i = 0; i + 1 < mesh_vertex_count; ++i) {
+					uint32_t p0 = map_visual_to_physics[global_v_offset + i];
+					uint32_t p1 = map_visual_to_physics[global_v_offset + i + 1];
+					if (p0 != p1) {
+						loose_edges.push_back({ p0, p1 });
+					}
+				}
+			}
+		}
+
+		global_v_offset += mesh_vertex_count;
+	}
+
+	uint32_t node_count = unique_vertices.size();
+	ERR_FAIL_COND(node_count == 0);
+
+	nodes.resize(node_count);
+	real_t inv_node_mass = node_count * inv_total_mass;
+	Vector3 leaf_size = Vector3(collision_margin, collision_margin, collision_margin) * 2.0;
+	for (uint32_t i = 0; i < node_count; ++i) {
+		Node &node = nodes[i];
+		node.s = unique_vertices[i];
+		node.x = node.s;
+		node.q = node.s;
+		node.im = inv_node_mass;
+
+		AABB node_aabb(node.x, leaf_size);
+		node.leaf = node_tree.insert(node_aabb, &node);
+		node.index = i;
+	}
+
+	// Create links and faces from triangles
+	LocalVector<bool> chks;
+	chks.resize(node_count * node_count);
+	memset(chks.ptr(), 0, chks.size() * sizeof(bool));
+
+	const uint32_t triangle_count = triangles.size() / 3;
+	for (uint32_t i = 0; i < triangle_count * 3; i += 3) {
+		const int idx[] = { triangles[i], triangles[i + 1], triangles[i + 2] };
+
+		for (int j = 2, k = 0; k < 3; j = k++) {
+			int chk = idx[k] * node_count + idx[j];
+			if (!chks[chk]) {
+				chks[chk] = true;
+				int inv_chk = idx[j] * node_count + idx[k];
+				chks[inv_chk] = true;
+
+				append_link(idx[j], idx[k]);
+			}
+		}
+
+		append_face(idx[0], idx[1], idx[2]);
+	}
+
+	// Create links from loose edges
+	for (const LooseEdge &le : loose_edges) {
+		int chk = le.v1 * node_count + le.v0;
+		if (!chks[chk]) {
+			chks[chk] = true;
+			int inv_chk = le.v0 * node_count + le.v1;
+			chks[inv_chk] = true;
+
+			append_link(le.v0, le.v1);
+		}
+	}
+
+	// Set pinned nodes
+	uint32_t pinned_count = pinned_vertices.size();
+	for (uint32_t i = 0; i < pinned_count; ++i) {
+		int pinned_vertex = pinned_vertices[i];
+		if (pinned_vertex >= (int)total_visual_vertices || pinned_vertex < 0) {
+			continue;
+		}
+		uint32_t node_index = map_visual_to_physics[pinned_vertex];
+		if (node_index < node_count) {
+			Node &node = nodes[node_index];
+			node.im = 0.0;
+		}
+	}
+
+	generate_bending_constraints(2);
+	reoptimize_link_order();
+
+	update_constants();
+	update_normals_and_centroids();
+	update_bounds();
 }
 
 void GodotSoftBody3D::update_rendering_server(PhysicsServer3DRenderingServerHandler *p_rendering_server_handler) {
@@ -924,6 +1118,20 @@ void GodotSoftBody3D::set_collision_margin(real_t p_val) {
 
 void GodotSoftBody3D::set_linear_stiffness(real_t p_val) {
 	linear_stiffness = p_val;
+}
+
+void GodotSoftBody3D::set_internal_springs(bool p_enabled) {
+	if (internal_springs == p_enabled) {
+		return;
+	}
+	internal_springs = p_enabled;
+	if (soft_mesh.is_valid()) {
+		set_mesh(soft_mesh);
+	}
+}
+
+void GodotSoftBody3D::set_internal_spring_stiffness(real_t p_val) {
+	internal_spring_stiffness = CLAMP(p_val, 0.0, 1.0);
 }
 
 void GodotSoftBody3D::set_shrinking_factor(real_t p_val) {

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -315,19 +315,23 @@ void GodotSoftBody3D::set_mesh(RID p_mesh) {
 		append_face(idx[0], idx[1], idx[2]);
 	}
 
-	// Create links from loose edges
-	for (const LooseEdge &le : loose_edges) {
-		int chk = le.v1 * node_count + le.v0;
-		if (!chks[chk]) {
-			chks[chk] = true;
-			int inv_chk = le.v0 * node_count + le.v1;
-			chks[inv_chk] = true;
+	// Create links from loose edges only when enabled
+	if (internal_springs) {
+		for (const LooseEdge &le : loose_edges) {
+			int chk = le.v1 * node_count + le.v0;
+			if (!chks[chk]) {
+				chks[chk] = true;
+				int inv_chk = le.v0 * node_count + le.v1;
+				chks[inv_chk] = true;
 
-			append_link(le.v0, le.v1);
+				append_link(le.v0, le.v1);
+			}
 		}
 	}
 
-	// Set pinned nodes
+	mesh_to_anchor.clear();
+
+	// Set pinned nodes & create anchor spring links for soft-pinned vertices
 	uint32_t pinned_count = pinned_vertices.size();
 	for (uint32_t i = 0; i < pinned_count; ++i) {
 		int pinned_vertex = pinned_vertices[i];
@@ -336,8 +340,34 @@ void GodotSoftBody3D::set_mesh(RID p_mesh) {
 		}
 		uint32_t node_index = map_visual_to_physics[pinned_vertex];
 		if (node_index < node_count) {
-			Node &node = nodes[node_index];
-			node.im = 0.0;
+			float weight = 1.0f;
+			if (pinned_weights.has(pinned_vertex)) {
+				weight = pinned_weights[pinned_vertex];
+			}
+			if (weight >= 0.999f) {
+				nodes[node_index].im = 0.0;
+			} else if (weight > 0.0f) {
+				// Soft pin: create dedicated anchor node (kinematic) and spring link
+				uint32_t anchor_idx = nodes.size();
+				Node anchor_node;
+				anchor_node.s = nodes[node_index].s;
+				anchor_node.x = nodes[node_index].x;
+				anchor_node.q = nodes[node_index].q;
+				anchor_node.im = 0.0;
+				anchor_node.index = anchor_idx;
+				AABB node_aabb(anchor_node.x, leaf_size);
+				anchor_node.leaf = node_tree.insert(node_aabb, &anchor_node);
+				nodes.push_back(anchor_node);
+
+				mesh_to_anchor[pinned_vertex] = anchor_idx;
+
+				append_link(node_index, anchor_idx);
+				Link &anchor_link = links[links.size() - 1];
+				anchor_link.rl = 0.0;
+				anchor_link.c1 = 0.0;
+				real_t kLST = CLAMP(weight, (real_t)0.001, (real_t)1.0);
+				anchor_link.c0 = nodes[node_index].im * kLST;
+			}
 		}
 	}
 
@@ -534,12 +564,25 @@ void GodotSoftBody3D::set_vertex_position(int p_index, const Vector3 &p_position
 	}
 
 	ERR_FAIL_COND(p_index >= (int)map_visual_to_physics.size());
-	uint32_t node_index = map_visual_to_physics[p_index];
-
-	ERR_FAIL_COND(node_index >= nodes.size());
-	Node &node = nodes[node_index];
-	node.q = node.x;
-	node.x = p_position;
+	const HashMap<int, int>::ConstIterator anchor_it = mesh_to_anchor.find(p_index);
+	if (anchor_it) {
+		uint32_t anchor_idx = anchor_it->value;
+		if (anchor_idx < nodes.size()) {
+			Node &node = nodes[anchor_idx];
+			node.q = node.x;
+			node.x = p_position;
+			node.v = Vector3();
+			node.bv = Vector3();
+		}
+	} else {
+		uint32_t node_index = map_visual_to_physics[p_index];
+		ERR_FAIL_COND(node_index >= nodes.size());
+		Node &node = nodes[node_index];
+		node.q = node.x;
+		node.x = p_position;
+		node.v = Vector3();
+		node.bv = Vector3();
+	}
 }
 
 void GodotSoftBody3D::pin_vertex(int p_index) {
@@ -557,7 +600,19 @@ void GodotSoftBody3D::pin_vertex(int p_index) {
 
 		ERR_FAIL_COND(node_index >= nodes.size());
 		Node &node = nodes[node_index];
-		node.im = 0.0;
+
+		real_t weight = 1.0;
+		const HashMap<int, real_t>::ConstIterator E = pinned_weights.find(p_index);
+		if (E) {
+			weight = E->value;
+		}
+
+		if (weight >= 0.999) {
+			node.im = 0.0;
+		} else if (weight > 0.0) {
+			real_t inv_node_mass = nodes.size() * inv_total_mass;
+			node.im = (1.0 - weight) * inv_node_mass;
+		}
 	}
 }
 
@@ -568,6 +623,7 @@ void GodotSoftBody3D::unpin_vertex(int p_index) {
 	for (uint32_t i = 0; i < pinned_count; ++i) {
 		if (p_index == pinned_vertices[i]) {
 			pinned_vertices.remove_at(i);
+			pinned_weights.erase(p_index);
 
 			if (!soft_mesh.is_null()) {
 				ERR_FAIL_COND(p_index >= (int)map_visual_to_physics.size());
@@ -602,6 +658,7 @@ void GodotSoftBody3D::unpin_all_vertices() {
 	}
 
 	pinned_vertices.clear();
+	pinned_weights.clear();
 }
 
 bool GodotSoftBody3D::is_vertex_pinned(int p_index) const {
@@ -615,6 +672,33 @@ bool GodotSoftBody3D::is_vertex_pinned(int p_index) const {
 	}
 
 	return false;
+}
+
+void GodotSoftBody3D::set_vertex_weight(int p_index, real_t p_weight) {
+	pinned_weights[p_index] = CLAMP(p_weight, (real_t)0.0, (real_t)1.0);
+	if (is_vertex_pinned(p_index) && !soft_mesh.is_null()) {
+		ERR_FAIL_COND(p_index >= (int)map_visual_to_physics.size());
+		uint32_t node_index = map_visual_to_physics[p_index];
+
+		ERR_FAIL_COND(node_index >= nodes.size());
+		Node &node = nodes[node_index];
+
+		real_t weight = pinned_weights[p_index];
+		if (weight >= 0.999) {
+			node.im = 0.0;
+		} else {
+			real_t inv_node_mass = nodes.size() * inv_total_mass;
+			node.im = (1.0 - weight) * inv_node_mass;
+		}
+	}
+}
+
+real_t GodotSoftBody3D::get_vertex_weight(int p_index) const {
+	const HashMap<int, real_t>::ConstIterator E = pinned_weights.find(p_index);
+	if (E) {
+		return E->value;
+	}
+	return 1.0;
 }
 
 uint32_t GodotSoftBody3D::get_node_count() const {
@@ -1348,7 +1432,11 @@ void GodotSoftBody3D::solve_links(real_t kst, real_t ti) {
 			Node &node_b = *link.n[1];
 			const Vector3 del = node_b.x - node_a.x;
 			const real_t len = del.length_squared();
-			if (link.c1 + len > CMP_EPSILON) {
+			if (link.rl == 0.0) {
+				const real_t k = (1.0 / link.c0) * kst;
+				node_a.x += del * (k * node_a.im);
+				node_b.x -= del * (k * node_b.im);
+			} else if (link.c1 + len > CMP_EPSILON) {
 				const real_t k = ((link.c1 - len) / (link.c0 * (link.c1 + len))) * kst;
 				node_a.x -= del * (k * node_a.im);
 				node_b.x += del * (k * node_b.im);

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -365,8 +365,9 @@ void GodotSoftBody3D::set_mesh(RID p_mesh) {
 				Link &anchor_link = links[links.size() - 1];
 				anchor_link.rl = 0.0;
 				anchor_link.c1 = 0.0;
-				real_t kLST = CLAMP(weight, (real_t)0.001, (real_t)1.0);
-				anchor_link.c0 = nodes[node_index].im * kLST;
+				int n = MAX(1, iteration_count);
+				real_t eff_weight = normalize_stiffness(CLAMP(weight, (real_t)0.0001, (real_t)1.0), n);
+				anchor_link.c0 = nodes[node_index].im / eff_weight;
 			}
 		}
 	}
@@ -510,8 +511,11 @@ void GodotSoftBody3D::reset_link_rest_lengths() {
 }
 
 void GodotSoftBody3D::update_link_constants() {
-	real_t inv_linear_stiffness = 1.0 / linear_stiffness;
-	real_t inv_internal_stiffness = 1.0 / internal_spring_stiffness;
+	int n = MAX(1, iteration_count);
+	real_t eff_linear_stiffness = normalize_stiffness(CLAMP(linear_stiffness, (real_t)0.0001, (real_t)1.0), n);
+	real_t eff_internal_stiffness = normalize_stiffness(CLAMP(internal_spring_stiffness, (real_t)0.0001, (real_t)1.0), n);
+	real_t inv_linear_stiffness = 1.0 / eff_linear_stiffness;
+	real_t inv_internal_stiffness = 1.0 / eff_internal_stiffness;
 	for (Link &link : links) {
 		if (link.type == Link::TYPE_ANCHOR) {
 			// Anchor link stiffness is calculated from pin weight
@@ -1184,7 +1188,11 @@ void GodotSoftBody3D::append_face(uint32_t p_node1, uint32_t p_node2, uint32_t p
 }
 
 void GodotSoftBody3D::set_iteration_count(int p_val) {
+	if (iteration_count == p_val) {
+		return;
+	}
 	iteration_count = p_val;
+	update_link_constants();
 }
 
 void GodotSoftBody3D::set_total_mass(real_t p_val) {
@@ -1212,7 +1220,11 @@ void GodotSoftBody3D::set_collision_margin(real_t p_val) {
 }
 
 void GodotSoftBody3D::set_linear_stiffness(real_t p_val) {
+	if (linear_stiffness == p_val) {
+		return;
+	}
 	linear_stiffness = p_val;
+	update_link_constants();
 }
 
 void GodotSoftBody3D::set_internal_springs(bool p_enabled) {
@@ -1226,7 +1238,12 @@ void GodotSoftBody3D::set_internal_springs(bool p_enabled) {
 }
 
 void GodotSoftBody3D::set_internal_spring_stiffness(real_t p_val) {
-	internal_spring_stiffness = CLAMP(p_val, 0.0, 1.0);
+	real_t clamped = CLAMP(p_val, 0.0, 1.0);
+	if (internal_spring_stiffness == clamped) {
+		return;
+	}
+	internal_spring_stiffness = clamped;
+	update_link_constants();
 }
 
 void GodotSoftBody3D::set_internal_spring_damping_coefficient(real_t p_val) {

--- a/modules/godot_physics_3d/godot_soft_body_3d.h
+++ b/modules/godot_physics_3d/godot_soft_body_3d.h
@@ -96,6 +96,8 @@ class GodotSoftBody3D : public GodotCollisionObject3D {
 
 	int iteration_count = 5;
 	real_t linear_stiffness = 0.5; // [0,1]
+	bool internal_springs = false;
+	real_t internal_spring_stiffness = 0.5; // [0,1]
 	real_t shrinking_factor = 0.0; // [-1,1]
 	real_t pressure_coefficient = 0.0; // [-inf,+inf]
 	real_t damping_coefficient = 0.01; // [0,1]
@@ -195,6 +197,12 @@ public:
 
 	void set_linear_stiffness(real_t p_val);
 	_FORCE_INLINE_ real_t get_linear_stiffness() const { return linear_stiffness; }
+
+	void set_internal_springs(bool p_enabled);
+	_FORCE_INLINE_ bool is_internal_springs_enabled() const { return internal_springs; }
+
+	void set_internal_spring_stiffness(real_t p_val);
+	_FORCE_INLINE_ real_t get_internal_spring_stiffness() const { return internal_spring_stiffness; }
 
 	void set_shrinking_factor(real_t p_val);
 	_FORCE_INLINE_ real_t get_shrinking_factor() const { return shrinking_factor; }

--- a/modules/godot_physics_3d/godot_soft_body_3d.h
+++ b/modules/godot_physics_3d/godot_soft_body_3d.h
@@ -198,6 +198,13 @@ public:
 	void get_face_points(uint32_t p_face_index, Vector3 &r_point_1, Vector3 &r_point_2, Vector3 &r_point_3) const;
 	Vector3 get_face_normal(uint32_t p_face_index) const;
 
+	_FORCE_INLINE_ static real_t normalize_stiffness(real_t p_stiffness, int p_iterations) {
+		if (p_iterations <= 1 || p_stiffness <= 0.0 || p_stiffness >= 1.0) {
+			return p_stiffness;
+		}
+		return 1.0 - Math::pow(1.0 - p_stiffness, (real_t)1.0 / p_iterations);
+	}
+
 	void set_iteration_count(int p_val);
 	_FORCE_INLINE_ real_t get_iteration_count() const { return iteration_count; }
 

--- a/modules/godot_physics_3d/godot_soft_body_3d.h
+++ b/modules/godot_physics_3d/godot_soft_body_3d.h
@@ -61,6 +61,12 @@ class GodotSoftBody3D : public GodotCollisionObject3D {
 	};
 
 	struct Link {
+		enum Type {
+			TYPE_SURFACE,
+			TYPE_INTERNAL_SPRING,
+			TYPE_ANCHOR,
+		} type = TYPE_SURFACE;
+
 		Vector3 c3; // gradient
 		Node *n[2] = { nullptr, nullptr }; // Node pointers
 		real_t rl = 0.0; // Rest length
@@ -98,9 +104,11 @@ class GodotSoftBody3D : public GodotCollisionObject3D {
 	real_t linear_stiffness = 0.5; // [0,1]
 	bool internal_springs = false;
 	real_t internal_spring_stiffness = 0.5; // [0,1]
+	real_t internal_spring_damping_coefficient = 0.0; // [0,1]
 	real_t shrinking_factor = 0.0; // [-1,1]
 	real_t pressure_coefficient = 0.0; // [-inf,+inf]
 	real_t damping_coefficient = 0.01; // [0,1]
+	real_t mesh_damping_coefficient = 0.0; // [0,1]
 	real_t drag_coefficient = 0.0; // [0,1]
 	LocalVector<int> pinned_vertices;
 	HashMap<int, real_t> pinned_weights;
@@ -208,6 +216,9 @@ public:
 	void set_internal_spring_stiffness(real_t p_val);
 	_FORCE_INLINE_ real_t get_internal_spring_stiffness() const { return internal_spring_stiffness; }
 
+	void set_internal_spring_damping_coefficient(real_t p_val);
+	_FORCE_INLINE_ real_t get_internal_spring_damping_coefficient() const { return internal_spring_damping_coefficient; }
+
 	void set_shrinking_factor(real_t p_val);
 	_FORCE_INLINE_ real_t get_shrinking_factor() const { return shrinking_factor; }
 
@@ -216,6 +227,9 @@ public:
 
 	void set_damping_coefficient(real_t p_val);
 	_FORCE_INLINE_ real_t get_damping_coefficient() const { return damping_coefficient; }
+
+	void set_mesh_damping_coefficient(real_t p_val);
+	_FORCE_INLINE_ real_t get_mesh_damping_coefficient() const { return mesh_damping_coefficient; }
 
 	void set_drag_coefficient(real_t p_val);
 	_FORCE_INLINE_ real_t get_drag_coefficient() const { return drag_coefficient; }
@@ -253,10 +267,11 @@ private:
 	bool create_from_trimesh(const Vector<int> &p_indices, const Vector<Vector3> &p_vertices);
 	void generate_bending_constraints(int p_distance);
 	void reoptimize_link_order();
-	void append_link(uint32_t p_node1, uint32_t p_node2);
+	void append_link(uint32_t p_node1, uint32_t p_node2, Link::Type p_type = Link::TYPE_SURFACE);
 	void append_face(uint32_t p_node1, uint32_t p_node2, uint32_t p_node3);
 
 	void solve_links(real_t kst, real_t ti);
+	void solve_link_damping();
 
 	void initialize_face_tree();
 	void update_face_tree(real_t p_delta);

--- a/modules/godot_physics_3d/godot_soft_body_3d.h
+++ b/modules/godot_physics_3d/godot_soft_body_3d.h
@@ -99,6 +99,7 @@ class GodotSoftBody3D : public GodotCollisionObject3D {
 
 	real_t total_mass = 1.0;
 	real_t inv_total_mass = 1.0;
+	real_t gravity_scale = 1.0;
 
 	int iteration_count = 5;
 	real_t linear_stiffness = 0.5; // [0,1]
@@ -203,6 +204,9 @@ public:
 	void set_total_mass(real_t p_val);
 	_FORCE_INLINE_ real_t get_total_mass() const { return total_mass; }
 	_FORCE_INLINE_ real_t get_total_inv_mass() const { return inv_total_mass; }
+
+	void set_gravity_scale(real_t p_val);
+	_FORCE_INLINE_ real_t get_gravity_scale() const { return gravity_scale; }
 
 	void set_collision_margin(real_t p_val);
 	_FORCE_INLINE_ real_t get_collision_margin() const { return collision_margin; }

--- a/modules/godot_physics_3d/godot_soft_body_3d.h
+++ b/modules/godot_physics_3d/godot_soft_body_3d.h
@@ -103,6 +103,8 @@ class GodotSoftBody3D : public GodotCollisionObject3D {
 	real_t damping_coefficient = 0.01; // [0,1]
 	real_t drag_coefficient = 0.0; // [0,1]
 	LocalVector<int> pinned_vertices;
+	HashMap<int, real_t> pinned_weights;
+	HashMap<int, int> mesh_to_anchor;
 
 	SelfList<GodotSoftBody3D> active_list;
 
@@ -169,6 +171,8 @@ public:
 	void unpin_vertex(int p_index);
 	void unpin_all_vertices();
 	bool is_vertex_pinned(int p_index) const;
+	void set_vertex_weight(int p_index, real_t p_weight);
+	real_t get_vertex_weight(int p_index) const;
 
 	uint32_t get_node_count() const;
 	real_t get_node_inv_mass(uint32_t p_node_index) const;

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -1141,6 +1141,20 @@ real_t JoltPhysicsServer3D::soft_body_get_total_mass(RID p_body) const {
 	return (real_t)body->get_mass();
 }
 
+void JoltPhysicsServer3D::soft_body_set_gravity_scale(RID p_body, real_t p_gravity_scale) {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	return body->set_gravity_scale((float)p_gravity_scale);
+}
+
+real_t JoltPhysicsServer3D::soft_body_get_gravity_scale(RID p_body) const {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, 0.0);
+
+	return (real_t)body->get_gravity_scale();
+}
+
 void JoltPhysicsServer3D::soft_body_set_linear_stiffness(RID p_body, real_t p_coefficient) {
 	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -1183,6 +1183,20 @@ real_t JoltPhysicsServer3D::soft_body_get_internal_spring_stiffness(RID p_body) 
 	return (real_t)body->get_internal_spring_stiffness();
 }
 
+void JoltPhysicsServer3D::soft_body_set_internal_spring_damping_coefficient(RID p_body, real_t p_damping_coefficient) {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	return body->set_internal_spring_damping_coefficient((float)p_damping_coefficient);
+}
+
+real_t JoltPhysicsServer3D::soft_body_get_internal_spring_damping_coefficient(RID p_body) const {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, 0.0);
+
+	return (real_t)body->get_internal_spring_damping_coefficient();
+}
+
 void JoltPhysicsServer3D::soft_body_set_shrinking_factor(RID p_body, real_t p_shrinking_factor) {
 	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
@@ -1223,6 +1237,20 @@ real_t JoltPhysicsServer3D::soft_body_get_damping_coefficient(RID p_body) const 
 	ERR_FAIL_NULL_V(body, 0.0);
 
 	return (real_t)body->get_linear_damping();
+}
+
+void JoltPhysicsServer3D::soft_body_set_mesh_damping_coefficient(RID p_body, real_t p_damping_coefficient) {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	return body->set_mesh_damping_coefficient((float)p_damping_coefficient);
+}
+
+real_t JoltPhysicsServer3D::soft_body_get_mesh_damping_coefficient(RID p_body) const {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, 0.0);
+
+	return (real_t)body->get_mesh_damping_coefficient();
 }
 
 void JoltPhysicsServer3D::soft_body_set_drag_coefficient(RID p_body, real_t p_coefficient) {

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -1278,6 +1278,20 @@ bool JoltPhysicsServer3D::soft_body_is_point_pinned(RID p_body, int p_point_inde
 	return body->is_vertex_pinned(p_point_index);
 }
 
+void JoltPhysicsServer3D::soft_body_set_point_weight(RID p_body, int p_point_index, real_t p_weight) {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->set_vertex_weight(p_point_index, (float)p_weight);
+}
+
+real_t JoltPhysicsServer3D::soft_body_get_point_weight(RID p_body, int p_point_index) const {
+	const JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, 1.0);
+
+	return (real_t)body->get_vertex_weight(p_point_index);
+}
+
 RID JoltPhysicsServer3D::joint_create() {
 	JoltJoint3D *joint = memnew(JoltJoint3D);
 	RID rid = joint_owner.make_rid(joint);

--- a/modules/jolt_physics/jolt_physics_server_3d.cpp
+++ b/modules/jolt_physics/jolt_physics_server_3d.cpp
@@ -1155,6 +1155,34 @@ real_t JoltPhysicsServer3D::soft_body_get_linear_stiffness(RID p_body) const {
 	return (real_t)body->get_stiffness_coefficient();
 }
 
+void JoltPhysicsServer3D::soft_body_set_internal_springs(RID p_body, bool p_enabled) {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->set_internal_springs(p_enabled);
+}
+
+bool JoltPhysicsServer3D::soft_body_is_internal_springs_enabled(RID p_body) const {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, false);
+
+	return body->is_internal_springs_enabled();
+}
+
+void JoltPhysicsServer3D::soft_body_set_internal_spring_stiffness(RID p_body, real_t p_stiffness) {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL(body);
+
+	body->set_internal_spring_stiffness((float)p_stiffness);
+}
+
+real_t JoltPhysicsServer3D::soft_body_get_internal_spring_stiffness(RID p_body) const {
+	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
+	ERR_FAIL_NULL_V(body, 0.0);
+
+	return (real_t)body->get_internal_spring_stiffness();
+}
+
 void JoltPhysicsServer3D::soft_body_set_shrinking_factor(RID p_body, real_t p_shrinking_factor) {
 	JoltSoftBody3D *body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -366,6 +366,8 @@ public:
 
 	virtual void soft_body_pin_point(RID p_body, int p_point_index, bool p_pin) override;
 	virtual bool soft_body_is_point_pinned(RID p_body, int p_point_index) const override;
+	virtual void soft_body_set_point_weight(RID p_body, int p_point_index, real_t p_weight) override;
+	virtual real_t soft_body_get_point_weight(RID p_body, int p_point_index) const override;
 
 	virtual RID joint_create() override;
 	virtual void joint_clear(RID p_joint) override;

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -333,6 +333,9 @@ public:
 	virtual void soft_body_set_total_mass(RID p_body, real_t p_total_mass) override;
 	virtual real_t soft_body_get_total_mass(RID p_body) const override;
 
+	virtual void soft_body_set_gravity_scale(RID p_body, real_t p_gravity_scale) override;
+	virtual real_t soft_body_get_gravity_scale(RID p_body) const override;
+
 	virtual void soft_body_set_linear_stiffness(RID p_body, real_t p_coefficient) override;
 	virtual real_t soft_body_get_linear_stiffness(RID p_body) const override;
 

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -342,6 +342,9 @@ public:
 	virtual void soft_body_set_internal_spring_stiffness(RID p_body, real_t p_stiffness) override;
 	virtual real_t soft_body_get_internal_spring_stiffness(RID p_body) const override;
 
+	virtual void soft_body_set_internal_spring_damping_coefficient(RID p_body, real_t p_damping_coefficient) override;
+	virtual real_t soft_body_get_internal_spring_damping_coefficient(RID p_body) const override;
+
 	virtual void soft_body_set_shrinking_factor(RID p_body, real_t p_shrinking_factor) override;
 	virtual real_t soft_body_get_shrinking_factor(RID p_body) const override;
 
@@ -350,6 +353,9 @@ public:
 
 	virtual void soft_body_set_damping_coefficient(RID p_body, real_t p_coefficient) override;
 	virtual real_t soft_body_get_damping_coefficient(RID p_body) const override;
+
+	virtual void soft_body_set_mesh_damping_coefficient(RID p_body, real_t p_damping_coefficient) override;
+	virtual real_t soft_body_get_mesh_damping_coefficient(RID p_body) const override;
 
 	virtual void soft_body_set_drag_coefficient(RID p_body, real_t p_coefficient) override;
 	virtual real_t soft_body_get_drag_coefficient(RID p_body) const override;

--- a/modules/jolt_physics/jolt_physics_server_3d.h
+++ b/modules/jolt_physics/jolt_physics_server_3d.h
@@ -336,6 +336,12 @@ public:
 	virtual void soft_body_set_linear_stiffness(RID p_body, real_t p_coefficient) override;
 	virtual real_t soft_body_get_linear_stiffness(RID p_body) const override;
 
+	virtual void soft_body_set_internal_springs(RID p_body, bool p_enabled) override;
+	virtual bool soft_body_is_internal_springs_enabled(RID p_body) const override;
+
+	virtual void soft_body_set_internal_spring_stiffness(RID p_body, real_t p_stiffness) override;
+	virtual real_t soft_body_get_internal_spring_stiffness(RID p_body) const override;
+
 	virtual void soft_body_set_shrinking_factor(RID p_body, real_t p_shrinking_factor) override;
 	virtual real_t soft_body_get_shrinking_factor(RID p_body) const override;
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -47,9 +47,20 @@
 namespace {
 
 template <typename TJoltVertex>
-void pin_vertices(const JoltSoftBody3D &p_body, const HashSet<int> &p_pinned_vertices, const LocalVector<int> &p_mesh_to_physics, JPH::Array<TJoltVertex> &r_physics_vertices) {
+void pin_vertices(const JoltSoftBody3D &p_body, const HashSet<int> &p_pinned_vertices, const HashMap<int, float> &p_pinned_weights, const LocalVector<int> &p_mesh_to_physics, const HashMap<int, int> &p_mesh_to_anchor, JPH::Array<TJoltVertex> &r_physics_vertices, float p_mass) {
 	const int mesh_vertex_count = p_mesh_to_physics.size();
 	const int physics_vertex_count = (int)r_physics_vertices.size();
+	const float default_inv_mass = (physics_vertex_count > 0 && p_mass > 0.0f) ? (float)physics_vertex_count / p_mass : 1.0f;
+
+	for (int i = 0; i < physics_vertex_count; ++i) {
+		r_physics_vertices[i].mInvMass = default_inv_mass;
+	}
+
+	for (const KeyValue<int, int> &E : p_mesh_to_anchor) {
+		if (E.value >= 0 && E.value < physics_vertex_count) {
+			r_physics_vertices[E.value].mInvMass = 0.0f;
+		}
+	}
 
 	for (int mesh_index : p_pinned_vertices) {
 		ERR_CONTINUE_MSG(mesh_index < 0 || mesh_index >= mesh_vertex_count, vformat("Index %d of pinned vertex in soft body '%s' is out of bounds. There are only %d vertices in the current mesh.", mesh_index, p_body.to_string(), mesh_vertex_count));
@@ -57,7 +68,15 @@ void pin_vertices(const JoltSoftBody3D &p_body, const HashSet<int> &p_pinned_ver
 		const int physics_index = p_mesh_to_physics[mesh_index];
 		ERR_CONTINUE_MSG(physics_index < 0 || physics_index >= physics_vertex_count, vformat("Index %d of pinned vertex in soft body '%s' is out of bounds. There are only %d vertices in the current mesh. This should not happen. Please report this.", physics_index, p_body.to_string(), physics_vertex_count));
 
-		r_physics_vertices[physics_index].mInvMass = 0.0f;
+		float weight = 1.0f;
+		const HashMap<int, float>::ConstIterator E = p_pinned_weights.find(mesh_index);
+		if (E) {
+			weight = E->value;
+		}
+
+		if (weight >= 0.999f) {
+			r_physics_vertices[physics_index].mInvMass = 0.0f;
+		}
 	}
 }
 
@@ -130,111 +149,6 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings() {
 	// This method blocks on the main thread to return data, but the main thread may be
 	// blocked waiting on us in PhysicsServer3D::sync().
 
-	if (!internal_springs) {
-		// Single-surface (surface 0) standard soft body
-		const Array mesh_data = rendering->mesh_surface_get_arrays(mesh, 0);
-		ERR_FAIL_COND_V(mesh_data.is_empty(), nullptr);
-
-		const PackedInt32Array mesh_indices = mesh_data[RSE::ARRAY_INDEX];
-		ERR_FAIL_COND_V(mesh_indices.is_empty(), nullptr);
-
-		const PackedVector3Array mesh_vertices = mesh_data[RSE::ARRAY_VERTEX];
-		ERR_FAIL_COND_V(mesh_vertices.is_empty(), nullptr);
-
-		JPH::SoftBodySharedSettings *settings = new JPH::SoftBodySharedSettings();
-		JPH::Array<JPH::SoftBodySharedSettings::Vertex> &physics_vertices = settings->mVertices;
-		JPH::Array<JPH::SoftBodySharedSettings::Face> &physics_faces = settings->mFaces;
-
-		HashMap<Vector3, int> vertex_to_physics;
-
-		const int mesh_vertex_count = mesh_vertices.size();
-		const int mesh_index_count = mesh_indices.size();
-
-		mesh_to_physics.resize(mesh_vertex_count);
-		for (int &index : mesh_to_physics) {
-			index = -1;
-		}
-		physics_vertices.reserve(mesh_vertex_count);
-		vertex_to_physics.reserve(mesh_vertex_count);
-
-		int physics_index_count = 0;
-
-		const JPH::RVec3 body_position = jolt_settings->mPosition;
-
-		for (int i = 0; i < mesh_index_count; i += 3) {
-			int physics_face[3];
-
-			for (int j = 0; j < 3; ++j) {
-				const int mesh_index = mesh_indices[i + j];
-				const Vector3 vertex = mesh_vertices[mesh_index];
-
-				HashMap<Vector3, int>::Iterator iter_physics_index = vertex_to_physics.find(vertex);
-
-				if (iter_physics_index == vertex_to_physics.end()) {
-					physics_vertices.emplace_back(JPH::Float3((float)(vertex.x - body_position.GetX()), (float)(vertex.y - body_position.GetY()), (float)(vertex.z - body_position.GetZ())), JPH::Float3(0.0f, 0.0f, 0.0f), 1.0f);
-					iter_physics_index = vertex_to_physics.insert(vertex, physics_index_count++);
-				}
-
-				physics_face[j] = iter_physics_index->value;
-				mesh_to_physics[mesh_index] = iter_physics_index->value;
-			}
-
-			if (physics_face[0] == physics_face[1] || physics_face[0] == physics_face[2] || physics_face[1] == physics_face[2]) {
-				continue; // We skip degenerate faces, since they're problematic, and Jolt will assert about it anyway.
-			}
-
-			// Jolt uses a different winding order, so we swap the indices to account for that.
-			physics_faces.emplace_back((JPH::uint32)physics_face[2], (JPH::uint32)physics_face[1], (JPH::uint32)physics_face[0]);
-		}
-
-		// Pin whatever pinned vertices we have currently. This is used during the `Optimize` call below to order the
-		// constraints. Note that it's fine if the pinned vertices change later, but that will reduce the effectiveness
-		// of the constraints a bit.
-		pin_vertices(*this, pinned_vertices, mesh_to_physics, physics_vertices);
-
-		// Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt uses actual stiffness for its
-		// edge constraints, we must map one to the other.
-		//
-		// Godot uses classic PBD edge constraints, which have a stiffness parameter k that is used in the position correction formula as follows:
-		// delta_x1 = -k * w1 / (w1 + w2) * (l - l0) / l * (x2 - x1)
-		// where k is the stiffness, w1 and w2 are the inverse masses of the two vertices, l is the current length of the edge = |x2 - x1|, l0 is the rest length of the edge, and x1 and x2 are the vertex positions.
-		//
-		// Note that the actual formula used in Godot physics seems to use an approximation of this which avoids calculating the square root:
-		// delta_x1 = -k * w1 / (w1 + w2) * (l^2 - l0^2) / (l^2 + l0^2) * (x2 - x1)
-		//
-		// Jolt uses XPBD which goes as follows:
-		// delta_x1 = -w1 / (w1 + w2 + compliance / dt^2) * (l - l0) / l * (x2 - x1)
-		// where compliance is the inverse of stiffness and dt is the timestep.
-		//
-		// We can derive Jolt's compliance from Godot's stiffness by evaluating:
-		// k * w1 / (w1 + w2) = w1 / (w1 + w2 + compliance / dt^2)
-		// which simplifies to:
-		// compliance = dt^2 * (1 / k - 1) * (w1 + w2)
-
-		// Assuming that the vertices have the same mass:
-		const float w1_plus_w2 = 2.0f * physics_vertices.size() / mass;
-
-		// Calculate time step of a single XPBD iteration
-		const float dt = 1.0f / Engine::get_singleton()->get_user_physics_ticks_per_second() / simulation_precision;
-
-		// Now calculate the compliance
-		const float surface_stiffness = CLAMP(stiffness_coefficient, 0.0001f, 1.0f);
-		const float inverse_stiffness = dt * dt * (1.0f / surface_stiffness - 1.0f) * w1_plus_w2;
-
-		JPH::SoftBodySharedSettings::VertexAttributes vertex_attrib;
-		vertex_attrib.mCompliance = vertex_attrib.mShearCompliance = inverse_stiffness;
-
-		settings->CreateConstraints(&vertex_attrib, 1, JPH::SoftBodySharedSettings::EBendType::None);
-		float multiplier = 1.0f - shrinking_factor;
-		for (JPH::SoftBodySharedSettings::Edge &e : settings->mEdgeConstraints) {
-			e.mRestLength *= multiplier;
-		}
-		settings->Optimize();
-
-		return settings;
-	}
-
-	// Multi-surface parsing with loose edge internal springs
 	const int surface_count = rendering->mesh_get_surface_count(mesh);
 	ERR_FAIL_COND_V(surface_count <= 0, nullptr);
 
@@ -371,7 +285,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings() {
 		global_vertex_offset += mesh_vertex_count;
 	}
 
-	pin_vertices(*this, pinned_vertices, mesh_to_physics, physics_vertices);
+	mesh_to_anchor.clear();
 
 	const float w1_plus_w2 = 2.0f * physics_vertices.size() / mass;
 	const float dt = 1.0f / Engine::get_singleton()->get_user_physics_ticks_per_second() / simulation_precision;
@@ -387,8 +301,8 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings() {
 		e.mRestLength *= multiplier;
 	}
 
-	// Add internal springs from loose edges
-	if (!loose_edges.is_empty()) {
+	// Add internal springs from loose edges only when enabled
+	if (internal_springs && !loose_edges.is_empty()) {
 		const float internal_stiffness = CLAMP(internal_spring_stiffness, 0.0001f, 1.0f);
 		const float internal_compliance = dt * dt * (1.0f / internal_stiffness - 1.0f) * w1_plus_w2;
 		for (const LooseEdge &le : loose_edges) {
@@ -405,7 +319,40 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings() {
 		}
 	}
 
+	// Add anchor vertices and spring edges for soft-pinned points
+	for (int mesh_index : pinned_vertices) {
+		if (mesh_index < 0 || mesh_index >= (int)mesh_to_physics.size()) {
+			continue;
+		}
+		const int mesh_physics_index = mesh_to_physics[mesh_index];
+		if (mesh_physics_index < 0 || mesh_physics_index >= (int)physics_vertices.size()) {
+			continue;
+		}
+
+		float weight = 1.0f;
+		const HashMap<int, float>::ConstIterator E = pinned_weights.find(mesh_index);
+		if (E) {
+			weight = E->value;
+		}
+
+		if (weight > 0.0f && weight < 0.999f) {
+			int anchor_physics_index = (int)physics_vertices.size();
+			const JPH::Float3 &mesh_pos = physics_vertices[mesh_physics_index].mPosition;
+			physics_vertices.emplace_back(mesh_pos, JPH::Float3(0.0f, 0.0f, 0.0f), 0.0f);
+			mesh_to_anchor[mesh_index] = anchor_physics_index;
+
+			const float spring_stiffness = CLAMP(weight, 0.0001f, 1.0f);
+			const float spring_compliance = dt * dt * (1.0f / spring_stiffness - 1.0f) * w1_plus_w2;
+
+			JPH::SoftBodySharedSettings::Edge anchor_edge((JPH::uint32)mesh_physics_index, (JPH::uint32)anchor_physics_index, spring_compliance);
+			anchor_edge.mRestLength = 0.0f;
+			settings->mEdgeConstraints.push_back(anchor_edge);
+		}
+	}
+
+	settings->mVertices = physics_vertices;
 	settings->Optimize();
+	pin_vertices(*this, pinned_vertices, pinned_weights, mesh_to_physics, mesh_to_anchor, settings->mVertices, mass);
 
 	return settings;
 }
@@ -505,7 +452,7 @@ void JoltSoftBody3D::_update_mass() {
 		vertex.mInvMass = inverse_vertex_mass;
 	}
 
-	pin_vertices(*this, pinned_vertices, mesh_to_physics, physics_vertices);
+	pin_vertices(*this, pinned_vertices, pinned_weights, mesh_to_physics, mesh_to_anchor, physics_vertices, mass);
 }
 
 void JoltSoftBody3D::_update_pressure() {
@@ -1017,7 +964,20 @@ void JoltSoftBody3D::set_vertex_position(int p_index, const Vector3 &p_position)
 	JPH::SoftBodyVertex &physics_vertex = physics_vertices[physics_index];
 
 	const JPH::RVec3 center_of_mass = jolt_body->GetCenterOfMassPosition();
-	physics_vertex.mPosition = JPH::Vec3(to_jolt_r(p_position) - center_of_mass);
+	const JPH::Vec3 target_rel_pos = JPH::Vec3(to_jolt_r(p_position) - center_of_mass);
+
+	const HashMap<int, int>::ConstIterator anchor_it = mesh_to_anchor.find(p_index);
+	if (anchor_it) {
+		const int anchor_index = anchor_it->value;
+		if (anchor_index >= 0 && anchor_index < (int)physics_vertices.size()) {
+			physics_vertices[anchor_index].mPosition = target_rel_pos;
+			physics_vertices[anchor_index].mVelocity = JPH::Vec3::sZero();
+		}
+	} else {
+		JPH::SoftBodyVertex &physics_vertex = physics_vertices[physics_index];
+		physics_vertex.mPosition = target_rel_pos;
+		physics_vertex.mVelocity = JPH::Vec3::sZero();
+	}
 
 	_vertices_changed();
 }
@@ -1030,12 +990,14 @@ void JoltSoftBody3D::pin_vertex(int p_index) {
 
 void JoltSoftBody3D::unpin_vertex(int p_index) {
 	pinned_vertices.erase(p_index);
+	pinned_weights.erase(p_index);
 
 	_pins_changed();
 }
 
 void JoltSoftBody3D::unpin_all_vertices() {
 	pinned_vertices.clear();
+	pinned_weights.clear();
 
 	_pins_changed();
 }
@@ -1046,4 +1008,17 @@ bool JoltSoftBody3D::is_vertex_pinned(int p_index) const {
 	ERR_FAIL_INDEX_V(p_index, (int)mesh_to_physics.size(), false);
 
 	return pinned_vertices.has(p_index);
+}
+
+void JoltSoftBody3D::set_vertex_weight(int p_index, float p_weight) {
+	pinned_weights[p_index] = CLAMP(p_weight, 0.0f, 1.0f);
+	_pins_changed();
+}
+
+float JoltSoftBody3D::get_vertex_weight(int p_index) const {
+	const HashMap<int, float>::ConstIterator E = pinned_weights.find(p_index);
+	if (E) {
+		return E->value;
+	}
+	return 1.0f;
 }

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -289,7 +289,8 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings() {
 
 	const float w1_plus_w2 = 2.0f * physics_vertices.size() / mass;
 	const float dt = 1.0f / Engine::get_singleton()->get_user_physics_ticks_per_second() / simulation_precision;
-	const float inverse_stiffness = dt * dt * (1.0f / stiffness_coefficient - 1.0f) * w1_plus_w2;
+	const float eff_stiffness = normalize_stiffness(CLAMP(stiffness_coefficient, 0.0001f, 1.0f), simulation_precision);
+	const float inverse_stiffness = dt * dt * (1.0f / eff_stiffness - 1.0f) * w1_plus_w2;
 
 	JPH::SoftBodySharedSettings::VertexAttributes vertex_attrib;
 	vertex_attrib.mCompliance = vertex_attrib.mShearCompliance = inverse_stiffness;
@@ -310,7 +311,8 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings() {
 	// Add internal springs from loose edges only when enabled
 	if (internal_springs && !loose_edges.is_empty()) {
 		const float internal_stiffness = CLAMP(internal_spring_stiffness, 0.0001f, 1.0f);
-		const float internal_compliance = dt * dt * (1.0f / internal_stiffness - 1.0f) * w1_plus_w2;
+		const float eff_internal_stiffness = normalize_stiffness(internal_stiffness, simulation_precision);
+		const float internal_compliance = dt * dt * (1.0f / eff_internal_stiffness - 1.0f) * w1_plus_w2;
 		for (const LooseEdge &le : loose_edges) {
 			const JPH::Float3 &pos0 = physics_vertices[le.v0].mPosition;
 			const JPH::Float3 &pos1 = physics_vertices[le.v1].mPosition;
@@ -349,7 +351,8 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings() {
 			mesh_to_anchor[mesh_index] = anchor_physics_index;
 
 			const float spring_stiffness = CLAMP(weight, 0.0001f, 1.0f);
-			const float spring_compliance = dt * dt * (1.0f / spring_stiffness - 1.0f) * w1_plus_w2;
+			const float eff_spring_stiffness = normalize_stiffness(spring_stiffness, simulation_precision);
+			const float spring_compliance = dt * dt * (1.0f / eff_spring_stiffness - 1.0f) * w1_plus_w2;
 
 			JPH::SoftBodySharedSettings::Edge anchor_edge((JPH::uint32)mesh_physics_index, (JPH::uint32)anchor_physics_index, spring_compliance);
 			anchor_edge.mRestLength = 0.0f;
@@ -521,6 +524,8 @@ void JoltSoftBody3D::_mesh_changed() {
 }
 
 void JoltSoftBody3D::_simulation_precision_changed() {
+	_update_simulation_precision();
+	_try_rebuild();
 	wake_up();
 }
 
@@ -822,7 +827,13 @@ float JoltSoftBody3D::get_stiffness_coefficient() const {
 }
 
 void JoltSoftBody3D::set_stiffness_coefficient(float p_coefficient) {
-	stiffness_coefficient = CLAMP(p_coefficient, 0.0f, 1.0f);
+	float clamped = CLAMP(p_coefficient, 0.0f, 1.0f);
+	if (unlikely(stiffness_coefficient == clamped)) {
+		return;
+	}
+	stiffness_coefficient = clamped;
+	_try_rebuild();
+	wake_up();
 }
 
 void JoltSoftBody3D::set_internal_springs(bool p_enabled) {
@@ -834,7 +845,13 @@ void JoltSoftBody3D::set_internal_springs(bool p_enabled) {
 }
 
 void JoltSoftBody3D::set_internal_spring_stiffness(float p_stiffness) {
-	internal_spring_stiffness = CLAMP(p_stiffness, 0.0f, 1.0f);
+	float clamped = CLAMP(p_stiffness, 0.0f, 1.0f);
+	if (unlikely(internal_spring_stiffness == clamped)) {
+		return;
+	}
+	internal_spring_stiffness = clamped;
+	_try_rebuild();
+	wake_up();
 }
 
 void JoltSoftBody3D::set_internal_spring_damping_coefficient(float p_damping) {

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -296,6 +296,12 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings() {
 
 	settings->CreateConstraints(&vertex_attrib, 1, JPH::SoftBodySharedSettings::EBendType::None);
 
+	LocalVector<EdgeType> unoptimized_edge_types;
+	unoptimized_edge_types.resize(settings->mEdgeConstraints.size());
+	for (uint32_t i = 0; i < (uint32_t)settings->mEdgeConstraints.size(); ++i) {
+		unoptimized_edge_types[i] = EDGE_TYPE_SURFACE;
+	}
+
 	float multiplier = 1.0f - shrinking_factor;
 	for (JPH::SoftBodySharedSettings::Edge &e : settings->mEdgeConstraints) {
 		e.mRestLength *= multiplier;
@@ -316,6 +322,7 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings() {
 			JPH::SoftBodySharedSettings::Edge edge_constraint((JPH::uint32)le.v0, (JPH::uint32)le.v1, internal_compliance);
 			edge_constraint.mRestLength = rest_len;
 			settings->mEdgeConstraints.push_back(edge_constraint);
+			unoptimized_edge_types.push_back(EDGE_TYPE_INTERNAL_SPRING);
 		}
 	}
 
@@ -347,11 +354,17 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings() {
 			JPH::SoftBodySharedSettings::Edge anchor_edge((JPH::uint32)mesh_physics_index, (JPH::uint32)anchor_physics_index, spring_compliance);
 			anchor_edge.mRestLength = 0.0f;
 			settings->mEdgeConstraints.push_back(anchor_edge);
+			unoptimized_edge_types.push_back(EDGE_TYPE_ANCHOR);
 		}
 	}
 
 	settings->mVertices = physics_vertices;
-	settings->Optimize();
+	JPH::SoftBodySharedSettings::OptimizationResults opt_results;
+	settings->Optimize(opt_results);
+	edge_types.resize(settings->mEdgeConstraints.size());
+	for (uint32_t i = 0; i < (uint32_t)unoptimized_edge_types.size(); ++i) {
+		edge_types[opt_results.mEdgeRemap[i]] = unoptimized_edge_types[i];
+	}
 	pin_vertices(*this, pinned_vertices, pinned_weights, mesh_to_physics, mesh_to_anchor, settings->mVertices, mass);
 
 	return settings;
@@ -615,8 +628,75 @@ Vector3 JoltSoftBody3D::get_velocity_at_position(const Vector3 &p_position) cons
 	return Vector3();
 }
 
+void JoltSoftBody3D::_apply_link_damping(float p_step) {
+	if (mesh_damping_coefficient <= CMP_EPSILON && internal_spring_damping_coefficient <= CMP_EPSILON) {
+		return;
+	}
+
+	if (!jolt_body || jolt_body->IsStatic()) {
+		return;
+	}
+
+	JPH::SoftBodyMotionProperties &motion_properties = static_cast<JPH::SoftBodyMotionProperties &>(*jolt_body->GetMotionPropertiesUnchecked());
+	const JPH::SoftBodySharedSettings *settings = motion_properties.GetSettings();
+	if (!settings) {
+		return;
+	}
+
+	JPH::Array<JPH::SoftBodyVertex> &physics_vertices = motion_properties.GetVertices();
+	const JPH::Array<JPH::SoftBodySharedSettings::Edge> &edge_constraints = settings->mEdgeConstraints;
+
+	uint32_t total_edges = (uint32_t)edge_constraints.size();
+	if (edge_types.size() != total_edges) {
+		return;
+	}
+
+	for (uint32_t i = 0; i < total_edges; ++i) {
+		float damp = 0.0f;
+		EdgeType type = edge_types[i];
+		if (type == EDGE_TYPE_SURFACE) {
+			damp = mesh_damping_coefficient;
+		} else if (type == EDGE_TYPE_INTERNAL_SPRING) {
+			damp = internal_spring_damping_coefficient;
+		} else {
+			// Anchor link
+			// for now, just use the mesh damping coefficient
+			damp = mesh_damping_coefficient;
+		}
+
+		if (damp <= CMP_EPSILON) {
+			continue;
+		}
+
+		const JPH::SoftBodySharedSettings::Edge &edge = edge_constraints[i];
+		JPH::SoftBodyVertex &v0 = physics_vertices[edge.mVertex[0]];
+		JPH::SoftBodyVertex &v1 = physics_vertices[edge.mVertex[1]];
+
+		float w_sum = v0.mInvMass + v1.mInvMass;
+		if (w_sum <= CMP_EPSILON) {
+			continue;
+		}
+
+		JPH::Vec3 diff = v1.mPosition - v0.mPosition;
+		float dist_sq = diff.LengthSq();
+		if (dist_sq <= 1.0e-12f) {
+			continue;
+		}
+
+		float dist = Math::sqrt(dist_sq);
+		JPH::Vec3 dir = diff / dist;
+		float v_rel_proj = (v1.mVelocity - v0.mVelocity).Dot(dir);
+
+		float damp_impulse = v_rel_proj * damp;
+
+		v0.mVelocity += dir * (damp_impulse * (v0.mInvMass / w_sum));
+		v1.mVelocity -= dir * (damp_impulse * (v1.mInvMass / w_sum));
+	}
+}
+
 void JoltSoftBody3D::pre_step(float p_step) {
 	_apply_environmental_forces(p_step);
+	_apply_link_damping(p_step);
 }
 
 void JoltSoftBody3D::set_mesh(const RID &p_mesh) {
@@ -749,7 +829,14 @@ void JoltSoftBody3D::set_internal_springs(bool p_enabled) {
 
 void JoltSoftBody3D::set_internal_spring_stiffness(float p_stiffness) {
 	internal_spring_stiffness = CLAMP(p_stiffness, 0.0f, 1.0f);
-	_try_rebuild();
+}
+
+void JoltSoftBody3D::set_internal_spring_damping_coefficient(float p_damping) {
+	if (unlikely(internal_spring_damping_coefficient == p_damping)) {
+		return;
+	}
+
+	internal_spring_damping_coefficient = CLAMP(p_damping, 0.0f, 1.0f);
 }
 
 float JoltSoftBody3D::get_shrinking_factor() const {
@@ -778,6 +865,14 @@ void JoltSoftBody3D::set_linear_damping(float p_damping) {
 	linear_damping = MAX(p_damping, 0.0f);
 
 	_damping_changed();
+}
+
+void JoltSoftBody3D::set_mesh_damping_coefficient(float p_damping) {
+	if (unlikely(mesh_damping_coefficient == p_damping)) {
+		return;
+	}
+
+	mesh_damping_coefficient = CLAMP(p_damping, 0.0f, 1.0f);
 }
 
 float JoltSoftBody3D::get_drag() const {

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -395,6 +395,8 @@ void JoltSoftBody3D::_apply_environmental_forces(float p_step) {
 		gravity += space->get_default_area()->compute_gravity(com_position);
 	}
 
+	gravity *= gravity_scale;
+
 	// Apply gravity to soft body. Note that this only works so long as vertices have uniform mass (excluding pinned vertices).
 	jolt_body->AddForce(to_jolt(gravity) * mass);
 
@@ -809,6 +811,10 @@ void JoltSoftBody3D::set_mass(float p_mass) {
 	mass = p_mass;
 
 	_mass_changed();
+}
+
+void JoltSoftBody3D::set_gravity_scale(float p_gravity_scale) {
+	gravity_scale = p_gravity_scale;
 }
 
 float JoltSoftBody3D::get_stiffness_coefficient() const {

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.cpp
@@ -129,14 +129,114 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings() {
 	// is not safe and can deadlock when physics/3d/run_on_separate_thread is enabled.
 	// This method blocks on the main thread to return data, but the main thread may be
 	// blocked waiting on us in PhysicsServer3D::sync().
-	const Array mesh_data = rendering->mesh_surface_get_arrays(mesh, 0);
-	ERR_FAIL_COND_V(mesh_data.is_empty(), nullptr);
 
-	const PackedInt32Array mesh_indices = mesh_data[RSE::ARRAY_INDEX];
-	ERR_FAIL_COND_V(mesh_indices.is_empty(), nullptr);
+	if (!internal_springs) {
+		// Single-surface (surface 0) standard soft body
+		const Array mesh_data = rendering->mesh_surface_get_arrays(mesh, 0);
+		ERR_FAIL_COND_V(mesh_data.is_empty(), nullptr);
 
-	const PackedVector3Array mesh_vertices = mesh_data[RSE::ARRAY_VERTEX];
-	ERR_FAIL_COND_V(mesh_vertices.is_empty(), nullptr);
+		const PackedInt32Array mesh_indices = mesh_data[RSE::ARRAY_INDEX];
+		ERR_FAIL_COND_V(mesh_indices.is_empty(), nullptr);
+
+		const PackedVector3Array mesh_vertices = mesh_data[RSE::ARRAY_VERTEX];
+		ERR_FAIL_COND_V(mesh_vertices.is_empty(), nullptr);
+
+		JPH::SoftBodySharedSettings *settings = new JPH::SoftBodySharedSettings();
+		JPH::Array<JPH::SoftBodySharedSettings::Vertex> &physics_vertices = settings->mVertices;
+		JPH::Array<JPH::SoftBodySharedSettings::Face> &physics_faces = settings->mFaces;
+
+		HashMap<Vector3, int> vertex_to_physics;
+
+		const int mesh_vertex_count = mesh_vertices.size();
+		const int mesh_index_count = mesh_indices.size();
+
+		mesh_to_physics.resize(mesh_vertex_count);
+		for (int &index : mesh_to_physics) {
+			index = -1;
+		}
+		physics_vertices.reserve(mesh_vertex_count);
+		vertex_to_physics.reserve(mesh_vertex_count);
+
+		int physics_index_count = 0;
+
+		const JPH::RVec3 body_position = jolt_settings->mPosition;
+
+		for (int i = 0; i < mesh_index_count; i += 3) {
+			int physics_face[3];
+
+			for (int j = 0; j < 3; ++j) {
+				const int mesh_index = mesh_indices[i + j];
+				const Vector3 vertex = mesh_vertices[mesh_index];
+
+				HashMap<Vector3, int>::Iterator iter_physics_index = vertex_to_physics.find(vertex);
+
+				if (iter_physics_index == vertex_to_physics.end()) {
+					physics_vertices.emplace_back(JPH::Float3((float)(vertex.x - body_position.GetX()), (float)(vertex.y - body_position.GetY()), (float)(vertex.z - body_position.GetZ())), JPH::Float3(0.0f, 0.0f, 0.0f), 1.0f);
+					iter_physics_index = vertex_to_physics.insert(vertex, physics_index_count++);
+				}
+
+				physics_face[j] = iter_physics_index->value;
+				mesh_to_physics[mesh_index] = iter_physics_index->value;
+			}
+
+			if (physics_face[0] == physics_face[1] || physics_face[0] == physics_face[2] || physics_face[1] == physics_face[2]) {
+				continue; // We skip degenerate faces, since they're problematic, and Jolt will assert about it anyway.
+			}
+
+			// Jolt uses a different winding order, so we swap the indices to account for that.
+			physics_faces.emplace_back((JPH::uint32)physics_face[2], (JPH::uint32)physics_face[1], (JPH::uint32)physics_face[0]);
+		}
+
+		// Pin whatever pinned vertices we have currently. This is used during the `Optimize` call below to order the
+		// constraints. Note that it's fine if the pinned vertices change later, but that will reduce the effectiveness
+		// of the constraints a bit.
+		pin_vertices(*this, pinned_vertices, mesh_to_physics, physics_vertices);
+
+		// Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt uses actual stiffness for its
+		// edge constraints, we must map one to the other.
+		//
+		// Godot uses classic PBD edge constraints, which have a stiffness parameter k that is used in the position correction formula as follows:
+		// delta_x1 = -k * w1 / (w1 + w2) * (l - l0) / l * (x2 - x1)
+		// where k is the stiffness, w1 and w2 are the inverse masses of the two vertices, l is the current length of the edge = |x2 - x1|, l0 is the rest length of the edge, and x1 and x2 are the vertex positions.
+		//
+		// Note that the actual formula used in Godot physics seems to use an approximation of this which avoids calculating the square root:
+		// delta_x1 = -k * w1 / (w1 + w2) * (l^2 - l0^2) / (l^2 + l0^2) * (x2 - x1)
+		//
+		// Jolt uses XPBD which goes as follows:
+		// delta_x1 = -w1 / (w1 + w2 + compliance / dt^2) * (l - l0) / l * (x2 - x1)
+		// where compliance is the inverse of stiffness and dt is the timestep.
+		//
+		// We can derive Jolt's compliance from Godot's stiffness by evaluating:
+		// k * w1 / (w1 + w2) = w1 / (w1 + w2 + compliance / dt^2)
+		// which simplifies to:
+		// compliance = dt^2 * (1 / k - 1) * (w1 + w2)
+
+		// Assuming that the vertices have the same mass:
+		const float w1_plus_w2 = 2.0f * physics_vertices.size() / mass;
+
+		// Calculate time step of a single XPBD iteration
+		const float dt = 1.0f / Engine::get_singleton()->get_user_physics_ticks_per_second() / simulation_precision;
+
+		// Now calculate the compliance
+		const float surface_stiffness = CLAMP(stiffness_coefficient, 0.0001f, 1.0f);
+		const float inverse_stiffness = dt * dt * (1.0f / surface_stiffness - 1.0f) * w1_plus_w2;
+
+		JPH::SoftBodySharedSettings::VertexAttributes vertex_attrib;
+		vertex_attrib.mCompliance = vertex_attrib.mShearCompliance = inverse_stiffness;
+
+		settings->CreateConstraints(&vertex_attrib, 1, JPH::SoftBodySharedSettings::EBendType::None);
+		float multiplier = 1.0f - shrinking_factor;
+		for (JPH::SoftBodySharedSettings::Edge &e : settings->mEdgeConstraints) {
+			e.mRestLength *= multiplier;
+		}
+		settings->Optimize();
+
+		return settings;
+	}
+
+	// Multi-surface parsing with loose edge internal springs
+	const int surface_count = rendering->mesh_get_surface_count(mesh);
+	ERR_FAIL_COND_V(surface_count <= 0, nullptr);
 
 	JPH::SoftBodySharedSettings *settings = new JPH::SoftBodySharedSettings();
 	JPH::Array<JPH::SoftBodySharedSettings::Vertex> &physics_vertices = settings->mVertices;
@@ -144,27 +244,53 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings() {
 
 	HashMap<Vector3, int> vertex_to_physics;
 
-	const int mesh_vertex_count = mesh_vertices.size();
-	const int mesh_index_count = mesh_indices.size();
+	int total_mesh_vertices = 0;
+	for (int s = 0; s < surface_count; s++) {
+		const Array surface_arrays = rendering->mesh_surface_get_arrays(mesh, s);
+		if (!surface_arrays.is_empty() && surface_arrays.size() > RSE::ARRAY_VERTEX) {
+			const PackedVector3Array verts = surface_arrays[RSE::ARRAY_VERTEX];
+			total_mesh_vertices += verts.size();
+		}
+	}
+	ERR_FAIL_COND_V(total_mesh_vertices == 0, nullptr);
 
-	mesh_to_physics.resize(mesh_vertex_count);
+	mesh_to_physics.resize(total_mesh_vertices);
 	for (int &index : mesh_to_physics) {
 		index = -1;
 	}
-	physics_vertices.reserve(mesh_vertex_count);
-	vertex_to_physics.reserve(mesh_vertex_count);
+	physics_vertices.reserve(total_mesh_vertices);
+	vertex_to_physics.reserve(total_mesh_vertices);
 
 	int physics_index_count = 0;
-
 	const JPH::RVec3 body_position = jolt_settings->mPosition;
 
-	for (int i = 0; i < mesh_index_count; i += 3) {
-		int physics_face[3];
+	struct LooseEdge {
+		int v0;
+		int v1;
+	};
+	LocalVector<LooseEdge> loose_edges;
 
-		for (int j = 0; j < 3; ++j) {
-			const int mesh_index = mesh_indices[i + j];
-			const Vector3 vertex = mesh_vertices[mesh_index];
+	int global_vertex_offset = 0;
 
+	for (int s = 0; s < surface_count; s++) {
+		const Array surface_arrays = rendering->mesh_surface_get_arrays(mesh, s);
+		if (surface_arrays.is_empty() || surface_arrays.size() <= RSE::ARRAY_VERTEX) {
+			continue;
+		}
+
+		const PackedVector3Array mesh_vertices = surface_arrays[RSE::ARRAY_VERTEX];
+		PackedInt32Array mesh_indices;
+		if (surface_arrays.size() > RSE::ARRAY_INDEX) {
+			mesh_indices = surface_arrays[RSE::ARRAY_INDEX];
+		}
+		const int mesh_vertex_count = mesh_vertices.size();
+		const int mesh_index_count = mesh_indices.size();
+
+		RenderingServerTypes::SurfaceData surface_data = rendering->mesh_get_surface(mesh, s);
+		RSE::PrimitiveType prim_type = surface_data.primitive;
+
+		for (int v = 0; v < mesh_vertex_count; ++v) {
+			const Vector3 vertex = mesh_vertices[v];
 			HashMap<Vector3, int>::Iterator iter_physics_index = vertex_to_physics.find(vertex);
 
 			if (iter_physics_index == vertex_to_physics.end()) {
@@ -172,59 +298,113 @@ JPH::SoftBodySharedSettings *JoltSoftBody3D::_create_shared_settings() {
 				iter_physics_index = vertex_to_physics.insert(vertex, physics_index_count++);
 			}
 
-			physics_face[j] = iter_physics_index->value;
-			mesh_to_physics[mesh_index] = iter_physics_index->value;
+			mesh_to_physics[global_vertex_offset + v] = iter_physics_index->value;
 		}
 
-		if (physics_face[0] == physics_face[1] || physics_face[0] == physics_face[2] || physics_face[1] == physics_face[2]) {
-			continue; // We skip degenerate faces, since they're problematic, and Jolt will assert about it anyway.
+		if (prim_type == RSE::PRIMITIVE_TRIANGLES) {
+			if (!mesh_indices.is_empty()) {
+				for (int i = 0; i < mesh_index_count; i += 3) {
+					int physics_face[3];
+					for (int j = 0; j < 3; ++j) {
+						int local_idx = mesh_indices[i + j];
+						physics_face[j] = mesh_to_physics[global_vertex_offset + local_idx];
+					}
+
+					if (physics_face[0] == physics_face[1] || physics_face[0] == physics_face[2] || physics_face[1] == physics_face[2]) {
+						continue;
+					}
+
+					physics_faces.emplace_back((JPH::uint32)physics_face[2], (JPH::uint32)physics_face[1], (JPH::uint32)physics_face[0]);
+				}
+			} else {
+				for (int i = 0; i + 2 < mesh_vertex_count; i += 3) {
+					int physics_face[3];
+					for (int j = 0; j < 3; ++j) {
+						physics_face[j] = mesh_to_physics[global_vertex_offset + i + j];
+					}
+
+					if (physics_face[0] == physics_face[1] || physics_face[0] == physics_face[2] || physics_face[1] == physics_face[2]) {
+						continue;
+					}
+
+					physics_faces.emplace_back((JPH::uint32)physics_face[2], (JPH::uint32)physics_face[1], (JPH::uint32)physics_face[0]);
+				}
+			}
+		} else if (prim_type == RSE::PRIMITIVE_LINES) {
+			if (!mesh_indices.is_empty()) {
+				for (int i = 0; i + 1 < mesh_index_count; i += 2) {
+					int p0 = mesh_to_physics[global_vertex_offset + mesh_indices[i]];
+					int p1 = mesh_to_physics[global_vertex_offset + mesh_indices[i + 1]];
+					if (p0 != p1) {
+						loose_edges.push_back({ p0, p1 });
+					}
+				}
+			} else {
+				for (int i = 0; i + 1 < mesh_vertex_count; i += 2) {
+					int p0 = mesh_to_physics[global_vertex_offset + i];
+					int p1 = mesh_to_physics[global_vertex_offset + i + 1];
+					if (p0 != p1) {
+						loose_edges.push_back({ p0, p1 });
+					}
+				}
+			}
+		} else if (prim_type == RSE::PRIMITIVE_LINE_STRIP) {
+			if (!mesh_indices.is_empty()) {
+				for (int i = 0; i + 1 < mesh_index_count; ++i) {
+					int p0 = mesh_to_physics[global_vertex_offset + mesh_indices[i]];
+					int p1 = mesh_to_physics[global_vertex_offset + mesh_indices[i + 1]];
+					if (p0 != p1) {
+						loose_edges.push_back({ p0, p1 });
+					}
+				}
+			} else {
+				for (int i = 0; i + 1 < mesh_vertex_count; ++i) {
+					int p0 = mesh_to_physics[global_vertex_offset + i];
+					int p1 = mesh_to_physics[global_vertex_offset + i + 1];
+					if (p0 != p1) {
+						loose_edges.push_back({ p0, p1 });
+					}
+				}
+			}
 		}
 
-		// Jolt uses a different winding order, so we swap the indices to account for that.
-		physics_faces.emplace_back((JPH::uint32)physics_face[2], (JPH::uint32)physics_face[1], (JPH::uint32)physics_face[0]);
+		global_vertex_offset += mesh_vertex_count;
 	}
 
-	// Pin whatever pinned vertices we have currently. This is used during the `Optimize` call below to order the
-	// constraints. Note that it's fine if the pinned vertices change later, but that will reduce the effectiveness
-	// of the constraints a bit.
 	pin_vertices(*this, pinned_vertices, mesh_to_physics, physics_vertices);
 
-	// Since Godot's stiffness is input as a coefficient between 0 and 1, and Jolt uses actual stiffness for its
-	// edge constraints, we must map one to the other.
-	//
-	// Godot uses classic PBD edge constraints, which have a stiffness parameter k that is used in the position correction formula as follows:
-	// delta_x1 = -k * w1 / (w1 + w2) * (l - l0) / l * (x2 - x1)
-	// where k is the stiffness, w1 and w2 are the inverse masses of the two vertices, l is the current length of the edge = |x2 - x1|, l0 is the rest length of the edge, and x1 and x2 are the vertex positions.
-	//
-	// Note that the actual formula used in Godot physics seems to use an approximation of this which avoids calculating the square root:
-	// delta_x1 = -k * w1 / (w1 + w2) * (l^2 - l0^2) / (l^2 + l0^2) * (x2 - x1)
-	//
-	// Jolt uses XPBD which goes as follows:
-	// delta_x1 = -w1 / (w1 + w2 + compliance / dt^2) * (l - l0) / l * (x2 - x1)
-	// where compliance is the inverse of stiffness and dt is the timestep.
-	//
-	// We can derive Jolt's compliance from Godot's stiffness by evaluating:
-	// k * w1 / (w1 + w2) = w1 / (w1 + w2 + compliance / dt^2)
-	// which simplifies to:
-	// compliance = dt^2 * (1 / k - 1) * (w1 + w2)
-
-	// Assuming that the vertices have the same mass:
 	const float w1_plus_w2 = 2.0f * physics_vertices.size() / mass;
-
-	// Calculate time step of a single XPBD iteration
 	const float dt = 1.0f / Engine::get_singleton()->get_user_physics_ticks_per_second() / simulation_precision;
-
-	// Now calculate the compliance
 	const float inverse_stiffness = dt * dt * (1.0f / stiffness_coefficient - 1.0f) * w1_plus_w2;
 
 	JPH::SoftBodySharedSettings::VertexAttributes vertex_attrib;
 	vertex_attrib.mCompliance = vertex_attrib.mShearCompliance = inverse_stiffness;
 
 	settings->CreateConstraints(&vertex_attrib, 1, JPH::SoftBodySharedSettings::EBendType::None);
+
 	float multiplier = 1.0f - shrinking_factor;
 	for (JPH::SoftBodySharedSettings::Edge &e : settings->mEdgeConstraints) {
 		e.mRestLength *= multiplier;
 	}
+
+	// Add internal springs from loose edges
+	if (!loose_edges.is_empty()) {
+		const float internal_stiffness = CLAMP(internal_spring_stiffness, 0.0001f, 1.0f);
+		const float internal_compliance = dt * dt * (1.0f / internal_stiffness - 1.0f) * w1_plus_w2;
+		for (const LooseEdge &le : loose_edges) {
+			const JPH::Float3 &pos0 = physics_vertices[le.v0].mPosition;
+			const JPH::Float3 &pos1 = physics_vertices[le.v1].mPosition;
+			float dx = pos0.x - pos1.x;
+			float dy = pos0.y - pos1.y;
+			float dz = pos0.z - pos1.z;
+			float rest_len = Math::sqrt(dx * dx + dy * dy + dz * dz) * multiplier;
+
+			JPH::SoftBodySharedSettings::Edge edge_constraint((JPH::uint32)le.v0, (JPH::uint32)le.v1, internal_compliance);
+			edge_constraint.mRestLength = rest_len;
+			settings->mEdgeConstraints.push_back(edge_constraint);
+		}
+	}
+
 	settings->Optimize();
 
 	return settings;
@@ -612,6 +792,19 @@ void JoltSoftBody3D::set_stiffness_coefficient(float p_coefficient) {
 	stiffness_coefficient = CLAMP(p_coefficient, 0.0f, 1.0f);
 }
 
+void JoltSoftBody3D::set_internal_springs(bool p_enabled) {
+	if (internal_springs == p_enabled) {
+		return;
+	}
+	internal_springs = p_enabled;
+	_try_rebuild();
+}
+
+void JoltSoftBody3D::set_internal_spring_stiffness(float p_stiffness) {
+	internal_spring_stiffness = CLAMP(p_stiffness, 0.0f, 1.0f);
+	_try_rebuild();
+}
+
 float JoltSoftBody3D::get_shrinking_factor() const {
 	return shrinking_factor;
 }
@@ -851,7 +1044,6 @@ bool JoltSoftBody3D::is_vertex_pinned(int p_index) const {
 	ERR_FAIL_COND_V_MSG(!in_space(), false, vformat("Failed retrieve pin status of point for '%s'. Doing so without a physics space is not supported when using Jolt Physics. If this relates to a node, try adding the node to a scene tree first.", to_string()));
 
 	ERR_FAIL_INDEX_V(p_index, (int)mesh_to_physics.size(), false);
-	const int physics_index = mesh_to_physics[p_index];
 
-	return pinned_vertices.has(physics_index);
+	return pinned_vertices.has(p_index);
 }

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -147,6 +147,13 @@ public:
 	void put_to_sleep() { set_is_sleeping(true); }
 	void wake_up() { set_is_sleeping(false); }
 
+	_FORCE_INLINE_ static float normalize_stiffness(float p_stiffness, int p_precision) {
+		if (p_precision <= 1 || p_stiffness <= 0.0f || p_stiffness >= 1.0f) {
+			return p_stiffness;
+		}
+		return 1.0f - Math::pow(1.0f - p_stiffness, 1.0f / (float)p_precision);
+	}
+
 	int get_simulation_precision() const { return simulation_precision; }
 	void set_simulation_precision(int p_precision);
 

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -45,6 +45,8 @@ class PhysicsServer3DRenderingServerHandler;
 
 class JoltSoftBody3D final : public JoltObject3D {
 	HashSet<int> pinned_vertices;
+	HashMap<int, float> pinned_weights;
+	HashMap<int, int> mesh_to_anchor;
 
 	LocalVector<int> mesh_to_physics;
 	LocalVector<JoltArea3D *> areas;
@@ -180,6 +182,8 @@ public:
 	void unpin_all_vertices();
 
 	bool is_vertex_pinned(int p_index) const;
+	void set_vertex_weight(int p_index, float p_weight);
+	float get_vertex_weight(int p_index) const;
 
 	void apply_vertex_impulse(int p_index, const Vector3 &p_impulse);
 	void apply_vertex_force(int p_index, const Vector3 &p_force);

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -65,6 +65,7 @@ class JoltSoftBody3D final : public JoltObject3D {
 	JPH::SoftBodyCreationSettings *jolt_settings = new JPH::SoftBodyCreationSettings();
 
 	float mass = 1.0f;
+	float gravity_scale = 1.0f;
 	float pressure = 0.0f;
 	float linear_damping = 0.01f;
 	float mesh_damping_coefficient = 0.0f;
@@ -151,6 +152,9 @@ public:
 
 	float get_mass() const { return mass; }
 	void set_mass(float p_mass);
+
+	float get_gravity_scale() const { return gravity_scale; }
+	void set_gravity_scale(float p_gravity_scale);
 
 	float get_stiffness_coefficient() const;
 	void set_stiffness_coefficient(float p_coefficient);

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -59,6 +59,8 @@ class JoltSoftBody3D final : public JoltObject3D {
 	float pressure = 0.0f;
 	float linear_damping = 0.01f;
 	float stiffness_coefficient = 0.5f;
+	bool internal_springs = false;
+	float internal_spring_stiffness = 0.5f;
 	float shrinking_factor = 0.0f;
 
 	int simulation_precision = 5;
@@ -140,6 +142,12 @@ public:
 
 	float get_stiffness_coefficient() const;
 	void set_stiffness_coefficient(float p_coefficient);
+
+	bool is_internal_springs_enabled() const { return internal_springs; }
+	void set_internal_springs(bool p_enabled);
+
+	float get_internal_spring_stiffness() const { return internal_spring_stiffness; }
+	void set_internal_spring_stiffness(float p_stiffness);
 
 	float get_shrinking_factor() const;
 	void set_shrinking_factor(float p_shrinking_factor);

--- a/modules/jolt_physics/objects/jolt_soft_body_3d.h
+++ b/modules/jolt_physics/objects/jolt_soft_body_3d.h
@@ -44,6 +44,12 @@ class JoltSpace3D;
 class PhysicsServer3DRenderingServerHandler;
 
 class JoltSoftBody3D final : public JoltObject3D {
+	enum EdgeType : uint8_t {
+		EDGE_TYPE_SURFACE,
+		EDGE_TYPE_INTERNAL_SPRING,
+		EDGE_TYPE_ANCHOR,
+	};
+
 	HashSet<int> pinned_vertices;
 	HashMap<int, float> pinned_weights;
 	HashMap<int, int> mesh_to_anchor;
@@ -52,6 +58,7 @@ class JoltSoftBody3D final : public JoltObject3D {
 	LocalVector<JoltArea3D *> areas;
 	LocalVector<Vector3> normals;
 	LocalVector<RID> exceptions;
+	LocalVector<EdgeType> edge_types;
 
 	RID mesh;
 
@@ -60,9 +67,11 @@ class JoltSoftBody3D final : public JoltObject3D {
 	float mass = 1.0f;
 	float pressure = 0.0f;
 	float linear_damping = 0.01f;
+	float mesh_damping_coefficient = 0.0f;
 	float stiffness_coefficient = 0.5f;
 	bool internal_springs = false;
 	float internal_spring_stiffness = 0.5f;
+	float internal_spring_damping_coefficient = 0.0f;
 	float shrinking_factor = 0.0f;
 
 	int simulation_precision = 5;
@@ -78,6 +87,7 @@ class JoltSoftBody3D final : public JoltObject3D {
 	JPH::SoftBodySharedSettings *_create_shared_settings();
 
 	void _apply_environmental_forces(float p_step);
+	void _apply_link_damping(float p_step);
 
 	void _update_mass();
 	void _update_pressure();
@@ -151,6 +161,9 @@ public:
 	float get_internal_spring_stiffness() const { return internal_spring_stiffness; }
 	void set_internal_spring_stiffness(float p_stiffness);
 
+	float get_internal_spring_damping_coefficient() const { return internal_spring_damping_coefficient; }
+	void set_internal_spring_damping_coefficient(float p_damping);
+
 	float get_shrinking_factor() const;
 	void set_shrinking_factor(float p_shrinking_factor);
 
@@ -159,6 +172,9 @@ public:
 
 	float get_linear_damping() const { return linear_damping; }
 	void set_linear_damping(float p_damping);
+
+	float get_mesh_damping_coefficient() const { return mesh_damping_coefficient; }
+	void set_mesh_damping_coefficient(float p_damping);
 
 	float get_drag() const;
 	void set_drag(float p_drag);

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -394,6 +394,9 @@ void SoftBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_total_mass", "mass"), &SoftBody3D::set_total_mass);
 	ClassDB::bind_method(D_METHOD("get_total_mass"), &SoftBody3D::get_total_mass);
 
+	ClassDB::bind_method(D_METHOD("set_gravity_scale", "gravity_scale"), &SoftBody3D::set_gravity_scale);
+	ClassDB::bind_method(D_METHOD("get_gravity_scale"), &SoftBody3D::get_gravity_scale);
+
 	ClassDB::bind_method(D_METHOD("set_linear_stiffness", "linear_stiffness"), &SoftBody3D::set_linear_stiffness);
 	ClassDB::bind_method(D_METHOD("get_linear_stiffness"), &SoftBody3D::get_linear_stiffness);
 
@@ -445,6 +448,7 @@ void SoftBody3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "parent_collision_ignore", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "CollisionObject3D"), "set_parent_collision_ignore", "get_parent_collision_ignore");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "simulation_precision", PROPERTY_HINT_RANGE, "1,100,1"), "set_simulation_precision", "get_simulation_precision");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "total_mass", PROPERTY_HINT_RANGE, "0.001,1000,0.001,or_greater,exp,suffix:kg"), "set_total_mass", "get_total_mass");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "gravity_scale", PROPERTY_HINT_RANGE, "-10,10,0.001,or_less,or_greater"), "set_gravity_scale", "get_gravity_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "linear_stiffness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_linear_stiffness", "get_linear_stiffness");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "internal_springs"), "set_internal_springs", "is_internal_springs_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "internal_spring_stiffness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_internal_spring_stiffness", "get_internal_spring_stiffness");
@@ -797,6 +801,14 @@ real_t SoftBody3D::get_total_mass() {
 
 void SoftBody3D::set_total_mass(real_t p_total_mass) {
 	PhysicsServer3D::get_singleton()->soft_body_set_total_mass(physics_rid, p_total_mass);
+}
+
+void SoftBody3D::set_gravity_scale(real_t p_gravity_scale) {
+	PhysicsServer3D::get_singleton()->soft_body_set_gravity_scale(physics_rid, p_gravity_scale);
+}
+
+real_t SoftBody3D::get_gravity_scale() const {
+	return PhysicsServer3D::get_singleton()->soft_body_get_gravity_scale(physics_rid);
 }
 
 void SoftBody3D::set_linear_stiffness(real_t p_linear_stiffness) {

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -35,6 +35,8 @@
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "scene/3d/physics/physics_body_3d.h"
+#include "scene/3d/skeleton_3d.h"
+#include "scene/resources/3d/skin.h"
 #include "servers/rendering/rendering_server.h"
 
 SoftBodyRenderingServerHandler::SoftBodyRenderingServerHandler() {}
@@ -422,12 +424,69 @@ void SoftBody3D::_update_physics_server() {
 	}
 
 	_update_cache_pin_points_datas();
-	// Submit bone attachment
+	_update_pinned_skin_cache();
+
+	Skeleton3D *skeleton = nullptr;
+	Ref<Skin> skin;
+	if (!get_skeleton_path().is_empty() && has_node(get_skeleton_path())) {
+		skeleton = Object::cast_to<Skeleton3D>(get_node(get_skeleton_path()));
+		if (skeleton) {
+			skin = get_skin();
+			if (skin.is_null() && get_skin_reference().is_valid()) {
+				skin = get_skin_reference()->get_skin();
+			}
+			if (skin.is_null()) {
+				skin = skeleton->create_skin_from_rest_transforms();
+			}
+		}
+	}
+
+	Transform3D skeleton_global_transform;
+	LocalVector<Transform3D> skin_transforms;
+	if (skeleton && skin.is_valid()) {
+		skeleton_global_transform = skeleton->get_global_transform();
+		int bind_count = skin->get_bind_count();
+		skin_transforms.resize(bind_count);
+		for (int i = 0; i < bind_count; ++i) {
+			int bone_idx = -1;
+			StringName bind_name = skin->get_bind_name(i);
+			if (bind_name != StringName()) {
+				bone_idx = skeleton->find_bone(bind_name);
+			} else if (skin->get_bind_bone(i) >= 0) {
+				bone_idx = skin->get_bind_bone(i);
+			} else {
+				bone_idx = i;
+			}
+
+			if (bone_idx >= 0 && bone_idx < skeleton->get_bone_count()) {
+				skin_transforms[i] = skeleton->get_bone_global_pose(bone_idx) * skin->get_bind_pose(i);
+			} else {
+				skin_transforms[i] = Transform3D();
+			}
+		}
+	}
+
+	// Submit bone attachment and skinning
 	const int pinned_points_indices_size = pinned_points.size();
 	const PinnedPoint *r = pinned_points.ptr();
 	for (int i = 0; i < pinned_points_indices_size; ++i) {
 		if (r[i].spatial_attachment) {
 			PhysicsServer3D::get_singleton()->soft_body_move_point(physics_rid, r[i].point_index, r[i].spatial_attachment->get_global_transform().xform(r[i].offset));
+		} else if (skeleton && skin.is_valid()) {
+			HashMap<int, PinnedSkinData>::ConstIterator E = pinned_skin_data_cache.find(r[i].point_index);
+			if (E) {
+				const PinnedSkinData &skin_data = E->value;
+				Vector3 skinned_vertex;
+				for (uint32_t b = 0; b < skin_data.bone_indices.size(); ++b) {
+					int skin_bind_idx = skin_data.bone_indices[b];
+					float weight = skin_data.bone_weights[b];
+					if (skin_bind_idx >= 0 && skin_bind_idx < (int)skin_transforms.size()) {
+						skinned_vertex += skin_transforms[skin_bind_idx].xform(skin_data.rest_vertex) * weight;
+					}
+				}
+				Vector3 world_pos = skeleton_global_transform.xform(skinned_vertex);
+				PhysicsServer3D::get_singleton()->soft_body_move_point(physics_rid, r[i].point_index, world_pos);
+			}
 		}
 	}
 }
@@ -452,6 +511,9 @@ void SoftBody3D::_draw_soft_mesh() {
 		callable_mp((Node3D *)this, &Node3D::set_as_top_level).call_deferred(true);
 		callable_mp((Node3D *)this, &Node3D::set_transform).call_deferred(Transform3D());
 	}
+
+	// Make sure GPU skinning is detached from visual instance to avoid double transformation
+	RS::get_singleton()->instance_attach_skeleton(get_instance(), RID());
 
 	_update_physics_server();
 
@@ -518,6 +580,7 @@ void SoftBody3D::_become_mesh_owner() {
 	}
 
 	owned_mesh = soft_mesh->get_rid();
+	_make_cache_dirty();
 }
 
 void SoftBody3D::set_collision_mask(uint32_t p_mask) {
@@ -762,8 +825,22 @@ SoftBody3D::~SoftBody3D() {
 	PhysicsServer3D::get_singleton()->free_rid(physics_rid);
 }
 
+Vector3 SoftBody3D::_get_point_local_position(int p_point_index) const {
+	if (mesh.is_valid() && mesh->get_surface_count() > 0) {
+		Array arrays = mesh->surface_get_arrays(0);
+		if (!arrays.is_empty() && arrays.size() > Mesh::ARRAY_VERTEX) {
+			const Vector<Vector3> &vertices = arrays[Mesh::ARRAY_VERTEX];
+			if (p_point_index >= 0 && p_point_index < vertices.size()) {
+				return vertices[p_point_index];
+			}
+		}
+	}
+	return Vector3();
+}
+
 void SoftBody3D::_make_cache_dirty() {
 	pinned_points_cache_dirty = true;
+	pinned_skin_data_cache_dirty = true;
 }
 
 void SoftBody3D::_update_cache_pin_points_datas() {
@@ -777,6 +854,76 @@ void SoftBody3D::_update_cache_pin_points_datas() {
 	for (int i = pinned_points.size() - 1; 0 <= i; --i) {
 		if (!w[i].spatial_attachment_path.is_empty()) {
 			w[i].spatial_attachment = Object::cast_to<Node3D>(get_node(w[i].spatial_attachment_path));
+		}
+	}
+}
+
+void SoftBody3D::_update_pinned_skin_cache() {
+	if (!pinned_skin_data_cache_dirty) {
+		return;
+	}
+
+	pinned_skin_data_cache_dirty = false;
+	pinned_skin_data_cache.clear();
+
+	if (mesh.is_null() || !mesh->get_surface_count()) {
+		return;
+	}
+
+	Array surface_arrays = mesh->surface_get_arrays(0);
+	if (surface_arrays.is_empty() || surface_arrays.size() != Mesh::ARRAY_MAX) {
+		return;
+	}
+
+	const Vector<Vector3> &vertices = surface_arrays[Mesh::ARRAY_VERTEX];
+	const Vector<int> &bones = surface_arrays[Mesh::ARRAY_BONES];
+	const Vector<float> &weights = surface_arrays[Mesh::ARRAY_WEIGHTS];
+
+	if (vertices.is_empty() || bones.is_empty() || weights.is_empty()) {
+		return;
+	}
+
+	uint32_t surface_format = mesh->surface_get_format(0);
+	int bones_per_vertex = (surface_format & Mesh::ARRAY_FLAG_USE_8_BONE_WEIGHTS) ? 8 : 4;
+
+	if (bones.size() != vertices.size() * bones_per_vertex || weights.size() != vertices.size() * bones_per_vertex) {
+		return;
+	}
+
+	const Vector3 *v_ptr = vertices.ptr();
+	const int *b_ptr = bones.ptr();
+	const float *w_ptr = weights.ptr();
+
+	for (int i = 0; i < pinned_points.size(); ++i) {
+		const PinnedPoint &pp = pinned_points[i];
+		if (!pp.spatial_attachment_path.is_empty()) {
+			continue;
+		}
+
+		int pt_idx = pp.point_index;
+		if (pt_idx < 0 || pt_idx >= vertices.size()) {
+			continue;
+		}
+
+		PinnedSkinData skin_data;
+		skin_data.rest_vertex = v_ptr[pt_idx];
+
+		float total_weight = 0.0f;
+		for (int b = 0; b < bones_per_vertex; ++b) {
+			int idx = pt_idx * bones_per_vertex + b;
+			float weight = w_ptr[idx];
+			if (weight > 0.0001f) {
+				skin_data.bone_indices.push_back(b_ptr[idx]);
+				skin_data.bone_weights.push_back(weight);
+				total_weight += weight;
+			}
+		}
+
+		if (total_weight > 0.0001f) {
+			for (float &weight : skin_data.bone_weights) {
+				weight /= total_weight;
+			}
+			pinned_skin_data_cache.insert(pt_idx, skin_data);
 		}
 	}
 }
@@ -795,7 +942,7 @@ void SoftBody3D::_add_pinned_point(int p_point_index, const NodePath &p_spatial_
 
 		if (!p_spatial_attachment_path.is_empty() && has_node(p_spatial_attachment_path)) {
 			pp.spatial_attachment = Object::cast_to<Node3D>(get_node(p_spatial_attachment_path));
-			pp.offset = (pp.spatial_attachment->get_global_transform().affine_inverse() * get_global_transform()).xform(PhysicsServer3D::get_singleton()->soft_body_get_point_global_position(physics_rid, pp.point_index));
+			pp.offset = (pp.spatial_attachment->get_global_transform().affine_inverse() * get_global_transform()).xform(_get_point_local_position(pp.point_index));
 		}
 
 		if (p_insert_at != -1) {
@@ -814,9 +961,10 @@ void SoftBody3D::_add_pinned_point(int p_point_index, const NodePath &p_spatial_
 			ERR_FAIL_NULL_MSG(attachment_node, "Attachment node path is invalid.");
 
 			pinned_point->spatial_attachment = attachment_node;
-			pinned_point->offset = (pinned_point->spatial_attachment->get_global_transform().affine_inverse() * get_global_transform()).xform(PhysicsServer3D::get_singleton()->soft_body_get_point_global_position(physics_rid, pinned_point->point_index));
+			pinned_point->offset = (pinned_point->spatial_attachment->get_global_transform().affine_inverse() * get_global_transform()).xform(_get_point_local_position(pinned_point->point_index));
 		}
 	}
+	_make_cache_dirty();
 }
 
 void SoftBody3D::_reset_points_offsets() {
@@ -837,7 +985,7 @@ void SoftBody3D::_reset_points_offsets() {
 			continue;
 		}
 
-		w[i].offset = (r[i].spatial_attachment->get_global_transform().affine_inverse() * get_global_transform()).xform(PhysicsServer3D::get_singleton()->soft_body_get_point_global_position(physics_rid, r[i].point_index));
+		w[i].offset = (r[i].spatial_attachment->get_global_transform().affine_inverse() * get_global_transform()).xform(_get_point_local_position(r[i].point_index));
 	}
 }
 
@@ -845,6 +993,7 @@ void SoftBody3D::_remove_pinned_point(int p_point_index) {
 	const int id(_has_pinned_point(p_point_index));
 	if (-1 != id) {
 		pinned_points.remove_at(id);
+		_make_cache_dirty();
 	}
 }
 

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -37,70 +37,112 @@
 #include "scene/3d/physics/physics_body_3d.h"
 #include "scene/3d/skeleton_3d.h"
 #include "scene/resources/3d/skin.h"
+#include "scene/resources/material.h"
 #include "servers/rendering/rendering_server.h"
 
 SoftBodyRenderingServerHandler::SoftBodyRenderingServerHandler() {}
 
-void SoftBodyRenderingServerHandler::prepare(RID p_mesh, int p_surface) {
+void SoftBodyRenderingServerHandler::prepare(RID p_mesh) {
 	clear();
 
 	ERR_FAIL_COND(!p_mesh.is_valid());
 
 	mesh = p_mesh;
-	surface = p_surface;
 
-	RenderingServerTypes::SurfaceData surface_data = RS::get_singleton()->mesh_get_surface(mesh, surface);
+	int surface_count = RS::get_singleton()->mesh_get_surface_count(mesh);
+	uint32_t current_offset = 0;
 
-	uint32_t surface_offsets[RSE::ARRAY_MAX];
-	uint32_t vertex_stride;
-	uint32_t normal_tangent_stride;
-	uint32_t attrib_stride;
-	uint32_t skin_stride;
-	RS::get_singleton()->mesh_surface_make_offsets_from_format(surface_data.format, surface_data.vertex_count, surface_data.index_count, surface_offsets, vertex_stride, normal_tangent_stride, attrib_stride, skin_stride);
+	for (int s = 0; s < surface_count; s++) {
+		RenderingServerTypes::SurfaceData surface_data = RS::get_singleton()->mesh_get_surface(mesh, s);
+		if (surface_data.vertex_count == 0) {
+			continue;
+		}
 
-	buffer = surface_data.vertex_data;
-	stride = vertex_stride;
-	normal_stride = normal_tangent_stride;
-	offset_vertices = surface_offsets[RSE::ARRAY_VERTEX];
-	offset_normal = surface_offsets[RSE::ARRAY_NORMAL];
+		SurfaceInfo si;
+		si.surface = s;
+		si.vertex_count = surface_data.vertex_count;
+		si.global_vertex_offset = current_offset;
+
+		uint32_t surface_offsets[RSE::ARRAY_MAX];
+		uint32_t vertex_stride;
+		uint32_t normal_tangent_stride;
+		uint32_t attrib_stride;
+		uint32_t skin_stride;
+		RS::get_singleton()->mesh_surface_make_offsets_from_format(surface_data.format, surface_data.vertex_count, surface_data.index_count, surface_offsets, vertex_stride, normal_tangent_stride, attrib_stride, skin_stride);
+
+		si.buffer = surface_data.vertex_data;
+		si.stride = vertex_stride;
+		si.normal_stride = normal_tangent_stride;
+		si.offset_vertices = surface_offsets[RSE::ARRAY_VERTEX];
+		si.offset_normal = surface_offsets[RSE::ARRAY_NORMAL];
+
+		surfaces.push_back(si);
+		current_offset += surface_data.vertex_count;
+	}
 }
 
 void SoftBodyRenderingServerHandler::clear() {
-	buffer.resize(0);
-	stride = 0;
-	normal_stride = 0;
-	offset_vertices = 0;
-	offset_normal = 0;
-
-	surface = 0;
+	surfaces.clear();
 	mesh = RID();
 }
 
 void SoftBodyRenderingServerHandler::open() {
-	write_buffer = buffer.ptrw();
+	for (int i = 0; i < surfaces.size(); i++) {
+		surfaces.write[i].write_buffer = surfaces.write[i].buffer.ptrw();
+	}
 }
 
 void SoftBodyRenderingServerHandler::close() {
-	write_buffer = nullptr;
+	for (int i = 0; i < surfaces.size(); i++) {
+		surfaces.write[i].write_buffer = nullptr;
+	}
 }
 
 void SoftBodyRenderingServerHandler::commit_changes() {
-	RS::get_singleton()->mesh_surface_update_vertex_region(mesh, surface, 0, buffer);
+	for (int i = 0; i < surfaces.size(); i++) {
+		RS::get_singleton()->mesh_surface_update_vertex_region(mesh, surfaces[i].surface, 0, surfaces[i].buffer);
+	}
 }
 
 void SoftBodyRenderingServerHandler::set_vertex(int p_vertex_id, const Vector3 &p_vertex) {
-	float *vertex_buffer = reinterpret_cast<float *>(write_buffer + p_vertex_id * stride + offset_vertices);
-	*vertex_buffer++ = (float)p_vertex.x;
-	*vertex_buffer++ = (float)p_vertex.y;
-	*vertex_buffer++ = (float)p_vertex.z;
+	if (p_vertex_id < 0) {
+		return;
+	}
+	for (int i = 0; i < surfaces.size(); i++) {
+		const SurfaceInfo &si = surfaces[i];
+		if ((uint32_t)p_vertex_id >= si.global_vertex_offset && (uint32_t)p_vertex_id < si.global_vertex_offset + si.vertex_count) {
+			if (!si.write_buffer) {
+				return;
+			}
+			uint32_t local_idx = (uint32_t)p_vertex_id - si.global_vertex_offset;
+			float *vertex_buffer = reinterpret_cast<float *>(si.write_buffer + local_idx * si.stride + si.offset_vertices);
+			*vertex_buffer++ = (float)p_vertex.x;
+			*vertex_buffer++ = (float)p_vertex.y;
+			*vertex_buffer++ = (float)p_vertex.z;
+			return;
+		}
+	}
 }
 
 void SoftBodyRenderingServerHandler::set_normal(int p_vertex_id, const Vector3 &p_normal) {
-	Vector2 res = p_normal.octahedron_encode();
-	uint32_t value = 0;
-	value |= (uint16_t)CLAMP(res.x * 65535, 0, 65535);
-	value |= (uint16_t)CLAMP(res.y * 65535, 0, 65535) << 16;
-	memcpy(&write_buffer[p_vertex_id * normal_stride + offset_normal], &value, sizeof(uint32_t));
+	if (p_vertex_id < 0) {
+		return;
+	}
+	for (int i = 0; i < surfaces.size(); i++) {
+		const SurfaceInfo &si = surfaces[i];
+		if ((uint32_t)p_vertex_id >= si.global_vertex_offset && (uint32_t)p_vertex_id < si.global_vertex_offset + si.vertex_count) {
+			if (!si.write_buffer) {
+				return;
+			}
+			uint32_t local_idx = (uint32_t)p_vertex_id - si.global_vertex_offset;
+			Vector2 res = p_normal.octahedron_encode();
+			uint32_t value = 0;
+			value |= (uint16_t)CLAMP(res.x * 65535, 0, 65535);
+			value |= (uint16_t)CLAMP(res.y * 65535, 0, 65535) << 16;
+			memcpy(&si.write_buffer[local_idx * si.normal_stride + si.offset_normal], &value, sizeof(uint32_t));
+			return;
+		}
+	}
 }
 
 void SoftBodyRenderingServerHandler::set_aabb(const AABB &p_aabb) {
@@ -324,6 +366,12 @@ void SoftBody3D::_notification(int p_what) {
 	}
 }
 
+void SoftBody3D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "internal_spring_stiffness" && !internal_springs) {
+		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
+	}
+}
+
 void SoftBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_physics_rid"), &SoftBody3D::get_physics_rid);
 
@@ -357,6 +405,12 @@ void SoftBody3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_linear_stiffness", "linear_stiffness"), &SoftBody3D::set_linear_stiffness);
 	ClassDB::bind_method(D_METHOD("get_linear_stiffness"), &SoftBody3D::get_linear_stiffness);
+
+	ClassDB::bind_method(D_METHOD("set_internal_springs", "enabled"), &SoftBody3D::set_internal_springs);
+	ClassDB::bind_method(D_METHOD("is_internal_springs_enabled"), &SoftBody3D::is_internal_springs_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_internal_spring_stiffness", "stiffness"), &SoftBody3D::set_internal_spring_stiffness);
+	ClassDB::bind_method(D_METHOD("get_internal_spring_stiffness"), &SoftBody3D::get_internal_spring_stiffness);
 
 	ClassDB::bind_method(D_METHOD("set_shrinking_factor", "shrinking_factor"), &SoftBody3D::set_shrinking_factor);
 	ClassDB::bind_method(D_METHOD("get_shrinking_factor"), &SoftBody3D::get_shrinking_factor);
@@ -393,6 +447,8 @@ void SoftBody3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "simulation_precision", PROPERTY_HINT_RANGE, "1,100,1"), "set_simulation_precision", "get_simulation_precision");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "total_mass", PROPERTY_HINT_RANGE, "0.001,1000,0.001,or_greater,exp,suffix:kg"), "set_total_mass", "get_total_mass");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "linear_stiffness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_linear_stiffness", "get_linear_stiffness");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "internal_springs"), "set_internal_springs", "is_internal_springs_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "internal_spring_stiffness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_internal_spring_stiffness", "get_internal_spring_stiffness");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "shrinking_factor", PROPERTY_HINT_RANGE, "-1,1,0.01,or_less,or_greater"), "set_shrinking_factor", "get_shrinking_factor");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pressure_coefficient"), "set_pressure_coefficient", "get_pressure_coefficient");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "damping_coefficient", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater"), "set_damping_coefficient", "get_damping_coefficient");
@@ -427,39 +483,39 @@ void SoftBody3D::_update_physics_server() {
 	_update_pinned_skin_cache();
 
 	Skeleton3D *skeleton = nullptr;
-	Ref<Skin> skin;
+	Ref<Skin> active_skin;
 	if (!get_skeleton_path().is_empty() && has_node(get_skeleton_path())) {
 		skeleton = Object::cast_to<Skeleton3D>(get_node(get_skeleton_path()));
 		if (skeleton) {
-			skin = get_skin();
-			if (skin.is_null() && get_skin_reference().is_valid()) {
-				skin = get_skin_reference()->get_skin();
+			active_skin = get_skin();
+			if (active_skin.is_null() && get_skin_reference().is_valid()) {
+				active_skin = get_skin_reference()->get_skin();
 			}
-			if (skin.is_null()) {
-				skin = skeleton->create_skin_from_rest_transforms();
+			if (active_skin.is_null()) {
+				active_skin = skeleton->create_skin_from_rest_transforms();
 			}
 		}
 	}
 
 	Transform3D skeleton_global_transform;
 	LocalVector<Transform3D> skin_transforms;
-	if (skeleton && skin.is_valid()) {
+	if (skeleton && active_skin.is_valid()) {
 		skeleton_global_transform = skeleton->get_global_transform();
-		int bind_count = skin->get_bind_count();
+		int bind_count = active_skin->get_bind_count();
 		skin_transforms.resize(bind_count);
 		for (int i = 0; i < bind_count; ++i) {
 			int bone_idx = -1;
-			StringName bind_name = skin->get_bind_name(i);
+			StringName bind_name = active_skin->get_bind_name(i);
 			if (bind_name != StringName()) {
 				bone_idx = skeleton->find_bone(bind_name);
-			} else if (skin->get_bind_bone(i) >= 0) {
-				bone_idx = skin->get_bind_bone(i);
+			} else if (active_skin->get_bind_bone(i) >= 0) {
+				bone_idx = active_skin->get_bind_bone(i);
 			} else {
 				bone_idx = i;
 			}
 
 			if (bone_idx >= 0 && bone_idx < skeleton->get_bone_count()) {
-				skin_transforms[i] = skeleton->get_bone_global_pose(bone_idx) * skin->get_bind_pose(i);
+				skin_transforms[i] = skeleton->get_bone_global_pose(bone_idx) * active_skin->get_bind_pose(i);
 			} else {
 				skin_transforms[i] = Transform3D();
 			}
@@ -472,7 +528,7 @@ void SoftBody3D::_update_physics_server() {
 	for (int i = 0; i < pinned_points_indices_size; ++i) {
 		if (r[i].spatial_attachment) {
 			PhysicsServer3D::get_singleton()->soft_body_move_point(physics_rid, r[i].point_index, r[i].spatial_attachment->get_global_transform().xform(r[i].offset));
-		} else if (skeleton && skin.is_valid()) {
+		} else if (skeleton && active_skin.is_valid()) {
 			HashMap<int, PinnedSkinData>::ConstIterator E = pinned_skin_data_cache.find(r[i].point_index);
 			if (E) {
 				const PinnedSkinData &skin_data = E->value;
@@ -504,7 +560,7 @@ void SoftBody3D::_draw_soft_mesh() {
 	}
 
 	if (!rendering_server_handler->is_ready(mesh_rid)) {
-		rendering_server_handler->prepare(mesh_rid, 0);
+		rendering_server_handler->prepare(mesh_rid);
 
 		/// Necessary in order to render the mesh correctly (Soft body nodes are in global space)
 		simulation_started = true;
@@ -559,24 +615,47 @@ void SoftBody3D::_become_mesh_owner() {
 
 	ERR_FAIL_COND(!mesh->get_surface_count());
 
-	// Get current mesh array and create new mesh array with necessary flag for SoftBody
-	Array surface_arrays = mesh->surface_get_arrays(0);
-	Array surface_blend_arrays = mesh->surface_get_blend_shape_arrays(0);
-	Dictionary surface_lods = mesh->surface_get_lods(0);
-	uint32_t surface_format = mesh->surface_get_format(0);
-
-	surface_format |= Mesh::ARRAY_FLAG_USE_DYNAMIC_UPDATE;
-	surface_format &= ~Mesh::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
-
 	Ref<ArrayMesh> soft_mesh;
 	soft_mesh.instantiate();
-	soft_mesh->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, surface_arrays, surface_blend_arrays, surface_lods, surface_format);
-	soft_mesh->surface_set_material(0, mesh->surface_get_material(0));
+
+	int surface_count = mesh->get_surface_count();
+	for (int s = 0; s < surface_count; s++) {
+		Array surface_arrays = mesh->surface_get_arrays(s);
+		Array surface_blend_arrays = mesh->surface_get_blend_shape_arrays(s);
+		Dictionary surface_lods = mesh->surface_get_lods(s);
+		uint32_t surface_format = mesh->surface_get_format(s);
+		Mesh::PrimitiveType primitive_type = mesh->surface_get_primitive_type(s);
+
+		surface_format |= Mesh::ARRAY_FLAG_USE_DYNAMIC_UPDATE;
+		surface_format &= ~Mesh::ARRAY_FLAG_COMPRESS_ATTRIBUTES;
+
+		soft_mesh->add_surface_from_arrays(primitive_type, surface_arrays, surface_blend_arrays, surface_lods, surface_format);
+
+		if (internal_springs && primitive_type != Mesh::PRIMITIVE_TRIANGLES) {
+			// Hide internal springs from final render
+			Ref<StandardMaterial3D> hidden_mat;
+			hidden_mat.instantiate();
+			hidden_mat->set_transparency(BaseMaterial3D::TRANSPARENCY_ALPHA);
+			hidden_mat->set_albedo(Color(0, 0, 0, 0));
+			soft_mesh->surface_set_material(s, hidden_mat);
+		} else {
+			soft_mesh->surface_set_material(s, mesh->surface_get_material(s));
+		}
+	}
 
 	set_mesh(soft_mesh);
 
 	for (int i = copy_materials.size() - 1; 0 <= i; --i) {
-		set_surface_override_material(i, copy_materials[i]);
+		Mesh::PrimitiveType prim_type = mesh->surface_get_primitive_type(i);
+		if (internal_springs && prim_type != Mesh::PRIMITIVE_TRIANGLES) {
+			Ref<StandardMaterial3D> hidden_mat;
+			hidden_mat.instantiate();
+			hidden_mat->set_transparency(BaseMaterial3D::TRANSPARENCY_ALPHA);
+			hidden_mat->set_albedo(Color(0, 0, 0, 0));
+			set_surface_override_material(i, hidden_mat);
+		} else {
+			set_surface_override_material(i, copy_materials[i]);
+		}
 	}
 
 	owned_mesh = soft_mesh->get_rid();
@@ -723,6 +802,28 @@ real_t SoftBody3D::get_linear_stiffness() {
 	return PhysicsServer3D::get_singleton()->soft_body_get_linear_stiffness(physics_rid);
 }
 
+void SoftBody3D::set_internal_springs(bool p_enabled) {
+	if (internal_springs == p_enabled) {
+		return;
+	}
+	internal_springs = p_enabled;
+	PhysicsServer3D::get_singleton()->soft_body_set_internal_springs(physics_rid, p_enabled);
+	notify_property_list_changed();
+}
+
+bool SoftBody3D::is_internal_springs_enabled() const {
+	return internal_springs;
+}
+
+void SoftBody3D::set_internal_spring_stiffness(real_t p_stiffness) {
+	internal_spring_stiffness = p_stiffness;
+	PhysicsServer3D::get_singleton()->soft_body_set_internal_spring_stiffness(physics_rid, p_stiffness);
+}
+
+real_t SoftBody3D::get_internal_spring_stiffness() const {
+	return internal_spring_stiffness;
+}
+
 void SoftBody3D::set_shrinking_factor(real_t p_shrinking_factor) {
 	PhysicsServer3D::get_singleton()->soft_body_set_shrinking_factor(physics_rid, p_shrinking_factor);
 }
@@ -764,9 +865,14 @@ int SoftBody3D::get_point_count() const {
 		return 0;
 	}
 
-	const int vertex_count = mesh->surface_get_array_len(0);
-	ERR_FAIL_COND_V(vertex_count < 0, 0);
-	return vertex_count;
+	int count = 0;
+	for (int s = 0; s < mesh->get_surface_count(); s++) {
+		int vertex_count = mesh->surface_get_array_len(s);
+		if (vertex_count > 0) {
+			count += vertex_count;
+		}
+	}
+	return count;
 }
 
 void SoftBody3D::apply_impulse(int p_point_index, const Vector3 &p_impulse) {
@@ -827,11 +933,16 @@ SoftBody3D::~SoftBody3D() {
 
 Vector3 SoftBody3D::_get_point_local_position(int p_point_index) const {
 	if (mesh.is_valid() && mesh->get_surface_count() > 0) {
-		Array arrays = mesh->surface_get_arrays(0);
-		if (!arrays.is_empty() && arrays.size() > Mesh::ARRAY_VERTEX) {
-			const Vector<Vector3> &vertices = arrays[Mesh::ARRAY_VERTEX];
-			if (p_point_index >= 0 && p_point_index < vertices.size()) {
-				return vertices[p_point_index];
+		int surf_count = mesh->get_surface_count();
+		int vertex_offset = 0;
+		for (int s = 0; s < surf_count; s++) {
+			Array arrays = mesh->surface_get_arrays(s);
+			if (!arrays.is_empty() && arrays.size() > Mesh::ARRAY_VERTEX) {
+				const Vector<Vector3> &vertices = arrays[Mesh::ARRAY_VERTEX];
+				if (p_point_index >= vertex_offset && p_point_index < vertex_offset + vertices.size()) {
+					return vertices[p_point_index - vertex_offset];
+				}
+				vertex_offset += vertices.size();
 			}
 		}
 	}
@@ -870,61 +981,71 @@ void SoftBody3D::_update_pinned_skin_cache() {
 		return;
 	}
 
-	Array surface_arrays = mesh->surface_get_arrays(0);
-	if (surface_arrays.is_empty() || surface_arrays.size() != Mesh::ARRAY_MAX) {
-		return;
-	}
+	int surface_count = mesh->get_surface_count();
+	int global_vertex_offset = 0;
 
-	const Vector<Vector3> &vertices = surface_arrays[Mesh::ARRAY_VERTEX];
-	const Vector<int> &bones = surface_arrays[Mesh::ARRAY_BONES];
-	const Vector<float> &weights = surface_arrays[Mesh::ARRAY_WEIGHTS];
-
-	if (vertices.is_empty() || bones.is_empty() || weights.is_empty()) {
-		return;
-	}
-
-	uint32_t surface_format = mesh->surface_get_format(0);
-	int bones_per_vertex = (surface_format & Mesh::ARRAY_FLAG_USE_8_BONE_WEIGHTS) ? 8 : 4;
-
-	if (bones.size() != vertices.size() * bones_per_vertex || weights.size() != vertices.size() * bones_per_vertex) {
-		return;
-	}
-
-	const Vector3 *v_ptr = vertices.ptr();
-	const int *b_ptr = bones.ptr();
-	const float *w_ptr = weights.ptr();
-
-	for (int i = 0; i < pinned_points.size(); ++i) {
-		const PinnedPoint &pp = pinned_points[i];
-		if (!pp.spatial_attachment_path.is_empty()) {
+	for (int s = 0; s < surface_count; s++) {
+		Array surface_arrays = mesh->surface_get_arrays(s);
+		if (surface_arrays.is_empty() || surface_arrays.size() != Mesh::ARRAY_MAX) {
 			continue;
 		}
 
-		int pt_idx = pp.point_index;
-		if (pt_idx < 0 || pt_idx >= vertices.size()) {
+		const Vector<Vector3> &vertices = surface_arrays[Mesh::ARRAY_VERTEX];
+		const Vector<int> &bones = surface_arrays[Mesh::ARRAY_BONES];
+		const Vector<float> &weights = surface_arrays[Mesh::ARRAY_WEIGHTS];
+
+		if (vertices.is_empty()) {
 			continue;
 		}
 
-		PinnedSkinData skin_data;
-		skin_data.rest_vertex = v_ptr[pt_idx];
+		uint32_t surface_format = mesh->surface_get_format(s);
+		int bones_per_vertex = (surface_format & Mesh::ARRAY_FLAG_USE_8_BONE_WEIGHTS) ? 8 : 4;
+		bool has_skin = !bones.is_empty() && !weights.is_empty() &&
+				bones.size() == vertices.size() * bones_per_vertex &&
+				weights.size() == vertices.size() * bones_per_vertex;
 
-		float total_weight = 0.0f;
-		for (int b = 0; b < bones_per_vertex; ++b) {
-			int idx = pt_idx * bones_per_vertex + b;
-			float weight = w_ptr[idx];
-			if (weight > 0.0001f) {
-				skin_data.bone_indices.push_back(b_ptr[idx]);
-				skin_data.bone_weights.push_back(weight);
-				total_weight += weight;
+		const Vector3 *v_ptr = vertices.ptr();
+		const int *b_ptr = has_skin ? bones.ptr() : nullptr;
+		const float *w_ptr = has_skin ? weights.ptr() : nullptr;
+
+		for (int i = 0; i < pinned_points.size(); ++i) {
+			const PinnedPoint &pp = pinned_points[i];
+			if (!pp.spatial_attachment_path.is_empty()) {
+				continue;
+			}
+
+			int pt_idx = pp.point_index;
+			if (pt_idx < global_vertex_offset || pt_idx >= global_vertex_offset + vertices.size()) {
+				continue;
+			}
+
+			int local_pt_idx = pt_idx - global_vertex_offset;
+
+			PinnedSkinData skin_data;
+			skin_data.rest_vertex = v_ptr[local_pt_idx];
+
+			if (has_skin) {
+				float total_weight = 0.0f;
+				for (int b = 0; b < bones_per_vertex; ++b) {
+					int idx = local_pt_idx * bones_per_vertex + b;
+					float weight = w_ptr[idx];
+					if (weight > 0.0001f) {
+						skin_data.bone_indices.push_back(b_ptr[idx]);
+						skin_data.bone_weights.push_back(weight);
+						total_weight += weight;
+					}
+				}
+
+				if (total_weight > 0.0001f) {
+					for (float &weight : skin_data.bone_weights) {
+						weight /= total_weight;
+					}
+					pinned_skin_data_cache.insert(pt_idx, skin_data);
+				}
 			}
 		}
 
-		if (total_weight > 0.0001f) {
-			for (float &weight : skin_data.bone_weights) {
-				weight /= total_weight;
-			}
-			pinned_skin_data_cache.insert(pt_idx, skin_data);
-		}
+		global_vertex_offset += vertices.size();
 	}
 }
 

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -157,6 +157,7 @@ SoftBody3D::PinnedPoint::PinnedPoint(const PinnedPoint &obj_tocopy) {
 	spatial_attachment_path = obj_tocopy.spatial_attachment_path;
 	spatial_attachment = obj_tocopy.spatial_attachment;
 	offset = obj_tocopy.offset;
+	weight = obj_tocopy.weight;
 }
 
 void SoftBody3D::PinnedPoint::operator=(const PinnedPoint &obj) {
@@ -164,6 +165,7 @@ void SoftBody3D::PinnedPoint::operator=(const PinnedPoint &obj) {
 	spatial_attachment_path = obj.spatial_attachment_path;
 	spatial_attachment = obj.spatial_attachment;
 	offset = obj.offset;
+	weight = obj.weight;
 }
 
 void SoftBody3D::_update_pickable() {
@@ -228,41 +230,24 @@ void SoftBody3D::_get_property_list(List<PropertyInfo> *p_list) const {
 		p_list->push_back(PropertyInfo(Variant::INT, prefix + PNAME("point_index")));
 		p_list->push_back(PropertyInfo(Variant::NODE_PATH, prefix + PNAME("spatial_attachment_path")));
 		p_list->push_back(PropertyInfo(Variant::VECTOR3, prefix + PNAME("offset")));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, prefix + PNAME("weight"), PROPERTY_HINT_RANGE, "0,1,0.01"));
 	}
 }
 
 bool SoftBody3D::_set_property_pinned_points_indices(const Array &p_indices) {
 	const int p_indices_size = p_indices.size();
 
-	{ // Remove the pined points on physics server that will be removed by resize
-		const PinnedPoint *r = pinned_points.ptr();
-		if (p_indices_size < pinned_points.size()) {
-			for (int i = pinned_points.size() - 1; i >= p_indices_size; --i) {
-				pin_point(r[i].point_index, false);
-			}
-		}
+	// Unpin old points from physics server
+	for (int i = 0; i < pinned_points.size(); ++i) {
+		_pin_point_on_physics_server(pinned_points[i].point_index, false);
 	}
+	pinned_points.clear();
 
-	pinned_points.resize(p_indices_size);
-
-	PinnedPoint *w = pinned_points.ptrw();
-	int point_index;
 	for (int i = 0; i < p_indices_size; ++i) {
-		point_index = p_indices.get(i);
-		if (w[i].point_index != point_index || pinned_points.size() < p_indices_size) {
-			bool insert = false;
-			if (w[i].point_index != -1 && p_indices.find(w[i].point_index) == -1) {
-				pin_point(w[i].point_index, false);
-				insert = true;
-			}
-			w[i].point_index = point_index;
-			if (insert) {
-				pin_point(w[i].point_index, true, NodePath(), i);
-			} else {
-				pin_point(w[i].point_index, true);
-			}
-		}
+		int point_index = p_indices.get(i);
+		pin_point(point_index, true);
 	}
+	_make_cache_dirty();
 	return true;
 }
 
@@ -277,12 +262,16 @@ bool SoftBody3D::_set_property_pinned_points_attachment(int p_item, const String
 		if (is_inside_tree()) {
 			callable_mp(this, &SoftBody3D::_pin_point_deferred).call_deferred(Variant(w[p_item].point_index), true, p_value);
 		} else {
-			pin_point(w[p_item].point_index, true, p_value);
+			pin_point(w[p_item].point_index, true, p_value, -1, w[p_item].weight);
 			_make_cache_dirty();
 		}
 	} else if ("offset" == p_what) {
 		PinnedPoint *w = pinned_points.ptrw();
 		w[p_item].offset = p_value;
+	} else if ("weight" == p_what) {
+		PinnedPoint *w = pinned_points.ptrw();
+		w[p_item].weight = CLAMP((real_t)p_value, (real_t)0.0, (real_t)1.0);
+		PhysicsServer3D::get_singleton()->soft_body_set_point_weight(physics_rid, w[p_item].point_index, w[p_item].weight);
 	} else {
 		return false;
 	}
@@ -302,6 +291,8 @@ bool SoftBody3D::_get_property_pinned_points(int p_item, const String &p_what, V
 		r_ret = r[p_item].spatial_attachment_path;
 	} else if ("offset" == p_what) {
 		r_ret = r[p_item].offset;
+	} else if ("weight" == p_what) {
+		r_ret = r[p_item].weight;
 	} else {
 		return false;
 	}
@@ -431,8 +422,10 @@ void SoftBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("apply_central_impulse", "impulse"), &SoftBody3D::apply_central_impulse);
 	ClassDB::bind_method(D_METHOD("apply_central_force", "force"), &SoftBody3D::apply_central_force);
 
-	ClassDB::bind_method(D_METHOD("set_point_pinned", "point_index", "pinned", "attachment_path", "insert_at"), &SoftBody3D::pin_point, DEFVAL(NodePath()), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("set_point_pinned", "point_index", "pinned", "attachment_path", "insert_at", "weight"), &SoftBody3D::pin_point, DEFVAL(NodePath()), DEFVAL(-1), DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("is_point_pinned", "point_index"), &SoftBody3D::is_point_pinned);
+	ClassDB::bind_method(D_METHOD("set_point_weight", "point_index", "weight"), &SoftBody3D::set_point_weight);
+	ClassDB::bind_method(D_METHOD("get_point_weight", "point_index"), &SoftBody3D::get_point_weight);
 
 	ClassDB::bind_method(D_METHOD("get_point_count"), &SoftBody3D::get_point_count);
 
@@ -600,6 +593,10 @@ void SoftBody3D::_prepare_physics_server() {
 			mesh_rid = mesh->get_rid();
 		}
 		PhysicsServer3D::get_singleton()->soft_body_set_mesh(physics_rid, mesh_rid);
+		for (int i = 0; i < pinned_points.size(); ++i) {
+				PhysicsServer3D::get_singleton()->soft_body_pin_point(physics_rid, pinned_points[i].point_index, true);
+				PhysicsServer3D::get_singleton()->soft_body_set_point_weight(physics_rid, pinned_points[i].point_index, pinned_points[i].weight);
+		}
 		RS::get_singleton()->connect("frame_pre_draw", callable_mp(this, &SoftBody3D::_draw_soft_mesh));
 	} else {
 		PhysicsServer3D::get_singleton()->soft_body_set_mesh(physics_rid, RID());
@@ -631,8 +628,8 @@ void SoftBody3D::_become_mesh_owner() {
 
 		soft_mesh->add_surface_from_arrays(primitive_type, surface_arrays, surface_blend_arrays, surface_lods, surface_format);
 
-		if (internal_springs && primitive_type != Mesh::PRIMITIVE_TRIANGLES) {
-			// Hide internal springs from final render
+		if (primitive_type != Mesh::PRIMITIVE_TRIANGLES) {
+			// Hide internal springs / loose lines / loose points from final render
 			Ref<StandardMaterial3D> hidden_mat;
 			hidden_mat.instantiate();
 			hidden_mat->set_transparency(BaseMaterial3D::TRANSPARENCY_ALPHA);
@@ -647,7 +644,7 @@ void SoftBody3D::_become_mesh_owner() {
 
 	for (int i = copy_materials.size() - 1; 0 <= i; --i) {
 		Mesh::PrimitiveType prim_type = mesh->surface_get_primitive_type(i);
-		if (internal_springs && prim_type != Mesh::PRIMITIVE_TRIANGLES) {
+		if (prim_type != Mesh::PRIMITIVE_TRIANGLES) {
 			Ref<StandardMaterial3D> hidden_mat;
 			hidden_mat.instantiate();
 			hidden_mat->set_transparency(BaseMaterial3D::TRANSPARENCY_ALPHA);
@@ -891,14 +888,40 @@ void SoftBody3D::apply_central_force(const Vector3 &p_force) {
 	PhysicsServer3D::get_singleton()->soft_body_apply_central_force(physics_rid, p_force);
 }
 
-void SoftBody3D::pin_point(int p_point_index, bool pin, const NodePath &p_spatial_attachment_path, int p_insert_at) {
+void SoftBody3D::pin_point(int p_point_index, bool pin, const NodePath &p_spatial_attachment_path, int p_insert_at, real_t p_weight) {
 	ERR_FAIL_COND_MSG(p_insert_at < -1 || p_insert_at >= pinned_points.size(), "Invalid index for pin point insertion position.");
+	if (p_weight <= 0.0) {
+		pin = false;
+	}
 	_pin_point_on_physics_server(p_point_index, pin);
 	if (pin) {
-		_add_pinned_point(p_point_index, p_spatial_attachment_path, p_insert_at);
+		_add_pinned_point(p_point_index, p_spatial_attachment_path, p_insert_at, p_weight);
+		PhysicsServer3D::get_singleton()->soft_body_set_point_weight(physics_rid, p_point_index, p_weight);
 	} else {
 		_remove_pinned_point(p_point_index);
 	}
+}
+
+void SoftBody3D::set_point_weight(int p_point_index, real_t p_weight) {
+	if (p_weight <= 0.0) {
+		pin_point(p_point_index, false);
+		return;
+	}
+	PinnedPoint *pp = nullptr;
+	int idx = _get_pinned_point(p_point_index, pp);
+	if (idx != -1 && pp) {
+		pp->weight = CLAMP(p_weight, (real_t)0.0, (real_t)1.0);
+		PhysicsServer3D::get_singleton()->soft_body_set_point_weight(physics_rid, p_point_index, pp->weight);
+	}
+}
+
+real_t SoftBody3D::get_point_weight(int p_point_index) const {
+	PinnedPoint *pp = nullptr;
+	int idx = _get_pinned_point(p_point_index, pp);
+	if (idx != -1 && pp) {
+		return pp->weight;
+	}
+	return 1.0;
 }
 
 void SoftBody3D::_pin_point_deferred(int p_point_index, bool pin, const NodePath p_spatial_attachment_path) {
@@ -1053,13 +1076,14 @@ void SoftBody3D::_pin_point_on_physics_server(int p_point_index, bool pin) {
 	PhysicsServer3D::get_singleton()->soft_body_pin_point(physics_rid, p_point_index, pin);
 }
 
-void SoftBody3D::_add_pinned_point(int p_point_index, const NodePath &p_spatial_attachment_path, int p_insert_at) {
+void SoftBody3D::_add_pinned_point(int p_point_index, const NodePath &p_spatial_attachment_path, int p_insert_at, real_t p_weight) {
 	SoftBody3D::PinnedPoint *pinned_point;
 	if (-1 == _get_pinned_point(p_point_index, pinned_point)) {
 		// Create new
 		PinnedPoint pp;
 		pp.point_index = p_point_index;
 		pp.spatial_attachment_path = p_spatial_attachment_path;
+		pp.weight = CLAMP(p_weight, (real_t)0.0, (real_t)1.0);
 
 		if (!p_spatial_attachment_path.is_empty() && has_node(p_spatial_attachment_path)) {
 			pp.spatial_attachment = Object::cast_to<Node3D>(get_node(p_spatial_attachment_path));
@@ -1075,6 +1099,7 @@ void SoftBody3D::_add_pinned_point(int p_point_index, const NodePath &p_spatial_
 	} else {
 		pinned_point->point_index = p_point_index;
 		pinned_point->spatial_attachment_path = p_spatial_attachment_path;
+		pinned_point->weight = CLAMP(p_weight, (real_t)0.0, (real_t)1.0);
 
 		if (!p_spatial_attachment_path.is_empty() && has_node(p_spatial_attachment_path)) {
 			Node3D *attachment_node = Object::cast_to<Node3D>(get_node(p_spatial_attachment_path));

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -358,7 +358,7 @@ void SoftBody3D::_notification(int p_what) {
 }
 
 void SoftBody3D::_validate_property(PropertyInfo &p_property) const {
-	if (p_property.name == "internal_spring_stiffness" && !internal_springs) {
+	if ((p_property.name == "internal_spring_stiffness" || p_property.name == "internal_spring_damping_coefficient") && !internal_springs) {
 		p_property.usage = PROPERTY_USAGE_NO_EDITOR;
 	}
 }
@@ -403,6 +403,9 @@ void SoftBody3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_internal_spring_stiffness", "stiffness"), &SoftBody3D::set_internal_spring_stiffness);
 	ClassDB::bind_method(D_METHOD("get_internal_spring_stiffness"), &SoftBody3D::get_internal_spring_stiffness);
 
+	ClassDB::bind_method(D_METHOD("set_internal_spring_damping_coefficient", "internal_spring_damping_coefficient"), &SoftBody3D::set_internal_spring_damping_coefficient);
+	ClassDB::bind_method(D_METHOD("get_internal_spring_damping_coefficient"), &SoftBody3D::get_internal_spring_damping_coefficient);
+
 	ClassDB::bind_method(D_METHOD("set_shrinking_factor", "shrinking_factor"), &SoftBody3D::set_shrinking_factor);
 	ClassDB::bind_method(D_METHOD("get_shrinking_factor"), &SoftBody3D::get_shrinking_factor);
 
@@ -411,6 +414,9 @@ void SoftBody3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_damping_coefficient", "damping_coefficient"), &SoftBody3D::set_damping_coefficient);
 	ClassDB::bind_method(D_METHOD("get_damping_coefficient"), &SoftBody3D::get_damping_coefficient);
+
+	ClassDB::bind_method(D_METHOD("set_mesh_damping_coefficient", "mesh_damping_coefficient"), &SoftBody3D::set_mesh_damping_coefficient);
+	ClassDB::bind_method(D_METHOD("get_mesh_damping_coefficient"), &SoftBody3D::get_mesh_damping_coefficient);
 
 	ClassDB::bind_method(D_METHOD("set_drag_coefficient", "drag_coefficient"), &SoftBody3D::set_drag_coefficient);
 	ClassDB::bind_method(D_METHOD("get_drag_coefficient"), &SoftBody3D::get_drag_coefficient);
@@ -442,9 +448,11 @@ void SoftBody3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "linear_stiffness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_linear_stiffness", "get_linear_stiffness");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "internal_springs"), "set_internal_springs", "is_internal_springs_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "internal_spring_stiffness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_internal_spring_stiffness", "get_internal_spring_stiffness");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "internal_spring_damping_coefficient", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_internal_spring_damping_coefficient", "get_internal_spring_damping_coefficient");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "shrinking_factor", PROPERTY_HINT_RANGE, "-1,1,0.01,or_less,or_greater"), "set_shrinking_factor", "get_shrinking_factor");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pressure_coefficient"), "set_pressure_coefficient", "get_pressure_coefficient");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "damping_coefficient", PROPERTY_HINT_RANGE, "0,1,0.01,or_greater"), "set_damping_coefficient", "get_damping_coefficient");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "mesh_damping_coefficient", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_mesh_damping_coefficient", "get_mesh_damping_coefficient");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "drag_coefficient", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_drag_coefficient", "get_drag_coefficient");
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ray_pickable"), "set_ray_pickable", "is_ray_pickable");
@@ -821,6 +829,15 @@ real_t SoftBody3D::get_internal_spring_stiffness() const {
 	return internal_spring_stiffness;
 }
 
+void SoftBody3D::set_internal_spring_damping_coefficient(real_t p_internal_spring_damping_coefficient) {
+	internal_spring_damping_coefficient = p_internal_spring_damping_coefficient;
+	PhysicsServer3D::get_singleton()->soft_body_set_internal_spring_damping_coefficient(physics_rid, p_internal_spring_damping_coefficient);
+}
+
+real_t SoftBody3D::get_internal_spring_damping_coefficient() const {
+	return internal_spring_damping_coefficient;
+}
+
 void SoftBody3D::set_shrinking_factor(real_t p_shrinking_factor) {
 	PhysicsServer3D::get_singleton()->soft_body_set_shrinking_factor(physics_rid, p_shrinking_factor);
 }
@@ -843,6 +860,14 @@ real_t SoftBody3D::get_damping_coefficient() {
 
 void SoftBody3D::set_damping_coefficient(real_t p_damping_coefficient) {
 	PhysicsServer3D::get_singleton()->soft_body_set_damping_coefficient(physics_rid, p_damping_coefficient);
+}
+
+real_t SoftBody3D::get_mesh_damping_coefficient() {
+	return PhysicsServer3D::get_singleton()->soft_body_get_mesh_damping_coefficient(physics_rid);
+}
+
+void SoftBody3D::set_mesh_damping_coefficient(real_t p_mesh_damping_coefficient) {
+	PhysicsServer3D::get_singleton()->soft_body_set_mesh_damping_coefficient(physics_rid, p_mesh_damping_coefficient);
 }
 
 real_t SoftBody3D::get_drag_coefficient() {

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -38,20 +38,25 @@ class PhysicsBody3D;
 class SoftBodyRenderingServerHandler : public PhysicsServer3DRenderingServerHandler {
 	friend class SoftBody3D;
 
-	RID mesh;
-	int surface = 0;
-	Vector<uint8_t> buffer;
-	uint32_t stride = 0;
-	uint32_t normal_stride = 0;
-	uint32_t offset_vertices = 0;
-	uint32_t offset_normal = 0;
+	struct SurfaceInfo {
+		int surface = 0;
+		Vector<uint8_t> buffer;
+		uint8_t *write_buffer = nullptr;
+		uint32_t vertex_count = 0;
+		uint32_t stride = 0;
+		uint32_t normal_stride = 0;
+		uint32_t offset_vertices = 0;
+		uint32_t offset_normal = 0;
+		uint32_t global_vertex_offset = 0;
+	};
 
-	uint8_t *write_buffer = nullptr;
+	RID mesh;
+	Vector<SurfaceInfo> surfaces;
 
 private:
 	SoftBodyRenderingServerHandler();
 	bool is_ready(RID p_mesh_rid) const { return mesh.is_valid() && mesh == p_mesh_rid; }
-	void prepare(RID p_mesh_rid, int p_surface);
+	void prepare(RID p_mesh_rid);
 	void clear();
 	void open();
 	void close();
@@ -106,6 +111,9 @@ private:
 	HashMap<int, PinnedSkinData> pinned_skin_data_cache;
 	bool pinned_skin_data_cache_dirty = true;
 
+	bool internal_springs = false;
+	real_t internal_spring_stiffness = 0.5;
+
 	Ref<ArrayMesh> debug_mesh_cache;
 	class MeshInstance3D *debug_mesh = nullptr;
 
@@ -121,6 +129,7 @@ private:
 	void _become_mesh_owner();
 
 protected:
+	void _validate_property(PropertyInfo &p_property) const;
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
@@ -172,6 +181,12 @@ public:
 
 	void set_linear_stiffness(real_t p_linear_stiffness);
 	real_t get_linear_stiffness();
+
+	void set_internal_springs(bool p_enabled);
+	bool is_internal_springs_enabled() const;
+
+	void set_internal_spring_stiffness(real_t p_stiffness);
+	real_t get_internal_spring_stiffness() const;
 
 	void set_shrinking_factor(real_t p_shrinking_factor);
 	real_t get_shrinking_factor();

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -114,6 +114,7 @@ private:
 
 	bool internal_springs = false;
 	real_t internal_spring_stiffness = 0.5;
+	real_t internal_spring_damping_coefficient = 0.0;
 
 	Ref<ArrayMesh> debug_mesh_cache;
 	class MeshInstance3D *debug_mesh = nullptr;
@@ -189,6 +190,9 @@ public:
 	void set_internal_spring_stiffness(real_t p_stiffness);
 	real_t get_internal_spring_stiffness() const;
 
+	void set_internal_spring_damping_coefficient(real_t p_internal_spring_damping_coefficient);
+	real_t get_internal_spring_damping_coefficient() const;
+
 	void set_shrinking_factor(real_t p_shrinking_factor);
 	real_t get_shrinking_factor();
 
@@ -197,6 +201,9 @@ public:
 
 	void set_damping_coefficient(real_t p_damping_coefficient);
 	real_t get_damping_coefficient();
+
+	void set_mesh_damping_coefficient(real_t p_mesh_damping_coefficient);
+	real_t get_mesh_damping_coefficient();
 
 	void set_drag_coefficient(real_t p_drag_coefficient);
 	real_t get_drag_coefficient();

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -181,6 +181,9 @@ public:
 	void set_total_mass(real_t p_total_mass);
 	real_t get_total_mass();
 
+	void set_gravity_scale(real_t p_gravity_scale);
+	real_t get_gravity_scale() const;
+
 	void set_linear_stiffness(real_t p_linear_stiffness);
 	real_t get_linear_stiffness();
 

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -82,6 +82,7 @@ public:
 		NodePath spatial_attachment_path;
 		Node3D *spatial_attachment = nullptr; // Cache
 		Vector3 offset;
+		real_t weight = 1.0;
 
 		PinnedPoint();
 		PinnedPoint(const PinnedPoint &obj_tocopy);
@@ -206,8 +207,10 @@ public:
 
 	Vector3 get_point_transform(int p_point_index);
 
-	void pin_point(int p_point_index, bool pin, const NodePath &p_spatial_attachment_path = NodePath(), int p_insert_at = -1);
+	void pin_point(int p_point_index, bool pin, const NodePath &p_spatial_attachment_path = NodePath(), int p_insert_at = -1, real_t p_weight = 1.0);
 	bool is_point_pinned(int p_point_index) const;
+	void set_point_weight(int p_point_index, real_t p_weight);
+	real_t get_point_weight(int p_point_index) const;
 
 	void _pin_point_deferred(int p_point_index, bool pin, const NodePath p_spatial_attachment_path);
 
@@ -229,7 +232,7 @@ private:
 	void _update_pinned_skin_cache();
 
 	void _pin_point_on_physics_server(int p_point_index, bool pin);
-	void _add_pinned_point(int p_point_index, const NodePath &p_spatial_attachment_path, int p_insert_at = -1);
+	void _add_pinned_point(int p_point_index, const NodePath &p_spatial_attachment_path, int p_insert_at = -1, real_t p_weight = 1.0);
 	void _reset_points_offsets();
 
 	void _remove_pinned_point(int p_point_index);

--- a/scene/3d/physics/soft_body_3d.h
+++ b/scene/3d/physics/soft_body_3d.h
@@ -98,6 +98,14 @@ private:
 	bool simulation_started = false;
 	bool pinned_points_cache_dirty = true;
 
+	struct PinnedSkinData {
+		Vector3 rest_vertex;
+		LocalVector<int> bone_indices;
+		LocalVector<float> bone_weights;
+	};
+	HashMap<int, PinnedSkinData> pinned_skin_data_cache;
+	bool pinned_skin_data_cache_dirty = true;
+
 	Ref<ArrayMesh> debug_mesh_cache;
 	class MeshInstance3D *debug_mesh = nullptr;
 
@@ -200,8 +208,10 @@ public:
 	~SoftBody3D();
 
 private:
+	Vector3 _get_point_local_position(int p_point_index) const;
 	void _make_cache_dirty();
 	void _update_cache_pin_points_datas();
+	void _update_pinned_skin_cache();
 
 	void _pin_point_on_physics_server(int p_point_index, bool pin);
 	void _add_pinned_point(int p_point_index, const NodePath &p_spatial_attachment_path, int p_insert_at = -1);

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -266,6 +266,12 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("soft_body_set_linear_stiffness", "body", "stiffness"), &PhysicsServer3D::soft_body_set_linear_stiffness);
 	ClassDB::bind_method(D_METHOD("soft_body_get_linear_stiffness", "body"), &PhysicsServer3D::soft_body_get_linear_stiffness);
 
+	ClassDB::bind_method(D_METHOD("soft_body_set_internal_springs", "body", "enabled"), &PhysicsServer3D::soft_body_set_internal_springs);
+	ClassDB::bind_method(D_METHOD("soft_body_is_internal_springs_enabled", "body"), &PhysicsServer3D::soft_body_is_internal_springs_enabled);
+
+	ClassDB::bind_method(D_METHOD("soft_body_set_internal_spring_stiffness", "body", "stiffness"), &PhysicsServer3D::soft_body_set_internal_spring_stiffness);
+	ClassDB::bind_method(D_METHOD("soft_body_get_internal_spring_stiffness", "body"), &PhysicsServer3D::soft_body_get_internal_spring_stiffness);
+
 	ClassDB::bind_method(D_METHOD("soft_body_set_shrinking_factor", "body", "shrinking_factor"), &PhysicsServer3D::soft_body_set_shrinking_factor);
 	ClassDB::bind_method(D_METHOD("soft_body_get_shrinking_factor", "body"), &PhysicsServer3D::soft_body_get_shrinking_factor);
 

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -263,6 +263,9 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("soft_body_set_total_mass", "body", "total_mass"), &PhysicsServer3D::soft_body_set_total_mass);
 	ClassDB::bind_method(D_METHOD("soft_body_get_total_mass", "body"), &PhysicsServer3D::soft_body_get_total_mass);
 
+	ClassDB::bind_method(D_METHOD("soft_body_set_gravity_scale", "body", "gravity_scale"), &PhysicsServer3D::soft_body_set_gravity_scale);
+	ClassDB::bind_method(D_METHOD("soft_body_get_gravity_scale", "body"), &PhysicsServer3D::soft_body_get_gravity_scale);
+
 	ClassDB::bind_method(D_METHOD("soft_body_set_linear_stiffness", "body", "stiffness"), &PhysicsServer3D::soft_body_set_linear_stiffness);
 	ClassDB::bind_method(D_METHOD("soft_body_get_linear_stiffness", "body"), &PhysicsServer3D::soft_body_get_linear_stiffness);
 

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -272,6 +272,9 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("soft_body_set_internal_spring_stiffness", "body", "stiffness"), &PhysicsServer3D::soft_body_set_internal_spring_stiffness);
 	ClassDB::bind_method(D_METHOD("soft_body_get_internal_spring_stiffness", "body"), &PhysicsServer3D::soft_body_get_internal_spring_stiffness);
 
+	ClassDB::bind_method(D_METHOD("soft_body_set_internal_spring_damping_coefficient", "body", "damping_coefficient"), &PhysicsServer3D::soft_body_set_internal_spring_damping_coefficient);
+	ClassDB::bind_method(D_METHOD("soft_body_get_internal_spring_damping_coefficient", "body"), &PhysicsServer3D::soft_body_get_internal_spring_damping_coefficient);
+
 	ClassDB::bind_method(D_METHOD("soft_body_set_shrinking_factor", "body", "shrinking_factor"), &PhysicsServer3D::soft_body_set_shrinking_factor);
 	ClassDB::bind_method(D_METHOD("soft_body_get_shrinking_factor", "body"), &PhysicsServer3D::soft_body_get_shrinking_factor);
 
@@ -280,6 +283,9 @@ void PhysicsServer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("soft_body_set_damping_coefficient", "body", "damping_coefficient"), &PhysicsServer3D::soft_body_set_damping_coefficient);
 	ClassDB::bind_method(D_METHOD("soft_body_get_damping_coefficient", "body"), &PhysicsServer3D::soft_body_get_damping_coefficient);
+
+	ClassDB::bind_method(D_METHOD("soft_body_set_mesh_damping_coefficient", "body", "damping_coefficient"), &PhysicsServer3D::soft_body_set_mesh_damping_coefficient);
+	ClassDB::bind_method(D_METHOD("soft_body_get_mesh_damping_coefficient", "body"), &PhysicsServer3D::soft_body_get_mesh_damping_coefficient);
 
 	ClassDB::bind_method(D_METHOD("soft_body_set_drag_coefficient", "body", "drag_coefficient"), &PhysicsServer3D::soft_body_set_drag_coefficient);
 	ClassDB::bind_method(D_METHOD("soft_body_get_drag_coefficient", "body"), &PhysicsServer3D::soft_body_get_drag_coefficient);

--- a/servers/physics_3d/physics_server_3d.cpp
+++ b/servers/physics_3d/physics_server_3d.cpp
@@ -290,8 +290,10 @@ void PhysicsServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("soft_body_remove_all_pinned_points", "body"), &PhysicsServer3D::soft_body_remove_all_pinned_points);
 
 	ClassDB::bind_method(D_METHOD("soft_body_pin_point", "body", "point_index", "pin"), &PhysicsServer3D::soft_body_pin_point);
-
 	ClassDB::bind_method(D_METHOD("soft_body_is_point_pinned", "body", "point_index"), &PhysicsServer3D::soft_body_is_point_pinned);
+
+	ClassDB::bind_method(D_METHOD("soft_body_set_point_weight", "body", "point_index", "weight"), &PhysicsServer3D::soft_body_set_point_weight);
+	ClassDB::bind_method(D_METHOD("soft_body_get_point_weight", "body", "point_index"), &PhysicsServer3D::soft_body_get_point_weight);
 
 	ClassDB::bind_method(D_METHOD("soft_body_apply_point_impulse", "body", "point_index", "impulse"), &PhysicsServer3D::soft_body_apply_point_impulse);
 	ClassDB::bind_method(D_METHOD("soft_body_apply_point_force", "body", "point_index", "force"), &PhysicsServer3D::soft_body_apply_point_force);

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -286,6 +286,9 @@ public:
 	virtual void soft_body_set_total_mass(RID p_body, real_t p_total_mass) = 0;
 	virtual real_t soft_body_get_total_mass(RID p_body) const = 0;
 
+	virtual void soft_body_set_gravity_scale(RID p_body, real_t p_gravity_scale) = 0;
+	virtual real_t soft_body_get_gravity_scale(RID p_body) const = 0;
+
 	virtual void soft_body_set_linear_stiffness(RID p_body, real_t p_stiffness) = 0;
 	virtual real_t soft_body_get_linear_stiffness(RID p_body) const = 0;
 

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -295,6 +295,9 @@ public:
 	virtual void soft_body_set_internal_spring_stiffness(RID p_body, real_t p_stiffness) = 0;
 	virtual real_t soft_body_get_internal_spring_stiffness(RID p_body) const = 0;
 
+	virtual void soft_body_set_internal_spring_damping_coefficient(RID p_body, real_t p_damping_coefficient) = 0;
+	virtual real_t soft_body_get_internal_spring_damping_coefficient(RID p_body) const = 0;
+
 	virtual void soft_body_set_shrinking_factor(RID p_body, real_t p_shrinking_factor) = 0;
 	virtual real_t soft_body_get_shrinking_factor(RID p_body) const = 0;
 
@@ -303,6 +306,9 @@ public:
 
 	virtual void soft_body_set_damping_coefficient(RID p_body, real_t p_damping_coefficient) = 0;
 	virtual real_t soft_body_get_damping_coefficient(RID p_body) const = 0;
+
+	virtual void soft_body_set_mesh_damping_coefficient(RID p_body, real_t p_damping_coefficient) = 0;
+	virtual real_t soft_body_get_mesh_damping_coefficient(RID p_body) const = 0;
 
 	virtual void soft_body_set_drag_coefficient(RID p_body, real_t p_drag_coefficient) = 0;
 	virtual real_t soft_body_get_drag_coefficient(RID p_body) const = 0;

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -289,6 +289,12 @@ public:
 	virtual void soft_body_set_linear_stiffness(RID p_body, real_t p_stiffness) = 0;
 	virtual real_t soft_body_get_linear_stiffness(RID p_body) const = 0;
 
+	virtual void soft_body_set_internal_springs(RID p_body, bool p_enabled) = 0;
+	virtual bool soft_body_is_internal_springs_enabled(RID p_body) const = 0;
+
+	virtual void soft_body_set_internal_spring_stiffness(RID p_body, real_t p_stiffness) = 0;
+	virtual real_t soft_body_get_internal_spring_stiffness(RID p_body) const = 0;
+
 	virtual void soft_body_set_shrinking_factor(RID p_body, real_t p_shrinking_factor) = 0;
 	virtual real_t soft_body_get_shrinking_factor(RID p_body) const = 0;
 

--- a/servers/physics_3d/physics_server_3d.h
+++ b/servers/physics_3d/physics_server_3d.h
@@ -318,6 +318,8 @@ public:
 	virtual void soft_body_remove_all_pinned_points(RID p_body) = 0;
 	virtual void soft_body_pin_point(RID p_body, int p_point_index, bool p_pin) = 0;
 	virtual bool soft_body_is_point_pinned(RID p_body, int p_point_index) const = 0;
+	virtual void soft_body_set_point_weight(RID p_body, int p_point_index, real_t p_weight) = 0;
+	virtual real_t soft_body_get_point_weight(RID p_body, int p_point_index) const = 0;
 
 	/* JOINT API */
 

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -353,6 +353,9 @@ public:
 	virtual void soft_body_set_internal_spring_stiffness(RID p_body, real_t p_stiffness) override {}
 	virtual real_t soft_body_get_internal_spring_stiffness(RID p_body) const override { return 0; }
 
+	virtual void soft_body_set_internal_spring_damping_coefficient(RID p_body, real_t p_damping_coefficient) override {}
+	virtual real_t soft_body_get_internal_spring_damping_coefficient(RID p_body) const override { return 0; }
+
 	virtual void soft_body_set_shrinking_factor(RID p_body, real_t p_shrinking_factor) override {}
 	virtual real_t soft_body_get_shrinking_factor(RID p_body) const override { return 0; }
 
@@ -361,6 +364,9 @@ public:
 
 	virtual void soft_body_set_damping_coefficient(RID p_body, real_t p_damping_coefficient) override {}
 	virtual real_t soft_body_get_damping_coefficient(RID p_body) const override { return 0; }
+
+	virtual void soft_body_set_mesh_damping_coefficient(RID p_body, real_t p_damping_coefficient) override {}
+	virtual real_t soft_body_get_mesh_damping_coefficient(RID p_body) const override { return 0; }
 
 	virtual void soft_body_set_drag_coefficient(RID p_body, real_t p_drag_coefficient) override {}
 	virtual real_t soft_body_get_drag_coefficient(RID p_body) const override { return 0; }

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -347,6 +347,12 @@ public:
 	virtual void soft_body_set_linear_stiffness(RID p_body, real_t p_stiffness) override {}
 	virtual real_t soft_body_get_linear_stiffness(RID p_body) const override { return 0; }
 
+	virtual void soft_body_set_internal_springs(RID p_body, bool p_enabled) override {}
+	virtual bool soft_body_is_internal_springs_enabled(RID p_body) const override { return false; }
+
+	virtual void soft_body_set_internal_spring_stiffness(RID p_body, real_t p_stiffness) override {}
+	virtual real_t soft_body_get_internal_spring_stiffness(RID p_body) const override { return 0; }
+
 	virtual void soft_body_set_shrinking_factor(RID p_body, real_t p_shrinking_factor) override {}
 	virtual real_t soft_body_get_shrinking_factor(RID p_body) const override { return 0; }
 

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -371,6 +371,8 @@ public:
 	virtual void soft_body_remove_all_pinned_points(RID p_body) override {}
 	virtual void soft_body_pin_point(RID p_body, int p_point_index, bool p_pin) override {}
 	virtual bool soft_body_is_point_pinned(RID p_body, int p_point_index) const override { return false; }
+	virtual void soft_body_set_point_weight(RID p_body, int p_point_index, real_t p_weight) override {}
+	virtual real_t soft_body_get_point_weight(RID p_body, int p_point_index) const override { return 1.0; }
 
 	virtual void soft_body_apply_point_impulse(RID p_body, int p_point_index, const Vector3 &p_impulse) override {}
 	virtual void soft_body_apply_point_force(RID p_body, int p_point_index, const Vector3 &p_force) override {}

--- a/servers/physics_3d/physics_server_3d_dummy.h
+++ b/servers/physics_3d/physics_server_3d_dummy.h
@@ -344,6 +344,9 @@ public:
 	virtual void soft_body_set_total_mass(RID p_body, real_t p_total_mass) override {}
 	virtual real_t soft_body_get_total_mass(RID p_body) const override { return 0; }
 
+	virtual void soft_body_set_gravity_scale(RID p_body, real_t p_gravity_scale) override {}
+	virtual real_t soft_body_get_gravity_scale(RID p_body) const override { return 1.0; }
+
 	virtual void soft_body_set_linear_stiffness(RID p_body, real_t p_stiffness) override {}
 	virtual real_t soft_body_get_linear_stiffness(RID p_body) const override { return 0; }
 

--- a/servers/physics_3d/physics_server_3d_extension.cpp
+++ b/servers/physics_3d/physics_server_3d_extension.cpp
@@ -343,6 +343,9 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_soft_body_set_total_mass, "body", "total_mass");
 	GDVIRTUAL_BIND(_soft_body_get_total_mass, "body");
 
+	GDVIRTUAL_BIND(_soft_body_set_gravity_scale, "body", "gravity_scale");
+	GDVIRTUAL_BIND(_soft_body_get_gravity_scale, "body");
+
 	GDVIRTUAL_BIND(_soft_body_set_linear_stiffness, "body", "linear_stiffness");
 	GDVIRTUAL_BIND(_soft_body_get_linear_stiffness, "body");
 

--- a/servers/physics_3d/physics_server_3d_extension.cpp
+++ b/servers/physics_3d/physics_server_3d_extension.cpp
@@ -374,6 +374,8 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_soft_body_remove_all_pinned_points, "body");
 	GDVIRTUAL_BIND(_soft_body_pin_point, "body", "point_index", "pin");
 	GDVIRTUAL_BIND(_soft_body_is_point_pinned, "body", "point_index");
+	GDVIRTUAL_BIND(_soft_body_set_point_weight, "body", "point_index", "weight");
+	GDVIRTUAL_BIND(_soft_body_get_point_weight, "body", "point_index");
 
 	GDVIRTUAL_BIND(_soft_body_apply_point_impulse, "body", "point_index", "impulse");
 	GDVIRTUAL_BIND(_soft_body_apply_point_force, "body", "point_index", "force");

--- a/servers/physics_3d/physics_server_3d_extension.cpp
+++ b/servers/physics_3d/physics_server_3d_extension.cpp
@@ -352,6 +352,9 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_soft_body_set_internal_spring_stiffness, "body", "internal_spring_stiffness");
 	GDVIRTUAL_BIND(_soft_body_get_internal_spring_stiffness, "body");
 
+	GDVIRTUAL_BIND(_soft_body_set_internal_spring_damping_coefficient, "body", "internal_spring_damping_coefficient");
+	GDVIRTUAL_BIND(_soft_body_get_internal_spring_damping_coefficient, "body");
+
 	GDVIRTUAL_BIND(_soft_body_set_shrinking_factor, "body", "shrinking_factor");
 	GDVIRTUAL_BIND(_soft_body_get_shrinking_factor, "body");
 
@@ -360,6 +363,9 @@ void PhysicsServer3DExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_soft_body_set_damping_coefficient, "body", "damping_coefficient");
 	GDVIRTUAL_BIND(_soft_body_get_damping_coefficient, "body");
+
+	GDVIRTUAL_BIND(_soft_body_set_mesh_damping_coefficient, "body", "mesh_damping_coefficient");
+	GDVIRTUAL_BIND(_soft_body_get_mesh_damping_coefficient, "body");
 
 	GDVIRTUAL_BIND(_soft_body_set_drag_coefficient, "body", "drag_coefficient");
 	GDVIRTUAL_BIND(_soft_body_get_drag_coefficient, "body");

--- a/servers/physics_3d/physics_server_3d_extension.cpp
+++ b/servers/physics_3d/physics_server_3d_extension.cpp
@@ -346,6 +346,12 @@ void PhysicsServer3DExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_soft_body_set_linear_stiffness, "body", "linear_stiffness");
 	GDVIRTUAL_BIND(_soft_body_get_linear_stiffness, "body");
 
+	GDVIRTUAL_BIND(_soft_body_set_internal_springs, "body", "enabled");
+	GDVIRTUAL_BIND(_soft_body_is_internal_springs_enabled, "body");
+
+	GDVIRTUAL_BIND(_soft_body_set_internal_spring_stiffness, "body", "internal_spring_stiffness");
+	GDVIRTUAL_BIND(_soft_body_get_internal_spring_stiffness, "body");
+
 	GDVIRTUAL_BIND(_soft_body_set_shrinking_factor, "body", "shrinking_factor");
 	GDVIRTUAL_BIND(_soft_body_get_shrinking_factor, "body");
 

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -451,6 +451,12 @@ public:
 	EXBIND2(soft_body_set_linear_stiffness, RID, real_t)
 	EXBIND1RC(real_t, soft_body_get_linear_stiffness, RID)
 
+	EXBIND2(soft_body_set_internal_springs, RID, bool)
+	EXBIND1RC(bool, soft_body_is_internal_springs_enabled, RID)
+
+	EXBIND2(soft_body_set_internal_spring_stiffness, RID, real_t)
+	EXBIND1RC(real_t, soft_body_get_internal_spring_stiffness, RID)
+
 	EXBIND2(soft_body_set_shrinking_factor, RID, real_t)
 	EXBIND1RC(real_t, soft_body_get_shrinking_factor, RID)
 

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -457,6 +457,9 @@ public:
 	EXBIND2(soft_body_set_internal_spring_stiffness, RID, real_t)
 	EXBIND1RC(real_t, soft_body_get_internal_spring_stiffness, RID)
 
+	EXBIND2(soft_body_set_internal_spring_damping_coefficient, RID, real_t)
+	EXBIND1RC(real_t, soft_body_get_internal_spring_damping_coefficient, RID)
+
 	EXBIND2(soft_body_set_shrinking_factor, RID, real_t)
 	EXBIND1RC(real_t, soft_body_get_shrinking_factor, RID)
 
@@ -465,6 +468,9 @@ public:
 
 	EXBIND2(soft_body_set_damping_coefficient, RID, real_t)
 	EXBIND1RC(real_t, soft_body_get_damping_coefficient, RID)
+
+	EXBIND2(soft_body_set_mesh_damping_coefficient, RID, real_t)
+	EXBIND1RC(real_t, soft_body_get_mesh_damping_coefficient, RID)
 
 	EXBIND2(soft_body_set_drag_coefficient, RID, real_t)
 	EXBIND1RC(real_t, soft_body_get_drag_coefficient, RID)

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -448,6 +448,9 @@ public:
 	EXBIND2(soft_body_set_total_mass, RID, real_t)
 	EXBIND1RC(real_t, soft_body_get_total_mass, RID)
 
+	EXBIND2(soft_body_set_gravity_scale, RID, real_t)
+	EXBIND1RC(real_t, soft_body_get_gravity_scale, RID)
+
 	EXBIND2(soft_body_set_linear_stiffness, RID, real_t)
 	EXBIND1RC(real_t, soft_body_get_linear_stiffness, RID)
 

--- a/servers/physics_3d/physics_server_3d_extension.h
+++ b/servers/physics_3d/physics_server_3d_extension.h
@@ -479,6 +479,8 @@ public:
 	EXBIND1(soft_body_remove_all_pinned_points, RID)
 	EXBIND3(soft_body_pin_point, RID, int, bool)
 	EXBIND2RC(bool, soft_body_is_point_pinned, RID, int)
+	EXBIND3(soft_body_set_point_weight, RID, int, real_t)
+	EXBIND2RC(real_t, soft_body_get_point_weight, RID, int)
 
 	EXBIND3(soft_body_apply_point_impulse, RID, int, const Vector3 &)
 	EXBIND3(soft_body_apply_point_force, RID, int, const Vector3 &)

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -344,6 +344,8 @@ public:
 	FUNC1(soft_body_remove_all_pinned_points, RID);
 	FUNC3(soft_body_pin_point, RID, int, bool);
 	FUNC2RC(bool, soft_body_is_point_pinned, RID, int);
+	FUNC3(soft_body_set_point_weight, RID, int, real_t);
+	FUNC2RC(real_t, soft_body_get_point_weight, RID, int);
 
 	/* JOINT API */
 

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -316,6 +316,12 @@ public:
 	FUNC2(soft_body_set_linear_stiffness, RID, real_t);
 	FUNC1RC(real_t, soft_body_get_linear_stiffness, RID);
 
+	FUNC2(soft_body_set_internal_springs, RID, bool);
+	FUNC1RC(bool, soft_body_is_internal_springs_enabled, RID);
+
+	FUNC2(soft_body_set_internal_spring_stiffness, RID, real_t);
+	FUNC1RC(real_t, soft_body_get_internal_spring_stiffness, RID);
+
 	FUNC2(soft_body_set_shrinking_factor, RID, real_t);
 	FUNC1RC(real_t, soft_body_get_shrinking_factor, RID);
 

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -313,6 +313,9 @@ public:
 	FUNC2(soft_body_set_total_mass, RID, real_t);
 	FUNC1RC(real_t, soft_body_get_total_mass, RID);
 
+	FUNC2(soft_body_set_gravity_scale, RID, real_t);
+	FUNC1RC(real_t, soft_body_get_gravity_scale, RID);
+
 	FUNC2(soft_body_set_linear_stiffness, RID, real_t);
 	FUNC1RC(real_t, soft_body_get_linear_stiffness, RID);
 

--- a/servers/physics_3d/physics_server_3d_wrap_mt.h
+++ b/servers/physics_3d/physics_server_3d_wrap_mt.h
@@ -322,6 +322,9 @@ public:
 	FUNC2(soft_body_set_internal_spring_stiffness, RID, real_t);
 	FUNC1RC(real_t, soft_body_get_internal_spring_stiffness, RID);
 
+	FUNC2(soft_body_set_internal_spring_damping_coefficient, RID, real_t);
+	FUNC1RC(real_t, soft_body_get_internal_spring_damping_coefficient, RID);
+
 	FUNC2(soft_body_set_shrinking_factor, RID, real_t);
 	FUNC1RC(real_t, soft_body_get_shrinking_factor, RID);
 
@@ -330,6 +333,9 @@ public:
 
 	FUNC2(soft_body_set_damping_coefficient, RID, real_t);
 	FUNC1RC(real_t, soft_body_get_damping_coefficient, RID);
+
+	FUNC2(soft_body_set_mesh_damping_coefficient, RID, real_t);
+	FUNC1RC(real_t, soft_body_get_mesh_damping_coefficient, RID);
 
 	FUNC2(soft_body_set_drag_coefficient, RID, real_t);
 	FUNC1RC(real_t, soft_body_get_drag_coefficient, RID);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

This pull request brings several enhancements and fixes to SoftBody3D, targeting better character-attached and volumetric soft body simulations on both the Default (Godot Physics) and Jolt Physics backends.


## Additional information

Note: While this is a large PR touching multiple interrelated features, the changes are strictly isolated by commit to facilitate modular review. If maintainers prefer this split into smaller PRs, I am happy to do so.

AI Usage: Most code is written by AI, but every line is reviewed, and I tried my best to keep things clean.

The several improvements are all for softbody physics, so I think it makes sense to have them in one PR:

### 1. Skeleton Deformation & Dynamic Pinning

* **Problem**: `SoftBody3D` does not work well with skeletons, even if they inherit MeshInstance3D. The skinned mesh visual transforms were applied via GPU while the physics is simulated in world space, leading to issues like double-transformations and wrong collision locations.
* **Solution**:
* For SoftBody3D that has skeleton and skin resources set, GPU deformation is disabled. Every pinned point follows the bone deformation calculated on the CPU and affects other non-pinned points via physics simulation (PhysicsServer3D::soft_body_move_point).
* For SoftBody3D without skeleton or skin resources set, original behavior remains unchanged.


### 2. Internal Springs (similar to the one in Blender)

* **Problem**: Soft bodies collapse under compression without internal volume constraints. The pressure option solves this for some use cases, but looks unrealistic for others (looks like a balloon instead of soft tissues).
* **Solution**:
* Implemented an internal spring option. When enabled, loose edges in the mesh are converted to spring links similar to mesh edges, and the user can design the mesh to have the correct amount of internal springs to fit the need.
* `internal_spring_stiffness` is controlled separatly than the original linear stiffness for better control.
* This also fixes the issue with meshes containing multiple surfaces (common when more than one material is used on the same mesh). Godot previously only parsed surface 0 and threw index out-of-bounds errors on multi-surface meshes or loose line primitives (`PRIMITIVE_LINES`).
* In-game, loose edges are automatically assigned a transparent material to keep them hidden.


### 3. Weighted Pinned Points & Viewport Tooling

* **Problem**: Current pinning was binary (fully rigid or free), preventing smooth skinning transitions (e.g., dynamic flesh or dangling cloth).
* **Solution**:
* Pinned attachments now accept an additional `weight` field (`0.0`–`1.0`).
* For weights == 0 or > 0.999, original behavior is used.
* For weights between 0 and 0.999 (soft-pinned vertices), the mesh point is unpinned, and instead, an elastic link to an anchor point is created, and any motion will move the anchor point, causing the mesh point to softly follow. The elastic link stiffness is controlled by the pin weight.
* Added a **SoftBody3D Editor Plugin** to the 3D viewport toolbar with a **"Set Pin Weights from Vertex Colors"** tool to make weight assignment easier.

### 4. Mesh Damping (Link-Space Friction)

* **Problem**: Global linear damping creates artificial "air drag" when an object translates through space at high speeds. This is useful for cloth simulation, but is unwanted for soft tissue simulation.
* **Solution**: Added mesh-space damping calculated across individual edge links, simulating internal material friction on each link. This damps the deformation and is independent of global linear velocity.

### 5. Gravity Scale

* Added `gravity_scale` property to `SoftBody3D`, matching the existing functionality in `RigidBody3D`.

### 6. Exponential Stiffness Solver Scaling

This is **breaking** change that modifies the original default behavior, but it is necessary for the pin weight feature to work properly.

* **Problem**: Stiffness coefficients are applied to the solver in each iteration. This makes the final simulation reault dependent on the `simulation_precision` config. And since this is an exponential scaling, a slightly higher iteration count requires the stiffness to be very low to get the same result.
The physical behavior should be independent of solver iteration settings.
* **Solution**: Normalized `linear_stiffness`, `internal_spring_stiffness`, and anchor weights exponentially relative to iteration count, ensuring physical behavior remains consistent regardless of solver quality settings.

---

## Testing & Verification

I extensively tested on the Jolt Physics engine, since it is the default. Some simple tests were done on the Godot Physics engine, but more tests are needed.

I'll add demos and reproduction scenes shortly.
