### PR TITLE
Allow compiling with min macOS version up to 14

### DIFF
--- a/modules/camera/camera_apple.mm
+++ b/modules/camera/camera_apple.mm
@@ -483,7 +483,9 @@ void CameraApple::update_feeds() {
 	if (@available(macOS 14.0, *)) {
 		session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternal, AVCaptureDeviceTypeBuiltInWideAngleCamera, AVCaptureDeviceTypeContinuityCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
 	} else {
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 140000
 		session = [AVCaptureDeviceDiscoverySession discoverySessionWithDeviceTypes:[NSArray arrayWithObjects:AVCaptureDeviceTypeExternalUnknown, AVCaptureDeviceTypeBuiltInWideAngleCamera, nil] mediaType:AVMediaTypeVideo position:AVCaptureDevicePositionUnspecified];
+#endif
 	}
 	devices = session.devices;
 #endif // APPLE_EMBEDDED_ENABLED

--- a/platform/macos/godot_application.mm
+++ b/platform/macos/godot_application.mm
@@ -169,6 +169,11 @@ GodotApplication *GodotApp = nil;
 	}
 }
 
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
+// This option was deprecated in macOS 14.0, replace it with 0 (no options) when min version is 14.0 or higher.
+#define NSApplicationActivateIgnoringOtherApps 0
+#endif
+
 - (void)forceUnbundledWindowActivationHackStep1 {
 	// Step 1: Switch focus to macOS SystemUIServer process.
 	// Required to perform step 2, TransformProcessType will fail if app is already the in focus.
@@ -192,5 +197,9 @@ GodotApplication *GodotApp = nil;
 	// Step 3: Switch focus back to app window.
 	[[NSRunningApplication currentApplication] activateWithOptions:NSApplicationActivateIgnoringOtherApps];
 }
+
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 140000
+#undef NSApplicationActivateIgnoringOtherApps
+#endif
 
 @end

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -933,7 +933,7 @@ String OS_MacOS::get_unique_id() const {
 	static String serial_number;
 
 	if (serial_number.is_empty()) {
-#if defined(__x86_64) || defined(__x86_64__)
+#if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
 		io_service_t platform_expert = IOServiceGetMatchingService(kIOMasterPortDefault, IOServiceMatching("IOPlatformExpertDevice"));
 #else
 		io_service_t platform_expert = IOServiceGetMatchingService(kIOMainPortDefault, IOServiceMatching("IOPlatformExpertDevice"));


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR fixes Godot's Objective-C++ code to allow compiling with newer minimum macOS versions, up to macOS 14.0.

Justification: We should give users the flexibility to customize the minimum macOS version if they need to, such as if a dependency requires a newer minimum macOS version.

## Additional information

No AI was used to make this PR.

This PR is a subset of PR #122524. This PR is for master, and I have already made separate PRs for cherry-picking to earlier Godot branches, such as PR #122561 for Godot 4.7.

The version numbers after `#if MAC_OS_X_VERSION_MIN_REQUIRED` correspond to exactly the version in which those features become deprecated and therefore stop compiling when warnings are enabled.

I tested with up to macOS 26.5, and the only remaining problem with going that far is `CGWindowListCreateImageFromArray` which is deprecated as of macOS 15.0. This will require migration to `ScreenCaptureKit`.
