### PR TITLE
Fix AreaLight3D energy in LightmapGI when physical light units enabled

### DIFF
--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1399,7 +1399,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 			} else if (Object::cast_to<AreaLight3D>(light)) {
 				AreaLight3D *l = Object::cast_to<AreaLight3D>(light);
 				if (use_physical_light_units) {
-					energy *= (1.0 / Math::PI * 2.0);
+					energy *= (1.0 / (Math::PI * 2.0));
 				}
 				Vector3 area_vec_x = xf.basis.get_column(Vector3::AXIS_X).normalized() * l->get_area_size().x;
 				Vector3 area_vec_y = xf.basis.get_column(Vector3::AXIS_Y).normalized() * l->get_area_size().y;


### PR DESCRIPTION
## What problem(s) does this PR solve?

When physical light units are enabled, an AreaLight3D baked by LightmapGI is significantly brighter than the same setup using VoxelGI.

LightmapGI uses a physical-units conversion coefficient that is four times larger than the existing direct-lighting and VoxelGI paths.


## Additional information

LightmapGI converts AreaLight3D luminous power using:

```cpp
1.0 / PI * 2.0
```

Due to operator precedence, this evaluates to `2 / PI`. The direct-lighting and VoxelGI paths use `1 / (2 * PI)`, so the LightmapGI value is four times larger.

This changes the expression to match those existing AreaLight3D paths.

## Testing

The MRP renders identical 16 lm AreaLight3D setups using LightmapGI and VoxelGI.

Before the fix, the LightmapGI result is significantly brighter. After rebaking with the fix, both results have closely matching brightness. Pixel-perfect agreement is not expected because LightmapGI and VoxelGI use different GI techniques.

The included MRP intentionally contains the affected LightmapGI bake. To verify the fix, rebake only the LightmapGI node with a patched build.

### Minimal reproduction project

[LightmapGI-AreaLight-VoxelGI-MRP.zip](https://github.com/user-attachments/files/31290068/LightmapGI-AreaLight-VoxelGI-MRP.zip)


### Before the fix


<img width="1280" height="720" alt="LightmapGI-AreaLight-vs-VoxelGI-before" src="https://github.com/user-attachments/assets/753661fa-371a-40bd-a082-078badcb0e25" />


### After the fix


<img width="1280" height="720" alt="LightmapGI-AreaLight-vs-VoxelGI-after" src="https://github.com/user-attachments/assets/7e6c3ab4-8cef-452c-8b07-83ae0c34bafe" />



## AI disclosure

I used AI to help analyze the root cause, prepare the minimal reproduction project, and review the proposed fix. I reviewed the code change and reproduction steps myself.