### PR TITLE
Make typed containers faster

### DIFF
--- a/core/extension/gdextension_interface.cpp
+++ b/core/extension/gdextension_interface.cpp
@@ -40,6 +40,7 @@
 #include "core/object/script_language_extension.h"
 #include "core/object/worker_thread_pool.h"
 #include "core/os/memory.h"
+#include "core/variant/container_type_validate.h"
 #include "core/variant/variant.h"
 #include "core/version.h"
 
@@ -1306,7 +1307,15 @@ void gdextension_array_set_typed(GDExtensionTypePtr p_self, GDExtensionVariantTy
 	Array *self = reinterpret_cast<Array *>(p_self);
 	const StringName *class_name = reinterpret_cast<const StringName *>(p_class_name);
 	const Variant *script = reinterpret_cast<const Variant *>(p_script);
-	self->set_typed((uint32_t)p_type, *class_name, *script);
+
+	ContainerType element_type = ContainerType::from_type((uint32_t)p_type);
+	element_type.class_name = *class_name;
+#ifdef DEBUG_ENABLED
+	element_type.script = *script;
+#else
+	element_type.script = Object::cast_to<Script>(script->operator Object *());
+#endif
+	self->set_typed(std::move(element_type));
 }
 
 /* Dictionary functions */
@@ -1327,7 +1336,22 @@ void gdextension_dictionary_set_typed(GDExtensionTypePtr p_self, GDExtensionVari
 	const Variant *key_script = reinterpret_cast<const Variant *>(p_key_script);
 	const StringName *value_class_name = reinterpret_cast<const StringName *>(p_value_class_name);
 	const Variant *value_script = reinterpret_cast<const Variant *>(p_value_script);
-	self->set_typed((uint32_t)p_key_type, *key_class_name, *key_script, (uint32_t)p_value_type, *value_class_name, *value_script);
+
+	ContainerType key_type = ContainerType::from_type((uint32_t)p_key_type);
+	key_type.class_name = *key_class_name;
+#ifdef DEBUG_ENABLED
+	key_type.script = *key_script;
+#else
+	key_type.script = Object::cast_to<Script>(key_script->operator Object *());
+#endif
+	ContainerType value_type = ContainerType::from_type((uint32_t)p_value_type);
+	value_type.class_name = *value_class_name;
+#ifdef DEBUG_ENABLED
+	value_type.script = *value_script;
+#else
+	value_type.script = Object::cast_to<Script>(value_script->operator Object *());
+#endif
+	self->set_typed(std::move(key_type), std::move(value_type));
 }
 
 /* OBJECT API */

--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -1289,7 +1289,7 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 					Dictionary ret;
 
 					if (key_type.builtin_type != Variant::NIL || value_type.builtin_type != Variant::NIL) {
-						ret.set_typed(key_type, value_type);
+						ret.set_typed(std::move(key_type), std::move(value_type));
 					}
 
 					ERR_FAIL_COND_V_MSG(p_depth > Variant::MAX_RECURSION_DEPTH, ret, "Variant is too deep. Bailing.");
