### PR TITLE
GDScript VM: Reduce lookups in `_profile_count_as_native`

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -46,7 +46,7 @@ static bool _profile_count_as_native(const Object *p_base_obj, const StringName 
 	if ((p_methodname == SNAME("new") && cname == GDScript::get_class_static()) || p_methodname == CoreStringName(call)) {
 		return false;
 	}
-	return ClassDB::class_exists(cname) && ClassDB::has_method(cname, p_methodname, false);
+	return ClassDB::has_method(cname, p_methodname, false);
 }
 
 static String _get_element_type(Variant::Type builtin_type, const StringName &native_type, const Ref<Script> &script_type) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

`_profile_count_as_native()` currently does a total of three map look-ups:
1. `ClassDB::class_exists()` checks if the class exists in the `classes` map.
2. `ClassDB::has_method()` gets the class info from the `classes` map...
3. ...then checks if the named method exists in the GDType's `method_map`.

Step 2 already returns `false` when the class can't be found, meaning all step 1 does is to make code slower and nothing else.

~~And thanks to #117599, we have direct access to the object's GDType, meaning step 2 may be skipped as well.~~

**Update**: Per maintainer request, I've kept step 2 as `GDType` is too new and subject to big changes to be used outside of core. It might come back once it's more feature complete, but not on this PR.