### PR TITLE
Add call stack navigation buttons and shortcuts

### DIFF
--- a/editor/debugger/debugger_editor_plugin.cpp
+++ b/editor/debugger/debugger_editor_plugin.cpp
@@ -46,6 +46,10 @@
 DebuggerEditorPlugin::DebuggerEditorPlugin(PopupMenu *p_debug_menu) {
 	EditorDebuggerServer::initialize();
 
+	ED_SHORTCUT("debugger/move_up_in_call_stack", TTRC("Move Up In Call Stack"));
+	ED_SHORTCUT("debugger/move_down_in_call_stack", TTRC("Move Down In Call Stack"));
+	ED_SHORTCUT("debugger/top_of_call_stack", TTRC("Top Of Call Stack"));
+	ED_SHORTCUT("debugger/bottom_of_call_stack", TTRC("Bottom Of Call Stack"));
 	ED_SHORTCUT("debugger/step_into", TTRC("Step Into"), Key::F11);
 	ED_SHORTCUT("debugger/step_over", TTRC("Step Over"), Key::F10);
 	ED_SHORTCUT("debugger/step_out", TTRC("Step Out"), KeyModifierMask::ALT | Key::F11);

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -578,6 +578,11 @@ void EditorDebuggerNode::set_script_debug_button(MenuButton *p_button) {
 	p->add_shortcut(ED_GET_SHORTCUT("debugger/break"), DEBUG_BREAK);
 	p->add_shortcut(ED_GET_SHORTCUT("debugger/continue"), DEBUG_CONTINUE);
 	p->add_separator();
+	p->add_shortcut(ED_GET_SHORTCUT("debugger/move_up_in_call_stack"), DEBUG_MOVE_UP_IN_CALL_STACK);
+	p->add_shortcut(ED_GET_SHORTCUT("debugger/move_down_in_call_stack"), DEBUG_MOVE_DOWN_CALL_STACK);
+	p->add_shortcut(ED_GET_SHORTCUT("debugger/top_of_call_stack"), DEBUG_TOP_OF_CALL_STACK);
+	p->add_shortcut(ED_GET_SHORTCUT("debugger/bottom_of_call_stack"), DEBUG_BOTTOM_OF_CALL_STACK);
+	p->add_separator();
 	p->add_check_shortcut(ED_GET_SHORTCUT("debugger/debug_with_external_editor"), DEBUG_WITH_EXTERNAL_EDITOR);
 	p->connect(SceneStringName(id_pressed), callable_mp(this, &EditorDebuggerNode::_menu_option));
 
@@ -601,6 +606,10 @@ void EditorDebuggerNode::_break_state_changed() {
 	p->set_item_disabled(p->get_item_index(DEBUG_STEP), !(breaked && can_debug));
 	p->set_item_disabled(p->get_item_index(DEBUG_BREAK), breaked);
 	p->set_item_disabled(p->get_item_index(DEBUG_CONTINUE), !breaked);
+	p->set_item_disabled(p->get_item_index(DEBUG_MOVE_UP_IN_CALL_STACK), !breaked);
+	p->set_item_disabled(p->get_item_index(DEBUG_MOVE_DOWN_CALL_STACK), !breaked);
+	p->set_item_disabled(p->get_item_index(DEBUG_TOP_OF_CALL_STACK), !breaked);
+	p->set_item_disabled(p->get_item_index(DEBUG_BOTTOM_OF_CALL_STACK), !breaked);
 }
 
 void EditorDebuggerNode::_menu_option(int p_id) {
@@ -616,6 +625,18 @@ void EditorDebuggerNode::_menu_option(int p_id) {
 		} break;
 		case DEBUG_CONTINUE: {
 			debug_continue();
+		} break;
+		case DEBUG_MOVE_UP_IN_CALL_STACK: {
+			debug_move_up_in_call_stack();
+		} break;
+		case DEBUG_MOVE_DOWN_CALL_STACK: {
+			debug_move_down_in_call_stack();
+		} break;
+		case DEBUG_TOP_OF_CALL_STACK: {
+			debug_top_of_call_stack();
+		} break;
+		case DEBUG_BOTTOM_OF_CALL_STACK: {
+			debug_bottom_of_call_stack();
 		} break;
 		case DEBUG_WITH_EXTERNAL_EDITOR: {
 			bool ischecked = script_menu->get_popup()->is_item_checked(script_menu->get_popup()->get_item_index(DEBUG_WITH_EXTERNAL_EDITOR));
@@ -713,6 +734,22 @@ void EditorDebuggerNode::debug_break() {
 
 void EditorDebuggerNode::debug_continue() {
 	get_current_debugger()->debug_continue();
+}
+
+void EditorDebuggerNode::debug_move_up_in_call_stack() {
+	get_current_debugger()->debug_move_up_in_call_stack();
+}
+
+void EditorDebuggerNode::debug_move_down_in_call_stack() {
+	get_current_debugger()->debug_move_down_in_call_stack();
+}
+
+void EditorDebuggerNode::debug_top_of_call_stack() {
+	get_current_debugger()->debug_top_of_call_stack();
+}
+
+void EditorDebuggerNode::debug_bottom_of_call_stack() {
+	get_current_debugger()->debug_bottom_of_call_stack();
 }
 
 String EditorDebuggerNode::get_var_value(const String &p_var) const {

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -60,6 +60,10 @@ private:
 		DEBUG_STEP,
 		DEBUG_BREAK,
 		DEBUG_CONTINUE,
+		DEBUG_MOVE_UP_IN_CALL_STACK,
+		DEBUG_MOVE_DOWN_CALL_STACK,
+		DEBUG_TOP_OF_CALL_STACK,
+		DEBUG_BOTTOM_OF_CALL_STACK,
 		DEBUG_WITH_EXTERNAL_EDITOR,
 	};
 
@@ -180,6 +184,10 @@ public:
 	void debug_step();
 	void debug_break();
 	void debug_continue();
+	void debug_move_up_in_call_stack();
+	void debug_move_down_in_call_stack();
+	void debug_top_of_call_stack();
+	void debug_bottom_of_call_stack();
 
 	void set_script_debug_button(MenuButton *p_button);
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -94,6 +94,34 @@ void ScriptEditorDebugger::debug_copy() {
 	DisplayServer::get_singleton()->clipboard_set(msg);
 }
 
+void ScriptEditorDebugger::debug_move_up_in_call_stack() {
+	if (stack_dump->get_selected() && stack_dump->get_selected()->get_prev_visible()) {
+		stack_dump->set_selected(stack_dump->get_selected()->get_prev_visible());
+		stack_dump->queue_redraw();
+	}
+}
+
+void ScriptEditorDebugger::debug_move_down_in_call_stack() {
+	if (stack_dump->get_selected() && stack_dump->get_selected()->get_next_visible()) {
+		stack_dump->set_selected(stack_dump->get_selected()->get_next_visible());
+		stack_dump->queue_redraw();
+	}
+}
+
+void ScriptEditorDebugger::debug_top_of_call_stack() {
+	if (stack_dump->get_root()) {
+		stack_dump->set_selected(stack_dump->get_root()->get_first_child());
+		stack_dump->queue_redraw();
+	}
+}
+
+void ScriptEditorDebugger::debug_bottom_of_call_stack() {
+	if (stack_dump->get_root()) {
+		stack_dump->set_selected(stack_dump->get_root()->get_prev_visible(true));
+		stack_dump->queue_redraw();
+	}
+}
+
 void ScriptEditorDebugger::debug_skip_breakpoints() {
 	skip_breakpoints_value = !skip_breakpoints_value;
 	if (skip_breakpoints_value) {
@@ -1119,6 +1147,10 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			step->set_button_icon(get_editor_theme_icon(SNAME("DebugStep")));
 			next->set_button_icon(get_editor_theme_icon(SNAME("DebugNext")));
 			out->set_button_icon(get_editor_theme_icon(SNAME("DebugOut")));
+			move_up_in_call_stack->set_button_icon(get_editor_theme_icon(SNAME("ArrowUp")));
+			move_down_in_call_stack->set_button_icon(get_editor_theme_icon(SNAME("ArrowDown")));
+			top_of_call_stack->set_button_icon(get_editor_theme_icon(SNAME("GuiResizerTopLeft")));
+			bottom_of_call_stack->set_button_icon(get_editor_theme_icon(SNAME("GuiResizer")));
 			dobreak->set_button_icon(get_editor_theme_icon(SNAME("Pause")));
 			docontinue->set_button_icon(get_editor_theme_icon(SNAME("DebugContinue")));
 			vmem_notice_icon->set_texture(get_editor_theme_icon(SNAME("NodeInfo")));
@@ -2159,6 +2191,34 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		hbc->add_child(buttons);
 
 		buttons->add_child(memnew(VSeparator));
+
+		move_up_in_call_stack = memnew(Button);
+		move_up_in_call_stack->set_theme_type_variation(SceneStringName(FlatButton));
+		buttons->add_child(move_up_in_call_stack);
+		move_up_in_call_stack->set_tooltip_text(TTRC("Move Up In Call Stack"));
+		move_up_in_call_stack->set_shortcut(ED_GET_SHORTCUT("debugger/move_up_in_call_stack"));
+		move_up_in_call_stack->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::debug_move_up_in_call_stack));
+
+		move_down_in_call_stack = memnew(Button);
+		move_down_in_call_stack->set_theme_type_variation(SceneStringName(FlatButton));
+		buttons->add_child(move_down_in_call_stack);
+		move_down_in_call_stack->set_tooltip_text(TTRC("Move Down In Call Stack"));
+		move_down_in_call_stack->set_shortcut(ED_GET_SHORTCUT("debugger/move_down_in_call_stack"));
+		move_down_in_call_stack->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::debug_move_down_in_call_stack));
+
+		top_of_call_stack = memnew(Button);
+		top_of_call_stack->set_theme_type_variation(SceneStringName(FlatButton));
+		buttons->add_child(top_of_call_stack);
+		top_of_call_stack->set_tooltip_text(TTRC("Top Of Call Stack"));
+		top_of_call_stack->set_shortcut(ED_GET_SHORTCUT("debugger/top_of_call_stack"));
+		top_of_call_stack->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::debug_top_of_call_stack));
+
+		bottom_of_call_stack = memnew(Button);
+		bottom_of_call_stack->set_theme_type_variation(SceneStringName(FlatButton));
+		buttons->add_child(bottom_of_call_stack);
+		bottom_of_call_stack->set_tooltip_text(TTRC("Bottom Of Call Stack"));
+		bottom_of_call_stack->set_shortcut(ED_GET_SHORTCUT("debugger/bottom_of_call_stack"));
+		bottom_of_call_stack->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::debug_bottom_of_call_stack));
 
 		skip_breakpoints = memnew(Button);
 		skip_breakpoints->set_theme_type_variation(SceneStringName(FlatButton));

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -126,6 +126,10 @@ private:
 
 	RichTextLabel *reason = nullptr;
 
+	Button *move_up_in_call_stack = nullptr;
+	Button *move_down_in_call_stack = nullptr;
+	Button *top_of_call_stack = nullptr;
+	Button *bottom_of_call_stack = nullptr;
 	Button *skip_breakpoints = nullptr;
 	Button *ignore_error_breaks = nullptr;
 	Button *copy = nullptr;
@@ -333,6 +337,10 @@ public:
 	void debug_ignore_error_breaks();
 	void debug_copy();
 
+	void debug_move_up_in_call_stack();
+	void debug_move_down_in_call_stack();
+	void debug_top_of_call_stack();
+	void debug_bottom_of_call_stack();
 	void debug_out();
 	void debug_next();
 	void debug_step();


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/discussions/15253

Adds buttons/ the ability to set hotkeys for:
- Jump up one call stack frame
- Jump down one call stack frame
- Jump to the bottom of the call stack
- Jump to the top of the call stack

https://github.com/user-attachments/assets/76dce226-441d-42a2-af9b-bfb856173095

## Additional information

No hotkeys are bound by default. In the video I am using a fork that has this change merged to allow the keypad buttons to be used https://github.com/godotengine/godot/pull/119763 (FIXED PR LINK)

No AI was used to make this PR.