### PR TITLE
FileSystem: Fix Collapse/Expand Hierarchy doing nothing in Split Mode

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -2257,7 +2257,24 @@ void FileSystemDock::_file_list_rmb_option(int p_option) {
 		_file_option(p_option, {});
 		return;
 	}
-	_file_option(p_option, _file_list_get_selected());
+
+	Vector<String> selected_strings = _file_list_get_selected();
+
+	switch (p_option) {
+		case FILE_MENU_EXPAND_ALL:
+		case FILE_MENU_COLLAPSE_ALL: {
+			// Expand or collapse the folder.
+			if (selected_strings.size() == 1) {
+				TreeItem **folder_item = folder_map.getptr(selected_strings[0]);
+				if (folder_item) {
+					(*folder_item)->set_collapsed_recursive(p_option == FILE_MENU_COLLAPSE_ALL);
+				}
+			}
+		} break;
+		default: {
+			_file_option(p_option, selected_strings);
+		} break;
+	}
 }
 
 void FileSystemDock::_generic_rmb_option_selected(int p_option) {


### PR DESCRIPTION
Fixes #122663

## Problem
In the FileSystem dock's Split Mode, right-clicking a folder in the file list (right panel) and choosing "Expand Hierarchy" or "Collapse Hierarchy" does nothing. The same action works fine from the tree (left panel).

## Root cause
`_tree_rmb_option()` (left panel) implements `FILE_MENU_EXPAND_ALL`/`FILE_MENU_COLLAPSE_ALL` by calling `set_collapsed_recursive()` on `tree->get_selected()`. `_file_list_rmb_option()` (right panel, used in Split Mode) instead forwarded every option unconditionally to `_file_option()`, which has no handling for these two — so the click was silently ignored.

## Fix
`_file_list_rmb_option()` now handles `FILE_MENU_EXPAND_ALL`/`FILE_MENU_COLLAPSE_ALL` explicitly: for a single selected folder, it looks up the corresponding `TreeItem` via the dock's existing `folder_map` (already used elsewhere in this file to go from a path to its tree node) and calls `set_collapsed_recursive()` on it — the same effect as the tree-panel path, just reached via path lookup instead of direct tree selection.

## Testing
Not compiled or run in this environment. The change is minimal (18 lines) and mirrors an existing, working code path exactly. I'd appreciate a maintainer or reviewer doing a quick manual check (Split Mode → right-click a folder in the file list → Expand/Collapse Hierarchy) before merge; happy to build and verify locally myself if needed.