### PR TITLE
Add worker threads to BVH

### DIFF
--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -52,6 +52,7 @@
 
 #include "core/math/bvh_tree.h"
 #include "core/math/geometry_3d.h"
+#include "core/object/worker_thread_pool.h"
 #include "core/os/mutex.h"
 
 #include <climits> // INT_MAX
@@ -59,8 +60,11 @@
 #define BVHTREE_CLASS BVH_Tree<T, NUM_TREES, 2, MAX_ITEMS, USER_PAIR_TEST_FUNCTION, USER_CULL_TEST_FUNCTION, USE_PAIRS, BOUNDS, POINT>
 #define BVH_LOCKED_FUNCTION BVHLockedFunction _lock_guard(&_mutex, BVH_THREAD_SAFE &&_thread_safe);
 
-template <typename T, int NUM_TREES = 1, bool USE_PAIRS = false, int MAX_ITEMS = 32, typename USER_PAIR_TEST_FUNCTION = BVH_DummyPairTestFunction<T>, typename USER_CULL_TEST_FUNCTION = BVH_DummyCullTestFunction<T>, typename BOUNDS = AABB, typename POINT = Vector3, bool BVH_THREAD_SAFE = true>
+template <typename T, int NUM_TREES = 1, bool USE_PAIRS = false, int MAX_ITEMS = 32, typename USER_PAIR_TEST_FUNCTION = BVH_DummyPairTestFunction<T>, typename USER_CULL_TEST_FUNCTION = BVH_DummyCullTestFunction<T>, typename BOUNDS = AABB, typename POINT = Vector3, bool BVH_THREAD_SAFE = true, bool BVH_USE_THREADS = false>
 class BVH_Manager {
+	static_assert(!BVH_USE_THREADS || std::is_same_v<USER_CULL_TEST_FUNCTION, std::nullptr_t>,
+			"Cannot use a cull function for BVH_Manager when `BVH_USE_THREADS` is true. Use std::nullptr_t for `USER_CULL_TEST_FUNCTION`.");
+
 public:
 	// note we are using uint32_t instead of BVHHandle, losing type safety, but this
 	// is for compatibility with octree
@@ -433,13 +437,9 @@ public:
 	}
 
 private:
