### PR TITLE
[Core]: Make `get_object_class_name_or_empty` return reference for use in typed containers

### DIFF
--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -319,11 +319,12 @@ Variant::Type get_variant_type() {
 }
 
 template <typename T>
-const String get_object_class_name_or_empty() {
+const StringName &get_object_class_name_or_empty() {
 	if constexpr (std::is_base_of_v<Object, T>) {
 		return T::get_class_static();
 	} else {
-		return "";
+		static const StringName EMPTY = "";
+		return EMPTY;
 	}
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

Currently `TypedArray<T>` and `TypedDictionary<K, V>` always create a new `StringName` on their creation, this PR makes them use either a reference from the class or an empty reference. It's needed to avoid the global mutex that is being used when non-empty `StringName` is created.

## Additional information

`get_object_class_name_or_empty` is only used for typed containers, so this should be pretty safe. And as it is a `StringName` it can be easily turned into `String` on site if anyone needs the original behaviour.

Also previously it didn't create new `StringName` here
Code in 4.5.2:
https://github.com/godotengine/godot/blob/6ce3de25aa58466e14ef354703ba8d9791a417da/core/variant/typed_array.h#L50-L51

Code in 4.6:
https://github.com/godotengine/godot/blob/89cea143987d564363e15d207438530651d943ac/core/variant/typed_array.h#L43-L44

It's being auto created by the `StringName` ctor:
https://github.com/godotengine/godot/blob/6ce3de25aa58466e14ef354703ba8d9791a417da/core/variant/array.h#L189