### PR TITLE
[Linux] Don't send an octet-stream MIME type for the "All Files" filter

### DIFF
--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -696,6 +696,9 @@ Error FreeDesktopPortalDesktop::file_dialog_show(DisplayServerEnums::WindowID p_
 		if (tokens.size() >= 1) {
 			String flt = tokens[0].strip_edges();
 			String mime = (tokens.size() >= 3) ? tokens[2].strip_edges() : String();
+			if (flt == "*.*" && mime == "application/octet-stream") {
+				mime = String();
+			}
 			if (!flt.is_empty() || !mime.is_empty()) {
 				if (tokens.size() >= 2) {
 					if (flt == "*.*") {


### PR DESCRIPTION
Disclaimer: AI helped me find the root cause, check that Godot had no existing issue or PR for it.

## What problem(s) does this PR solve?

A native save dialog can return a name ending in a bare dot, so `ResourceSaver` refuses to write it and the save silently fails behind a warning.

```
WARNING: Failed to save mesh <name> to 'res://models/new_asset_2.res.'.
```

The problem comes from the OS native save dialog, not from Godot. But the same kind of problem happened in the past for macOS, and it was fixed directly inside Godot :  [#113757](https://github.com/godotengine/godot/pull/113757) and [#114781](https://github.com/godotengine/godot/pull/114781)

No issue opened, given the size of the fix. I can write one if you prefer.

## Additional information

Glad to move the guard to `platform/linuxbsd/freedesktop_portal_desktop.cpp` (the placement matching the macOS fixes), if it is preferred.

Reproducer — needs a Plasma session on `xdg-desktop-portal-kde` with KIO < 6.13 and a target file that does not exist yet.

Here are the screenshots of how it happens on my machine: 

<img width="821" height="411" alt="1 (1)" src="https://github.com/user-attachments/assets/eb24f0ba-6fd3-48c2-8959-c5d02466c12c" />

<img width="1047" height="765" alt="2 (1)" src="https://github.com/user-attachments/assets/48c26a1d-4f49-4799-9eef-f56639d453c3" />

<img width="1184" height="413" alt="3 (1)" src="https://github.com/user-attachments/assets/ad925b4c-521a-4f53-9953-0e58afcdb46e" />

<img width="889" height="59" alt="4 (1)" src="https://github.com/user-attachments/assets/4121c56d-d504-4509-86a7-d68c909cdb06" />