@@ -1312,7 +1312,7 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 					Array ret;
 
 					if (elem_type.builtin_type != Variant::NIL) {
-						ret.set_typed(elem_type);
+						ret.set_typed(std::move(elem_type));
 					}
 
 					ERR_FAIL_COND_V_MSG(p_depth > Variant::MAX_RECURSION_DEPTH, ret, "Variant is too deep. Bailing.");

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -807,7 +807,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 
 			Dictionary dict;
 			if (key_type.builtin_type != Variant::NIL || value_type.builtin_type != Variant::NIL) {
-				dict.set_typed(key_type, value_type);
+				dict.set_typed(std::move(key_type), std::move(value_type));
 			}
 
 			for (int i = 0; i < count; i++) {
@@ -861,7 +861,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 
 			Array array;
 			if (type.builtin_type != Variant::NIL) {
-				array.set_typed(type);
+				array.set_typed(std::move(type));
 			}
 
 			for (int i = 0; i < count; i++) {

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -345,7 +345,7 @@ Variant Resource::_duplicate_recursive(const Variant &p_variant, const Duplicate
 			const Dictionary &src = p_variant;
 			Dictionary dst;
 			if (src.is_typed()) {
-				dst.set_typed(src.get_typed_key_builtin(), src.get_typed_key_class_name(), src.get_typed_key_script(), src.get_typed_value_builtin(), src.get_typed_value_class_name(), src.get_typed_value_script());
+				dst.set_typed(src.get_key_type(), src.get_value_type());
 			}
 			for (const Variant &k : src.get_key_list()) {
 				const Variant &v = src[k];

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -790,7 +790,7 @@ Error ResourceLoaderBinary::load() {
 				if (is_get_valid && get_value.get_type() == Variant::ARRAY) {
 					Array get_array = get_value;
 					if (!set_array.is_same_typed(get_array)) {
-						value = Array(set_array, get_array.get_typed_builtin(), get_array.get_typed_class_name(), get_array.get_typed_script());
+						value = Array(set_array, get_array.get_element_type());
 					}
 				}
 			}
@@ -802,8 +802,7 @@ Error ResourceLoaderBinary::load() {
 				if (is_get_valid && get_value.get_type() == Variant::DICTIONARY) {
 					Dictionary get_dict = get_value;
 					if (!set_dict.is_same_typed(get_dict)) {
-						value = Dictionary(set_dict, get_dict.get_typed_key_builtin(), get_dict.get_typed_key_class_name(), get_dict.get_typed_key_script(),
-								get_dict.get_typed_value_builtin(), get_dict.get_typed_value_class_name(), get_dict.get_typed_value_script());
+						value = Dictionary(set_dict, get_dict.get_key_type(), get_dict.get_value_type());
 					}
 				}
 			}

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -915,11 +915,19 @@ uint32_t Array::get_typed_builtin() const {
 	return _p->typed.builtin_type;
 }
 
-StringName Array::get_typed_class_name() const {
+const StringName &Array::get_typed_class_name() const {
 	return _p->typed.class_name;
 }
 
-Variant Array::get_typed_script() const {
+const Ref<Script> &Array::get_typed_script() const {
+	return _p->typed.script;
+}
+
+StringName Array::_get_typed_class_name_bind() const {
+	return _p->typed.class_name;
+}
+
+Variant Array::_get_typed_script_bind() const {
 	return _p->typed.script;
 }
 

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -869,30 +869,40 @@ const void *Array::id() const {
 	return _p;
 }
 
-Array::Array(const Array &p_from, uint32_t p_type, const StringName &p_class_name, const Variant &p_script) {
-	_p = memnew(ArrayPrivate);
-	_p->refcount.init();
-	set_typed(p_type, p_class_name, p_script);
-	assign(p_from);
+#define ARRAY_SET_TYPED_VALIDATE(m_type, m_class_name, m_script) \
+	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state."); \
+	ERR_FAIL_COND_MSG(_p->array.size() > 0, "Type can only be set when array is empty."); \
+	ERR_FAIL_COND_MSG(_p->refcount.get() > 1, "Type can only be set when array has no more than one user."); \
+	ERR_FAIL_COND_MSG(_p->typed.builtin_type != Variant::NIL, "Type can only be set once."); \
+	ERR_FAIL_COND_MSG(m_class_name != StringName() && m_type != Variant::OBJECT, "Class names can only be set for type OBJECT"); \
+	ERR_FAIL_COND_MSG(m_script.is_valid() && m_class_name == StringName(), "Script class can only be set together with base class name")
+
+void Array::_set_typed(uint32_t p_type, StringName p_class_name, Ref<Script> p_script) {
+	ARRAY_SET_TYPED_VALIDATE(p_type, p_class_name, p_script);
+
+	_p->typed.builtin_type = Variant::Type(p_type);
+	_p->typed.class_name = std::move(p_class_name);
+	_p->typed.script = std::move(p_script);
+	_p->typed.where = "TypedArray";
 }
 
 void Array::set_typed(const ContainerType &p_element_type) {
-	set_typed(p_element_type.builtin_type, p_element_type.class_name, p_element_type.script);
+	ARRAY_SET_TYPED_VALIDATE(p_element_type.builtin_type, p_element_type.class_name, p_element_type.script);
+
+	_p->typed.builtin_type = p_element_type.builtin_type;
+	_p->typed.class_name = p_element_type.class_name;
+	_p->typed.script = p_element_type.script;
+	_p->typed.where = "TypedArray";
+}
+
+#undef ARRAY_SET_TYPED_VALIDATE
+
+void Array::set_typed(ContainerType &&p_element_type) {
+	_set_typed(p_element_type.builtin_type, std::move(p_element_type.class_name), std::move(p_element_type.script));
 }
 
 void Array::set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script) {
-	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
-	ERR_FAIL_COND_MSG(_p->array.size() > 0, "Type can only be set when array is empty.");
-	ERR_FAIL_COND_MSG(_p->refcount.get() > 1, "Type can only be set when array has no more than one user.");
-	ERR_FAIL_COND_MSG(_p->typed.builtin_type != Variant::NIL, "Type can only be set once.");
-	ERR_FAIL_COND_MSG(p_class_name != StringName() && p_type != Variant::OBJECT, "Class names can only be set for type OBJECT");
-	Ref<Script> script = p_script;
-	ERR_FAIL_COND_MSG(script.is_valid() && p_class_name == StringName(), "Script class can only be set together with base class name");
-
-	_p->typed.builtin_type = Variant::Type(p_type);
-	_p->typed.class_name = p_class_name;
-	_p->typed.script = script;
-	_p->typed.where = "TypedArray";
+	_set_typed(p_type, p_class_name, Ref<Script>(p_script));
 }
 
 bool Array::is_typed() const {
@@ -951,19 +961,39 @@ Span<Variant> Array::span() const {
 	return _p->array.span();
 }
 
-Array::Array(const Array &p_from) {
-	_p = nullptr;
+Array::Array(uint32_t p_type, const StringName &p_class_name) : _p(memnew(ArrayPrivate)) {
+	_p->refcount.init();
+	set_typed(p_type, p_class_name, Ref<Script>());
+}
+
+Array::Array(const Array &p_from, const ContainerType &p_element_type) : _p(memnew(ArrayPrivate)) {
+	_p->refcount.init();
+	set_typed(p_element_type);
+	assign(p_from);
+}
+
+Array::Array(const Array &p_from, ContainerType &&p_element_type) : _p(memnew(ArrayPrivate)) {
+	_p->refcount.init();
+	set_typed(std::move(p_element_type));
+	assign(p_from);
+}
+
+Array::Array(const Array &p_from, uint32_t p_type, const StringName &p_class_name, const Variant &p_script) : _p(memnew(ArrayPrivate)) {
+	_p->refcount.init();
+	set_typed(p_type, p_class_name, p_script);
+	assign(p_from);
+}
+
+Array::Array(const Array &p_from) : _p(nullptr) {
 	_ref(p_from);
 }
 
-Array::Array(std::initializer_list<Variant> p_init) {
-	_p = memnew(ArrayPrivate);
+Array::Array(std::initializer_list<Variant> p_init) : _p(memnew(ArrayPrivate)) {
 	_p->refcount.init();
 	_p->array = Vector<Variant>(p_init);
 }
 
-Array::Array() {
-	_p = memnew(ArrayPrivate);
+Array::Array() : _p(memnew(ArrayPrivate)) {
 	_p->refcount.init();
 }
 

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -216,7 +216,7 @@ void Array::assign(const Array &p_array) {
 	const ContainerTypeValidate &typed = _p->typed;
 	const ContainerTypeValidate &source_typed = p_array._p->typed;
 
-	if (typed == source_typed || typed.type == Variant::NIL || (source_typed.type == Variant::OBJECT && typed.can_reference(source_typed))) {
+	if (typed == source_typed || typed.builtin_type == Variant::NIL || (source_typed.builtin_type == Variant::OBJECT && typed.can_reference(source_typed))) {
 		// from same to same or
 		// from anything to variants or
 		// from subclasses to base classes
@@ -227,51 +227,51 @@ void Array::assign(const Array &p_array) {
 	const Variant *source = p_array._p->array.ptr();
 	int size = p_array._p->array.size();
 
-	if ((source_typed.type == Variant::NIL && typed.type == Variant::OBJECT) || (source_typed.type == Variant::OBJECT && source_typed.can_reference(typed))) {
+	if ((source_typed.builtin_type == Variant::NIL && typed.builtin_type == Variant::OBJECT) || (source_typed.builtin_type == Variant::OBJECT && source_typed.can_reference(typed))) {
 		// from variants to objects or
 		// from base classes to subclasses
 		for (int i = 0; i < size; i++) {
 			const Variant &element = source[i];
 			if (element.get_type() != Variant::NIL && (element.get_type() != Variant::OBJECT || !typed.validate_object(element, "assign"))) {
-				ERR_FAIL_MSG(vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(element.get_type()), Variant::get_type_name(typed.type)));
+				ERR_FAIL_MSG(vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(element.get_type()), Variant::get_type_name(typed.builtin_type)));
 			}
 		}
 		_p->array = p_array._p->array;
 		return;
 	}
-	if (typed.type == Variant::OBJECT || source_typed.type == Variant::OBJECT) {
-		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Array[%s]" to "Array[%s]".)", Variant::get_type_name(source_typed.type), Variant::get_type_name(typed.type)));
+	if (typed.builtin_type == Variant::OBJECT || source_typed.builtin_type == Variant::OBJECT) {
+		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Array[%s]" to "Array[%s]".)", Variant::get_type_name(source_typed.builtin_type), Variant::get_type_name(typed.builtin_type)));
 	}
 
 	Vector<Variant> array;
 	array.resize(size);
 	Variant *data = array.ptrw();
 
-	if (source_typed.type == Variant::NIL && typed.type != Variant::OBJECT) {
+	if (source_typed.builtin_type == Variant::NIL && typed.builtin_type != Variant::OBJECT) {
 		// from variants to primitives
 		for (int i = 0; i < size; i++) {
 			const Variant *value = source + i;
-			if (value->get_type() == typed.type) {
+			if (value->get_type() == typed.builtin_type) {
 				data[i] = *value;
 				continue;
 			}
-			if (!Variant::can_convert_strict(value->get_type(), typed.type)) {
-				ERR_FAIL_MSG(vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.type)));
+			if (!Variant::can_convert_strict(value->get_type(), typed.builtin_type)) {
+				ERR_FAIL_MSG(vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.builtin_type)));
 			}
 			Callable::CallError ce;
-			Variant::construct(typed.type, data[i], &value, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.type)));
+			Variant::construct(typed.builtin_type, data[i], &value, 1, ce);
+			ERR_FAIL_COND_MSG(ce.error, vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.builtin_type)));
 		}
-	} else if (Variant::can_convert_strict(source_typed.type, typed.type)) {
+	} else if (Variant::can_convert_strict(source_typed.builtin_type, typed.builtin_type)) {
 		// from primitives to different convertible primitives
 		for (int i = 0; i < size; i++) {
 			const Variant *value = source + i;
 			Callable::CallError ce;
-			Variant::construct(typed.type, data[i], &value, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.type)));
+			Variant::construct(typed.builtin_type, data[i], &value, 1, ce);
+			ERR_FAIL_COND_MSG(ce.error, vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.builtin_type)));
 		}
 	} else {
-		ERR_FAIL_MSG(vformat("Cannot assign contents of 'Array[%s]' to 'Array[%s]'.", Variant::get_type_name(source_typed.type), Variant::get_type_name(typed.type)));
+		ERR_FAIL_MSG(vformat("Cannot assign contents of 'Array[%s]' to 'Array[%s]'.", Variant::get_type_name(source_typed.builtin_type), Variant::get_type_name(typed.builtin_type)));
 	}
 
 	_p->array = array;
@@ -303,7 +303,7 @@ void Array::append_array(const Array &p_array) {
 
 Error Array::resize(int p_new_size) {
 	ERR_FAIL_COND_V_MSG(_p->read_only, ERR_LOCKED, "Array is in read-only state.");
-	Variant::Type &variant_type = _p->typed.type;
+	Variant::Type &variant_type = _p->typed.builtin_type;
 	int old_size = _p->array.size();
 	Error err = _p->array.resize_initialized(p_new_size);
 	if (!err && variant_type != Variant::NIL && variant_type != Variant::OBJECT) {
@@ -884,19 +884,19 @@ void Array::set_typed(uint32_t p_type, const StringName &p_class_name, const Var
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
 	ERR_FAIL_COND_MSG(_p->array.size() > 0, "Type can only be set when array is empty.");
 	ERR_FAIL_COND_MSG(_p->refcount.get() > 1, "Type can only be set when array has no more than one user.");
-	ERR_FAIL_COND_MSG(_p->typed.type != Variant::NIL, "Type can only be set once.");
+	ERR_FAIL_COND_MSG(_p->typed.builtin_type != Variant::NIL, "Type can only be set once.");
 	ERR_FAIL_COND_MSG(p_class_name != StringName() && p_type != Variant::OBJECT, "Class names can only be set for type OBJECT");
 	Ref<Script> script = p_script;
 	ERR_FAIL_COND_MSG(script.is_valid() && p_class_name == StringName(), "Script class can only be set together with base class name");
 
-	_p->typed.type = Variant::Type(p_type);
+	_p->typed.builtin_type = Variant::Type(p_type);
 	_p->typed.class_name = p_class_name;
 	_p->typed.script = script;
 	_p->typed.where = "TypedArray";
 }
 
 bool Array::is_typed() const {
-	return _p->typed.type != Variant::NIL;
+	return _p->typed.builtin_type != Variant::NIL;
 }
 
 bool Array::is_same_typed(const Array &p_other) const {
@@ -907,16 +907,12 @@ bool Array::is_same_instance(const Array &p_other) const {
 	return _p == p_other._p;
 }
 
-ContainerType Array::get_element_type() const {
-	ContainerType type;
-	type.builtin_type = _p->typed.type;
-	type.class_name = _p->typed.class_name;
-	type.script = _p->typed.script;
-	return type;
+const ContainerType &Array::get_element_type() const {
+	return _p->typed;
 }
 
 uint32_t Array::get_typed_builtin() const {
-	return _p->typed.type;
+	return _p->typed.builtin_type;
 }
 
 StringName Array::get_typed_class_name() const {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -56,6 +56,10 @@ class _WARN_UNUSED_ Array {
 	mutable ArrayPrivate *_p;
 	void _ref(const Array &p_from) const;
 	void _unref() const;
+	_FORCE_INLINE_ void _set_typed(uint32_t p_type, StringName p_class_name, Ref<Script> p_script);
+
+protected:
+	Array(uint32_t p_type, const StringName &p_class_name);
 
 public:
 	struct ConstIterator {
@@ -183,6 +187,7 @@ public:
 	const void *id() const;
 
 	void set_typed(const ContainerType &p_element_type);
+	void set_typed(ContainerType &&p_element_type);
 	void set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
 
 	bool is_typed() const;
@@ -206,6 +211,8 @@ public:
 		return this->span();
 	}
 
+	Array(const Array &p_base, const ContainerType &p_element_type);
+	Array(const Array &p_base, ContainerType &&p_element_type);
 	Array(const Array &p_base, uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
 	Array(const Array &p_from);
 	Array(std::initializer_list<Variant> p_init);

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -187,7 +187,7 @@ public:
 	bool is_same_typed(const Array &p_other) const;
 	bool is_same_instance(const Array &p_other) const;
 
-	ContainerType get_element_type() const;
+	const ContainerType &get_element_type() const _LIFETIME_BOUND_;
 	uint32_t get_typed_builtin() const;
 	StringName get_typed_class_name() const;
 	Variant get_typed_script() const;

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -40,7 +40,9 @@
 class Callable;
 class StringName;
 class Variant;
-
+class Script;
+template <typename T>
+class Ref;
 struct ArrayPrivate;
 struct ContainerType;
 
@@ -189,8 +191,11 @@ public:
 
 	const ContainerType &get_element_type() const _LIFETIME_BOUND_;
 	uint32_t get_typed_builtin() const;
-	StringName get_typed_class_name() const;
-	Variant get_typed_script() const;
+	const StringName &get_typed_class_name() const _LIFETIME_BOUND_;
+	const Ref<Script> &get_typed_script() const _LIFETIME_BOUND_;
+
+	StringName _get_typed_class_name_bind() const;
+	Variant _get_typed_script_bind() const;
 
 	void make_read_only();
 	bool is_read_only() const;

--- a/core/variant/container_type_validate.h
+++ b/core/variant/container_type_validate.h
@@ -40,28 +40,25 @@ struct ContainerType {
 	Ref<Script> script;
 };
 
-struct ContainerTypeValidate {
-	Variant::Type type = Variant::NIL;
-	StringName class_name;
-	Ref<Script> script;
+struct ContainerTypeValidate : public ContainerType {
 	const char *where = "container";
 
 private:
 	_FORCE_INLINE_ bool _internal_validate(Variant &r_inout_variant, const char *p_operation, bool p_output_errors) const {
-		if (type == Variant::NIL) {
+		if (builtin_type == Variant::NIL) {
 			return true;
 		}
 
-		if (type != r_inout_variant.get_type()) {
-			if (r_inout_variant.get_type() == Variant::NIL && type == Variant::OBJECT) {
+		if (builtin_type != r_inout_variant.get_type()) {
+			if (r_inout_variant.get_type() == Variant::NIL && builtin_type == Variant::OBJECT) {
 				return true;
 			}
 
-			if (Variant::can_convert_strict(r_inout_variant.get_type(), type)) {
+			if (Variant::can_convert_strict(r_inout_variant.get_type(), builtin_type)) {
 				Variant converted_to;
 				const Variant *converted_from = &r_inout_variant;
 				Callable::CallError call_error;
-				Variant::construct(type, converted_to, &converted_from, 1, call_error);
+				Variant::construct(builtin_type, converted_to, &converted_from, 1, call_error);
 
 				if (call_error.error == Callable::CallError::CALL_OK) {
 					r_inout_variant = converted_to;
@@ -70,13 +67,13 @@ private:
 			}
 
 			if (p_output_errors) {
-				ERR_FAIL_V_MSG(false, vformat("Attempted to %s a variable of type '%s' into a %s of incompatible type '%s'.", String(p_operation), Variant::get_type_name(r_inout_variant.get_type()), where, Variant::get_type_name(type)));
+				ERR_FAIL_V_MSG(false, vformat("Attempted to %s a variable of type '%s' into a %s of incompatible type '%s'.", String(p_operation), Variant::get_type_name(r_inout_variant.get_type()), where, Variant::get_type_name(builtin_type)));
 			} else {
 				return false;
 			}
 		}
 
-		if (type != Variant::OBJECT) {
+		if (builtin_type != Variant::OBJECT) {
 			return true;
 		}
 
@@ -164,9 +161,9 @@ public:
 	}
 
 	_FORCE_INLINE_ bool can_reference(const ContainerTypeValidate &p_type) const {
-		if (type != p_type.type) {
+		if (builtin_type != p_type.builtin_type) {
 			return false;
-		} else if (type != Variant::OBJECT) {
+		} else if (builtin_type != Variant::OBJECT) {
 			return true;
 		}
 
@@ -190,9 +187,9 @@ public:
 	}
 
 	_FORCE_INLINE_ bool operator==(const ContainerTypeValidate &p_type) const {
-		return type == p_type.type && class_name == p_type.class_name && script == p_type.script;
+		return builtin_type == p_type.builtin_type && class_name == p_type.class_name && script == p_type.script;
 	}
 	_FORCE_INLINE_ bool operator!=(const ContainerTypeValidate &p_type) const {
-		return type != p_type.type || class_name != p_type.class_name || script != p_type.script;
+		return builtin_type != p_type.builtin_type || class_name != p_type.class_name || script != p_type.script;
 	}
 };

--- a/core/variant/container_type_validate.h
+++ b/core/variant/container_type_validate.h
@@ -38,6 +38,13 @@ struct ContainerType {
 	Variant::Type builtin_type = Variant::NIL;
 	StringName class_name;
 	Ref<Script> script;
+
+	_ALWAYS_INLINE_ static ContainerType from_type(uint32_t p_builtin_type) {
+		return ContainerType{ Variant::Type(p_builtin_type), StringName(), Ref<Script>() };
+	}
+	_ALWAYS_INLINE_ static ContainerType from_type(Variant::Type p_builtin_type) {
+		return ContainerType{ p_builtin_type, StringName(), Ref<Script>() };
+	}
 };
 
 struct ContainerTypeValidate : public ContainerType {
@@ -125,7 +132,11 @@ private:
 			return true; // All good, no script requested.
 		}
 
+#ifdef DEBUG_ENABLED
 		Ref<Script> other_script = object->get_script();
+#else
+		Ref<Script> other_script = Object::cast_to<Script>(object->get_script().operator Object *());
+#endif
 
 		// Check base script..
 		if (other_script.is_null()) {

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -99,20 +99,20 @@ Variant &Dictionary::operator[](const Variant &p_key) {
 		if (unlikely(!_p->typed_fallback)) {
 			_p->typed_fallback = memnew(Variant);
 		}
-		VariantInternal::initialize(_p->typed_fallback, _p->typed_value.type);
+		VariantInternal::initialize(_p->typed_fallback, _p->typed_value.builtin_type);
 		return *_p->typed_fallback;
 	} else if (unlikely(_p->read_only)) {
 		if (likely(_p->variant_map.has(key))) {
 			*_p->read_only = _p->variant_map[key];
 		} else {
-			VariantInternal::initialize(_p->read_only, _p->typed_value.type);
+			VariantInternal::initialize(_p->read_only, _p->typed_value.builtin_type);
 		}
 		return *_p->read_only;
 	} else {
 		const uint32_t old_size = _p->variant_map.size();
 		Variant &value = _p->variant_map[key];
 		if (_p->variant_map.size() > old_size) {
-			VariantInternal::initialize(&value, _p->typed_value.type);
+			VariantInternal::initialize(&value, _p->typed_value.builtin_type);
 		}
 		return value;
 	}
@@ -124,7 +124,7 @@ const Variant &Dictionary::operator[](const Variant &p_key) const {
 		if (unlikely(!_p->typed_fallback)) {
 			_p->typed_fallback = memnew(Variant);
 		}
-		VariantInternal::initialize(_p->typed_fallback, _p->typed_value.type);
+		VariantInternal::initialize(_p->typed_fallback, _p->typed_value.builtin_type);
 		return *_p->typed_fallback;
 	} else {
 		static Variant empty;
@@ -426,8 +426,8 @@ void Dictionary::assign(const Dictionary &p_dictionary) {
 	const ContainerTypeValidate &typed_value = _p->typed_value;
 	const ContainerTypeValidate &typed_value_source = p_dictionary._p->typed_value;
 
-	if ((typed_key == typed_key_source || typed_key.type == Variant::NIL || (typed_key_source.type == Variant::OBJECT && typed_key.can_reference(typed_key_source))) &&
-			(typed_value == typed_value_source || typed_value.type == Variant::NIL || (typed_value_source.type == Variant::OBJECT && typed_value.can_reference(typed_value_source)))) {
+	if ((typed_key == typed_key_source || typed_key.builtin_type == Variant::NIL || (typed_key_source.builtin_type == Variant::OBJECT && typed_key.can_reference(typed_key_source))) &&
+			(typed_value == typed_value_source || typed_value.builtin_type == Variant::NIL || (typed_value_source.builtin_type == Variant::OBJECT && typed_value.can_reference(typed_value_source)))) {
 		// From same to same or,
 		// from anything to variants or,
 		// from subclasses to base classes.
@@ -446,7 +446,7 @@ void Dictionary::assign(const Dictionary &p_dictionary) {
 	value_array.resize(size);
 	Variant *value_data = value_array.ptrw();
 
-	if (typed_key == typed_key_source || typed_key.type == Variant::NIL || (typed_key_source.type == Variant::OBJECT && typed_key.can_reference(typed_key_source))) {
+	if (typed_key == typed_key_source || typed_key.builtin_type == Variant::NIL || (typed_key_source.builtin_type == Variant::OBJECT && typed_key.can_reference(typed_key_source))) {
 		// From same to same or,
 		// from anything to variants or,
 		// from subclasses to base classes.
@@ -455,51 +455,51 @@ void Dictionary::assign(const Dictionary &p_dictionary) {
 			const Variant *key = &E.key;
 			key_data[i++] = *key;
 		}
-	} else if ((typed_key_source.type == Variant::NIL && typed_key.type == Variant::OBJECT) || (typed_key_source.type == Variant::OBJECT && typed_key_source.can_reference(typed_key))) {
+	} else if ((typed_key_source.builtin_type == Variant::NIL && typed_key.builtin_type == Variant::OBJECT) || (typed_key_source.builtin_type == Variant::OBJECT && typed_key_source.can_reference(typed_key))) {
 		// From variants to objects or,
 		// from base classes to subclasses.
 		int i = 0;
 		for (const KeyValue<Variant, Variant> &E : p_dictionary._p->variant_map) {
 			const Variant *key = &E.key;
 			if (key->get_type() != Variant::NIL && (key->get_type() != Variant::OBJECT || !typed_key.validate_object(*key, "assign"))) {
-				ERR_FAIL_MSG(vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.type)));
+				ERR_FAIL_MSG(vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.builtin_type)));
 			}
 			key_data[i++] = *key;
 		}
-	} else if (typed_key.type == Variant::OBJECT || typed_key_source.type == Variant::OBJECT) {
-		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s]".)", Variant::get_type_name(typed_key_source.type), Variant::get_type_name(typed_value_source.type),
-				Variant::get_type_name(typed_key.type), Variant::get_type_name(typed_value.type)));
-	} else if (typed_key_source.type == Variant::NIL && typed_key.type != Variant::OBJECT) {
+	} else if (typed_key.builtin_type == Variant::OBJECT || typed_key_source.builtin_type == Variant::OBJECT) {
+		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s]".)", Variant::get_type_name(typed_key_source.builtin_type), Variant::get_type_name(typed_value_source.builtin_type),
+				Variant::get_type_name(typed_key.builtin_type), Variant::get_type_name(typed_value.builtin_type)));
+	} else if (typed_key_source.builtin_type == Variant::NIL && typed_key.builtin_type != Variant::OBJECT) {
 		// From variants to primitives.
 		int i = 0;
 		for (const KeyValue<Variant, Variant> &E : p_dictionary._p->variant_map) {
 			const Variant *key = &E.key;
-			if (key->get_type() == typed_key.type) {
+			if (key->get_type() == typed_key.builtin_type) {
 				key_data[i++] = *key;
 				continue;
 			}
-			if (!Variant::can_convert_strict(key->get_type(), typed_key.type)) {
-				ERR_FAIL_MSG(vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.type)));
+			if (!Variant::can_convert_strict(key->get_type(), typed_key.builtin_type)) {
+				ERR_FAIL_MSG(vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.builtin_type)));
 			}
 			Callable::CallError ce;
-			Variant::construct(typed_key.type, key_data[i++], &key, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.type)));
+			Variant::construct(typed_key.builtin_type, key_data[i++], &key, 1, ce);
+			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.builtin_type)));
 		}
-	} else if (Variant::can_convert_strict(typed_key_source.type, typed_key.type)) {
+	} else if (Variant::can_convert_strict(typed_key_source.builtin_type, typed_key.builtin_type)) {
 		// From primitives to different convertible primitives.
 		int i = 0;
 		for (const KeyValue<Variant, Variant> &E : p_dictionary._p->variant_map) {
 			const Variant *key = &E.key;
 			Callable::CallError ce;
-			Variant::construct(typed_key.type, key_data[i++], &key, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.type)));
+			Variant::construct(typed_key.builtin_type, key_data[i++], &key, 1, ce);
+			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.builtin_type)));
 		}
 	} else {
-		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s].)", Variant::get_type_name(typed_key_source.type), Variant::get_type_name(typed_value_source.type),
-				Variant::get_type_name(typed_key.type), Variant::get_type_name(typed_value.type)));
+		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s].)", Variant::get_type_name(typed_key_source.builtin_type), Variant::get_type_name(typed_value_source.builtin_type),
+				Variant::get_type_name(typed_key.builtin_type), Variant::get_type_name(typed_value.builtin_type)));
 	}
 
-	if (typed_value == typed_value_source || typed_value.type == Variant::NIL || (typed_value_source.type == Variant::OBJECT && typed_value.can_reference(typed_value_source))) {
+	if (typed_value == typed_value_source || typed_value.builtin_type == Variant::NIL || (typed_value_source.builtin_type == Variant::OBJECT && typed_value.can_reference(typed_value_source))) {
 		// From same to same or,
 		// from anything to variants or,
 		// from subclasses to base classes.
@@ -508,48 +508,48 @@ void Dictionary::assign(const Dictionary &p_dictionary) {
 			const Variant *value = &E.value;
 			value_data[i++] = *value;
 		}
-	} else if (((typed_value_source.type == Variant::NIL && typed_value.type == Variant::OBJECT) || (typed_value_source.type == Variant::OBJECT && typed_value_source.can_reference(typed_value)))) {
+	} else if (((typed_value_source.builtin_type == Variant::NIL && typed_value.builtin_type == Variant::OBJECT) || (typed_value_source.builtin_type == Variant::OBJECT && typed_value_source.can_reference(typed_value)))) {
 		// From variants to objects or,
 		// from base classes to subclasses.
 		int i = 0;
 		for (const KeyValue<Variant, Variant> &E : p_dictionary._p->variant_map) {
 			const Variant *value = &E.value;
 			if (value->get_type() != Variant::NIL && (value->get_type() != Variant::OBJECT || !typed_value.validate_object(*value, "assign"))) {
-				ERR_FAIL_MSG(vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.type)));
+				ERR_FAIL_MSG(vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.builtin_type)));
 			}
 			value_data[i++] = *value;
 		}
