### PR TITLE
🤖 Avoid duplicate scans when indexing loose resource directories

### DIFF
--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -413,13 +413,27 @@ void PackedSourceDirectory::add_directory(const String &p_path, bool p_replace_f
 	}
 	da->set_include_hidden(true);
 
-	for (const String &file_name : da->get_files()) {
-		String file_path = p_path.path_join(file_name);
-		uint8_t md5[16] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-		PackedData::get_singleton()->add_path(p_path, file_path, 0, 0, md5, this, p_replace_files, false, false, false);
+	Vector<String> sub_dirs;
+	if (da->list_dir_begin() != OK) {
+		return;
 	}
 
-	for (const String &sub_dir_name : da->get_directories()) {
+	String entry_name = da->get_next();
+	while (!entry_name.is_empty()) {
+		if (entry_name != "." && entry_name != "..") {
+			if (da->current_is_dir()) {
+				sub_dirs.push_back(entry_name);
+			} else {
+				String file_path = p_path.path_join(entry_name);
+				uint8_t md5[16] = {};
+				PackedData::get_singleton()->add_path(p_path, file_path, 0, 0, md5, this, p_replace_files, false, false, false);
+			}
+		}
+		entry_name = da->get_next();
+	}
+	da->list_dir_end();
+
+	for (const String &sub_dir_name : sub_dirs) {
 		String sub_dir_path = p_path.path_join(sub_dir_name);
 		add_directory(sub_dir_path, p_replace_files);
 	}


### PR DESCRIPTION
> [!INFO] *AI disclosure*: This contribution was authored by on an autonomous AI agent, on behalf of a user to reduce the editor-side resource pack loading cost reported in #122438. The agent inspected the implementation, authored this localized change, built and tested it, and measured the before/after behavior.

## What problem(s) does this PR solve?

PackedSourceDirectory::add_directory() called get_files() and get_directories() separately. Both helpers enumerate and sort the same directory, so registering a loose project in PackedData visited every directory twice before loading the first dynamic resource pack.

This is a localized partial improvement for #122438. It does not change which directories or files are registered, and it deliberately keeps the current eager-recursion design.

## Additional information

The function now consumes one directory listing, registers files immediately, collects subdirectories, and then recurses. Hidden entries, replacement behavior, and the existing PackedData visibility model remain unchanged.

Local benchmark on Windows 11 using a tests-enabled dev editor build and a warm filesystem cache over a 17,631-file Godot worktree:

| Implementation | 5-run mean | 5-run median |
| --- | ---: | ---: |
| Existing two-pass scan | 940.7 ms | 937.7 ms |
| Single-pass scan | 820.3 ms | 835.5 ms |

This reduced the mean by 12.8% and the median by 10.9% in this setup. The benchmark is intended to measure this specific duplicate-enumeration cost; it does not claim to remove the full eager-indexing stall described in #122438.

Validation:

- MSVC Windows dev editor build with tests enabled
- PCKPacker tests: 4 test cases and 17 assertions passed