### PR TITLE
iOS - Metal Shader Baking compilation fix / Update rendering_shader_container_metal.cpp

### DIFF
--- a/drivers/metal/rendering_shader_container_metal.cpp
+++ b/drivers/metal/rendering_shader_container_metal.cpp
@@ -78,7 +78,7 @@ void RenderingShaderContainerMetal::_initialize_toolchain_properties() {
 		}
 	}
 
-	parts.append_array({ "-", "|", "grep", "-E", R"(\"__METAL_VERSION__|__ENVIRONMENT_OS\")" });
+	parts.append_array({ "-", "|", "grep", "-E", "'__METAL_VERSION__|__ENVIRONMENT_OS'" });
 
 	List<String> args = { "-c", String(" ").join(parts) };
 


### PR DESCRIPTION
We've been revising the implementation with Claude AI, and it's possible it found and Fixed the root cause of:

> Metal Shader Baking limited to SPIR-V: Unable to determine toolchain properties on iOS export.

-Two bugs on the same line in drivers/metal/rendering_shader_container_metal.cpp:81

```
// BROKEN — escaped quotes become literal characters in the shell pattern, 
// AND the unquoted | is interpreted as a second pipe by sh -c 
parts.append_array({ "-", "|", "grep", "-E", R"(\"__METAL_VERSION__|__ENVIRONMENT_OS\")" });

// FIXED
parts.append_array({ "-", "|", "grep", "-E", "'__METAL_VERSION__|__ENVIRONMENT_OS'" });
```

Also requires to install the MetalToolchain (not installed by default):
xcodebuild -downloadComponent MetalToolchain`

-With both fixes applied, the Export Warning disappears, 
Shader Baker step completes and .metallib compilation runs at export time.

IOW No more SPIR-V warning message;
and the shader compilation step can be seen in Godot export.