-	} else if (typed_value.type == Variant::OBJECT || typed_value_source.type == Variant::OBJECT) {
-		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s]".)", Variant::get_type_name(typed_key_source.type), Variant::get_type_name(typed_value_source.type),
-				Variant::get_type_name(typed_key.type), Variant::get_type_name(typed_value.type)));
-	} else if (typed_value_source.type == Variant::NIL && typed_value.type != Variant::OBJECT) {
+	} else if (typed_value.builtin_type == Variant::OBJECT || typed_value_source.builtin_type == Variant::OBJECT) {
+		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s]".)", Variant::get_type_name(typed_key_source.builtin_type), Variant::get_type_name(typed_value_source.builtin_type),
+				Variant::get_type_name(typed_key.builtin_type), Variant::get_type_name(typed_value.builtin_type)));
+	} else if (typed_value_source.builtin_type == Variant::NIL && typed_value.builtin_type != Variant::OBJECT) {
 		// From variants to primitives.
 		int i = 0;
 		for (const KeyValue<Variant, Variant> &E : p_dictionary._p->variant_map) {
 			const Variant *value = &E.value;
-			if (value->get_type() == typed_value.type) {
+			if (value->get_type() == typed_value.builtin_type) {
 				value_data[i++] = *value;
 				continue;
 			}
-			if (!Variant::can_convert_strict(value->get_type(), typed_value.type)) {
-				ERR_FAIL_MSG(vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.type)));
+			if (!Variant::can_convert_strict(value->get_type(), typed_value.builtin_type)) {
+				ERR_FAIL_MSG(vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.builtin_type)));
 			}
 			Callable::CallError ce;
-			Variant::construct(typed_value.type, value_data[i++], &value, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i - 1], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.type)));
+			Variant::construct(typed_value.builtin_type, value_data[i++], &value, 1, ce);
+			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i - 1], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.builtin_type)));
 		}
