### PR TITLE
Fix language server remote host being overwritten by debug remote host

### DIFF
--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1520,10 +1520,15 @@ void EditorSettings::setup_language(bool p_initial_setup) {
 }
 
 void EditorSettings::setup_network() {
+	_setup_network("network/debug/remote_host");
+	_setup_network("network/language_server/remote_host");
+}
+
+void EditorSettings::_setup_network(const String &p_remote_host_setting) {
 	List<IPAddress> local_ip;
 	IP::get_singleton()->get_local_addresses(&local_ip);
 	String hint;
-	String current = has_setting("network/debug/remote_host") ? get("network/debug/remote_host") : "";
+	String current = has_setting(p_remote_host_setting) ? get(p_remote_host_setting) : "";
 	String selected = "127.0.0.1";
 
 	// Check that current remote_host is a valid interface address and populate hints.
@@ -1547,11 +1552,9 @@ void EditorSettings::setup_network() {
 	}
 
 	// Add hints with valid IP addresses to remote_host property.
-	add_property_hint(PropertyInfo(Variant::STRING, "network/debug/remote_host", PROPERTY_HINT_ENUM, hint));
-	add_property_hint(PropertyInfo(Variant::STRING, "network/language_server/remote_host", PROPERTY_HINT_ENUM, hint));
+	add_property_hint(PropertyInfo(Variant::STRING, p_remote_host_setting, PROPERTY_HINT_ENUM, hint));
 	// Fix potentially invalid remote_host due to network change.
-	set("network/debug/remote_host", selected);
-	set("network/language_server/remote_host", selected);
+	set(p_remote_host_setting, selected);
 }
 
 void EditorSettings::save() {

--- a/editor/settings/editor_settings.h
+++ b/editor/settings/editor_settings.h
@@ -118,6 +118,7 @@ private:
 	void _add_property_info_bind(const Dictionary &p_info);
 	bool _property_can_revert(const StringName &p_name) const;
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const;
+	void _setup_network(const String &p_remote_host_setting);
 
 	void _set_initialized();
 	void _load_defaults(Ref<ConfigFile> p_extra_config = Ref<ConfigFile>());


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Modifying `network/debug/remote_host` in Editor Settings was overwriting `network/language_server/remote_host`. This occurred because `EditorSettings::setup_network()` setting values based on `network/debug/remote_host` for both properties.

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

Tested on Windows 11 (x86_64)

Fixes #121073 
