### PR TITLE
[macOS 27] Fix missing menu icons.

### DIFF
--- a/platform/macos/native_menu_macos.mm
+++ b/platform/macos/native_menu_macos.mm
@@ -540,6 +540,15 @@ int NativeMenuMacOS::add_icon_item(const RID &p_rid, const Ref<Texture2D> &p_ico
 			NSImage *image = ds->_convert_to_nsimg(obj->img);
 			[image setSize:NSMakeSize(16, 16)];
 			[menu_item setImage:image];
+#if (__MAC_OS_X_VERSION_MAX_ALLOWED < 270000)
+			if ([menu_item respondsToSelector:@selector(preferredImageVisibility)]) {
+				[menu_item setValue:@(1) forKey:@"preferredImageVisibility"];
+			}
+#else
+			if (@available(macOS 27.0, *)) {
+				menu_item.preferredImageVisibility = NSMenuItemImageVisibilityVisible;
+			}
+#endif
 		}
 		[menu_item setKeyEquivalentModifierMask:KeyMappingMacOS::keycode_get_native_mask(p_accel)];
 		[menu_item setRepresentedObject:obj];
@@ -571,6 +580,15 @@ int NativeMenuMacOS::add_icon_check_item(const RID &p_rid, const Ref<Texture2D> 
 			NSImage *image = ds->_convert_to_nsimg(obj->img);
 			[image setSize:NSMakeSize(16, 16)];
 			[menu_item setImage:image];
+#if (__MAC_OS_X_VERSION_MAX_ALLOWED < 270000)
+			if ([menu_item respondsToSelector:@selector(preferredImageVisibility)]) {
+				[menu_item setValue:@(1) forKey:@"preferredImageVisibility"];
+			}
+#else
+			if (@available(macOS 27.0, *)) {
+				menu_item.preferredImageVisibility = NSMenuItemImageVisibilityVisible;
+			}
+#endif
 		}
 		[menu_item setKeyEquivalentModifierMask:KeyMappingMacOS::keycode_get_native_mask(p_accel)];
 		[menu_item setRepresentedObject:obj];
@@ -622,6 +640,15 @@ int NativeMenuMacOS::add_icon_radio_check_item(const RID &p_rid, const Ref<Textu
 			NSImage *image = ds->_convert_to_nsimg(obj->img);
 			[image setSize:NSMakeSize(16, 16)];
 			[menu_item setImage:image];
+#if (__MAC_OS_X_VERSION_MAX_ALLOWED < 270000)
+			if ([menu_item respondsToSelector:@selector(preferredImageVisibility)]) {
+				[menu_item setValue:@(1) forKey:@"preferredImageVisibility"];
+			}
+#else
+			if (@available(macOS 27.0, *)) {
+				menu_item.preferredImageVisibility = NSMenuItemImageVisibilityVisible;
+			}
+#endif
 		}
 		[menu_item setKeyEquivalentModifierMask:KeyMappingMacOS::keycode_get_native_mask(p_accel)];
 		[menu_item setRepresentedObject:obj];
@@ -1383,6 +1410,15 @@ void NativeMenuMacOS::set_item_icon(const RID &p_rid, int p_idx, const Ref<Textu
 			NSImage *image = ds->_convert_to_nsimg(obj->img);
 			[image setSize:NSMakeSize(16, 16)];
 			[menu_item setImage:image];
+#if (__MAC_OS_X_VERSION_MAX_ALLOWED < 270000)
+			if ([menu_item respondsToSelector:@selector(preferredImageVisibility)]) {
+				[menu_item setValue:@(1) forKey:@"preferredImageVisibility"];
+			}
+#else
+			if (@available(macOS 27.0, *)) {
+				menu_item.preferredImageVisibility = NSMenuItemImageVisibilityVisible;
+			}
+#endif
 		} else {
 			obj->img = Ref<Image>();
 			[menu_item setImage:nil];


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Menu icons on macOS 27.

## Additional information

Before:
<img width="806" height="500" alt="Screenshot 2026-08-22 at 19 04 51" src="https://github.com/user-attachments/assets/0a9245f1-a374-4f41-b9ae-50201c1d36ae" />

After:
<img width="806" height="500" alt="Screenshot 2026-08-22 at 19 06 00" src="https://github.com/user-attachments/assets/75226392-869e-45b9-8f25-c5d71714d3ae" />
