### PR TITLE
`GDType`: Consolidate integer constants in property map

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -446,17 +446,19 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 
 		{ //constants
 
-			List<StringName> snames;
+			LocalVector<StringName> snames;
 
-			for (const KeyValue<StringName, int64_t> &F : t->gdtype->get_integer_constant_map(true)) {
-				snames.push_back(F.key);
+			for (const KeyValue<StringName, GDType::Property> &F : t->gdtype->get_property_map(true)) {
+				if (F.value.type == GDType::Property::Type::INTEGER_CONSTANT) {
+					snames.push_back(F.key);
+				}
 			}
 
 			snames.sort_custom<StringName::AlphCompare>();
 
 			for (const StringName &F : snames) {
 				hash = hash_murmur3_one_64(F.hash(), hash);
-				hash = hash_murmur3_one_64(uint64_t(t->gdtype->get_integer_constant_map(true)[F]), hash);
+				hash = hash_murmur3_one_64(uint64_t(t->gdtype->get_property_map(true)[F].payload.integer), hash);
 			}
 		}
 
@@ -1167,8 +1169,10 @@ void ClassDB::get_integer_constant_list(const StringName &p_class, List<String> 
 	ClassInfo *type = classes.getptr(p_class);
 	ERR_FAIL_NO_CLASS(type, p_class);
 
-	for (const KeyValue<StringName, int64_t> &E : type->gdtype->get_integer_constant_map(p_no_inheritance)) {
-		p_constants->push_back(E.key);
+	for (const KeyValue<StringName, GDType::Property> &E : type->gdtype->get_property_map(p_no_inheritance)) {
+		if (E.value.type == GDType::Property::Type::INTEGER_CONSTANT) {
+			p_constants->push_back(E.key);
+		}
 	}
 }
 
@@ -1177,8 +1181,7 @@ int64_t ClassDB::get_integer_constant(const StringName &p_class, const StringNam
 
 	ClassInfo *type = classes.getptr(p_class);
 	if (type) {
-		const int64_t *constant = type->gdtype->get_integer_constant_map(false).getptr(p_name);
-		if (constant) {
+		if (const int64_t *constant = type->gdtype->get_integer_constant(p_name)) {
 			if (p_success) {
 				*p_success = true;
 			}
@@ -1198,7 +1201,7 @@ bool ClassDB::has_integer_constant(const StringName &p_class, const StringName &
 	ClassInfo *type = classes.getptr(p_class);
 	ERR_FAIL_NULL_V(type, false);
 
-	return type->gdtype->get_integer_constant_map(p_no_inheritance).has(p_name);
+	return type->gdtype->has_integer_constant(p_name, p_no_inheritance);
 }
 
 StringName ClassDB::get_integer_constant_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance) {

--- a/core/object/gdtype.cpp
+++ b/core/object/gdtype.cpp
@@ -70,7 +70,6 @@ void GDType::initialize() {
 		// parts in _bind_methods, which is called on registration.
 		super_type->init_state = InitState::FINALIZED;
 
-		constant_map = super_type->constant_map;
 		enum_map = super_type->enum_map;
 		signal_map = super_type->signal_map;
 		method_map = super_type->method_map;
@@ -83,11 +82,9 @@ void GDType::initialize() {
 void GDType::bind_integer_constant(const StringName &p_enum, const StringName &p_name, int64_t p_constant, bool p_is_bitfield) {
 	ERR_FAIL_COND(!Thread::is_main_thread());
 	ERR_FAIL_COND(init_state != InitState::MUTABLE);
-	ERR_FAIL_COND_MSG(self_constant_map.has(p_name), vformat("Class '%s' already has constant '%s'.", String(name), String(p_name)));
+	ERR_FAIL_COND_MSG(has_integer_constant(p_name, true), vformat("Class '%s' already has constant '%s'.", String(name), String(p_name)));
 	ERR_FAIL_COND_MSG(property_map.has(p_name), vformat("Object '%s' already has property '%s'.", get_name(), p_name));
 
-	constant_map[p_name] = p_constant;
-	self_constant_map[p_name] = p_constant;
 	property_map.insert(p_name, Property(Property::Type::INTEGER_CONSTANT, p_constant));
 	self_property_map.insert(p_name, Property(Property::Type::INTEGER_CONSTANT, p_constant));
 
@@ -112,6 +109,16 @@ void GDType::bind_integer_constant(const StringName &p_enum, const StringName &p
 			enum_map[enum_name] = enum_info;
 		}
 	}
+}
+
+const int64_t *GDType::get_integer_constant(const StringName &p_name, bool p_no_inheritance) const {
+	const GDType::Property *p = get_property_map(p_no_inheritance).getptr(p_name);
+	return p && p->type == Property::Type::INTEGER_CONSTANT ? &p->payload.integer : nullptr;
+}
+
+bool GDType::has_integer_constant(const StringName &p_name, bool p_no_inheritance) const {
+	const GDType::Property *p = get_property_map(p_no_inheritance).getptr(p_name);
+	return p && p->type == Property::Type::INTEGER_CONSTANT;
 }
 
 const GDType::EnumInfo *GDType::get_integer_constant_enum(const StringName &p_name, bool p_no_inheritance) const {

--- a/core/object/gdtype.h
+++ b/core/object/gdtype.h
@@ -95,9 +95,6 @@ protected:
 	/// `name` is the first element and `Object` is the last (for `Object` types).
 	Vector<StringName> name_hierarchy;
 
-	AHashMap<StringName, int64_t> constant_map;
-	AHashMap<StringName, int64_t> self_constant_map;
-
 	AHashMap<StringName, const EnumInfo *> enum_map;
 	AHashMap<StringName, const EnumInfo *> self_enum_map;
 
@@ -131,8 +128,9 @@ public:
 	const Vector<StringName> &get_name_hierarchy() const { return name_hierarchy; }
 
 	void bind_integer_constant(const StringName &p_enum, const StringName &p_name, int64_t p_constant, bool p_is_bitfield = false);
-	const AHashMap<StringName, int64_t> &get_integer_constant_map(bool p_no_inheritance = false) const { return p_no_inheritance ? self_constant_map : constant_map; }
 	const AHashMap<StringName, const EnumInfo *> &get_enum_map(bool p_no_inheritance = false) const { return p_no_inheritance ? self_enum_map : enum_map; }
+	const int64_t *get_integer_constant(const StringName &p_name, bool p_no_inheritance = false) const;
+	bool has_integer_constant(const StringName &p_name, bool p_no_inheritance = false) const;
 	const EnumInfo *get_integer_constant_enum(const StringName &p_name, bool p_no_inheritance = false) const;
 
 	void add_signal(MethodInfo p_signal);

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1223,7 +1223,7 @@ struct _VariantCall {
 #ifdef DEBUG_ENABLED
 		ERR_FAIL_COND(variant_constants[p_type].has(p_constant_name));
 		ERR_FAIL_COND(Variant::_get_gdtype_for_type(static_cast<Variant::Type>(p_type)).get_enum_map(true).has(p_constant_name));
-		ERR_FAIL_COND(Variant::_get_gdtype_for_type(static_cast<Variant::Type>(p_type)).get_integer_constant_map(true).has(p_constant_name));
+		ERR_FAIL_COND(Variant::_get_gdtype_for_type(static_cast<Variant::Type>(p_type)).has_integer_constant(p_constant_name, true));
 #endif // DEBUG_ENABLED
 		variant_constants[p_type][p_constant_name] = p_constant_value;
 	}
@@ -1655,8 +1655,8 @@ void Variant::get_method_list(List<MethodInfo> *p_list) const {
 void Variant::get_constants_for_type(Variant::Type p_type, List<StringName> *p_constants) {
 	ERR_FAIL_INDEX(p_type, Variant::VARIANT_MAX);
 
-	for (const KeyValue<StringName, int64_t> &E : _get_gdtype_for_type(p_type).get_integer_constant_map(false)) {
-		if (_get_gdtype_for_type(p_type).get_integer_constant_enum(E.key, false) == nullptr) {
+	for (const KeyValue<StringName, GDType::Property> &E : _get_gdtype_for_type(p_type).get_property_map(false)) {
+		if (E.value.type == GDType::Property::Type::INTEGER_CONSTANT && _get_gdtype_for_type(p_type).get_integer_constant_enum(E.key, false) == nullptr) {
 			p_constants->push_back(E.key);
 		}
 	}
@@ -1677,7 +1677,7 @@ int Variant::get_constants_count_for_type(Variant::Type p_type) {
 bool Variant::has_constant(Variant::Type p_type, const StringName &p_value) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, false);
 	const bool is_non_enum_integer_constant =
-			_get_gdtype_for_type(p_type).get_integer_constant_map(false).has(p_value) &&
+			_get_gdtype_for_type(p_type).has_integer_constant(p_value, false) &&
 			_get_gdtype_for_type(p_type).get_integer_constant_enum(p_value, false) == nullptr;
 	return is_non_enum_integer_constant || _VariantCall::variant_constants[p_type].has(p_value);
 }
@@ -1689,7 +1689,7 @@ Variant Variant::get_constant_value(Variant::Type p_type, const StringName &p_va
 
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, 0);
 
-	const int64_t *int_value = _get_gdtype_for_type(p_type).get_integer_constant_map(false).getptr(p_value);
+	const int64_t *int_value = _get_gdtype_for_type(p_type).get_integer_constant(p_value, false);
 	if (int_value && _get_gdtype_for_type(p_type).get_integer_constant_enum(p_value, false) == nullptr) {
 		if (r_valid) {
 			*r_valid = true;

--- a/modules/mono/class_db_api_json.cpp
+++ b/modules/mono/class_db_api_json.cpp
@@ -119,10 +119,12 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 		{ //constants
 
-			List<StringName> snames;
+			LocalVector<StringName> snames;
 
-			for (const KeyValue<StringName, int64_t> &F : t->gdtype->get_integer_constant_map(true)) {
-				snames.push_back(F.key);
+			for (const KeyValue<StringName, GDType::Property> &F : t->gdtype->get_property_map(true)) {
+				if (F.value.type == GDType::Property::Type::INTEGER_CONSTANT) {
+					snames.push_back(F.key);
+				}
 			}
 
 			snames.sort_custom<StringName::AlphCompare>();
@@ -134,7 +136,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 				constants.push_back(constant_dict);
 
 				constant_dict["name"] = F;
-				constant_dict["value"] = t->gdtype->get_integer_constant_map(true)[F];
+				constant_dict["value"] = t->gdtype->get_property_map(true)[F].payload.integer;
 			}
 
 			if (!constants.is_empty()) {

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -4388,7 +4388,7 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 		}
 
 		for (const String &constant_name : constants) {
-			const int64_t *value = class_info->gdtype->get_integer_constant_map(true).getptr(StringName(constant_name));
+			const int64_t *value = class_info->gdtype->get_integer_constant(StringName(constant_name), true);
 			ERR_FAIL_NULL_V(value, false);
 
 			String constant_proxy_name = snake_to_pascal_case(constant_name, true);

--- a/tests/core/object/test_class_db.cpp
+++ b/tests/core/object/test_class_db.cpp
@@ -775,7 +775,7 @@ void add_exposed_classes(Context &r_context) {
 				TEST_FAIL_COND(String(constant_name).contains("::"),
 						"Enum constant contains '::', check bindings to remove the scope: '",
 						String(class_name), ".", String(enum_.name), ".", String(constant_name), "'.");
-				const int64_t *value = class_info->gdtype->get_integer_constant_map(false).getptr(constant_name);
+				const int64_t *value = class_info->gdtype->get_integer_constant(constant_name, false);
 				TEST_FAIL_COND(!value, "Missing enum constant value: '",
 						String(class_name), ".", String(enum_.name), ".", String(constant_name), "'.");
 				constants.erase(constant_name);
@@ -797,7 +797,7 @@ void add_exposed_classes(Context &r_context) {
 			TEST_FAIL_COND(constant_name.contains("::"),
 					"Constant contains '::', check bindings to remove the scope: '",
 					String(class_name), ".", constant_name, "'.");
-			const int64_t *value = class_info->gdtype->get_integer_constant_map(false).getptr(StringName(E));
+			const int64_t *value = class_info->gdtype->get_integer_constant(StringName(E), false);
 			TEST_FAIL_COND(!value, "Missing constant value: '", String(class_name), ".", String(constant_name), "'.");
 
 			ConstantData constant;


### PR DESCRIPTION
- Follow up of #122596

## What problem(s) does this PR solve?

#112596 introduced property maps in `GDType`, which made integer constants exist both in a dedicated integer constant map and the property map.

Like how it's done with setgets, it should be possible to get the property map, validate that the type is integer constant, then get the integer from its payload.

## Memory usage test

- Build command: `scons target=editor linker=mold dev_build=yes optimize=debug debug_symbols=yes werror=yes tests=yes`

Test script:
```gdscript
extends Node

func _ready():
	print(OS.get_static_memory_usage())
	await get_tree().process_frame
	get_tree().quit()
```

On a simple project that just prints `OS.get_static_memory_usage()` then quits, I got the following from running in headless mode:
|Build|Memory usage (bytes)|
|-|-|
|`master`| 88894464|
|PR| 86315132|

Effectively a reduction of 2.46 MiB.

## Additional information

The aforementioned PR mentions the new maps added over 20MB in RAM usage. This is just my attempt to mitigate part of it, but it could be superseded as soon as someone comes with a better/bigger solution to the problem.