### PR TITLE
Do not suggest `.new()` for abstract classes

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -598,6 +598,20 @@ struct GDScriptCompletionIdentifier {
 	const GDScriptParser::ExpressionNode *assigned_expression = nullptr;
 };
 
+static bool _is_constructible_object(GDScriptParser::DataType &p_datatype) {
+	switch (p_datatype.kind) {
+		case GDScriptParser::DataType::NATIVE:
+			return !ClassDB::is_abstract(p_datatype.native_type);
+		case GDScriptParser::DataType::SCRIPT:
+			return p_datatype.script_type.is_valid() && !p_datatype.script_type->is_abstract() && !ClassDB::is_abstract(p_datatype.native_type);
+		case GDScriptParser::DataType::CLASS:
+			return p_datatype.class_type && !p_datatype.class_type->is_abstract && !ClassDB::is_abstract(p_datatype.class_type->base_type.native_type);
+		default:
+			ERR_FAIL_V_MSG(false, "GDScript bug (please report): Unexpected datatype kind.");
+	}
+	return true;
+}
+
 // LOCATION METHODS
 // These methods are used to populate the `CodeCompletionOption::location` integer.
 // For these methods, the location is based on the depth in the inheritance chain that the property
@@ -1332,7 +1346,8 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 
 	GDScriptParser::DataType base_type = p_base.type;
 
-	if (!p_types_only && base_type.is_meta_type && base_type.kind != GDScriptParser::DataType::BUILTIN && base_type.kind != GDScriptParser::DataType::ENUM) {
+	// Check only at recursion depth 0 if the most specific type is constructible.
+	if (p_recursion_depth == 0 && !p_types_only && base_type.is_meta_type && base_type.kind != GDScriptParser::DataType::BUILTIN && base_type.kind != GDScriptParser::DataType::ENUM && _is_constructible_object(base_type) && !Engine::get_singleton()->has_singleton(base_type.native_type)) {
 		EditorLanguage::CompletionOption option("new", EditorLanguage::CompletionKind::FUNCTION, EditorLanguage::CompletionLocation::LOCAL);
 		if (p_add_braces) {
 			option.insert_text += "(";

--- a/modules/gdscript/tests/scripts/completion/common/no_constructor_abstract_inner_class.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/no_constructor_abstract_inner_class.cfg
@@ -1,0 +1,6 @@
+[output]
+exclude=[
+    {"display": "new(…)"},
+    {"display": "new()"},
+    {"display": "new"},
+]

--- a/modules/gdscript/tests/scripts/completion/common/no_constructor_abstract_inner_class.gd
+++ b/modules/gdscript/tests/scripts/completion/common/no_constructor_abstract_inner_class.gd
@@ -1,0 +1,4 @@
+@abstract class InnerClass:
+	pass
+
+var prop = InnerClass.➡

--- a/modules/gdscript/tests/scripts/completion/common/no_constructor_abstract_native.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/no_constructor_abstract_native.cfg
@@ -1,0 +1,6 @@
+[output]
+exclude=[
+    {"display": "new(…)"},
+    {"display": "new()"},
+    {"display": "new"},
+]

--- a/modules/gdscript/tests/scripts/completion/common/no_constructor_abstract_native.gd
+++ b/modules/gdscript/tests/scripts/completion/common/no_constructor_abstract_native.gd
@@ -1,0 +1,1 @@
+var prop = CanvasItem.➡

--- a/modules/gdscript/tests/scripts/completion/common/no_constructor_abstract_script.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/no_constructor_abstract_script.cfg
@@ -1,0 +1,6 @@
+[output]
+exclude=[
+    {"display": "new(…)"},
+    {"display": "new()"},
+    {"display": "new"},
+]

--- a/modules/gdscript/tests/scripts/completion/common/no_constructor_abstract_script.gd
+++ b/modules/gdscript/tests/scripts/completion/common/no_constructor_abstract_script.gd
@@ -1,0 +1,3 @@
+@abstract class_name AbstractScript
+
+var prop = AbstractScript.➡

--- a/modules/gdscript/tests/scripts/completion/common/no_constructor_global_singleton.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/no_constructor_global_singleton.cfg
@@ -1,0 +1,6 @@
+[output]
+exclude=[
+    {"display": "new(…)"},
+    {"display": "new()"},
+    {"display": "new"},
+]

--- a/modules/gdscript/tests/scripts/completion/common/no_constructor_global_singleton.gd
+++ b/modules/gdscript/tests/scripts/completion/common/no_constructor_global_singleton.gd
@@ -1,0 +1,1 @@
+var prop = Engine.➡

--- a/modules/gdscript/tests/scripts/completion/common/no_constructor_inner_class_extends_abstract_native.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/no_constructor_inner_class_extends_abstract_native.cfg
@@ -1,0 +1,6 @@
+[output]
+exclude=[
+    {"display": "new(…)"},
+    {"display": "new()"},
+    {"display": "new"},
+]

--- a/modules/gdscript/tests/scripts/completion/common/no_constructor_inner_class_extends_abstract_native.gd
+++ b/modules/gdscript/tests/scripts/completion/common/no_constructor_inner_class_extends_abstract_native.gd
@@ -1,0 +1,4 @@
+class InnerClass extends CanvasItem:
+    pass
+
+var prop = InnerClass.➡

--- a/modules/gdscript/tests/scripts/completion/common/no_constructor_script_extends_abstract_native.cfg
+++ b/modules/gdscript/tests/scripts/completion/common/no_constructor_script_extends_abstract_native.cfg
@@ -1,0 +1,6 @@
+[output]
+exclude=[
+    {"display": "new(…)"},
+    {"display": "new()"},
+    {"display": "new"},
+]

--- a/modules/gdscript/tests/scripts/completion/common/no_constructor_script_extends_abstract_native.gd
+++ b/modules/gdscript/tests/scripts/completion/common/no_constructor_script_extends_abstract_native.gd
@@ -1,0 +1,3 @@
+class_name CanvasItemScript extends CanvasItem
+
+var prop = CanvasItemScript.➡


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Fixes godotengine/godot-proposals#14487

## Additional information

I used the suggestions in the above issue to fix this. I didn't scour much if `is_constructible` was needed anywhere else since they require more specific types, so I just changed the place that @dalexeev mentioned. They can be replaced in a future PR, however.

Hopefully the tests are good enough for now. N/AI (I wrote everything myself)

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
