### PR TITLE
Fix inverted normals for double sided 3D meshes with negative scale

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1342,6 +1342,7 @@ void RasterizerSceneGLES3::_fill_render_list(RenderListType p_render_list, const
 		if (inst->non_uniform_scale) {
 			flags |= INSTANCE_DATA_FLAGS_NON_UNIFORM_SCALE;
 		}
+		flags |= inst->mirror ? static_cast<uint32_t>(0) : static_cast<uint32_t>(INSTANCE_DATA_FLAG_POSITIVE_DET);
 
 		// Sets the index values for lookup in the shader
 		// This has to be done after _setup_lights was called this frame

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -379,6 +379,7 @@ private:
 	virtual uint32_t get_max_lights_per_mesh() override;
 
 	enum {
+		INSTANCE_DATA_FLAG_POSITIVE_DET = 1 << 0,
 		INSTANCE_DATA_FLAGS_DYNAMIC = 1 << 3,
 		INSTANCE_DATA_FLAGS_NON_UNIFORM_SCALE = 1 << 4,
 		INSTANCE_DATA_FLAG_USE_GI_BUFFERS = 1 << 5,

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -178,6 +178,7 @@ layout(location = 21) in highp uvec4 prev_instance_color_custom_data;
 #endif // USE_INSTANCING
 #endif // RENDER_MOTION_VECTORS
 
+#define FLAGS_POSITIVE_DET (1 << 0)
 #define FLAGS_NON_UNIFORM_SCALE (1 << 4)
 
 layout(std140) uniform GlobalShaderUniformData { //ubo:1
@@ -765,7 +766,12 @@ void vertex_shader(vec4 vertex_angle_attrib_input,
 	// Normalize TBN vectors to account for model/normal transforms that may have scale
 #ifdef NORMAL_USED
 	normal_interp = normalize(normal);
+#ifdef DO_SIDE_CHECK
+	if (!bool(model_flags_input & uint(FLAGS_POSITIVE_DET))) {
+		normal_interp = -normal_interp;
+	}
 #endif
+#endif // #ifdef NORMAL_USED
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(BENT_NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED)
 	tangent_interp = normalize(tangent);

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -990,6 +990,7 @@ void RenderForwardClustered::_fill_render_list(RenderListType p_render_list, con
 		if (inst->non_uniform_scale) {
 			flags |= INSTANCE_DATA_FLAGS_NON_UNIFORM_SCALE;
 		}
+		flags |= inst->mirror ? static_cast<uint32_t>(0) : static_cast<uint32_t>(INSTANCE_DATA_FLAG_POSITIVE_DET);
 		bool uses_lightmap = false;
 		bool uses_lightmap_specular = false;
 		bool uses_gi = false;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -273,6 +273,7 @@ private:
 
 	// When changing any of these enums, remember to change the corresponding enums in the shader files as well.
 	enum {
+		INSTANCE_DATA_FLAG_POSITIVE_DET = 1 << 0,
 		INSTANCE_DATA_FLAG_MULTIMESH_INDIRECT = 1 << 2,
 		INSTANCE_DATA_FLAGS_DYNAMIC = 1 << 3,
 		INSTANCE_DATA_FLAGS_NON_UNIFORM_SCALE = 1 << 4,

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -2251,7 +2251,7 @@ void RenderForwardMobile::_fill_render_list(RenderListType p_render_list, const 
 		if (inst->non_uniform_scale) {
 			flags |= INSTANCE_DATA_FLAGS_NON_UNIFORM_SCALE;
 		}
-
+		flags |= inst->mirror ? static_cast<uint32_t>(0) : static_cast<uint32_t>(INSTANCE_DATA_FLAG_POSITIVE_DET);
 		bool uses_lightmap = false;
 		bool uses_lightmap_specular = false;
 		// bool uses_gi = false;

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -447,6 +447,7 @@ protected:
 
 	// When changing any of these enums, remember to change the corresponding enums in the shader files as well.
 	enum {
+		INSTANCE_DATA_FLAG_POSITIVE_DET = 1 << 0,
 		INSTANCE_DATA_FLAG_MULTIMESH_INDIRECT = 1 << 2,
 		INSTANCE_DATA_FLAGS_DYNAMIC = 1 << 3,
 		INSTANCE_DATA_FLAGS_NON_UNIFORM_SCALE = 1 << 4,

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -490,7 +490,12 @@ void vertex_shader(vec3 vertex_input,
 	// Normalize TBN vectors to account for model/normal transforms that may have scale
 #ifdef NORMAL_USED
 	normal_interp = normalize(normal);
+#ifdef DO_SIDE_CHECK
+	if ((instances.data[instance_index].flags & INSTANCE_FLAGS_POSITIVE_DET) == 0) {
+		normal_interp = -normal_interp;
+	}
 #endif
+#endif // #ifdef NORMAL_USED
 
 #ifdef TANGENT_USED
 	tangent_interp = normalize(tangent);

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered_inc.glsl
@@ -183,6 +183,7 @@ layout(constant_id = 2) const bool sc_emulate_point_size = false;
 
 layout(set = 0, binding = 2) uniform sampler shadow_sampler;
 
+#define INSTANCE_FLAGS_POSITIVE_DET (1 << 0)
 #define INSTANCE_FLAGS_DYNAMIC (1 << 3)
 #define INSTANCE_FLAGS_NON_UNIFORM_SCALE (1 << 4)
 #define INSTANCE_FLAGS_USE_GI_BUFFERS (1 << 5)

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -517,7 +517,12 @@ void vertex_shader(in vec3 vertex,
 	// Normalize TBN vectors to account for model/normal transforms that may have scale
 #ifdef NORMAL_USED
 	normal_interp = hvec3(normalize(normal_highp));
+#ifdef DO_SIDE_CHECK
+	if ((instances.data[instance_index].flags & INSTANCE_FLAGS_POSITIVE_DET) == 0) {
+		normal_interp = -normal_interp;
+	}
 #endif
+#endif // #ifdef NORMAL_USED
 
 #if defined(TANGENT_USED) || defined(NORMAL_MAP_USED) || defined(LIGHT_ANISOTROPY_USED) || defined(BENT_NORMAL_MAP_USED)
 	tangent_interp = hvec3(normalize(tangent_highp));

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile_inc.glsl
@@ -253,6 +253,7 @@ layout(constant_id = 3) const bool sc_emulate_point_size = false;
 
 layout(set = 0, binding = 2) uniform sampler shadow_sampler;
 
+#define INSTANCE_FLAGS_POSITIVE_DET (1 << 0)
 #define INSTANCE_FLAGS_DYNAMIC (1 << 3)
 #define INSTANCE_FLAGS_NON_UNIFORM_SCALE (1 << 4)
 #define INSTANCE_FLAGS_USE_GI_BUFFERS (1 << 5)


### PR DESCRIPTION
Fixes #122323 

The issue is not specific to Sprite3D. But rather is an issue with normals in double sided geometry.

This solution is more of a workaround for the underlying problem. The fix to the underlying issue would require quite a big change to the render pipelines.

The original issue is related to face winding order. When the determinant of the scale is negative the direction of the vertex winding flips. For meshes with face culling enabled, the workaround was to flip culling face for negative determinant values.

Both workarounds don't work with instanced meshes right now. Implementing normal correction for double sided geometry would require modifying InstanceData buffers. And changing the culling face for each instance is not possible, as far as I know.

Solution to the underlying problem likely will require adding a Geometry shader to the pipeline and reversing the vertex order on negative determinant.

Currently I made the double sided and single sided geometry behavior consistent visually.

## Technical details

For the compatibility renderer I just added a uniform variable for per object normal sign correction. 

For forward plus and forward mobile I added a single float variable to the push constants.

All of the renderers add a single float multiplication for the normals in the vertex shader.

Here's the test project with some test cases: [test.zip](https://github.com/user-attachments/files/31308024/test.zip)

Everything was only tested on Windows 11 machine.