### PR TITLE
Add edited scenes mouse forward / back navigation

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -1112,7 +1112,7 @@
 			The size of the font in the editor interface.
 		</member>
 		<member name="interface/editor/input/mouse_extra_buttons_navigate_history" type="bool" setter="" getter="">
-			If [code]true[/code], the mouse's additional side buttons will be usable to navigate in the script editor's file history. Set this to [code]false[/code] if you're using the side buttons for other purposes (such as a push-to-talk button in a VoIP program).
+			If [code]true[/code], the mouse's additional side buttons will be usable to navigate in the script editor's file and scene editor's history. Set this to [code]false[/code] if you're using the side buttons for other purposes (such as a push-to-talk button in a VoIP program).
 		</member>
 		<member name="interface/editor/input/tablet_driver" type="int" setter="" getter="">
 			Overrides the tablet driver used by the editor.

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -492,6 +492,15 @@ int EditorData::get_scene_history_id(int p_idx) const {
 	return edited_scene[p_idx].history_id;
 }
 
+int EditorData::get_edited_scene_from_history_id(int p_history_id) const {
+	for (int i = 0; i < edited_scene.size(); i++) {
+		if (edited_scene[i].history_id == p_history_id) {
+			return i;
+		}
+	}
+	return -1;
+}
+
 void EditorData::add_undo_redo_inspector_hook_callback(Callable p_callable) {
 	undo_redo_callbacks.push_back(p_callable);
 }

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -233,6 +233,7 @@ public:
 	int get_scene_history_id_from_path(const String &p_path) const;
 	int get_current_edited_scene_history_id() const;
 	int get_scene_history_id(int p_idx) const;
+	int get_edited_scene_from_history_id(int p_history_id) const;
 
 	void set_plugin_window_layout(Ref<ConfigFile> p_layout);
 	void get_plugin_window_layout(Ref<ConfigFile> p_layout);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -408,16 +408,37 @@ void EditorNode::_update_unsaved_cache() {
 	}
 }
 
+void EditorNode::set_block_input(bool p_block) {
+	block_input = p_block;
+}
+
 void EditorNode::input(const Ref<InputEvent> &p_event) {
-	// EditorNode::get_singleton()->set_process_input is set to true in ProgressDialog
+	// EditorNode::get_singleton()->set_block_input is set to true in ProgressDialog
 	// only when the progress dialog is visible.
 	// We need to discard all key events to disable all shortcuts while the progress
 	// dialog is displayed, simulating an exclusive popup. Mouse events are
 	// captured by a full-screen container in front of the EditorNode in ProgressDialog,
 	// allowing interaction with the actual dialog where a Cancel button may be visible.
-	Ref<InputEventKey> k = p_event;
-	if (k.is_valid()) {
-		get_tree()->get_root()->set_input_as_handled();
+	if (block_input) {
+		Ref<InputEventKey> k = p_event;
+		if (k.is_valid()) {
+			get_tree()->get_root()->set_input_as_handled();
+			return;
+		}
+	}
+
+	// Script editor should take mouse button priority while open.
+	// Will need a rework if many more mouse button scenarios are added to the editor.
+	Control *focus_owner = get_viewport()->gui_get_focus_owner();
+	if (focus_owner && (ScriptEditor::get_singleton() == focus_owner || ScriptEditor::get_singleton()->is_ancestor_of(focus_owner)) && EDITOR_GET("interface/editor/input/mouse_extra_buttons_navigate_history")) {
+		Ref<InputEventMouseButton> mb = p_event;
+		if (mb.is_valid() && mb->is_pressed()) {
+			if (mb->get_button_index() == MouseButton::MB_XBUTTON1) {
+				_history_back();
+			} else if (mb->get_button_index() == MouseButton::MB_XBUTTON2) {
+				_history_forward();
+			}
+		}
 	}
 }
 
@@ -4649,6 +4670,8 @@ void EditorNode::_remove_edited_scene(bool p_change_tab) {
 		new_index = 1;
 	}
 
+	_remove_scene_from_history(editor_data.get_scene_history_id(old_index));
+
 	if (p_change_tab) {
 		_set_current_scene(new_index);
 	}
@@ -4669,6 +4692,7 @@ void EditorNode::_remove_scene(int p_idx, bool p_change_tab) {
 		_remove_edited_scene(p_change_tab);
 	} else {
 		// Scene to remove is not active scene.
+		_remove_scene_from_history(editor_data.get_scene_history_id(p_idx));
 		editor_data.remove_scene(p_idx);
 	}
 }
@@ -4799,7 +4823,72 @@ void EditorNode::_set_current_scene(int p_idx) {
 	_set_current_scene_nocheck(p_idx);
 }
 
