### PR TITLE
Betsy: Optimize and improve for certain source image formats

### DIFF
--- a/modules/betsy/image_compress_betsy.cpp
+++ b/modules/betsy/image_compress_betsy.cpp
@@ -331,18 +331,25 @@ void BetsyCompressor::finish() {
 
 // Helper functions.
 
-static Error get_src_texture_format(Image *r_img, RD::DataFormat &r_format, bool &r_is_rgb) {
-	r_is_rgb = false;
+static Error get_src_texture_format(Image *r_img, RD::DataFormat &r_format, bool &r_convert_rgb_to_rgba, RD::TextureView &r_view) {
+	r_convert_rgb_to_rgba = false;
 
+	// The code for RGB formats is commented-out for now since it didn't lead to noticeable improvements.
 	switch (r_img->get_format()) {
 		case Image::FORMAT_L8:
-			r_img->convert(Image::FORMAT_RGBA8);
-			r_format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
+			r_view.swizzle_r = RD::TEXTURE_SWIZZLE_R;
+			r_view.swizzle_g = RD::TEXTURE_SWIZZLE_R;
+			r_view.swizzle_b = RD::TEXTURE_SWIZZLE_R;
+			r_view.swizzle_a = RD::TEXTURE_SWIZZLE_ONE;
+			r_format = RD::DATA_FORMAT_R8_UNORM;
 			break;
 
 		case Image::FORMAT_LA8:
-			r_img->convert(Image::FORMAT_RGBA8);
-			r_format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
+			r_view.swizzle_r = RD::TEXTURE_SWIZZLE_R;
+			r_view.swizzle_g = RD::TEXTURE_SWIZZLE_R;
+			r_view.swizzle_b = RD::TEXTURE_SWIZZLE_R;
+			r_view.swizzle_a = RD::TEXTURE_SWIZZLE_G;
+			r_format = RD::DATA_FORMAT_R8G8_UNORM;
 			break;
 
 		case Image::FORMAT_R8:
@@ -354,12 +361,24 @@ static Error get_src_texture_format(Image *r_img, RD::DataFormat &r_format, bool
 			break;
 
 		case Image::FORMAT_RGB8:
-			r_is_rgb = true;
-			r_format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
+			r_convert_rgb_to_rgba = true; // !RD::get_singleton()->texture_is_format_supported_for_usage(RD::DATA_FORMAT_R8G8B8_UNORM, RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT);
+			r_format = r_convert_rgb_to_rgba ? RD::DATA_FORMAT_R8G8B8A8_UNORM : RD::DATA_FORMAT_R8G8B8_UNORM;
 			break;
 
 		case Image::FORMAT_RGBA8:
 			r_format = RD::DATA_FORMAT_R8G8B8A8_UNORM;
+			break;
+
+		case Image::FORMAT_RGBA4444:
+			r_view.swizzle_r = RD::TEXTURE_SWIZZLE_B;
+			r_view.swizzle_g = RD::TEXTURE_SWIZZLE_G;
+			r_view.swizzle_b = RD::TEXTURE_SWIZZLE_R;
+			r_view.swizzle_a = RD::TEXTURE_SWIZZLE_A;
+			r_format = RD::DATA_FORMAT_B4G4R4A4_UNORM_PACK16;
+			break;
+
+		case Image::FORMAT_RGB565:
+			r_format = RD::DATA_FORMAT_R5G6B5_UNORM_PACK16;
 			break;
 
 		case Image::FORMAT_RH:
@@ -371,8 +390,8 @@ static Error get_src_texture_format(Image *r_img, RD::DataFormat &r_format, bool
 			break;
 
 		case Image::FORMAT_RGBH:
-			r_is_rgb = true;
-			r_format = RD::DATA_FORMAT_R16G16B16A16_SFLOAT;
+			r_convert_rgb_to_rgba = true; //!RD::get_singleton()->texture_is_format_supported_for_usage(RD::DATA_FORMAT_R16G16B16_SFLOAT, RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT);
+			r_format = r_convert_rgb_to_rgba ? RD::DATA_FORMAT_R16G16B16A16_SFLOAT : RD::DATA_FORMAT_R16G16B16_SFLOAT;
 			break;
 
 		case Image::FORMAT_RGBAH:
@@ -388,8 +407,8 @@ static Error get_src_texture_format(Image *r_img, RD::DataFormat &r_format, bool
 			break;
 
 		case Image::FORMAT_RGBF:
-			r_is_rgb = true;
-			r_format = RD::DATA_FORMAT_R32G32B32A32_SFLOAT;
+			r_convert_rgb_to_rgba = true; //!RD::get_singleton()->texture_is_format_supported_for_usage(RD::DATA_FORMAT_R32G32B32_SFLOAT, RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT);
+			r_format = r_convert_rgb_to_rgba ? RD::DATA_FORMAT_R32G32B32A32_SFLOAT : RD::DATA_FORMAT_R32G32B32_SFLOAT;
 			break;
 
 		case Image::FORMAT_RGBAF:
@@ -409,8 +428,8 @@ static Error get_src_texture_format(Image *r_img, RD::DataFormat &r_format, bool
 			break;
 
 		case Image::FORMAT_RGB16:
-			r_is_rgb = true;
-			r_format = RD::DATA_FORMAT_R16G16B16A16_UNORM;
+			r_convert_rgb_to_rgba = true; //!RD::get_singleton()->texture_is_format_supported_for_usage(RD::DATA_FORMAT_R16G16B16_UNORM, RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT);
+			r_format = r_convert_rgb_to_rgba ? RD::DATA_FORMAT_R16G16B16A16_UNORM : RD::DATA_FORMAT_R16G16B16_UNORM;
 			break;
 
 		case Image::FORMAT_RGBA16:
@@ -475,11 +494,12 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 		src_texture_format.depth = 1;
 		src_texture_format.mipmaps = 1;
 		src_texture_format.texture_type = RD::TEXTURE_TYPE_2D;
-		src_texture_format.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
+		src_texture_format.usage_bits = RD::TEXTURE_USAGE_SAMPLING_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT;
 	}
 
+	RD::TextureView src_texture_view;
 	bool needs_rgb_to_rgba = false;
-	err = get_src_texture_format(r_img, src_texture_format.format, needs_rgb_to_rgba);
+	err = get_src_texture_format(r_img, src_texture_format.format, needs_rgb_to_rgba, src_texture_view);
 
 	if (err != OK) {
 		return err;
@@ -487,7 +507,7 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 
 	// For the destination format just copy the source format and change the usage bits.
 	RD::TextureFormat dst_texture_format = src_texture_format;
-	dst_texture_format.usage_bits = RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
+	dst_texture_format.usage_bits = RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT;
 	dst_texture_format.format = dst_rd_format;
 
 	RD::TextureFormat dst_texture_format_alpha;
@@ -546,10 +566,6 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 		dst_texture_format.height = (height + 3) >> 2;
 		dst_texture_format.width = (width + 3) >> 2;
 
-		// Create a buffer filled with the source mip layer data.
-		src_image_ptr[0].resize(src_mip_size);
-		memcpy(src_image_ptr[0].ptrw(), r_img->ptr() + src_mip_ofs, src_mip_size);
-
 		// Create the textures on the GPU.
 		RID src_texture;
 		RID dst_texture_primary = compress_rd->texture_create(dst_texture_format, RD::TextureView());
@@ -577,11 +593,11 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 			}
 
 			// The source 'RGB' buffer.
-			RID source_buffer = compress_rd->storage_buffer_create(src_image_ptr[0].size(), src_image_ptr[0].span());
+			RID source_buffer = compress_rd->storage_buffer_create(src_mip_size, Span<uint8_t>(r_img->ptr() + src_mip_ofs, src_mip_size));
 
 			RD::TextureFormat rgba_texture_format = src_texture_format;
-			rgba_texture_format.usage_bits |= RD::TEXTURE_USAGE_COLOR_ATTACHMENT_BIT | RD::TEXTURE_USAGE_STORAGE_BIT | RD::TEXTURE_USAGE_CAN_COPY_FROM_BIT | RD::TEXTURE_USAGE_CAN_COPY_TO_BIT | RD::TEXTURE_USAGE_CAN_UPDATE_BIT;
-			src_texture = compress_rd->texture_create(rgba_texture_format, RD::TextureView());
+			rgba_texture_format.usage_bits |= RD::TEXTURE_USAGE_STORAGE_BIT;
+			src_texture = compress_rd->texture_create(rgba_texture_format, src_texture_view);
 
 			Vector<RD::Uniform> uniforms;
 			{
@@ -621,7 +637,11 @@ Error BetsyCompressor::_compress(BetsyFormat p_format, Image *r_img) {
 
 			compress_rd->free_rid(source_buffer);
 		} else {
-			src_texture = compress_rd->texture_create(src_texture_format, RD::TextureView(), src_images);
+			// Create a buffer filled with the source mip layer data.
+			src_image_ptr[0].resize(src_mip_size);
+			memcpy(src_image_ptr[0].ptrw(), r_img->ptr() + src_mip_ofs, src_mip_size);
+
+			src_texture = compress_rd->texture_create(src_texture_format, src_texture_view, src_images);
 		}
 
 		{


### PR DESCRIPTION
## What problem(s) does this PR solve?

Improves the compression performance by using component swizzling for luminance formats and allowing RGB textures to be sampled directly when the hardware supports it.
Additionally, the texture usage bitflags have been narrowed down to only the necessary minimum.

## Additional information

TODO:
- [x] Ensure the luminance swizzling works for all Betsy formats,
- [x] Test on an Intel iGPU to ensure the RGB sampling works correctly. - [Intel UHD Graphics 620 (WHL GT2)](https://vulkan.gpuinfo.org/displayreport.php?id=44245)
- [x] Post the performance results
- [x] Decide on what to do with the direct RGB sampling optimization

### Results:
System: Fedora Linux 43 (KDE Plasma) on Wayland
GPU: integrated Intel(R) UHD Graphics 620 (WHL GT2)
CPU: Intel(R) Core(TM) i7-8665U CPU @ 1.90GHz (8 threads)
RAM: 16 GB

| Format | master | this PR |
|---------|---------|---------|
| 2048x2048 L8 | 20 ms | 9ms |
| 2048x2048 LA8 | 25ms | 15ms |
| 2048x2048 RGB8 | 16ms | 11ms |
| 2048x2048 RGB16 | 20ms | 29ms |
| 2048x2048 RGBH | 20ms | 30ms |
| 2048x2048 RGBF | 60ms | 54ms |

Mostly as expected in terms of the luminance formats, thought the 8-bit and 32-bit formats only show an improvement of ~5ms. The 16-bit ones have actually regressed as they take 10ms more. 
I'll probably end up removing the direct RGB sampling since it doesn't improve the performance as much as I would have liked.