### PR TITLE
Style: Create static constant `EMPTY` for `String` and `StringName`

### DIFF
--- a/core/object/gdtype.h
+++ b/core/object/gdtype.h
@@ -124,10 +124,7 @@ public:
 
 	const GDType *get_super_type() const { return super_type; }
 	const StringName &get_name() const { return name; }
-	const StringName &get_super_type_name() const {
-		static const StringName EMPTY;
-		return super_type ? super_type->name : EMPTY;
-	}
+	const StringName &get_super_type_name() const { return super_type ? super_type->name : StringName::EMPTY; }
 	const Vector<StringName> &get_name_hierarchy() const { return name_hierarchy; }
 
 	void bind_integer_constant(const StringName &p_enum, const StringName &p_name, int64_t p_constant, bool p_is_bitfield = false);

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -85,6 +85,8 @@ class [[nodiscard]] _WARN_UNUSED_ StringName {
 	StringName(_Data *p_data) { _data = p_data; }
 
 public:
+	static const StringName &EMPTY;
+
 	_FORCE_INLINE_ explicit operator bool() const { return _data; }
 
 	bool operator==(const String &p_name) const;
@@ -92,7 +94,7 @@ public:
 	bool operator!=(const String &p_name) const;
 	bool operator!=(const char *p_name) const;
 
-	const char32_t *get_data() const { return _data ? _data->name.ptr() : U""; }
+	const char32_t *get_data() const { return _data ? _data->name.ptr() : String::EMPTY.ptr(); }
 	char32_t operator[](int p_index) const;
 	int length() const;
 	_FORCE_INLINE_ bool is_empty() const { return !_data; }
@@ -135,8 +137,7 @@ public:
 	}
 
 	_FORCE_INLINE_ const String &string() const _LIFETIME_BOUND_ {
-		static const String EMPTY;
-		return _data ? _data->name : EMPTY;
+		return _data ? _data->name : String::EMPTY;
 	}
 
 	_FORCE_INLINE_ operator const String &() const _LIFETIME_BOUND_ {
@@ -197,6 +198,8 @@ public:
 	static void set_debug_stringnames(bool p_enable) { debug_stringname = p_enable; }
 #endif
 };
+
+inline const StringName &StringName::EMPTY = StringName();
 
 // Zero-constructing StringName initializes _data to nullptr (and thus empty).
 template <>

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -309,6 +309,8 @@ public:
 		npos = -1 ///<for "some" compatibility with std::string (npos is a huge value in std::string)
 	};
 
+	static const String &EMPTY;
+
 	_FORCE_INLINE_ char32_t *ptrw() _LIFETIME_BOUND_ { return _cowdata.ptrw(); }
 	_FORCE_INLINE_ const char32_t *ptr() const _LIFETIME_BOUND_ { return _cowdata.ptr(); }
 	_FORCE_INLINE_ const char32_t *get_data() const _LIFETIME_BOUND_ { return size() ? ptr() : &_null; }
@@ -714,6 +716,8 @@ public:
 		append_utf32(p_cstr);
 	}
 };
+
+inline const String &String::EMPTY = String();
 
 // Zero-constructing String initializes _cowdata.ptr() to nullptr and thus empty.
 template <>

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -323,8 +323,7 @@ const StringName &get_object_class_name_or_empty() {
 	if constexpr (std::is_base_of_v<Object, T>) {
 		return T::get_class_static();
 	} else {
-		static const StringName EMPTY = "";
-		return EMPTY;
+		return StringName::EMPTY;
 	}
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

After #122690 made me realize that we were wasting allocations of `StringName` references, it made me wonder if we could go a step further than the solution presented in that PR. Because, while it's a fantastic solution, it still creates an individual static variable for every non-object type call. Instead of having an empty reference located at a given funtion's call site, why not formalize the `EMPTY` reference within the class itself?

This PR adds a static, publically-accessable constant of `EMPTY` to both `String` and `StringName`. This constant is a reference type, so any functions that need to pass a constant reference but also require a dummy fallback are now able to pass the built-in `EMPTY`. This should slim down our build sizes, and pave the way for cleaner code wherever these dummy references would be required.

## Additional information
It's possible that other classes would benefit from equivalent `EMPTY` constants, but I limited it to `String` and `StringName` as they're the most obvious and readily-applicable cases that currently exist.