-void EditorNode::_set_current_scene_nocheck(int p_idx, bool p_ignore_state) {
+void EditorNode::_history_back() {
+	while (tab_history_pos > 0) {
+		if (editor_data.get_edited_scene_from_history_id(tab_history[tab_history_pos - 1]) == -1) {
+			WARN_PRINT("Invalid scene found in history.");
+			_remove_scene_from_history(tab_history[tab_history_pos - 1]);
+			continue;
+		}
+		_update_history_pos(tab_history_pos - 1);
+		break;
+	}
+}
+
+void EditorNode::_history_forward() {
+	while (tab_history_pos < static_cast<int>(tab_history.size()) - 1) {
+		if (editor_data.get_edited_scene_from_history_id(tab_history[tab_history_pos + 1]) == -1) {
+			WARN_PRINT("Invalid scene found in history.");
+			_remove_scene_from_history(tab_history[tab_history_pos + 1]);
+			continue;
+		}
+		_update_history_pos(tab_history_pos + 1);
+		break;
+	}
+}
+
+void EditorNode::_update_history_pos(int p_new_pos) {
+	ERR_FAIL_INDEX_MSG(p_new_pos, static_cast<int>(tab_history.size()), "History position out of bounds.");
+	tab_history_pos = p_new_pos;
+
+	int scene_idx = editor_data.get_edited_scene_from_history_id(tab_history[tab_history_pos]);
+	if (scene_idx == -1 || scene_idx == editor_data.get_edited_scene()) {
+		return;
+	}
+
+	_set_current_scene_nocheck(scene_idx, false, false);
+	scene_tabs->update_scene_tabs();
+}
+
+void EditorNode::_remove_scene_from_history(int p_history_id) {
+	for (int i = 0; i < static_cast<int>(tab_history.size()); i++) {
+		if (tab_history[i] != p_history_id) {
+			continue;
+		}
+		tab_history.remove_at(i);
+		if (tab_history_pos >= i) {
+			tab_history_pos--;
+		}
+		i--;
+	}
+}
+
+void EditorNode::_push_scene_to_history(int p_history_id) {
+	if (tab_history_pos >= 0 && tab_history[tab_history_pos] == p_history_id) {
+		return;
+	}
+
+	// Discard old forward history by only keeping history until the current index plus new element.
+	tab_history.resize(tab_history_pos + 1);
+	tab_history.push_back(p_history_id);
+	tab_history_pos++;
+}
+
+void EditorNode::_set_current_scene_nocheck(int p_idx, bool p_ignore_state, bool p_save_history) {
+	if (p_save_history) {
+		_push_scene_to_history(editor_data.get_scene_history_id(p_idx));
+	}
+
 	// Save the folding in case the scene gets reloaded.
 	const String scene_path = editor_data.get_scene_path(p_idx);
 	if (scene_path.is_empty() && editor_data.get_edited_scene_root(p_idx)) {
@@ -9627,6 +9716,7 @@ EditorNode::EditorNode() {
 	saving_resource = Ref<Resource>();
 
 	set_process(true);
+	set_process_input(true);
 
 	open_imported = memnew(ConfirmationDialog);
 	open_imported->set_flag(Window::FLAG_RESIZE_DISABLED, true);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -317,6 +317,11 @@ private:
 	// Main tabs.
 	EditorSceneTabs *scene_tabs = nullptr;
 
+	LocalVector<int> tab_history;
+	int tab_history_pos = -1;
+
+	bool block_input = false;
+
 	int tab_closing_idx = 0;
 	List<String> tabs_to_close;
 	List<int> scenes_to_save_as;
@@ -602,7 +607,12 @@ private:
 	void _save_scene_silently();
 
 	void _set_current_scene(int p_idx);
-	void _set_current_scene_nocheck(int p_idx, bool p_ignore_state = false);
+	void _set_current_scene_nocheck(int p_idx, bool p_ignore_state = false, bool p_save_history = true);
+	void _history_back();
+	void _history_forward();
+	void _update_history_pos(int p_new_pos);
+	void _remove_scene_from_history(int p_history_id);
+	void _push_scene_to_history(int p_history_id);
 	void _nav_to_selected_scene();
 	bool _validate_scene_recursive(const String &p_filename, Node *p_node);
 	void _save_scene(String p_file, int idx = -1);
@@ -872,6 +882,8 @@ public:
 	String get_multiwindow_support_tooltip_text() const;
 
 	bool is_changing_scene() const;
+
+	void set_block_input(bool p_block);
 
 	SubViewport *get_scene_root() { return scene_root; } // Root of the scene being edited.
 

--- a/editor/gui/progress_dialog.cpp
+++ b/editor/gui/progress_dialog.cpp
@@ -165,9 +165,9 @@ void ProgressDialog::_update_ui() {
 }
 
 void ProgressDialog::_popup() {
-	// Activate processing of all inputs in EditorNode, and the EditorNode::input method
+	// Activate blocking of all inputs in EditorNode, and the EditorNode::input method
 	// will discard every key input.
-	EditorNode::get_singleton()->set_process_input(true);
+	EditorNode::get_singleton()->set_block_input(true);
 	// Disable all other windows to prevent interaction with them.
 	for (ObjectID wid : host_windows) {
 		Window *w = ObjectDB::get_instance<Window>(wid);
@@ -275,7 +275,7 @@ void ProgressDialog::end_task(const String &p_task) {
 
 	if (tasks.is_empty()) {
 		hide();
-		EditorNode::get_singleton()->set_process_input(false);
+		EditorNode::get_singleton()->set_block_input(false);
 		for (ObjectID wid : host_windows) {
 			Window *w = ObjectDB::get_instance<Window>(wid);
 			if (w) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Partially adresses https://github.com/godotengine/godot-proposals/issues/954

Adds navigation between recent opened scenes with mouse forward and back buttons

## Additional information

I didn't manage to make keyboard shortcuts with alt+arrow work as in the script editor as various other UI parts consume any arrow key inputs beforehand. With some changes there this could be made possible. I also didn't add UI arrow buttons yet because of space considerations, but maybe it would be a a good thing.

The implementation could also be expanded in a separate pr to include node selections as history points, as e.g. seen in script editors with caret positions, if that would be desired..

<details>
<summary>Verification</summary>

https://github.com/user-attachments/assets/d692ebe3-0ca2-44a4-a7e9-531a4c8a83cf

</details>