-	} else if (Variant::can_convert_strict(typed_value_source.type, typed_value.type)) {
+	} else if (Variant::can_convert_strict(typed_value_source.builtin_type, typed_value.builtin_type)) {
 		// From primitives to different convertible primitives.
 		int i = 0;
 		for (const KeyValue<Variant, Variant> &E : p_dictionary._p->variant_map) {
 			const Variant *value = &E.value;
 			Callable::CallError ce;
-			Variant::construct(typed_value.type, value_data[i++], &value, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i - 1], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.type)));
+			Variant::construct(typed_value.builtin_type, value_data[i++], &value, 1, ce);
+			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i - 1], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.builtin_type)));
 		}
 	} else {
-		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s].)", Variant::get_type_name(typed_key_source.type), Variant::get_type_name(typed_value_source.type),
-				Variant::get_type_name(typed_key.type), Variant::get_type_name(typed_value.type)));
+		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s].)", Variant::get_type_name(typed_key_source.builtin_type), Variant::get_type_name(typed_value_source.builtin_type),
+				Variant::get_type_name(typed_key.builtin_type), Variant::get_type_name(typed_value.builtin_type)));
 	}
 
 	for (int i = 0; i < size; i++) {
@@ -641,19 +641,19 @@ void Dictionary::set_typed(uint32_t p_key_type, const StringName &p_key_class_na
 	ERR_FAIL_COND_MSG(_p->read_only, "Dictionary is in read-only state.");
 	ERR_FAIL_COND_MSG(_p->variant_map.size() > 0, "Type can only be set when dictionary is empty.");
 	ERR_FAIL_COND_MSG(_p->refcount.get() > 1, "Type can only be set when dictionary has no more than one user.");
-	ERR_FAIL_COND_MSG(_p->typed_key.type != Variant::NIL || _p->typed_value.type != Variant::NIL, "Type can only be set once.");
+	ERR_FAIL_COND_MSG(_p->typed_key.builtin_type != Variant::NIL || _p->typed_value.builtin_type != Variant::NIL, "Type can only be set once.");
 	ERR_FAIL_COND_MSG((p_key_class_name != StringName() && p_key_type != Variant::OBJECT) || (p_value_class_name != StringName() && p_value_type != Variant::OBJECT), "Class names can only be set for type OBJECT.");
 	Ref<Script> key_script = p_key_script;
 	ERR_FAIL_COND_MSG(key_script.is_valid() && p_key_class_name == StringName(), "Script class can only be set together with base class name.");
 	Ref<Script> value_script = p_value_script;
 	ERR_FAIL_COND_MSG(value_script.is_valid() && p_value_class_name == StringName(), "Script class can only be set together with base class name.");
 
-	_p->typed_key.type = Variant::Type(p_key_type);
+	_p->typed_key.builtin_type = Variant::Type(p_key_type);
 	_p->typed_key.class_name = p_key_class_name;
 	_p->typed_key.script = key_script;
 	_p->typed_key.where = "TypedDictionary.Key";
 
-	_p->typed_value.type = Variant::Type(p_value_type);
+	_p->typed_value.builtin_type = Variant::Type(p_value_type);
 	_p->typed_value.class_name = p_value_class_name;
 	_p->typed_value.script = value_script;
 	_p->typed_value.where = "TypedDictionary.Value";
@@ -664,11 +664,11 @@ bool Dictionary::is_typed() const {
 }
 
 bool Dictionary::is_typed_key() const {
-	return _p->typed_key.type != Variant::NIL;
+	return _p->typed_key.builtin_type != Variant::NIL;
 }
 
 bool Dictionary::is_typed_value() const {
-	return _p->typed_value.type != Variant::NIL;
+	return _p->typed_value.builtin_type != Variant::NIL;
 }
 
 bool Dictionary::is_same_instance(const Dictionary &p_other) const {
@@ -687,28 +687,20 @@ bool Dictionary::is_same_typed_value(const Dictionary &p_other) const {
 	return _p->typed_value == p_other._p->typed_value;
 }
 
-ContainerType Dictionary::get_key_type() const {
-	ContainerType type;
-	type.builtin_type = _p->typed_key.type;
-	type.class_name = _p->typed_key.class_name;
-	type.script = _p->typed_key.script;
-	return type;
+const ContainerType &Dictionary::get_key_type() const {
+	return _p->typed_key;
 }
 
-ContainerType Dictionary::get_value_type() const {
-	ContainerType type;
-	type.builtin_type = _p->typed_value.type;
-	type.class_name = _p->typed_value.class_name;
-	type.script = _p->typed_value.script;
-	return type;
+const ContainerType &Dictionary::get_value_type() const {
+	return _p->typed_value;
 }
 
 uint32_t Dictionary::get_typed_key_builtin() const {
-	return _p->typed_key.type;
+	return _p->typed_key.builtin_type;
 }
 
 uint32_t Dictionary::get_typed_value_builtin() const {
-	return _p->typed_value.type;
+	return _p->typed_value.builtin_type;
 }
 
 StringName Dictionary::get_typed_key_class_name() const {

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -703,19 +703,19 @@ uint32_t Dictionary::get_typed_value_builtin() const {
 	return _p->typed_value.builtin_type;
 }
 
-StringName Dictionary::get_typed_key_class_name() const {
+const StringName &Dictionary::get_typed_key_class_name() const {
 	return _p->typed_key.class_name;
 }
 
-StringName Dictionary::get_typed_value_class_name() const {
+const StringName &Dictionary::get_typed_value_class_name() const {
 	return _p->typed_value.class_name;
 }
 
-Variant Dictionary::get_typed_key_script() const {
+const Ref<Script> &Dictionary::get_typed_key_script() const {
 	return _p->typed_key.script;
 }
 
-Variant Dictionary::get_typed_value_script() const {
+const Ref<Script> &Dictionary::get_typed_value_script() const {
 	return _p->typed_value.script;
 }
 
@@ -725,6 +725,22 @@ const ContainerTypeValidate &Dictionary::get_key_validator() const {
 
 const ContainerTypeValidate &Dictionary::get_value_validator() const {
 	return _p->typed_value;
+}
+
+StringName Dictionary::_get_typed_key_class_name_bind() const {
+	return _p->typed_key.class_name;
+}
+
+StringName Dictionary::_get_typed_value_class_name_bind() const {
+	return _p->typed_value.class_name;
+}
+
+Variant Dictionary::_get_typed_key_script_bind() const {
+	return _p->typed_key.script;
+}
+
+Variant Dictionary::_get_typed_value_script_bind() const {
+	return _p->typed_value.script;
 }
 
 void Dictionary::operator=(const Dictionary &p_dictionary) {

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -382,7 +382,7 @@ uint32_t Dictionary::recursive_hash(int p_recursion_count) const {
 Array Dictionary::keys() const {
 	Array varr;
 	if (is_typed_key()) {
-		varr.set_typed(get_typed_key_builtin(), get_typed_key_class_name(), get_typed_key_script());
+		varr.set_typed(get_key_type());
 	}
 	if (_p->variant_map.is_empty()) {
 		return varr;
@@ -402,7 +402,7 @@ Array Dictionary::keys() const {
 Array Dictionary::values() const {
 	Array varr;
 	if (is_typed_value()) {
-		varr.set_typed(get_typed_value_builtin(), get_typed_value_class_name(), get_typed_value_script());
+		varr.set_typed(get_value_type());
 	}
 	if (_p->variant_map.is_empty()) {
 		return varr;
@@ -633,30 +633,50 @@ Dictionary Dictionary::recursive_duplicate(bool p_deep, ResourceDeepDuplicateMod
 	return n;
 }
 
-void Dictionary::set_typed(const ContainerType &p_key_type, const ContainerType &p_value_type) {
-	set_typed(p_key_type.builtin_type, p_key_type.class_name, p_key_type.script, p_value_type.builtin_type, p_value_type.class_name, p_value_type.script);
-}
+#define DICTIONARY_SET_TYPED_VALIDATE(m_key_type, m_key_class_name, m_key_script, m_value_type, m_value_class_name, m_value_script) \
+	ERR_FAIL_COND_MSG(_p->read_only, "Dictionary is in read-only state."); \
+	ERR_FAIL_COND_MSG(_p->variant_map.size() > 0, "Type can only be set when dictionary is empty."); \
+	ERR_FAIL_COND_MSG(_p->refcount.get() > 1, "Type can only be set when dictionary has no more than one user."); \
+	ERR_FAIL_COND_MSG(_p->typed_key.builtin_type != Variant::NIL || _p->typed_value.builtin_type != Variant::NIL, "Type can only be set once."); \
+	ERR_FAIL_COND_MSG((m_key_class_name != StringName() && m_key_type != Variant::OBJECT) || (m_value_class_name != StringName() && m_value_type != Variant::OBJECT), "Class names can only be set for type OBJECT."); \
+	ERR_FAIL_COND_MSG(m_key_script.is_valid() && m_key_class_name == StringName(), "Script class can only be set together with base class name."); \
+	ERR_FAIL_COND_MSG(m_value_script.is_valid() && m_value_class_name == StringName(), "Script class can only be set together with base class name.")
 
-void Dictionary::set_typed(uint32_t p_key_type, const StringName &p_key_class_name, const Variant &p_key_script, uint32_t p_value_type, const StringName &p_value_class_name, const Variant &p_value_script) {
-	ERR_FAIL_COND_MSG(_p->read_only, "Dictionary is in read-only state.");
-	ERR_FAIL_COND_MSG(_p->variant_map.size() > 0, "Type can only be set when dictionary is empty.");
-	ERR_FAIL_COND_MSG(_p->refcount.get() > 1, "Type can only be set when dictionary has no more than one user.");
-	ERR_FAIL_COND_MSG(_p->typed_key.builtin_type != Variant::NIL || _p->typed_value.builtin_type != Variant::NIL, "Type can only be set once.");
-	ERR_FAIL_COND_MSG((p_key_class_name != StringName() && p_key_type != Variant::OBJECT) || (p_value_class_name != StringName() && p_value_type != Variant::OBJECT), "Class names can only be set for type OBJECT.");
-	Ref<Script> key_script = p_key_script;
-	ERR_FAIL_COND_MSG(key_script.is_valid() && p_key_class_name == StringName(), "Script class can only be set together with base class name.");
-	Ref<Script> value_script = p_value_script;
-	ERR_FAIL_COND_MSG(value_script.is_valid() && p_value_class_name == StringName(), "Script class can only be set together with base class name.");
+void Dictionary::_set_typed(uint32_t p_key_type, StringName p_key_class_name, Ref<Script> p_key_script, uint32_t p_value_type, StringName p_value_class_name, Ref<Script> p_value_script) {
+	DICTIONARY_SET_TYPED_VALIDATE(p_key_type, p_key_class_name, p_key_script, p_value_type, p_value_class_name, p_value_script);
 
 	_p->typed_key.builtin_type = Variant::Type(p_key_type);
-	_p->typed_key.class_name = p_key_class_name;
-	_p->typed_key.script = key_script;
+	_p->typed_key.class_name = std::move(p_key_class_name);
+	_p->typed_key.script = std::move(p_key_script);
 	_p->typed_key.where = "TypedDictionary.Key";
 
 	_p->typed_value.builtin_type = Variant::Type(p_value_type);
-	_p->typed_value.class_name = p_value_class_name;
-	_p->typed_value.script = value_script;
+	_p->typed_value.class_name = std::move(p_value_class_name);
+	_p->typed_value.script = std::move(p_value_script);
 	_p->typed_value.where = "TypedDictionary.Value";
+}
+
+void Dictionary::set_typed(const ContainerType &p_key_type, const ContainerType &p_value_type) {
+	DICTIONARY_SET_TYPED_VALIDATE(p_key_type.builtin_type, p_key_type.class_name, p_key_type.script, p_value_type.builtin_type, p_value_type.class_name, p_value_type.script);
+
+	_p->typed_key.builtin_type = p_key_type.builtin_type;
+	_p->typed_key.class_name = p_key_type.class_name;
+	_p->typed_key.script = p_key_type.script;
+	_p->typed_key.where = "TypedDictionary.Key";
+
+	_p->typed_value.builtin_type = p_value_type.builtin_type;
+	_p->typed_value.class_name = p_value_type.class_name;
+	_p->typed_value.script = p_value_type.script;
+	_p->typed_value.where = "TypedDictionary.Value";
+}
+
+void Dictionary::set_typed(ContainerType &&p_key_type, ContainerType &&p_value_type) {
+	_set_typed(p_key_type.builtin_type, std::move(p_key_type.class_name), std::move(p_key_type.script),
+			p_value_type.builtin_type, std::move(p_value_type.class_name), std::move(p_value_type.script));
+}
+
+void Dictionary::set_typed(uint32_t p_key_type, const StringName &p_key_class_name, const Variant &p_key_script, uint32_t p_value_type, const StringName &p_value_class_name, const Variant &p_value_script) {
+	_set_typed(p_key_type, p_key_class_name, Ref<Script>(p_key_script), p_value_type, p_value_class_name, Ref<Script>(p_value_script));
 }
 
 bool Dictionary::is_typed() const {
@@ -754,25 +774,37 @@ const void *Dictionary::id() const {
 	return _p;
 }
 
-Dictionary::Dictionary(const Dictionary &p_base, uint32_t p_key_type, const StringName &p_key_class_name, const Variant &p_key_script, uint32_t p_value_type, const StringName &p_value_class_name, const Variant &p_value_script) {
-	_p = memnew(DictionaryPrivate);
+Dictionary::Dictionary(uint32_t p_key_type, const StringName &p_key_class_name, uint32_t p_value_type, const StringName &p_value_class_name) : _p(memnew(DictionaryPrivate)) {
+	_p->refcount.init();
+	set_typed(p_key_type, p_key_class_name, Ref<Script>(), p_value_type, p_value_class_name, Ref<Script>());
+}
+
+Dictionary::Dictionary(const Dictionary &p_base, const ContainerType &p_key_type, const ContainerType &p_value_type) : _p(memnew(DictionaryPrivate)) {
+	_p->refcount.init();
+	set_typed(p_key_type, p_value_type);
+	assign(p_base);
+}
+Dictionary::Dictionary(const Dictionary &p_base, ContainerType &&p_key_type, ContainerType &&p_value_type) : _p(memnew(DictionaryPrivate)) {
+	_p->refcount.init();
+	set_typed(std::move(p_key_type), std::move(p_value_type));
+	assign(p_base);
+}
+
+Dictionary::Dictionary(const Dictionary &p_base, uint32_t p_key_type, const StringName &p_key_class_name, const Variant &p_key_script, uint32_t p_value_type, const StringName &p_value_class_name, const Variant &p_value_script) : _p(memnew(DictionaryPrivate)) {
 	_p->refcount.init();
 	set_typed(p_key_type, p_key_class_name, p_key_script, p_value_type, p_value_class_name, p_value_script);
 	assign(p_base);
 }
 
-Dictionary::Dictionary(const Dictionary &p_from) {
-	_p = nullptr;
+Dictionary::Dictionary(const Dictionary &p_from) : _p(nullptr) {
 	_ref(p_from);
 }
 
-Dictionary::Dictionary() {
-	_p = memnew(DictionaryPrivate);
+Dictionary::Dictionary() : _p(memnew(DictionaryPrivate)) {
 	_p->refcount.init();
 }
 
-Dictionary::Dictionary(std::initializer_list<KeyValue<Variant, Variant>> p_init) {
-	_p = memnew(DictionaryPrivate);
+Dictionary::Dictionary(std::initializer_list<KeyValue<Variant, Variant>> p_init) : _p(memnew(DictionaryPrivate)) {
 	_p->refcount.init();
 
 	for (const KeyValue<Variant, Variant> &E : p_init) {

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -59,6 +59,10 @@ class _WARN_UNUSED_ Dictionary {
 
 	void _ref(const Dictionary &p_from) const;
 	void _unref() const;
+	_FORCE_INLINE_ void _set_typed(uint32_t p_key_type, StringName p_key_class_name, Ref<Script> p_key_script, uint32_t p_value_type, StringName p_value_class_name, Ref<Script> p_value_script);
+
+protected:
+	Dictionary(uint32_t p_key_type, const StringName &p_key_class_name, uint32_t p_value_type, const StringName &p_value_class_name);
 
 public:
 	using ConstIterator = HashMap<Variant, Variant, HashMapHasherDefault, StringLikeVariantComparator>::ConstIterator;
@@ -114,6 +118,7 @@ public:
 	Dictionary recursive_duplicate(bool p_deep, ResourceDeepDuplicateMode p_deep_subresources_mode, int p_recursion_count) const;
 
 	void set_typed(const ContainerType &p_key_type, const ContainerType &p_value_type);
+	void set_typed(ContainerType &&p_key_type, ContainerType &&p_value_type);
 	void set_typed(uint32_t p_key_type, const StringName &p_key_class_name, const Variant &p_key_script, uint32_t p_value_type, const StringName &p_value_class_name, const Variant &p_value_script);
 
 	bool is_typed() const;
@@ -145,6 +150,8 @@ public:
 
 	const void *id() const;
 
+	Dictionary(const Dictionary &p_base, const ContainerType &p_key_type, const ContainerType &p_value_type);
+	Dictionary(const Dictionary &p_base, ContainerType &&p_key_type, ContainerType &&p_value_type);
 	Dictionary(const Dictionary &p_base, uint32_t p_key_type, const StringName &p_key_class_name, const Variant &p_key_script, uint32_t p_value_type, const StringName &p_value_class_name, const Variant &p_value_script);
 	Dictionary(const Dictionary &p_from);
 	Dictionary(std::initializer_list<KeyValue<Variant, Variant>> p_init);

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -38,6 +38,9 @@
 class Array;
 class StringName;
 class Variant;
+class Script;
+template <typename T>
+class Ref;
 struct ContainerType;
 struct ContainerTypeValidate;
 struct DictionaryPrivate;
@@ -125,12 +128,17 @@ public:
 	const ContainerType &get_value_type() const _LIFETIME_BOUND_;
 	uint32_t get_typed_key_builtin() const;
 	uint32_t get_typed_value_builtin() const;
-	StringName get_typed_key_class_name() const;
-	StringName get_typed_value_class_name() const;
-	Variant get_typed_key_script() const;
-	Variant get_typed_value_script() const;
+	const StringName &get_typed_key_class_name() const _LIFETIME_BOUND_;
+	const StringName &get_typed_value_class_name() const _LIFETIME_BOUND_;
+	const Ref<Script> &get_typed_key_script() const _LIFETIME_BOUND_;
+	const Ref<Script> &get_typed_value_script() const _LIFETIME_BOUND_;
 	const ContainerTypeValidate &get_key_validator() const _LIFETIME_BOUND_;
 	const ContainerTypeValidate &get_value_validator() const _LIFETIME_BOUND_;
+
+	StringName _get_typed_key_class_name_bind() const;
+	StringName _get_typed_value_class_name_bind() const;
+	Variant _get_typed_key_script_bind() const;
+	Variant _get_typed_value_script_bind() const;
 
 	void make_read_only();
 	bool is_read_only() const;

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -121,16 +121,16 @@ public:
 	bool is_same_typed_key(const Dictionary &p_other) const;
 	bool is_same_typed_value(const Dictionary &p_other) const;
 
-	ContainerType get_key_type() const;
-	ContainerType get_value_type() const;
+	const ContainerType &get_key_type() const _LIFETIME_BOUND_;
+	const ContainerType &get_value_type() const _LIFETIME_BOUND_;
 	uint32_t get_typed_key_builtin() const;
 	uint32_t get_typed_value_builtin() const;
 	StringName get_typed_key_class_name() const;
 	StringName get_typed_value_class_name() const;
 	Variant get_typed_key_script() const;
 	Variant get_typed_value_script() const;
-	const ContainerTypeValidate &get_key_validator() const;
-	const ContainerTypeValidate &get_value_validator() const;
+	const ContainerTypeValidate &get_key_validator() const _LIFETIME_BOUND_;
+	const ContainerTypeValidate &get_value_validator() const _LIFETIME_BOUND_;
 
 	void make_read_only();
 	bool is_read_only() const;

--- a/core/variant/typed_array.h
+++ b/core/variant/typed_array.h
@@ -40,8 +40,8 @@ public:
 		Array::operator=(p_array);
 	}
 
-	_FORCE_INLINE_ TypedArray(const Array &p_array) {
-		set_typed(GodotTypeInfo::Internal::get_variant_type<T>(), GodotTypeInfo::Internal::get_object_class_name_or_empty<T>(), Variant());
+	_FORCE_INLINE_ TypedArray(const Array &p_array) :
+			Array(GodotTypeInfo::Internal::get_variant_type<T>(), GodotTypeInfo::Internal::get_object_class_name_or_empty<T>()) {
 		if (is_same_typed(p_array)) {
 			Array::operator=(p_array);
 		} else {
@@ -52,7 +52,6 @@ public:
 	_FORCE_INLINE_ TypedArray(std::initializer_list<Variant> p_init) :
 			TypedArray(Array(p_init)) {}
 
-	_FORCE_INLINE_ TypedArray() {
-		set_typed(GodotTypeInfo::Internal::get_variant_type<T>(), GodotTypeInfo::Internal::get_object_class_name_or_empty<T>(), Variant());
-	}
+	_FORCE_INLINE_ TypedArray() :
+			Array(GodotTypeInfo::Internal::get_variant_type<T>(), GodotTypeInfo::Internal::get_object_class_name_or_empty<T>()) {}
 };

--- a/core/variant/typed_dictionary.h
+++ b/core/variant/typed_dictionary.h
@@ -40,9 +40,9 @@ public:
 		Dictionary::operator=(p_dictionary);
 	}
 
-	_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) {
-		set_typed(GodotTypeInfo::Internal::get_variant_type<K>(), GodotTypeInfo::Internal::get_object_class_name_or_empty<K>(), Variant(),
-				GodotTypeInfo::Internal::get_variant_type<V>(), GodotTypeInfo::Internal::get_object_class_name_or_empty<V>(), Variant());
+	_FORCE_INLINE_ TypedDictionary(const Dictionary &p_dictionary) :
+			Dictionary(GodotTypeInfo::Internal::get_variant_type<K>(), GodotTypeInfo::Internal::get_object_class_name_or_empty<K>(),
+					GodotTypeInfo::Internal::get_variant_type<V>(), GodotTypeInfo::Internal::get_object_class_name_or_empty<V>()) {
 		if (is_same_typed(p_dictionary)) {
 			Dictionary::operator=(p_dictionary);
 		} else {
@@ -53,8 +53,7 @@ public:
 	_FORCE_INLINE_ TypedDictionary(std::initializer_list<KeyValue<Variant, Variant>> p_init) :
 			TypedDictionary(Dictionary(p_init)) {}
 
-	_FORCE_INLINE_ TypedDictionary() {
-		set_typed(GodotTypeInfo::Internal::get_variant_type<K>(), GodotTypeInfo::Internal::get_object_class_name_or_empty<K>(), Variant(),
-				GodotTypeInfo::Internal::get_variant_type<V>(), GodotTypeInfo::Internal::get_object_class_name_or_empty<V>(), Variant());
-	}
+	_FORCE_INLINE_ TypedDictionary() :
+			Dictionary(GodotTypeInfo::Internal::get_variant_type<K>(), GodotTypeInfo::Internal::get_object_class_name_or_empty<K>(),
+					GodotTypeInfo::Internal::get_variant_type<V>(), GodotTypeInfo::Internal::get_object_class_name_or_empty<V>()) {}
 };

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2616,10 +2616,10 @@ static void _register_variant_builtin_methods_misc() {
 	bind_method(Dictionary, is_same_typed_value, sarray("dictionary"), varray());
 	bind_method(Dictionary, get_typed_key_builtin, sarray(), varray());
 	bind_method(Dictionary, get_typed_value_builtin, sarray(), varray());
-	bind_method(Dictionary, get_typed_key_class_name, sarray(), varray());
-	bind_method(Dictionary, get_typed_value_class_name, sarray(), varray());
-	bind_method(Dictionary, get_typed_key_script, sarray(), varray());
-	bind_method(Dictionary, get_typed_value_script, sarray(), varray());
+	bind_methodv(Dictionary, get_typed_key_class_name, &Dictionary::_get_typed_key_class_name_bind, sarray(), varray());
+	bind_methodv(Dictionary, get_typed_value_class_name, &Dictionary::_get_typed_value_class_name_bind, sarray(), varray());
+	bind_methodv(Dictionary, get_typed_key_script, &Dictionary::_get_typed_key_script_bind, sarray(), varray());
+	bind_methodv(Dictionary, get_typed_value_script, &Dictionary::_get_typed_value_script_bind, sarray(), varray());
 	bind_method(Dictionary, make_read_only, sarray(), varray());
 	bind_method(Dictionary, is_read_only, sarray(), varray());
 	bind_method(Dictionary, recursive_equal, sarray("dictionary", "recursion_count"), varray());
@@ -2678,8 +2678,8 @@ static void _register_variant_builtin_methods_array() {
 	bind_method(Array, is_typed, sarray(), varray());
 	bind_method(Array, is_same_typed, sarray("array"), varray());
 	bind_method(Array, get_typed_builtin, sarray(), varray());
-	bind_method(Array, get_typed_class_name, sarray(), varray());
-	bind_method(Array, get_typed_script, sarray(), varray());
+	bind_methodv(Array, get_typed_class_name, &Array::_get_typed_class_name_bind, sarray(), varray());
+	bind_methodv(Array, get_typed_script, &Array::_get_typed_script_bind, sarray(), varray());
 	bind_method(Array, make_read_only, sarray(), varray());
 	bind_method(Array, is_read_only, sarray(), varray());
 

--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -710,7 +710,7 @@ public:
 		int bsize = p_array_right.size();
 
 		if (p_array_left.is_typed() && p_array_left.is_same_typed(p_array_right)) {
-			r_sum.set_typed(p_array_left.get_typed_builtin(), p_array_left.get_typed_class_name(), p_array_left.get_typed_script());
+			r_sum.set_typed(p_array_left.get_element_type());
 		}
 
 		r_sum.resize(asize + bsize);

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -36,6 +36,7 @@
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "core/string/string_buffer.h"
+#include "core/variant/container_type_validate.h"
 
 char32_t VariantParser::Stream::get_char() {
 	// is within buffer?
@@ -1135,12 +1136,10 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			}
 
 			Dictionary dict;
-			Variant::Type key_type = Variant::NIL;
-			StringName key_class_name;
-			Variant key_script;
+			ContainerType key_type;
 			bool got_comma_token = false;
 			if (builtin_types.has(r_token.value)) {
-				key_type = builtin_types.get(r_token.value);
+				key_type.builtin_type = builtin_types.get(r_token.value);
 			} else if (r_token.value == "Resource" || r_token.value == "SubResource" || r_token.value == "ExtResource") {
 				Variant resource;
 				err = parse_value(r_token, resource, p_stream, r_line, r_err_str, p_res_parser);
@@ -1148,8 +1147,8 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 					if (r_token.value == "Resource" && err == ERR_PARSE_ERROR && r_err_str == "Expected '('" && r_token.type == TK_COMMA) {
 						err = OK;
 						r_err_str = String();
-						key_type = Variant::OBJECT;
-						key_class_name = r_token.value;
+						key_type.builtin_type = Variant::OBJECT;
+						key_type.class_name = r_token.value;
 						got_comma_token = true;
 					} else {
 						return err;
@@ -1157,14 +1156,14 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 				} else {
 					Ref<Script> script = resource;
 					if (script.is_valid() && script->is_script_valid()) {
-						key_type = Variant::OBJECT;
-						key_class_name = script->get_instance_base_type();
-						key_script = script;
+						key_type.builtin_type = Variant::OBJECT;
+						key_type.class_name = script->get_instance_base_type();
+						key_type.script = script;
 					}
 				}
 			} else if (ClassDB::class_exists(r_token.value)) {
-				key_type = Variant::OBJECT;
-				key_class_name = r_token.value;
+				key_type.builtin_type = Variant::OBJECT;
+				key_type.class_name = r_token.value;
 			}
 
 			if (!got_comma_token) {
@@ -1181,12 +1180,10 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 				return ERR_PARSE_ERROR;
 			}
 
-			Variant::Type value_type = Variant::NIL;
-			StringName value_class_name;
-			Variant value_script;
+			ContainerType value_type;
 			bool got_bracket_token = false;
 			if (builtin_types.has(r_token.value)) {
-				value_type = builtin_types.get(r_token.value);
+				value_type.builtin_type = builtin_types.get(r_token.value);
 			} else if (r_token.value == "Resource" || r_token.value == "SubResource" || r_token.value == "ExtResource") {
 				Variant resource;
 				err = parse_value(r_token, resource, p_stream, r_line, r_err_str, p_res_parser);
@@ -1194,8 +1191,8 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 					if (r_token.value == "Resource" && err == ERR_PARSE_ERROR && r_err_str == "Expected '('" && r_token.type == TK_BRACKET_CLOSE) {
 						err = OK;
 						r_err_str = String();
-						value_type = Variant::OBJECT;
-						value_class_name = r_token.value;
+						value_type.builtin_type = Variant::OBJECT;
+						value_type.class_name = r_token.value;
 						got_bracket_token = true;
 					} else {
 						return err;
@@ -1203,18 +1200,18 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 				} else {
 					Ref<Script> script = resource;
 					if (script.is_valid() && script->is_script_valid()) {
-						value_type = Variant::OBJECT;
-						value_class_name = script->get_instance_base_type();
-						value_script = script;
+						value_type.builtin_type = Variant::OBJECT;
+						value_type.class_name = script->get_instance_base_type();
+						value_type.script = script;
 					}
 				}
 			} else if (ClassDB::class_exists(r_token.value)) {
-				value_type = Variant::OBJECT;
-				value_class_name = r_token.value;
+				value_type.builtin_type = Variant::OBJECT;
+				value_type.class_name = r_token.value;
 			}
 
-			if (key_type != Variant::NIL || value_type != Variant::NIL) {
-				dict.set_typed(key_type, key_class_name, key_script, value_type, value_class_name, value_script);
+			if (key_type.builtin_type != Variant::NIL || value_type.builtin_type != Variant::NIL) {
+				dict.set_typed(std::move(key_type), std::move(value_type));
 			}
 
 			if (!got_bracket_token) {
@@ -1275,9 +1272,10 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 			}
 
 			Array array = Array();
+			ContainerType element_type;
 			bool got_bracket_token = false;
 			if (builtin_types.has(r_token.value)) {
-				array.set_typed(builtin_types.get(r_token.value), StringName(), Variant());
+				element_type.builtin_type = builtin_types.get(r_token.value);
 			} else if (r_token.value == "Resource" || r_token.value == "SubResource" || r_token.value == "ExtResource") {
 				Variant resource;
 				err = parse_value(r_token, resource, p_stream, r_line, r_err_str, p_res_parser);
@@ -1285,7 +1283,8 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 					if (r_token.value == "Resource" && err == ERR_PARSE_ERROR && r_err_str == "Expected '('" && r_token.type == TK_BRACKET_CLOSE) {
 						err = OK;
 						r_err_str = String();
-						array.set_typed(Variant::OBJECT, r_token.value, Variant());
+						element_type.builtin_type = Variant::OBJECT;
+						element_type.class_name = r_token.value;
 						got_bracket_token = true;
 					} else {
 						return err;
@@ -1293,11 +1292,18 @@ Error VariantParser::parse_value(Token &r_token, Variant &r_value, Stream *p_str
 				} else {
 					Ref<Script> script = resource;
 					if (script.is_valid() && script->is_script_valid()) {
-						array.set_typed(Variant::OBJECT, script->get_instance_base_type(), script);
+						element_type.builtin_type = Variant::OBJECT;
+						element_type.class_name = script->get_instance_base_type();
+						element_type.script = script;
 					}
 				}
 			} else if (ClassDB::class_exists(r_token.value)) {
-				array.set_typed(Variant::OBJECT, r_token.value, Variant());
+				element_type.builtin_type = Variant::OBJECT;
+				element_type.class_name = r_token.value;
+			}
+
+			if (element_type.builtin_type != Variant::NIL) {
+				array.set_typed(std::move(element_type));
 			}
 
 			if (!got_bracket_token) {
@@ -2115,8 +2121,8 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				p_store_string_func(p_store_string_ud, "Dictionary[");
 
 				Variant::Type key_builtin_type = (Variant::Type)dict.get_typed_key_builtin();
-				StringName key_class_name = dict.get_typed_key_class_name();
-				Ref<Script> key_script = dict.get_typed_key_script();
+				const StringName &key_class_name = dict.get_typed_key_class_name();
+				const Ref<Script> &key_script = dict.get_typed_key_script();
 
 				if (key_script.is_valid()) {
 					String resource_text;
@@ -2144,8 +2150,8 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				p_store_string_func(p_store_string_ud, ", ");
 
 				Variant::Type value_builtin_type = (Variant::Type)dict.get_typed_value_builtin();
-				StringName value_class_name = dict.get_typed_value_class_name();
-				Ref<Script> value_script = dict.get_typed_value_script();
+				const StringName &value_class_name = dict.get_typed_value_class_name();
+				const Ref<Script> &value_script = dict.get_typed_value_script();
 
 				if (value_script.is_valid()) {
 					String resource_text;
@@ -2214,8 +2220,8 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				p_store_string_func(p_store_string_ud, "Array[");
 
 				Variant::Type builtin_type = (Variant::Type)array.get_typed_builtin();
-				StringName class_name = array.get_typed_class_name();
-				Ref<Script> script = array.get_typed_script();
+				const StringName &class_name = array.get_typed_class_name();
+				const Ref<Script> &script = array.get_typed_script();
 
 				if (script.is_valid()) {
 					String resource_text = String();

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -35,6 +35,7 @@
 #include "core/io/resource_loader.h"
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "core/variant/container_type_validate.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
@@ -241,14 +242,13 @@ String EditorPropertyDictionaryObject::get_label_for_index(int p_index) {
 void EditorPropertyArray::initialize_array(Variant &p_array) {
 	if (array_type == Variant::ARRAY && subtype != Variant::NIL) {
 		Array array;
-		StringName subtype_class;
-		Ref<Script> subtype_script;
+		ContainerType element_type_subtype = ContainerType::from_type(subtype);
 		if (subtype == Variant::OBJECT && !subtype_hint_string.is_empty()) {
 			if (ClassDB::class_exists(subtype_hint_string)) {
-				subtype_class = subtype_hint_string;
+				element_type_subtype.class_name = subtype_hint_string;
 			}
 		}
-		array.set_typed(subtype, subtype_class, subtype_script);
+		array.set_typed(std::move(element_type_subtype));
 		p_array = array;
 	} else {
 		VariantInternal::initialize(&p_array, array_type);
@@ -1046,17 +1046,15 @@ EditorPropertyArray::EditorPropertyArray() {
 void EditorPropertyDictionary::initialize_dictionary(Variant &p_dictionary) {
 	if (key_subtype != Variant::NIL || value_subtype != Variant::NIL) {
 		Dictionary dict;
-		StringName key_subtype_class;
-		Ref<Script> key_subtype_script;
+		ContainerType key_type_subtype = ContainerType::from_type(key_subtype);
 		if (key_subtype == Variant::OBJECT && !key_subtype_hint_string.is_empty() && ClassDB::class_exists(key_subtype_hint_string)) {
-			key_subtype_class = key_subtype_hint_string;
+			key_type_subtype.class_name = key_subtype_hint_string;
 		}
-		StringName value_subtype_class;
-		Ref<Script> value_subtype_script;
+		ContainerType value_type_subtype = ContainerType::from_type(value_subtype);
 		if (value_subtype == Variant::OBJECT && !value_subtype_hint_string.is_empty() && ClassDB::class_exists(value_subtype_hint_string)) {
-			value_subtype_class = value_subtype_hint_string;
+			value_type_subtype.class_name = value_subtype_hint_string;
 		}
-		dict.set_typed(key_subtype, key_subtype_class, key_subtype_script, value_subtype, value_subtype_class, value_subtype_script);
+		dict.set_typed(std::move(key_type_subtype), std::move(value_type_subtype));
 		p_dictionary = dict;
 	} else {
 		VariantInternal::initialize(&p_dictionary, Variant::DICTIONARY);

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -185,7 +185,7 @@ String GDScriptDocGen::_docvalue_from_variant(const Variant &p_variant, int p_re
 			if (dict.is_typed()) {
 				result += "Dictionary[";
 
-				Ref<Script> key_script = dict.get_typed_key_script();
+				const Ref<Script> &key_script = dict.get_typed_key_script();
 				if (key_script.is_valid()) {
 					if (key_script->get_global_name() != StringName()) {
 						result += key_script->get_global_name();
@@ -204,7 +204,7 @@ String GDScriptDocGen::_docvalue_from_variant(const Variant &p_variant, int p_re
 
 				result += ", ";
 
-				Ref<Script> value_script = dict.get_typed_value_script();
+				const Ref<Script> &value_script = dict.get_typed_value_script();
 				if (value_script.is_valid()) {
 					if (value_script->get_global_name() != StringName()) {
 						result += value_script->get_global_name();
@@ -258,7 +258,7 @@ String GDScriptDocGen::_docvalue_from_variant(const Variant &p_variant, int p_re
 			if (array.is_typed()) {
 				result += "Array[";
 
-				Ref<Script> script = array.get_typed_script();
+				const Ref<Script> &script = array.get_typed_script();
 				if (script.is_valid()) {
 					if (script->get_global_name() != StringName()) {
 						result += script->get_global_name();

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -41,6 +41,7 @@
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/templates/rb_set.h"
+#include "core/variant/container_type_validate.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/gdscript_docgen.h"
@@ -701,13 +702,14 @@ void GDScript::_static_default_init() {
 		if (type.builtin_type == Variant::ARRAY && type.has_container_element_type(0)) {
 			const GDScriptDataType element_type = type.get_container_element_type(0);
 			Array default_value;
-			default_value.set_typed(element_type.builtin_type, element_type.native_type, element_type.script_type);
+			default_value.set_typed(ContainerType{ element_type.builtin_type, element_type.native_type, element_type.script_type_ref });
 			static_variables.write[E.value.index] = default_value;
 		} else if (type.builtin_type == Variant::DICTIONARY && type.has_container_element_types()) {
 			const GDScriptDataType key_type = type.get_container_element_type_or_variant(0);
 			const GDScriptDataType value_type = type.get_container_element_type_or_variant(1);
 			Dictionary default_value;
-			default_value.set_typed(key_type.builtin_type, key_type.native_type, key_type.script_type, value_type.builtin_type, value_type.native_type, value_type.script_type);
+			default_value.set_typed(ContainerType{ key_type.builtin_type, key_type.native_type, key_type.script_type_ref },
+					ContainerType{ value_type.builtin_type, value_type.native_type, value_type.script_type_ref });
 			static_variables.write[E.value.index] = default_value;
 		} else {
 			Variant default_value;
@@ -1769,7 +1771,7 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 
 							String elem_type;
 							if (arr.is_typed()) {
-								const Ref<Script> script_type = arr.get_typed_script();
+								const Ref<Script> &script_type = arr.get_typed_script();
 								if (script_type.is_valid() && script_type->is_script_valid()) {
 									elem_type = GDScript::debug_get_script_name(script_type);
 								} else if (!arr.get_typed_class_name().is_empty()) {

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -5808,7 +5808,7 @@ GDScriptParser::DataType GDScriptAnalyzer::type_from_variant(const Variant &p_va
 
 	if (p_value.get_type() == Variant::ARRAY) {
 		const Array &array = p_value;
-		if (array.get_typed_script()) {
+		if (array.get_typed_script().is_valid()) {
 			result.set_container_element_type(0, type_from_metatype(type_from_script(array.get_typed_script(), p_source, true)));
 		} else if (array.get_typed_class_name()) {
 			result.set_container_element_type(0, type_from_metatype(make_native_meta_type(array.get_typed_class_name())));
@@ -5817,14 +5817,14 @@ GDScriptParser::DataType GDScriptAnalyzer::type_from_variant(const Variant &p_va
 		}
 	} else if (p_value.get_type() == Variant::DICTIONARY) {
 		const Dictionary &dict = p_value;
-		if (dict.get_typed_key_script()) {
+		if (dict.get_typed_key_script().is_valid()) {
 			result.set_container_element_type(0, type_from_metatype(type_from_script(dict.get_typed_key_script(), p_source, true)));
 		} else if (dict.get_typed_key_class_name()) {
 			result.set_container_element_type(0, type_from_metatype(make_native_meta_type(dict.get_typed_key_class_name())));
 		} else if (dict.get_typed_key_builtin() != Variant::NIL) {
 			result.set_container_element_type(0, type_from_metatype(make_builtin_meta_type((Variant::Type)dict.get_typed_key_builtin())));
 		}
-		if (dict.get_typed_value_script()) {
+		if (dict.get_typed_value_script().is_valid()) {
 			result.set_container_element_type(1, type_from_metatype(type_from_script(dict.get_typed_value_script(), p_source, true)));
 		} else if (dict.get_typed_value_class_name()) {
 			result.set_container_element_type(1, type_from_metatype(make_native_meta_type(dict.get_typed_value_class_name())));

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -42,6 +42,7 @@
 #include "core/object/class_db.h"
 #include "core/object/script_language.h"
 #include "core/templates/hash_map.h"
+#include "core/variant/container_type_validate.h"
 #include "scene/main/node.h"
 
 #include "modules/gdscript/gdscript_parser.h"
@@ -5666,9 +5667,9 @@ Array GDScriptAnalyzer::make_array_from_element_datatype(const GDScriptParser::D
 			script_type.reference_ptr(scr->find_class(p_element_datatype.class_type->fqcn));
 		}
 
-		array.set_typed(p_element_datatype.builtin_type, p_element_datatype.native_type, script_type);
+		array.set_typed(ContainerType{ p_element_datatype.builtin_type, p_element_datatype.native_type, script_type });
 	} else {
-		array.set_typed(p_element_datatype.builtin_type, StringName(), Variant());
+		array.set_typed(ContainerType{ p_element_datatype.builtin_type, StringName(), Ref<Script>() });
 	}
 
 	return array;
@@ -5676,10 +5677,8 @@ Array GDScriptAnalyzer::make_array_from_element_datatype(const GDScriptParser::D
 
 Dictionary GDScriptAnalyzer::make_dictionary_from_element_datatype(const GDScriptParser::DataType &p_key_element_datatype, const GDScriptParser::DataType &p_value_element_datatype, const GDScriptParser::Node *p_source_node) {
 	Dictionary dictionary;
-	StringName key_name;
-	Variant key_script;
-	StringName value_name;
-	Variant value_script;
+	ContainerType key_type = ContainerType::from_type(p_key_element_datatype.builtin_type);
+	ContainerType value_type = ContainerType::from_type(p_value_element_datatype.builtin_type);
 
 	if (p_key_element_datatype.builtin_type == Variant::OBJECT) {
 		Ref<Script> script_type = p_key_element_datatype.script_type;
@@ -5693,8 +5692,8 @@ Dictionary GDScriptAnalyzer::make_dictionary_from_element_datatype(const GDScrip
 			script_type.reference_ptr(scr->find_class(p_key_element_datatype.class_type->fqcn));
 		}
 
-		key_name = p_key_element_datatype.native_type;
-		key_script = script_type;
+		key_type.class_name = p_key_element_datatype.native_type;
+		key_type.script = script_type;
 	}
 
 	if (p_value_element_datatype.builtin_type == Variant::OBJECT) {
@@ -5709,11 +5708,11 @@ Dictionary GDScriptAnalyzer::make_dictionary_from_element_datatype(const GDScrip
 			script_type.reference_ptr(scr->find_class(p_value_element_datatype.class_type->fqcn));
 		}
 
-		value_name = p_value_element_datatype.native_type;
-		value_script = script_type;
+		value_type.class_name = p_value_element_datatype.native_type;
+		value_type.script = script_type;
 	}
 
-	dictionary.set_typed(p_key_element_datatype.builtin_type, key_name, key_script, p_value_element_datatype.builtin_type, value_name, value_script);
+	dictionary.set_typed(std::move(key_type), std::move(value_type));
 	return dictionary;
 }
 

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -47,8 +47,8 @@ bool GDScriptDataType::is_type(const Variant &p_variant, bool p_allow_implicit_c
 				if (array.is_typed()) {
 					const GDScriptDataType &elem_type = container_element_types[0];
 					Variant::Type array_builtin_type = (Variant::Type)array.get_typed_builtin();
-					StringName array_native_type = array.get_typed_class_name();
-					Ref<Script> array_script_type_ref = array.get_typed_script();
+					const StringName &array_native_type = array.get_typed_class_name();
+					const Ref<Script> &array_script_type_ref = array.get_typed_script();
 
 					if (array_script_type_ref.is_valid()) {
 						valid = (elem_type.kind == SCRIPT || elem_type.kind == GDSCRIPT) && elem_type.script_type == array_script_type_ref.ptr();
@@ -66,8 +66,8 @@ bool GDScriptDataType::is_type(const Variant &p_variant, bool p_allow_implicit_c
 					if (dictionary.is_typed_key()) {
 						GDScriptDataType key = get_container_element_type_or_variant(0);
 						Variant::Type key_builtin_type = (Variant::Type)dictionary.get_typed_key_builtin();
-						StringName key_native_type = dictionary.get_typed_key_class_name();
-						Ref<Script> key_script_type_ref = dictionary.get_typed_key_script();
+						const StringName &key_native_type = dictionary.get_typed_key_class_name();
+						const Ref<Script> &key_script_type_ref = dictionary.get_typed_key_script();
 
 						if (key_script_type_ref.is_valid()) {
 							valid = (key.kind == SCRIPT || key.kind == GDSCRIPT) && key.script_type == key_script_type_ref.ptr();
@@ -81,8 +81,8 @@ bool GDScriptDataType::is_type(const Variant &p_variant, bool p_allow_implicit_c
 					if (valid && dictionary.is_typed_value()) {
 						GDScriptDataType value = get_container_element_type_or_variant(1);
 						Variant::Type value_builtin_type = (Variant::Type)dictionary.get_typed_value_builtin();
-						StringName value_native_type = dictionary.get_typed_value_class_name();
-						Ref<Script> value_script_type_ref = dictionary.get_typed_value_script();
+						const StringName &value_native_type = dictionary.get_typed_value_class_name();
+						const Ref<Script> &value_script_type_ref = dictionary.get_typed_value_script();
 
 						if (value_script_type_ref.is_valid()) {
 							valid = (value.kind == SCRIPT || value.kind == GDSCRIPT) && value.script_type == value_script_type_ref.ptr();

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -35,6 +35,7 @@
 #include "core/object/class_db.h"
 #include "core/os/os.h"
 #include "core/profiling/profiling.h"
+#include "core/variant/container_type_validate.h"
 
 #ifdef DEBUG_ENABLED
 
@@ -124,7 +125,7 @@ Variant GDScriptFunction::_get_default_variant_for_data_type(const GDScriptDataT
 			// Typed array.
 			if (p_data_type.has_container_element_type(0)) {
 				const GDScriptDataType &element_type = p_data_type.get_container_element_type(0);
-				array.set_typed(element_type.builtin_type, element_type.native_type, element_type.script_type);
+				array.set_typed(ContainerType{ element_type.builtin_type, element_type.native_type, element_type.script_type_ref });
 			}
 
 			return array;
@@ -134,7 +135,8 @@ Variant GDScriptFunction::_get_default_variant_for_data_type(const GDScriptDataT
 			if (p_data_type.has_container_element_types()) {
 				const GDScriptDataType &key_type = p_data_type.get_container_element_type_or_variant(0);
 				const GDScriptDataType &value_type = p_data_type.get_container_element_type_or_variant(1);
-				dict.set_typed(key_type.builtin_type, key_type.native_type, key_type.script_type, value_type.builtin_type, value_type.native_type, value_type.script_type);
+				dict.set_typed(ContainerType{ key_type.builtin_type, key_type.native_type, key_type.script_type_ref },
+						ContainerType{ value_type.builtin_type, value_type.native_type, value_type.script_type_ref });
 			}
 
 			return dict;
@@ -600,11 +602,12 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				if (argument_types[i].builtin_type == Variant::DICTIONARY && argument_types[i].has_container_element_types()) {
 					const GDScriptDataType &arg_key_type = argument_types[i].get_container_element_type_or_variant(0);
 					const GDScriptDataType &arg_value_type = argument_types[i].get_container_element_type_or_variant(1);
-					Dictionary dict(p_args[i]->operator Dictionary(), arg_key_type.builtin_type, arg_key_type.native_type, arg_key_type.script_type, arg_value_type.builtin_type, arg_value_type.native_type, arg_value_type.script_type);
+					Dictionary dict(p_args[i]->operator Dictionary(), ContainerType{ arg_key_type.builtin_type, arg_key_type.native_type, arg_key_type.script_type_ref },
+							ContainerType{ arg_value_type.builtin_type, arg_value_type.native_type, arg_value_type.script_type_ref });
 					memnew_placement(&stack[i + FIXED_ADDRESSES_MAX], Variant(dict));
 				} else if (argument_types[i].builtin_type == Variant::ARRAY && argument_types[i].has_container_element_type(0)) {
 					const GDScriptDataType &arg_type = argument_types[i].container_element_types[0];
-					Array array(p_args[i]->operator Array(), arg_type.builtin_type, arg_type.native_type, arg_type.script_type);
+					Array array(p_args[i]->operator Array(), ContainerType{ arg_type.builtin_type, arg_type.native_type, arg_type.script_type_ref });
 					memnew_placement(&stack[i + FIXED_ADDRESSES_MAX], Variant(array));
 				} else {
 					Variant variant;
@@ -879,7 +882,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GET_VARIANT_PTR(dst, 0);
 				GET_VARIANT_PTR(value, 1);
 
-				GET_VARIANT_PTR(script_type, 2);
+				GET_VARIANT_PTR(element_type, 2);
+				Script *element_script_type = Object::cast_to<Script>(element_type->operator Object *());
 				Variant::Type builtin_type = (Variant::Type)_code_ptr[ip + 4];
 				int native_type_idx = _code_ptr[ip + 5];
 				GD_ERR_BREAK(native_type_idx < 0 || native_type_idx >= _global_names_count);
@@ -888,7 +892,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				bool result = false;
 				if (value->get_type() == Variant::ARRAY) {
 					Array *array = VariantInternal::get_array(value);
-					result = array->get_typed_builtin() == ((uint32_t)builtin_type) && array->get_typed_class_name() == native_type && array->get_typed_script() == *script_type;
+					result = array->get_typed_builtin() == ((uint32_t)builtin_type) && array->get_typed_class_name() == native_type && array->get_typed_script() == element_script_type;
 				}
 
 				*dst = result;
@@ -902,13 +906,15 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GET_VARIANT_PTR(dst, 0);
 				GET_VARIANT_PTR(value, 1);
 
-				GET_VARIANT_PTR(key_script_type, 2);
+				GET_VARIANT_PTR(key_type, 2);
+				Script *key_script_type = Object::cast_to<Script>(key_type->operator Object *());
 				Variant::Type key_builtin_type = (Variant::Type)_code_ptr[ip + 5];
 				int key_native_type_idx = _code_ptr[ip + 6];
 				GD_ERR_BREAK(key_native_type_idx < 0 || key_native_type_idx >= _global_names_count);
 				const StringName &key_native_type = _global_names_ptr[key_native_type_idx];
 
-				GET_VARIANT_PTR(value_script_type, 3);
+				GET_VARIANT_PTR(value_type, 3);
+				Script *value_script_type = Object::cast_to<Script>(value_type->operator Object *());
 				Variant::Type value_builtin_type = (Variant::Type)_code_ptr[ip + 7];
 				int value_native_type_idx = _code_ptr[ip + 8];
 				GD_ERR_BREAK(value_native_type_idx < 0 || value_native_type_idx >= _global_names_count);
@@ -917,8 +923,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				bool result = false;
 				if (value->get_type() == Variant::DICTIONARY) {
 					Dictionary *dictionary = VariantInternal::get_dictionary(value);
-					result = dictionary->get_typed_key_builtin() == ((uint32_t)key_builtin_type) && dictionary->get_typed_key_class_name() == key_native_type && dictionary->get_typed_key_script() == *key_script_type &&
-							dictionary->get_typed_value_builtin() == ((uint32_t)value_builtin_type) && dictionary->get_typed_value_class_name() == value_native_type && dictionary->get_typed_value_script() == *value_script_type;
+					result = dictionary->get_typed_key_builtin() == ((uint32_t)key_builtin_type) && dictionary->get_typed_key_class_name() == key_native_type && dictionary->get_typed_key_script() == key_script_type &&
+							dictionary->get_typed_value_builtin() == ((uint32_t)value_builtin_type) && dictionary->get_typed_value_class_name() == value_native_type && dictionary->get_typed_value_script() == value_script_type;
 				}
 
 				*dst = result;
@@ -1457,7 +1463,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GET_VARIANT_PTR(dst, 0);
 				GET_VARIANT_PTR(src, 1);
 
-				GET_VARIANT_PTR(script_type, 2);
+				GET_VARIANT_PTR(element_type, 2);
+				Script *element_script_type = Object::cast_to<Script>(element_type->operator Object *());
 				Variant::Type builtin_type = (Variant::Type)_code_ptr[ip + 4];
 				int native_type_idx = _code_ptr[ip + 5];
 				GD_ERR_BREAK(native_type_idx < 0 || native_type_idx >= _global_names_count);
@@ -1466,17 +1473,17 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				if (src->get_type() != Variant::ARRAY) {
 #ifdef DEBUG_ENABLED
 					err_text = vformat(R"(Trying to assign a value of type "%s" to a variable of type "Array[%s]".)",
-							_get_var_type(src), _get_element_type(builtin_type, native_type, *script_type));
+							_get_var_type(src), _get_element_type(builtin_type, native_type, Ref<Script>(element_script_type)));
 #endif // DEBUG_ENABLED
 					OPCODE_BREAK;
 				}
 
 				Array *array = VariantInternal::get_array(src);
 
-				if (array->get_typed_builtin() != ((uint32_t)builtin_type) || array->get_typed_class_name() != native_type || array->get_typed_script() != *script_type) {
+				if (array->get_typed_builtin() != ((uint32_t)builtin_type) || array->get_typed_class_name() != native_type || array->get_typed_script() != element_script_type) {
 #ifdef DEBUG_ENABLED
 					err_text = vformat(R"(Trying to assign an array of type "%s" to a variable of type "Array[%s]".)",
-							_get_var_type(src), _get_element_type(builtin_type, native_type, *script_type));
+							_get_var_type(src), _get_element_type(builtin_type, native_type, Ref<Script>(element_script_type)));
 #endif // DEBUG_ENABLED
 					OPCODE_BREAK;
 				}
@@ -1492,13 +1499,15 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				GET_VARIANT_PTR(dst, 0);
 				GET_VARIANT_PTR(src, 1);
 
-				GET_VARIANT_PTR(key_script_type, 2);
+				GET_VARIANT_PTR(key_type, 2);
+				Script *key_script_type = Object::cast_to<Script>(key_type->operator Object *());
 				Variant::Type key_builtin_type = (Variant::Type)_code_ptr[ip + 5];
 				int key_native_type_idx = _code_ptr[ip + 6];
 				GD_ERR_BREAK(key_native_type_idx < 0 || key_native_type_idx >= _global_names_count);
 				const StringName &key_native_type = _global_names_ptr[key_native_type_idx];
 
-				GET_VARIANT_PTR(value_script_type, 3);
+				GET_VARIANT_PTR(value_type, 3);
+				Script *value_script_type = Object::cast_to<Script>(value_type->operator Object *());
 				Variant::Type value_builtin_type = (Variant::Type)_code_ptr[ip + 7];
 				int value_native_type_idx = _code_ptr[ip + 8];
 				GD_ERR_BREAK(value_native_type_idx < 0 || value_native_type_idx >= _global_names_count);
@@ -1507,20 +1516,20 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				if (src->get_type() != Variant::DICTIONARY) {
 #ifdef DEBUG_ENABLED
 					err_text = vformat(R"(Trying to assign a value of type "%s" to a variable of type "Dictionary[%s, %s]".)",
-							_get_var_type(src), _get_element_type(key_builtin_type, key_native_type, *key_script_type),
-							_get_element_type(value_builtin_type, value_native_type, *value_script_type));
+							_get_var_type(src), _get_element_type(key_builtin_type, key_native_type, Ref<Script>(key_builtin_type)),
+							_get_element_type(value_builtin_type, value_native_type, Ref<Script>(value_script_type)));
 #endif // DEBUG_ENABLED
 					OPCODE_BREAK;
 				}
 
 				Dictionary *dictionary = VariantInternal::get_dictionary(src);
 
-				if (dictionary->get_typed_key_builtin() != ((uint32_t)key_builtin_type) || dictionary->get_typed_key_class_name() != key_native_type || dictionary->get_typed_key_script() != *key_script_type ||
-						dictionary->get_typed_value_builtin() != ((uint32_t)value_builtin_type) || dictionary->get_typed_value_class_name() != value_native_type || dictionary->get_typed_value_script() != *value_script_type) {
+				if (dictionary->get_typed_key_builtin() != ((uint32_t)key_builtin_type) || dictionary->get_typed_key_class_name() != key_native_type || dictionary->get_typed_key_script() != key_script_type ||
+						dictionary->get_typed_value_builtin() != ((uint32_t)value_builtin_type) || dictionary->get_typed_value_class_name() != value_native_type || dictionary->get_typed_value_script() != value_script_type) {
 #ifdef DEBUG_ENABLED
 					err_text = vformat(R"(Trying to assign a dictionary of type "%s" to a variable of type "Dictionary[%s, %s]".)",
-							_get_var_type(src), _get_element_type(key_builtin_type, key_native_type, *key_script_type),
-							_get_element_type(value_builtin_type, value_native_type, *value_script_type));
+							_get_var_type(src), _get_element_type(key_builtin_type, key_native_type, Ref<Script>(key_script_type)),
+							_get_element_type(value_builtin_type, value_native_type, Ref<Script>(value_script_type)));
 #endif // DEBUG_ENABLED
 					OPCODE_BREAK;
 				}
@@ -1812,14 +1821,16 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				int argc = _code_ptr[ip + 1];
 
+				ContainerType element_type;
 				GET_INSTRUCTION_ARG(script_type, argc + 1);
-				Variant::Type builtin_type = (Variant::Type)_code_ptr[ip + 2];
+				element_type.script = Object::cast_to<Script>(script_type->operator Object *());
+				element_type.builtin_type = (Variant::Type)_code_ptr[ip + 2];
 				int native_type_idx = _code_ptr[ip + 3];
 				GD_ERR_BREAK(native_type_idx < 0 || native_type_idx >= _global_names_count);
-				const StringName &native_type = _global_names_ptr[native_type_idx];
+				element_type.class_name = _global_names_ptr[native_type_idx];
 
 				Array array;
-				array.set_typed(builtin_type, native_type, *script_type);
+				array.set_typed(std::move(element_type));
 				array.resize(argc);
 				for (int i = 0; i < argc; i++) {
 					// Use .set instead of operator[] to handle type conversion / validation.
@@ -1867,20 +1878,24 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				int argc = _code_ptr[ip + 1];
 
+				ContainerType key_type;
 				GET_INSTRUCTION_ARG(key_script_type, argc * 2 + 1);
-				Variant::Type key_builtin_type = (Variant::Type)_code_ptr[ip + 2];
+				key_type.script = Object::cast_to<Script>(key_script_type->operator Object *());
+				key_type.builtin_type = (Variant::Type)_code_ptr[ip + 2];
 				int key_native_type_idx = _code_ptr[ip + 3];
 				GD_ERR_BREAK(key_native_type_idx < 0 || key_native_type_idx >= _global_names_count);
-				const StringName &key_native_type = _global_names_ptr[key_native_type_idx];
+				key_type.class_name = _global_names_ptr[key_native_type_idx];
 
+				ContainerType value_type;
 				GET_INSTRUCTION_ARG(value_script_type, argc * 2 + 2);
-				Variant::Type value_builtin_type = (Variant::Type)_code_ptr[ip + 4];
+				value_type.script = Object::cast_to<Script>(value_script_type->operator Object *());
+				value_type.builtin_type = (Variant::Type)_code_ptr[ip + 4];
 				int value_native_type_idx = _code_ptr[ip + 5];
 				GD_ERR_BREAK(value_native_type_idx < 0 || value_native_type_idx >= _global_names_count);
-				const StringName &value_native_type = _global_names_ptr[value_native_type_idx];
+				value_type.class_name = _global_names_ptr[value_native_type_idx];
 
 				Dictionary dict;
-				dict.set_typed(key_builtin_type, key_native_type, *key_script_type, value_builtin_type, value_native_type, *value_script_type);
+				dict.set_typed(std::move(key_type), std::move(value_type));
 				dict.reserve(argc);
 				for (int i = 0; i < argc; i++) {
 					GET_INSTRUCTION_ARG(k, i * 2 + 0);
@@ -2858,7 +2873,8 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				CHECK_SPACE(5);
 				GET_VARIANT_PTR(r, 0);
 
-				GET_VARIANT_PTR(script_type, 1);
+				GET_VARIANT_PTR(element_type, 1);
+				Script *element_script_type = Object::cast_to<Script>(element_type->operator Object *());
 				Variant::Type builtin_type = (Variant::Type)_code_ptr[ip + 3];
 				int native_type_idx = _code_ptr[ip + 4];
 				GD_ERR_BREAK(native_type_idx < 0 || native_type_idx >= _global_names_count);
@@ -2874,10 +2890,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 				Array *array = VariantInternal::get_array(r);
 
-				if (array->get_typed_builtin() != ((uint32_t)builtin_type) || array->get_typed_class_name() != native_type || array->get_typed_script() != *script_type) {
+				if (array->get_typed_builtin() != ((uint32_t)builtin_type) || array->get_typed_class_name() != native_type || array->get_typed_script() != element_script_type) {
 #ifdef DEBUG_ENABLED
 					err_text = vformat(R"(Trying to return a value of type "%s" from a function whose return type is "Array[%s]".)",
-							_get_var_type(r), _get_element_type(builtin_type, native_type, *script_type));
+							_get_var_type(r), _get_element_type(builtin_type, native_type, Ref<Script>(element_script_type)));
 #endif // DEBUG_ENABLED
 					OPCODE_BREAK;
 				}
@@ -2894,13 +2910,15 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				CHECK_SPACE(8);
 				GET_VARIANT_PTR(r, 0);
 
-				GET_VARIANT_PTR(key_script_type, 1);
+				GET_VARIANT_PTR(key_type, 1);
+				Script *key_script_type = Object::cast_to<Script>(key_type->operator Object *());
 				Variant::Type key_builtin_type = (Variant::Type)_code_ptr[ip + 4];
 				int key_native_type_idx = _code_ptr[ip + 5];
 				GD_ERR_BREAK(key_native_type_idx < 0 || key_native_type_idx >= _global_names_count);
 				const StringName &key_native_type = _global_names_ptr[key_native_type_idx];
 
-				GET_VARIANT_PTR(value_script_type, 2);
+				GET_VARIANT_PTR(value_type, 2);
+				Script *value_script_type = Object::cast_to<Script>(value_type->operator Object *());
 				Variant::Type value_builtin_type = (Variant::Type)_code_ptr[ip + 6];
 				int value_native_type_idx = _code_ptr[ip + 7];
 				GD_ERR_BREAK(value_native_type_idx < 0 || value_native_type_idx >= _global_names_count);
@@ -2909,20 +2927,20 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				if (r->get_type() != Variant::DICTIONARY) {
 #ifdef DEBUG_ENABLED
 					err_text = vformat(R"(Trying to return a value of type "%s" from a function whose return type is "Dictionary[%s, %s]".)",
-							_get_var_type(r), _get_element_type(key_builtin_type, key_native_type, *key_script_type),
-							_get_element_type(value_builtin_type, value_native_type, *value_script_type));
+							_get_var_type(r), _get_element_type(key_builtin_type, key_native_type, Ref<Script>(key_script_type)),
+							_get_element_type(value_builtin_type, value_native_type, Ref<Script>(value_script_type)));
 #endif // DEBUG_ENABLED
 					OPCODE_BREAK;
 				}
 
 				Dictionary *dictionary = VariantInternal::get_dictionary(r);
 
-				if (dictionary->get_typed_key_builtin() != ((uint32_t)key_builtin_type) || dictionary->get_typed_key_class_name() != key_native_type || dictionary->get_typed_key_script() != *key_script_type ||
-						dictionary->get_typed_value_builtin() != ((uint32_t)value_builtin_type) || dictionary->get_typed_value_class_name() != value_native_type || dictionary->get_typed_value_script() != *value_script_type) {
+				if (dictionary->get_typed_key_builtin() != ((uint32_t)key_builtin_type) || dictionary->get_typed_key_class_name() != key_native_type || dictionary->get_typed_key_script() != key_script_type ||
+						dictionary->get_typed_value_builtin() != ((uint32_t)value_builtin_type) || dictionary->get_typed_value_class_name() != value_native_type || dictionary->get_typed_value_script() != value_script_type) {
 #ifdef DEBUG_ENABLED
 					err_text = vformat(R"(Trying to return a value of type "%s" from a function whose return type is "Dictionary[%s, %s]".)",
-							_get_var_type(r), _get_element_type(key_builtin_type, key_native_type, *key_script_type),
-							_get_element_type(value_builtin_type, value_native_type, *value_script_type));
+							_get_var_type(r), _get_element_type(key_builtin_type, key_native_type, Ref<Script>(key_script_type)),
+							_get_element_type(value_builtin_type, value_native_type, Ref<Script>(value_script_type)));
 #endif // DEBUG_ENABLED
 					OPCODE_BREAK;
 				}

--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -48,6 +48,7 @@
 #include "core/object/method_bind.h"
 #include "core/os/os.h"
 #include "core/string/string_name.h"
+#include "core/variant/container_type_validate.h"
 #include "core/variant/variant_parser.h"
 
 #ifdef TOOLS_ENABLED
@@ -1123,7 +1124,7 @@ void godotsharp_array_set_typed(Array *p_self, uint32_t p_elem_type, const Strin
 	if (p_elem_script && p_elem_script->is_valid()) {
 		elem_class_name = p_elem_script->ptr()->get_instance_base_type();
 	}
-	p_self->set_typed(p_elem_type, elem_class_name, p_elem_script->ptr());
+	p_self->set_typed(ContainerType{ Variant::Type(p_elem_type), elem_class_name, *p_elem_script });
 }
 
 bool godotsharp_array_is_typed(const Array *p_self) {
@@ -1289,7 +1290,8 @@ void godotsharp_dictionary_set_typed(Dictionary *p_self, uint32_t p_key_type, co
 	if (p_value_script && p_value_script->is_valid()) {
 		value_class_name = p_value_script->ptr()->get_instance_base_type();
 	}
-	p_self->set_typed(p_key_type, key_class_name, p_key_script->ptr(), p_value_type, value_class_name, p_value_script->ptr());
+	p_self->set_typed(ContainerType{ Variant::Type(p_key_type), key_class_name, *p_key_script },
+			ContainerType{ Variant::Type(p_value_type), value_class_name, *p_value_script });
 }
 
 bool godotsharp_dictionary_is_typed_key(const Dictionary *p_self) {

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -33,6 +33,7 @@
 
 #include "core/io/marshalls.h"
 #include "core/object/class_db.h"
+#include "core/variant/container_type_validate.h"
 
 bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 	String prop_name = p_name;
@@ -5916,7 +5917,7 @@ Variant Animation::add_variant(const Variant &a, const Variant &b) {
 				bool is_a_larger = inform_variant_array(min_size, max_size);
 
 				Array result;
-				result.set_typed(MAX(arr_a.get_typed_builtin(), arr_b.get_typed_builtin()), StringName(), Variant());
+				result.set_typed(ContainerType::from_type(MAX(arr_a.get_typed_builtin(), arr_b.get_typed_builtin())));
 				result.resize(min_size);
 				int i = 0;
 				for (; i < min_size; i++) {
@@ -6030,7 +6031,7 @@ Variant Animation::subtract_variant(const Variant &a, const Variant &b) {
 				bool is_a_larger = inform_variant_array(min_size, max_size);
 
 				Array result;
-				result.set_typed(MAX(arr_a.get_typed_builtin(), arr_b.get_typed_builtin()), StringName(), Variant());
+				result.set_typed(ContainerType::from_type(MAX(arr_a.get_typed_builtin(), arr_b.get_typed_builtin())));
 				result.resize(min_size);
 				int i = 0;
 				for (; i < min_size; i++) {
@@ -6166,7 +6167,7 @@ Variant Animation::blend_variant(const Variant &a, const Variant &b, float c) {
 				bool is_a_larger = inform_variant_array(min_size, max_size);
 
 				Array result;
-				result.set_typed(MAX(arr_a.get_typed_builtin(), arr_b.get_typed_builtin()), StringName(), Variant());
+				result.set_typed(ContainerType::from_type(MAX(arr_a.get_typed_builtin(), arr_b.get_typed_builtin())));
 				result.resize(min_size);
 				int i = 0;
 				for (; i < min_size; i++) {
@@ -6303,7 +6304,7 @@ Variant Animation::interpolate_variant(const Variant &a, const Variant &b, float
 				bool is_a_larger = inform_variant_array(min_size, max_size);
 
 				Array result;
-				result.set_typed(MAX(arr_a.get_typed_builtin(), arr_b.get_typed_builtin()), StringName(), Variant());
+				result.set_typed(ContainerType::from_type(MAX(arr_a.get_typed_builtin(), arr_b.get_typed_builtin())));
 				result.resize(min_size);
 				int i = 0;
 				for (; i < min_size; i++) {
@@ -6484,7 +6485,7 @@ Variant Animation::cubic_interpolate_in_time_variant(const Variant &pre_a, const
 				bool is_a_larger = inform_variant_array(min_size, max_size);
 
 				Array result;
-				result.set_typed(MAX(arr_a.get_typed_builtin(), arr_b.get_typed_builtin()), StringName(), Variant());
+				result.set_typed(ContainerType::from_type(MAX(arr_a.get_typed_builtin(), arr_b.get_typed_builtin())));
 				result.resize(min_size);
 
 				if (min_size == 0 && max_size == 0) {

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -126,7 +126,7 @@ Variant SceneState::_duplicate_recursive(const Variant &p_variant, HashMap<Node 
 			bool has_fallback = true;
 			Dictionary dst;
 			if (src.is_typed()) {
-				dst.set_typed(src.get_typed_key_builtin(), src.get_typed_key_class_name(), src.get_typed_key_script(), src.get_typed_value_builtin(), src.get_typed_value_class_name(), src.get_typed_value_script());
+				dst.set_typed(src.get_key_type(), src.get_value_type());
 				has_fallback = false;
 				if (fallback.is_typed()) {
 					has_fallback =
@@ -530,7 +530,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 								if (set_array.is_same_typed(get_array)) {
 									set_array = set_array.duplicate();
 								} else {
-									set_array = Array(set_array, get_array.get_typed_builtin(), get_array.get_typed_class_name(), get_array.get_typed_script());
+									set_array = Array(set_array, get_array.get_element_type());
 								}
 							}
 
@@ -547,7 +547,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 								if (set_dict.is_same_typed(get_dict)) {
 									set_dict = set_dict.duplicate();
 								} else {
-									set_dict = Dictionary(set_dict, get_dict.get_typed_key_builtin(), get_dict.get_typed_key_class_name(), get_dict.get_typed_key_script(), get_dict.get_typed_value_builtin(), get_dict.get_typed_value_class_name(), get_dict.get_typed_value_script());
+									set_dict = Dictionary(set_dict, get_dict.get_key_type(), get_dict.get_value_type());
 								}
 							}
 

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -678,7 +678,7 @@ Error ResourceLoaderText::load() {
 						if (is_get_valid && get_value.get_type() == Variant::ARRAY) {
 							Array get_array = get_value;
 							if (!set_array.is_same_typed(get_array)) {
-								value = Array(set_array, get_array.get_typed_builtin(), get_array.get_typed_class_name(), get_array.get_typed_script());
+								value = Array(set_array, get_array.get_element_type());
 							}
 						}
 					}
@@ -690,8 +690,7 @@ Error ResourceLoaderText::load() {
 						if (is_get_valid && get_value.get_type() == Variant::DICTIONARY) {
 							Dictionary get_dict = get_value;
 							if (!set_dict.is_same_typed(get_dict)) {
-								value = Dictionary(set_dict, get_dict.get_typed_key_builtin(), get_dict.get_typed_key_class_name(), get_dict.get_typed_key_script(),
-										get_dict.get_typed_value_builtin(), get_dict.get_typed_value_class_name(), get_dict.get_typed_value_script());
+								value = Dictionary(set_dict, get_dict.get_key_type(), get_dict.get_value_type());
 							}
 						}
 					}
@@ -819,7 +818,7 @@ Error ResourceLoaderText::load() {
 					if (is_get_valid && get_value.get_type() == Variant::ARRAY) {
 						Array get_array = get_value;
 						if (!set_array.is_same_typed(get_array)) {
-							value = Array(set_array, get_array.get_typed_builtin(), get_array.get_typed_class_name(), get_array.get_typed_script());
+							value = Array(set_array, get_array.get_element_type());
 						}
 					}
 				}
@@ -831,8 +830,7 @@ Error ResourceLoaderText::load() {
 					if (is_get_valid && get_value.get_type() == Variant::DICTIONARY) {
 						Dictionary get_dict = get_value;
 						if (!set_dict.is_same_typed(get_dict)) {
-							value = Dictionary(set_dict, get_dict.get_typed_key_builtin(), get_dict.get_typed_key_class_name(), get_dict.get_typed_key_script(),
-									get_dict.get_typed_value_builtin(), get_dict.get_typed_value_class_name(), get_dict.get_typed_value_script());
+							value = Dictionary(set_dict, get_dict.get_key_type(), get_dict.get_value_type());
 						}
 					}
 				}


### PR DESCRIPTION
## What problem(s) does this PR solve?

Faster typed containers, both overall and in multi-threading.

## Additional information

It achieves it by making them do less copies involved with assigning, reading, and checking types. Also by extracting script directly from variant without using ref constructor in a couple of places.

## Design decisions

<details>
<summary>Return `ContainerType` as reference</summary>

### Return `ContainerType` as reference

By making `ContainerTypeValidate` inherit from `ContainerType` we can make `get_element_type`, `get_key_type`, and `get_value_type` returns const references, because references also work with polymorphism, they just can't be rebound. We don't actually need any virtual methods or any usual polymorphism stuff here, the inheritance is here purely to make less copies. While the current NRVO is pretty good, there is code in marshals (json, binary, text, etc.) that only reads them, so NRVO doesn't help here, it still makes copies.

---
</details>
<details>
<summary>Return references to ref counted types</summary>

### Return references to ref counted types

There is also a bunch of code that does this:
```C++
	has_fallback =
			src.get_typed_key_builtin() == fallback.get_typed_key_builtin() &&
			src.get_typed_key_class_name() == fallback.get_typed_key_class_name() &&
			src.get_typed_key_script() == fallback.get_typed_key_script() &&
			src.get_typed_value_builtin() == fallback.get_typed_value_builtin() &&
			src.get_typed_value_class_name() == fallback.get_typed_value_class_name() &&
			src.get_typed_value_script() == fallback.get_typed_value_script();
```
And tbh there is nothing wrong with the usage itself, we can even say it is the expected usage with typed containers. So we should optimize for it instead, so now class name and script also return const references, which, in the example, removes 8 copies. Thanks to conversion operators this should be fully compatible with all already existing code. This optimization is also important for the GDScript VM optimizations.

---
</details>
<details>
<summary>Adjust `set_typed` to prefer the `ContainerType`</summary>

### Adjust `set_typed` to prefer the `ContainerType`

Now that it is decided that `ContainerType` is returned by reference, we should adjust `set_typed` to do copy assignments directly from the reference without any intermediates. We can also add move overload for temporary `ContainerType` values, which will allow us to preserve the current public `set_typed` API, while speeding it up. And because we already need to create temporary `Ref<Script>` from the `const Variant &` in the original `set_typed`, we can funnel both of them into into a new inner function with hopefully copy elided arguments, that we will move assign values from to the container type, which should make less copies overall. As for the string name ref, originally it was doing a direct copy assignment from the reference, but in the new version it creates a temporary with copy ctor, and then move assigns from it, which is slightly slower, but I think it is acceptable for easier implementation.

There was also an attempt to do
```C++
void set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script);
void set_typed(uint32_t p_type, const StringName &p_class_name, Script *p_script);
void set_typed(uint32_t p_type, const StringName &p_class_name, const Ref<Script> &p_script);
```
But it made it too cluttered, so it was not used.

---
</details>
<details>
<summary>Optimise `set_typed` usage</summary>

### Optimise `set_typed` usage

Since `ContainerType` is now always faster to use (mainly because `Variant` to `Ref<T>` conversion uses `get_validated_object`, which uses `ObjectDB::get_instance` with a global spin lock) switches almost all usage of `set_typed` to use `ContainerType`. I think `variant_construct.h` is almost the only place left that basically uses the `set_typed` with variant script through `VariantConstructorTypedArray`, I didn't change it, because it can be easily worked around and I didn't want to introduce new includes into headers.

---
</details>
<details>
<summary>Optimize GDScript VM</summary>

### Optimize GDScript VM

Directly extracts scripts for usage with typed containers, similar to already existing opcodes, for example this is already being used, so we copy the approach for use in typed containers:
```C++
			OPCODE(OPCODE_TYPE_TEST_SCRIPT) {
				// ...
				GET_VARIANT_PTR(type, 2);
				Script *script_type = Object::cast_to<Script>(type->operator Object *());
```
And combined with reference returns, we can now directly compare similar code
```C++
array->get_typed_builtin() != ((uint32_t)builtin_type) || array->get_typed_class_name() != native_type || array->get_typed_script() != element_script_type
```
in the VM itself, without making new copies or using intermediates. Speed up opcodes:
- `OPCODE_TYPE_TEST_ARRAY`
- `OPCODE_TYPE_TEST_DICTIONARY`
- `OPCODE_ASSIGN_TYPED_ARRAY`
- `OPCODE_ASSIGN_TYPED_DICTIONARY`
- `OPCODE_CONSTRUCT_TYPED_ARRAY`
- `OPCODE_CONSTRUCT_TYPED_DICTIONARY`
- `OPCODE_RETURN_TYPED_ARRAY`
- `OPCODE_RETURN_TYPED_DICTIONARY`

It also uses `ContainerType` where possible, it seems to be for calls with conversion from packed arrays to typed array.

---
</details>
<details>
<summary>Extract script from variant directly in a couple of hot spots in release</summary>

### Extract script from variant directly in a couple of hot spots in release

It does it in the `container_type_validate.h` and `gdextension_interface.cpp`, as this is serious hot spots and it should be safe enough to use in release, otherwise it would go through `ObjectDB::get_instance` with a global spin lock, which will make multi-threading slow to a crawl. Example from `_internal_validate_object`:
```C++
#ifdef DEBUG_ENABLED
		Ref<Script> other_script = object->get_script();
#else
		Ref<Script> other_script = Object::cast_to<Script>(object->get_script().operator Object *());
#endif
```
As seen here, it still uses `Ref<Script>`, so it only avoids `ObjectDB::get_instance`, which shouldn't matter for script types.

And as it does get called on every indexed set, it means that without the `#ifdef` setting the value on the typed array with object type with an object will involve a global spin lock.

After `ObjectDB::get_instance` is fixed (I hope it at least stops being a global spin lock) (it's basically unusable in multi-threading) it could be changed back.

---
</details>
<details>
<summary>Preserve compatibility with existing code</summary>

### Preserve compatibility with existing code

Copied old bindings and bound them with the original name in `variant_call.cpp` to preserve compatibility.

For the code change from `StringName` to `const StringName &` is fully safe. But other `Variant` to `const Ref<Script> &` needs `ref_counted.h` to be included to make the conversion operator available to be compatible, seeing that if you called `get_typed_script` (or similar) means you want to access the script, it also means that `ref_counted.h` is also included in the majority of cases, so should be pretty safe. The `set_typed` public API didn't change, it just added overload for `ContainerType &&`, so it is also safe.

---
</details>

## Benchmarks

The results are in tables with numbers measuring ns/op. The columns indicate how many threads were used for that run. Each run had the same workload that was split between running threads. Only tests release templates.

Compile command: `scons target=template_release optimize=speed accesskit=no use_llvm=yes linker=lld production=yes`
Project: [test-threads.zip](https://github.com/user-attachments/files/31336877/test-threads.zip)
Tested Master: 893cf5cbfe789ae67c9389708e1428141bb39b18
<details>
<summary>System Info</summary>

> Godot v4.8.dev (c95fd5d7c) - EndeavourOS `#1` SMP PREEMPT_DYNAMIC Tue, 28 Jul 2026 13:49:51 +0000 on X11 - X11 display driver, Multi-window, 2 monitors - Vulkan (Forward+) - dedicated NVIDIA GeForce GTX 1650 (nvidia; 610.43.03) - Intel(R) Core(TM) i5-9300H CPU @ 2.40GHz (8 threads) - 15.49 GiB memory - PulseAudio (44100 Hz, Stereo/mono)
</details>

### Core marshals

<details>
<summary>func_type_parse</summary>

<details>
<summary>func_type_parse_builtin Array[bool]</summary>

```gdscript
func func_type_parse_builtin(count: int) -> int:
    var sum := 0
    var arr: Array[bool] = []
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        str_to_var(var_to_str(arr))
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum
```
</details>
<details>
<summary>func_type_parse_object Array[Resource]</summary>

```gdscript
func func_type_parse_object(count: int) -> int:
    var sum := 0
    var arr: Array[Resource] = []
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        str_to_var(var_to_str(arr))
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum
```
</details>
<details>
<summary>func_type_parse_script Array[HelperResource]</summary>

```gdscript
func func_type_parse_script(count: int) -> int:
    var sum := 0
    var arr: Array[HelperResource] = []
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        str_to_var(var_to_str(arr))
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum
```
</details>

|   Type | Name                     |       0 |       1 |       2 |       3 |       4 |       5 |       6 |       7 |       8 | 
| ------ | ------------------------ |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |
| Master | func_type_parse_builtin  |   871.9 |   927.6 |   530.7 |   358.8 |   294.1 |   329.0 |   308.0 |   293.6 |   282.3 |
|     PR | func_type_parse_builtin  |   830.1 |   872.9 |   474.3 |   328.3 |   275.4 |   309.8 |   277.5 |   278.5 |   268.0 |
| Master | func_type_parse_object   |  1171.9 |  1300.6 |   743.1 |   528.6 |   526.1 |   540.5 |   529.6 |   506.5 |   497.3 |
|     PR | func_type_parse_object   |  1112.7 |  1233.8 |   704.7 |   513.5 |   496.0 |   493.6 |   471.8 |   447.2 |   434.4 |
| Master | func_type_parse_script   |  4829.7 |  5002.8 |  3039.6 |  2505.2 |  2739.6 |  2797.0 |  2789.0 |  2664.4 |  2555.3 |
|     PR | func_type_parse_script   |  4599.0 |  5029.3 |  2910.3 |  2402.3 |  2670.2 |  2742.6 |  2666.4 |  2596.6 |  2483.9 |

---
</details>
<details>
<summary>func_type_bytes</summary>

In code it is called `func_type_duplicate`, but I renamed it to take less space in the table.
<details>
<summary>func_type_bytes_builtin Array[bool]</summary>

```gdscript
func func_type_duplicate_builtin(count: int) -> int:
    var sum := 0
    var arrs: Array[Array]
    for i in 20:
        arrs.push_back([] as Array[bool])
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        bytes_to_var_with_objects(var_to_bytes_with_objects(arrs))
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum
```
</details>
<details>
<summary>func_type_bytes_object Array[Resource]</summary>

```gdscript
func func_type_duplicate_object(count: int) -> int:
    var sum := 0
    var arrs: Array[Array]
    for i in 20:
        arrs.push_back([] as Array[Resource])
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        bytes_to_var_with_objects(var_to_bytes_with_objects(arrs))
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum
```
</details>
<details>
<summary>func_type_bytes_script Array[HelperResource]</summary>

```gdscript
func func_type_duplicate_script(count: int) -> int:
    var sum := 0
    var arrs: Array[Array]
    for i in 20:
        arrs.push_back([] as Array[HelperResource])
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        bytes_to_var_with_objects(var_to_bytes_with_objects(arrs))
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum
```
</details>

|   Type | Name                     |       0 |       1 |       2 |       3 |       4 |       5 |       6 |       7 |       8 | 
| ------ | ------------------------ |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |
| Master | func_type_bytes_builtin  |  4454.9 |  4351.4 |  2532.5 |  1938.4 |  1710.1 |  1800.1 |  1668.6 |  1595.4 |  1646.7 |
|     PR | func_type_bytes_builtin  |  3778.6 |  3619.2 |  1948.8 |  1317.8 |  1047.8 |  1171.3 |  1055.4 |   984.8 |   953.8 |
| Master | func_type_bytes_object   |  8181.3 |  8870.9 | 10611.2 | 11261.9 | 11147.0 | 11134.5 | 11769.9 | 12252.8 | 12629.2 |
|     PR | func_type_bytes_object   |  6646.7 |  6689.3 |  4711.7 |  4752.9 |  5146.3 |  5570.8 |  5896.4 |  6100.9 |  6235.0 |
| Master | func_type_bytes_script   | 46622.3 | 50688.9 | 41252.5 | 41989.9 | 42004.7 | 41121.5 | 40032.3 | 38956.7 | 37884.1 |
|     PR | func_type_bytes_script   | 40359.1 | 44395.2 | 37387.1 | 36128.9 | 36902.0 | 36502.8 | 34921.6 | 33877.8 | 33011.0 |

---
</details>
</details>

These benchmarks test changes in `variant_parser.cpp` and `marshals.cpp` specifically. The changes do have a positive effect, so other places will have a similar boost.

### GDScript Opcodes

Now that we stopped chasing temporaries around and compare types directly we have the biggest performance boost here.
<details>
<summary>func_type_call_convert</summary>

This one uses `ContainerType &&` overload, so it seems to be working 
<details>
<summary>Code</summary>

```gdscript
func func_type_call_convert(count: int) -> int:
    var sum := 0
    var arr: PackedInt64Array
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        _type_call_convert(arr, arr, arr)
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum

func _type_call_convert(_0: Array[int], _1: Array[int], _2: Array[int]) -> void:
    pass
```
</details>

|   Type | Name                     |       0 |       1 |       2 |       3 |       4 |       5 |       6 |       7 |       8 | 
| ------ | ------------------------ |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |
| Master | func_type_call_convert   |   318.5 |   326.7 |   232.7 |   217.4 |   229.4 |   215.8 |   218.1 |   241.8 |   261.7 |
|     PR | func_type_call_convert   |   288.4 |   306.3 |   158.5 |   152.9 |   116.4 |   103.5 |    95.4 |    92.1 |    85.9 |

---
</details>
<details>
<summary>func_type_check</summary>

These are designed to always be false in `if`, so it should only check the condition itself
<details>
<summary>func_type_check_builtin Array[int]</summary>

```gdscript
func func_type_check_builtin(count: int) -> int:
    var sum := 0
    var arr: Array = [] as Array[int]
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        if arr is Array[bool]:
            sum += 1
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum
```
</details>
<details>
<summary>func_type_check_object Array[Node]</summary>

```gdscript
func func_type_check_object(count: int) -> int:
    var sum := 0
    var arr: Array = [] as Array[Node]
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        if arr is Array[Resource]:
            sum += 1
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum
```
</details>
<details>
<summary>func_type_check_script Array[HelperObj]</summary>

```gdscript
func func_type_check_script(count: int) -> int:
    var sum := 0
    var arr: Array = [] as Array[HelperObj]
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        if arr is Array[HelperResource]:
            sum += 1
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum
```
</details>

|   Type | Name                     |       0 |       1 |       2 |       3 |       4 |       5 |       6 |       7 |       8 | 
| ------ | ------------------------ |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |
| Master | func_type_check_builtin  |    14.6 |    14.4 |     8.5 |     6.1 |     5.2 |     4.4 |     4.1 |     3.4 |     3.4 |
|     PR | func_type_check_builtin  |    14.4 |    18.2 |     8.0 |     6.7 |     5.0 |     4.9 |     4.4 |     3.9 |     4.0 |
| Master | func_type_check_object   |    26.8 |    28.4 |    70.9 |    84.0 |    83.9 |    84.7 |    86.5 |    87.7 |    91.7 |
|     PR | func_type_check_object   |    14.6 |    15.8 |     9.2 |     6.1 |     5.0 |     5.2 |     4.6 |     4.0 |     3.7 |
| Master | func_type_check_script   |    26.7 |    28.4 |    66.4 |    81.6 |    82.2 |    83.0 |    83.9 |    87.5 |    90.4 |
|     PR | func_type_check_script   |    14.8 |    15.9 |     9.4 |     6.5 |     4.9 |     5.8 |     4.6 |     4.0 |     5.8 |

---
</details>
<details>
<summary>func_type_create</summary>

<details>
<summary>func_type_create_builtin Array[bool]</summary>

```gdscript
func func_type_create_builtin(count: int) -> int:
    var sum := 0
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        @warning_ignore("standalone_expression")
        [] as Array[bool]
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum
```
</details>
<details>
<summary>func_type_create_object Array[Node]</summary>

```gdscript
func func_type_create_object(count: int) -> int:
    var sum := 0
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        @warning_ignore("standalone_expression")
        [] as Array[Node]
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum
```
</details>
<details>
<summary>func_type_create_script Array[HelperNode]</summary>

```gdscript
func func_type_create_script(count: int) -> int:
    var sum := 0
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        @warning_ignore("standalone_expression")
        [] as Array[HelperNode]
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum
```
</details>

|   Type | Name                     |       0 |       1 |       2 |       3 |       4 |       5 |       6 |       7 |       8 | 
| ------ | ------------------------ |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |
| Master | func_type_create_builtin |   106.3 |   114.5 |    83.8 |    82.6 |    77.0 |    71.4 |    72.1 |    84.8 |    91.5 |
|     PR | func_type_create_builtin |   101.8 |   115.7 |    54.7 |    38.2 |    30.6 |    38.7 |    42.5 |    39.8 |    36.4 |
| Master | func_type_create_object  |   118.5 |   123.9 |   120.9 |   107.2 |   103.8 |   102.3 |    99.2 |   100.4 |   102.7 |
|     PR | func_type_create_object  |   113.0 |   128.5 |    89.4 |    85.4 |    88.0 |    87.8 |    88.9 |    92.0 |    93.1 |
| Master | func_type_create_script  |   167.9 |   174.9 |   233.8 |   256.3 |   270.4 |   259.4 |   260.3 |   259.2 |   259.7 |
|     PR | func_type_create_script  |   138.3 |   145.3 |   150.5 |   133.8 |   128.4 |   125.8 |   121.6 |   119.4 |   118.3 |

---
</details>
<details>
<summary>func_type_assign</summary>

<details>
<summary>func_type_assign_builtin Array[bool]</summary>

```gdscript
func func_type_assign_builtin(count: int) -> int:
    var sum := 0
    @warning_ignore("unused_variable")
    var arr: Array[bool]
    var other: Array[bool]
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        arr = other
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum
```
</details>
<details>
<summary>func_type_assign_object Array[Node]</summary>

```gdscript
func func_type_assign_object(count: int) -> int:
    var sum := 0
    @warning_ignore("unused_variable")
    var arr: Array[Node]
    var other: Array[Node]
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        arr = other
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum
```
</details>
<details>
<summary>func_type_assign_script Array[HelperNode]</summary>

```gdscript
func func_type_assign_script(count: int) -> int:
    var sum := 0
    @warning_ignore("unused_variable")
    var arr: Array[HelperNode]
    var other: Array[HelperNode]
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        arr = other
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum
```
</details>

|   Type | Name                     |       0 |       1 |       2 |       3 |       4 |       5 |       6 |       7 |       8 | 
| ------ | ------------------------ |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |
| Master | func_type_assign_builtin |    31.6 |    37.5 |    70.5 |   109.7 |   132.1 |   109.6 |   113.5 |   122.0 |   133.9 |
|     PR | func_type_assign_builtin |    12.3 |    13.7 |     7.7 |     4.8 |     4.0 |     4.1 |     3.6 |     3.2 |     3.2 |
| Master | func_type_assign_object  |    43.9 |    47.4 |    99.7 |   119.4 |   145.3 |   137.6 |   135.7 |   143.6 |   152.7 |
|     PR | func_type_assign_object  |    12.3 |    14.1 |     7.8 |     5.0 |     4.1 |     4.1 |     3.7 |     3.2 |     3.2 |
| Master | func_type_assign_script  |    70.5 |    72.8 |   145.4 |   137.2 |   134.9 |   138.8 |   136.3 |   139.7 |   153.0 |
|     PR | func_type_assign_script  |    12.2 |    12.9 |     7.2 |     5.1 |     3.9 |     4.1 |     3.7 |     3.3 |     3.0 |

---
</details>
<details>
<summary>func_type_return</summary>

<details>
<summary>func_type_return_builtin Array[bool]</summary>

```gdscript
func func_type_return_builtin(count: int) -> int:
    var sum := 0
    var arr: Array[bool]
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        _type_return_builtin(arr)
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum

func _type_return_builtin(arr: Array[bool]) -> Array[bool]:
    return arr
```
</details>
<details>
<summary>func_type_return_object Array[Node]</summary>

```gdscript
func func_type_return_object(count: int) -> int:
    var sum := 0
    var arr: Array[Node]
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        _type_return_object(arr)
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum

func _type_return_object(arr: Array[Node]) -> Array[Node]:
    return arr
```
</details>
<details>
<summary>func_type_return_script Array[HelperNode]</summary>

```gdscript
func func_type_return_script(count: int) -> int:
    var sum := 0
    var arr: Array[HelperNode]
    if sem: sem.wait()
    var time_start := Time.get_ticks_usec()
    for i in count:
        _type_return_script(arr)
    var time_end := Time.get_ticks_usec()
    finished.emit.call_deferred(time_end - time_start)
    return sum

func _type_return_script(arr: Array[HelperNode]) -> Array[HelperNode]:
    return arr
```
</details>

|   Type | Name                     |       0 |       1 |       2 |       3 |       4 |       5 |       6 |       7 |       8 | 
| ------ | ------------------------ |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |   ----: |
| Master | func_type_return_builtin |   103.0 |   134.0 |    79.9 |    80.7 |    78.9 |    73.6 |    68.7 |    82.0 |    89.9 |
|     PR | func_type_return_builtin |    88.6 |    99.9 |    50.5 |    35.9 |    37.2 |    32.8 |    28.3 |    31.4 |    35.1 |
| Master | func_type_return_object  |   111.6 |   124.6 |   111.3 |    98.9 |   103.8 |    99.1 |    98.4 |    95.6 |    96.0 |
|     PR | func_type_return_object  |    87.8 |    91.7 |    51.9 |    34.2 |    27.5 |    34.8 |    32.2 |    27.7 |    24.5 |
| Master | func_type_return_script  |   167.0 |   170.2 |   231.3 |   254.3 |   258.8 |   248.7 |   253.0 |   258.3 |   263.5 |
|     PR | func_type_return_script  |    86.8 |    90.2 |    51.2 |    34.9 |    34.2 |    34.0 |    28.6 |    26.5 |    32.3 |

---
</details>

Tbh I was really surprised by how much faster assign and type check became. And while all other benchmarks are pretty  unrealistic, assignment and type check are realistic enough in their usage.

## Closing thoughts

Not sure if I like or dislike the aspect of C++ that allows you to easily create a bunch of copies that works, but slows everything down. Like, this PR doesn't use any new algorithms, it just stops making so much copies and avoids a global spin lock in a couple of places, and suddenly it is fast again.

Currently uses separate commits for easier reviewing.

No AI used.