### PR TITLE
Fix windows screen always keep on

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -5879,7 +5879,10 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			{
 				case SC_SCREENSAVE: // Screensaver trying to start?
 				case SC_MONITORPOWER: // Monitor trying to enter powersave?
-					return 0; // Prevent from happening.
+					if (screen_is_kept_on()) {
+						return 0; // Prevent from happening.
+					}
+					break;
 				case SC_KEYMENU:
 					Engine *engine = Engine::get_singleton();
 					if (((lParam >> 16) <= 0) && !engine->is_project_manager_hint() && !engine->is_editor_hint() && !GLOBAL_GET_CACHED(bool, "application/run/enable_alt_space_menu")) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #118833

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

When the system wound turn off the screen, it sends an `SC_MONITORPOWER` message. However, `DisplayServer` directly returning `0` that would always keep the screen on, it ignores the default EditorSetting `keep screen on = false`.