-	// do this after moving etc.
-	void _check_for_collisions(bool p_full_check = false) {
-		if (!changed_items.size()) {
-			// noop
-			return;
-		}
+	mutable LocalVector<LocalVector<Pair<uint32_t, uint32_t>>> _cull_hits_mt;
 
+	void _cull_mt(uint32_t p_changed_index, void *p_userdata) const {
 		typename BVHTREE_CLASS::CullParams params;
 
 		params.result_count_overall = 0;
@@ -447,40 +447,117 @@ private:
 		params.result_array = nullptr;
 		params.subindex_array = nullptr;
 
+		//for (const BVHHandle &h : changed_items) {
+		// use the expanded aabb for pairing
+		const BVHHandle &h = changed_items[p_changed_index];
+		const BOUNDS &expanded_aabb = tree._pairs[h.id()].expanded_aabb;
+		BVHABB_CLASS abb;
+		abb.from(expanded_aabb);
+
+		tree.item_fill_cullparams(h, params);
+
+		params.abb = abb;
+		params.result_count_overall = 0; // might not be needed
+		tree._cull_aabb_mt(_cull_hits_mt[WorkerThreadPool::get_singleton()->get_thread_index()], params, h.id());
+	}
+
+	void _check_for_collisions_mt(bool p_full_check = false) {
+		if (!changed_items.size()) {
+			// noop
+			return;
+		}
+
 		for (const BVHHandle &h : changed_items) {
-			// use the expanded aabb for pairing
 			const BOUNDS &expanded_aabb = tree._pairs[h.id()].expanded_aabb;
 			BVHABB_CLASS abb;
 			abb.from(expanded_aabb);
 
-			tree.item_fill_cullparams(h, params);
-
 			// find all the existing paired aabbs that are no longer
 			// paired, and send callbacks
 			_find_leavers(h, abb, p_full_check);
+		}
 
-			uint32_t changed_item_ref_id = h.id();
+		WorkerThreadPool *pool = WorkerThreadPool::get_singleton();
+		_cull_hits_mt.resize(pool->get_thread_count());
+		for (LocalVector<Pair<uint32_t, uint32_t>> &c : _cull_hits_mt) {
+			c.clear();
+		}
 
-			params.abb = abb;
+		WorkerThreadPool::GroupID group_task = pool->add_template_group_task(this, &BVH_Manager::_cull_mt, nullptr, changed_items.size(), -1, true, SNAME("BVH Collision Tests"));
+		WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
 
-			params.result_count_overall = 0; // might not be needed
-			tree.cull_aabb(params, false);
-
-			for (const uint32_t ref_id : tree._cull_hits) {
+		for (const LocalVector<Pair<uint32_t, uint32_t>> &c : _cull_hits_mt) {
+			for (const Pair<uint32_t, uint32_t> &p : c) {
 				// don't collide against ourself
-				if (ref_id == changed_item_ref_id) {
+				if (p.first == p.second) {
 					continue;
 				}
 
 				// checkmasks is already done in the cull routine.
 				BVHHandle h_collidee;
-				h_collidee.set_id(ref_id);
+				h_collidee.set_id(p.second);
+				BVHHandle h;
+				h.set_id(p.first);
 
 				// find NEW enterers, and send callbacks for them only
 				_collide(h, h_collidee);
 			}
 		}
 		_reset();
+	}
+
+	// do this after moving etc.
+	void _check_for_collisions(bool p_full_check = false) {
+		if constexpr (BVH_USE_THREADS) {
+			_check_for_collisions_mt(p_full_check);
+		} else {
+			if (!changed_items.size()) {
+				// noop
+				return;
+			}
+
+			typename BVHTREE_CLASS::CullParams params;
+
+			params.result_count_overall = 0;
+			params.result_max = INT_MAX;
+			params.result_array = nullptr;
+			params.subindex_array = nullptr;
+
+			for (const BVHHandle &h : changed_items) {
+				// use the expanded aabb for pairing
+				const BOUNDS &expanded_aabb = tree._pairs[h.id()].expanded_aabb;
+				BVHABB_CLASS abb;
+				abb.from(expanded_aabb);
+
+				tree.item_fill_cullparams(h, params);
+
+				// find all the existing paired aabbs that are no longer
+				// paired, and send callbacks
+				_find_leavers(h, abb, p_full_check);
+
+				uint32_t changed_item_ref_id = h.id();
+
+				params.abb = abb;
+
+				params.result_count_overall = 0; // might not be needed
+				tree.cull_aabb(params, false);
+
+				for (const uint32_t ref_id : tree._cull_hits) {
+					// don't collide against ourself
+					if (ref_id == changed_item_ref_id) {
+						continue;
+					}
+
+					// checkmasks is already done in the cull routine.
+					BVHHandle h_collidee;
+					h_collidee.set_id(ref_id);
+
+					// find NEW enterers, and send callbacks for them only
+					_collide(h, h_collidee);
+				}
+			}
+			_reset();
+		}
 	}
 
 public:

--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -437,6 +437,12 @@ public:
 	}
 
 private:
+	struct ResultIndex {
+		uint32_t start;
+		uint16_t count;
+		uint16_t thread;
+	};
+	mutable LocalVector<ResultIndex> result_index;
 	mutable LocalVector<LocalVector<Pair<uint32_t, uint32_t>>> _cull_hits_mt;
 
 	void _cull_mt(uint32_t p_changed_index, void *p_userdata) const {
@@ -447,7 +453,6 @@ private:
 		params.result_array = nullptr;
 		params.subindex_array = nullptr;
 
-		//for (const BVHHandle &h : changed_items) {
 		// use the expanded aabb for pairing
 		const BVHHandle &h = changed_items[p_changed_index];
 		const BOUNDS &expanded_aabb = tree._pairs[h.id()].expanded_aabb;
@@ -458,7 +463,25 @@ private:
 
 		params.abb = abb;
 		params.result_count_overall = 0; // might not be needed
-		tree._cull_aabb_mt(_cull_hits_mt[WorkerThreadPool::get_singleton()->get_thread_index()], params, h.id());
+
+		int thread_index = WorkerThreadPool::get_singleton()->get_thread_index();
+		DEV_ASSERT(thread_index >= 0 && thread_index < WorkerThreadPool::get_singleton()->get_thread_count());
+		if (thread_index < 0) {
+			// Thread index will be -1 if we are on the main thread rather than a worker.
+			// We shouldn't get here, but if we do, there no reason we can't continue.
+			thread_index = 0;
+		}
+
+		int start = _cull_hits_mt[thread_index].size();
+		tree._cull_aabb_mt(_cull_hits_mt[thread_index], params, h.id());
+		int count = _cull_hits_mt[thread_index].size() - start;
+		if (count) {
+			DEV_ASSERT(count < UINT16_MAX);
+			// NOTE: If there are > 65536 hits, nothing should crash, but the excess hits won't get reported
+			result_index[p_changed_index].count = CLAMP(count, 0, UINT16_MAX);
+			result_index[p_changed_index].thread = thread_index;
+			result_index[p_changed_index].start = start;
+		}
 	}
 
 	void _check_for_collisions_mt(bool p_full_check = false) {
@@ -478,7 +501,12 @@ private:
 		}
 
 		WorkerThreadPool *pool = WorkerThreadPool::get_singleton();
-		_cull_hits_mt.resize(pool->get_thread_count());
+		int worker_thread_count = pool->get_thread_count();
+		DEV_ASSERT(worker_thread_count > 1);
+
+		result_index.clear();
+		result_index.resize_initialized(changed_items.size());
+		_cull_hits_mt.resize(worker_thread_count);
 		for (LocalVector<Pair<uint32_t, uint32_t>> &c : _cull_hits_mt) {
 			c.clear();
 		}
@@ -486,21 +514,27 @@ private:
 		WorkerThreadPool::GroupID group_task = pool->add_template_group_task(this, &BVH_Manager::_cull_mt, nullptr, changed_items.size(), -1, true, SNAME("BVH Collision Tests"));
 		WorkerThreadPool::get_singleton()->wait_for_group_task_completion(group_task);
 
-		for (const LocalVector<Pair<uint32_t, uint32_t>> &c : _cull_hits_mt) {
-			for (const Pair<uint32_t, uint32_t> &p : c) {
-				// don't collide against ourself
-				if (p.first == p.second) {
-					continue;
+		for (const ResultIndex ri : result_index) {
+			if (ri.count) {
+				const LocalVector<Pair<uint32_t, uint32_t>> &c = _cull_hits_mt[ri.thread];
+				uint32_t end = ri.start + ri.count;
+				for (uint32_t i = ri.start; i < end; ++i) {
+					const Pair<uint32_t, uint32_t> &p = c[i];
+
+					// don't collide against ourself
+					if (p.first == p.second) {
+						continue;
+					}
+
+					// checkmasks is already done in the cull routine.
+					BVHHandle h_collidee;
+					h_collidee.set_id(p.second);
+					BVHHandle h;
+					h.set_id(p.first);
+
+					// find NEW enterers, and send callbacks for them only
+					_collide(h, h_collidee);
 				}
-
-				// checkmasks is already done in the cull routine.
-				BVHHandle h_collidee;
-				h_collidee.set_id(p.second);
-				BVHHandle h;
-				h.set_id(p.first);
-
-				// find NEW enterers, and send callbacks for them only
-				_collide(h, h_collidee);
 			}
 		}
 		_reset();
@@ -508,56 +542,61 @@ private:
 
 	// do this after moving etc.
 	void _check_for_collisions(bool p_full_check = false) {
+		// `_check_for_collisions_mt` and the single threaded implementation below it
+		// must produce the same output order (to be deterministic).
 		if constexpr (BVH_USE_THREADS) {
-			_check_for_collisions_mt(p_full_check);
-		} else {
-			if (!changed_items.size()) {
-				// noop
+			if (WorkerThreadPool::get_singleton()->get_thread_count() > 1) {
+				_check_for_collisions_mt(p_full_check);
 				return;
 			}
-
-			typename BVHTREE_CLASS::CullParams params;
-
-			params.result_count_overall = 0;
-			params.result_max = INT_MAX;
-			params.result_array = nullptr;
-			params.subindex_array = nullptr;
-
-			for (const BVHHandle &h : changed_items) {
-				// use the expanded aabb for pairing
-				const BOUNDS &expanded_aabb = tree._pairs[h.id()].expanded_aabb;
-				BVHABB_CLASS abb;
-				abb.from(expanded_aabb);
-
-				tree.item_fill_cullparams(h, params);
-
-				// find all the existing paired aabbs that are no longer
-				// paired, and send callbacks
-				_find_leavers(h, abb, p_full_check);
-
-				uint32_t changed_item_ref_id = h.id();
-
-				params.abb = abb;
-
-				params.result_count_overall = 0; // might not be needed
-				tree.cull_aabb(params, false);
-
-				for (const uint32_t ref_id : tree._cull_hits) {
-					// don't collide against ourself
-					if (ref_id == changed_item_ref_id) {
-						continue;
-					}
-
-					// checkmasks is already done in the cull routine.
-					BVHHandle h_collidee;
-					h_collidee.set_id(ref_id);
-
-					// find NEW enterers, and send callbacks for them only
-					_collide(h, h_collidee);
-				}
-			}
-			_reset();
 		}
+
+		if (!changed_items.size()) {
+			// noop
+			return;
+		}
+
+		typename BVHTREE_CLASS::CullParams params;
+
+		params.result_count_overall = 0;
+		params.result_max = INT_MAX;
+		params.result_array = nullptr;
+		params.subindex_array = nullptr;
+
+		for (const BVHHandle &h : changed_items) {
+			// use the expanded aabb for pairing
+			const BOUNDS &expanded_aabb = tree._pairs[h.id()].expanded_aabb;
+			BVHABB_CLASS abb;
+			abb.from(expanded_aabb);
+
+			tree.item_fill_cullparams(h, params);
+
+			// find all the existing paired aabbs that are no longer
+			// paired, and send callbacks
+			_find_leavers(h, abb, p_full_check);
+
+			uint32_t changed_item_ref_id = h.id();
+
+			params.abb = abb;
+
+			params.result_count_overall = 0; // might not be needed
+			tree.cull_aabb(params, false);
+
+			for (const uint32_t ref_id : tree._cull_hits) {
+				// don't collide against ourself
+				if (ref_id == changed_item_ref_id) {
+					continue;
+				}
+
+				// checkmasks is already done in the cull routine.
+				BVHHandle h_collidee;
+				h_collidee.set_id(ref_id);
+
+				// find NEW enterers, and send callbacks for them only
+				_collide(h, h_collidee);
+			}
+		}
+		_reset();
 	}
 
 public:

--- a/core/math/bvh_cull.inc
+++ b/core/math/bvh_cull.inc
@@ -177,7 +177,32 @@ int cull_aabb(CullParams &r_params, bool p_translate_hits = true) {
 	return r_params.result_count;
 }
 
-bool _cull_hits_full(const CullParams &p_params) {
+int _cull_aabb_mt(LocalVector<Pair<uint32_t, uint32_t>> &r_cull_hits, CullParams &r_params, uint32_t test_id) const {
+	r_params.result_count = 0;
+	uint32_t tree_test_mask = 0;
+
+	for (int n = 0; n < NUM_TREES; n++) {
+		tree_test_mask <<= 1;
+		if (!tree_test_mask) {
+			tree_test_mask = 1;
+		}
+
+		if (_root_node_id[n] == BVHCommon::INVALID) {
+			continue;
+		}
+
+		// the tree collision mask determines which trees to collide test against
+		if (!(r_params.tree_collision_mask & tree_test_mask)) {
+			continue;
+		}
+
+		_cull_aabb_iterative_mt(r_cull_hits, _root_node_id[n], r_params, test_id);
+	}
+
+	return r_params.result_count;
+}
+
+bool _cull_hits_full(const CullParams &p_params) const {
 	// instead of checking every hit, we can do a lazy check for this condition.
 	// it isn't a problem if we write too much _cull_hits because they only the
 	// result_max amount will be translated and outputted. But we might as
@@ -189,7 +214,7 @@ void _cull_hit(uint32_t p_ref_id, CullParams &r_params) {
 	// take into account masks etc
 	// this would be more efficient to do before plane checks,
 	// but done here for ease to get started
-	if (USE_PAIRS) {
+	if constexpr (USE_PAIRS && !std::is_same_v<USER_CULL_TEST_FUNCTION, std::nullptr_t>) {
 		const ItemExtra &ex = _extra[p_ref_id];
 
 		// user supplied function (for e.g. pairable types and pairable masks in the render tree)
@@ -313,6 +338,108 @@ bool _cull_point_iterative(uint32_t p_node_id, CullParams &r_params) {
 				// add to the stack
 				CullPointParams *child = ii.request();
 				child->node_id = child_id;
+			}
+		}
+
+	} // while more nodes to pop
+
+	// true indicates results are not full
+	return true;
+}
+
+// Note: This is a very hot loop profiling wise. Take care when changing this and profile.
+bool _cull_aabb_iterative_mt(LocalVector<Pair<uint32_t, uint32_t>> &r_cull_hits, uint32_t p_node_id, CullParams &r_params, uint32_t test_id, bool p_fully_within = false) const {
+	// our function parameters to keep on a stack
+	struct CullAABBParams {
+		uint32_t node_id;
+		bool fully_within;
+	};
+
+	// most of the iterative functionality is contained in this helper class
+	BVH_IterativeInfo<CullAABBParams> ii;
+
+	// alloca must allocate the stack from this function, it cannot be allocated in the
+	// helper class
+	ii.stack = (CullAABBParams *)alloca(ii.get_alloca_stacksize());
+
+	// seed the stack
+	ii.get_first()->node_id = p_node_id;
+	ii.get_first()->fully_within = p_fully_within;
+
+	CullAABBParams cap;
+
+	// while there are still more nodes on the stack
+	while (ii.pop(cap)) {
+		const TNode &tnode = _nodes[cap.node_id];
+
+		if (tnode.is_leaf()) {
+			// lazy check for hits full up condition
+			if (_cull_hits_full(r_params)) {
+				return false;
+			}
+
+			const TLeaf &leaf = _node_get_leaf(tnode);
+
+			// if fully within we can just add all items
+			// as long as they pass mask checks
+			if (cap.fully_within) {
+				for (int n = 0; n < leaf.num_items; n++) {
+					uint32_t child_id = leaf.get_item_ref_id(n);
+
+					// register hit
+					r_cull_hits.push_back(Pair<uint32_t, uint32_t>(test_id, child_id));
+				}
+			} else {
+				// This section is the hottest area in profiling, so
+				// is optimized highly
+				// get this into a local register and preconverted to correct type
+				int leaf_num_items = leaf.num_items;
+
+				BVHABB_CLASS swizzled_tester;
+				swizzled_tester.min = -r_params.abb.neg_max;
+				swizzled_tester.neg_max = -r_params.abb.min;
+
+				for (int n = 0; n < leaf_num_items; n++) {
+					const BVHABB_CLASS &aabb = leaf.get_aabb(n);
+
+					if (swizzled_tester.intersects_swizzled(aabb)) {
+						uint32_t child_id = leaf.get_item_ref_id(n);
+
+						// register hit
+						r_cull_hits.push_back(Pair<uint32_t, uint32_t>(test_id, child_id));
+					}
+				}
+			} // not fully within
+		} else {
+			if (!cap.fully_within) {
+				// test children individually
+				for (int n = 0; n < tnode.num_children; n++) {
+					uint32_t child_id = tnode.children[n];
+					const BVHABB_CLASS &child_abb = _nodes[child_id].aabb;
+
+					if (child_abb.intersects(r_params.abb)) {
+						// is the node totally within the aabb?
+						bool fully_within = r_params.abb.is_other_within(child_abb);
+
+						// add to the stack
+						CullAABBParams *child = ii.request();
+
+						// should always return valid child
+						child->node_id = child_id;
+						child->fully_within = fully_within;
+					}
+				}
+			} else {
+				for (int n = 0; n < tnode.num_children; n++) {
+					uint32_t child_id = tnode.children[n];
+
+					// add to the stack
+					CullAABBParams *child = ii.request();
+
+					// should always return valid child
+					child->node_id = child_id;
+					child->fully_within = true;
+				}
 			}
 		}
 

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -43,6 +43,7 @@
 #include "core/math/vector3.h"
 #include "core/templates/local_vector.h"
 #include "core/templates/pooled_list.h"
+#include "core/variant/variant.h"
 
 #define BVHABB_CLASS BVH_ABB<BOUNDS, POINT>
 

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -42,17 +42,15 @@
 #include "core/math/bvh_abb.h"
 #include "core/math/vector3.h"
 #include "core/templates/local_vector.h"
+#include "core/templates/pair.h"
 #include "core/templates/pooled_list.h"
-#include "core/variant/variant.h"
-
-#define BVHABB_CLASS BVH_ABB<BOUNDS, POINT>
-
-// not sure if this is better yet so making optional
-#define BVH_EXPAND_LEAF_AABBS
 
 // never do these checks in release
 #ifdef DEV_ENABLED
 //#define BVH_VERBOSE
+#ifdef BVH_VERBOSE
+#include "core/string/print_string.h"
+#endif
 //#define BVH_VERBOSE_TREE
 //#define BVH_VERBOSE_PAIRING
 //#define BVH_VERBOSE_MOVES
@@ -61,6 +59,11 @@
 //#define BVH_CHECKS
 //#define BVH_INTEGRITY_CHECKS
 #endif
+
+#define BVHABB_CLASS BVH_ABB<BOUNDS, POINT>
+
+// not sure if this is better yet so making optional
+#define BVH_EXPAND_LEAF_AABBS
 
 // debug only assert
 #ifdef BVH_CHECKS

--- a/modules/godot_physics_2d/godot_broad_phase_2d_bvh.h
+++ b/modules/godot_physics_2d/godot_broad_phase_2d_bvh.h
@@ -46,14 +46,6 @@ class GodotBroadPhase2DBVH : public GodotBroadPhase2D {
 		}
 	};
 
-	template <typename T>
-	class UserCullTestFunction {
-	public:
-		static bool user_cull_check(const T *p_a, const T *p_b) {
-			return true;
-		}
-	};
-
 	enum Tree {
 		TREE_STATIC = 0,
 		TREE_DYNAMIC = 1,
@@ -64,7 +56,7 @@ class GodotBroadPhase2DBVH : public GodotBroadPhase2D {
 		TREE_FLAG_DYNAMIC = 1 << TREE_DYNAMIC,
 	};
 
-	BVH_Manager<GodotCollisionObject2D, 2, true, 128, UserPairTestFunction<GodotCollisionObject2D>, UserCullTestFunction<GodotCollisionObject2D>, Rect2, Vector2> bvh;
+	BVH_Manager<GodotCollisionObject2D, 2, true, 128, UserPairTestFunction<GodotCollisionObject2D>, std::nullptr_t, Rect2, Vector2, true, true> bvh;
 
 	static void *_pair_callback(void *, uint32_t, GodotCollisionObject2D *, int, uint32_t, GodotCollisionObject2D *, int);
 	static void _unpair_callback(void *, uint32_t, GodotCollisionObject2D *, int, uint32_t, GodotCollisionObject2D *, int, void *);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Achieves up to 2-3x performance for broad phase collision testing. Broad phase collision was the slowest profiled component in my game (with a lot of moving objects). 

It can be tested on: godot-benchmarks: Physics > CharacterBody 2D. 
This PR cuts 40% off this benchmark on my Mac Pro M5

## Additional information

This PR accelerates the BVH_Manager._check_for_collisions() function with WorkerThreads. It leaves all other pathways alone (as much as possible). 

The threaded pathway can be turned on and off with a template parameter.

I have tested the multithreaded BVH performance using my own game with an enemy horde chasing the player: 

MacOS M5 10 core - ~2-3x
Windows 11 AMD Ryzen 7 9800X3D, 8 core, 16 thread -  ~2-3x
Linux Ubuntu NUC (12 years old, reporting 4 cores, think it is a low end Intel i5) - 20-30%
iOS 26.6, iPhone 11 Pro - 10 - 20% 
Steam Deck - ~2-3x

*These numbers are the performance of the BVH, so 3x BVH performance might have a 10% speed up for my game overall.*