### PR TITLE
Add `copy_bone_skin_scale` to `RetargetModifier3D`

### DIFF
--- a/doc/classes/RetargetModifier3D.xml
+++ b/doc/classes/RetargetModifier3D.xml
@@ -52,6 +52,11 @@
 		</method>
 	</methods>
 	<members>
+		<member name="copy_bone_skin_scale" type="bool" setter="set_copy_bone_skin_scale" getter="is_copying_bone_skin_scale" default="true">
+			If [code]true[/code], copies [method Skeleton3D.get_bone_skin_scale] of the source skeleton's bones to the child skeletons' mapped bones.
+			If [code]false[/code], the skin scale of the child skeletons' mapped bones are reset to [code]Vector3(1, 1, 1)[/code] once and will not be overwritten after that.
+			[b]Note:[/b] If you want to use [method Skeleton3D.set_bone_skin_scale] on a child skeleton's mapped bone, set this to [code]false[/code]. Even if you are not using [method Skeleton3D.set_bone_skin_scale] with parent skeleton, [code]Vector3(1, 1, 1)[/code] will always be set for the child skeletons' mapped bones.
+		</member>
 		<member name="enable" type="int" setter="set_enable_flags" getter="get_enable_flags" enum="RetargetModifier3D.TransformFlag" is_bitfield="true" default="7">
 			Flags to control the process of the transform elements individually when [member use_global_pose] is disabled.
 		</member>

--- a/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
+++ b/editor/import/3d/post_import_plugin_skeleton_rest_fixer.cpp
@@ -53,6 +53,7 @@ void PostImportPluginSkeletonRestFixer::get_internal_import_options(InternalImpo
 						Variant::STRING, U"retarget/rest_fixer/\u26A0_validation_warning/skeleton_bones_must_be_renamed",
 						PROPERTY_HINT_MULTILINE_TEXT, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_READ_ONLY),
 				Variant(skeleton_bones_must_be_renamed_warning)));
+		r_options->push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::BOOL, "retarget/rest_fixer/copy_bone_skin_scale"), true));
 		r_options->push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::BOOL, "retarget/rest_fixer/use_global_pose"), true));
 		r_options->push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::STRING, "retarget/rest_fixer/original_skeleton_name"), "OriginalSkeleton"));
 		r_options->push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::BOOL, "retarget/rest_fixer/fix_silhouette/enable", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), false));
@@ -75,7 +76,7 @@ Variant PostImportPluginSkeletonRestFixer::get_internal_option_visibility(Intern
 			}
 		} else if (p_option == "retarget/rest_fixer/keep_global_rest_on_leftovers") {
 			return int(p_options["retarget/rest_fixer/retarget_method"]) == 1;
-		} else if (p_option == "retarget/rest_fixer/original_skeleton_name" || p_option == "retarget/rest_fixer/use_global_pose") {
+		} else if (p_option == "retarget/rest_fixer/original_skeleton_name" || p_option == "retarget/rest_fixer/copy_bone_skin_scale" || p_option == "retarget/rest_fixer/use_global_pose") {
 			return int(p_options["retarget/rest_fixer/retarget_method"]) == 2;
 		} else if (p_option.begins_with("retarget/") && p_option.ends_with("skeleton_bones_must_be_renamed")) {
 			return int(p_options["retarget/rest_fixer/retarget_method"]) == 2 && bool(p_options["retarget/bone_renamer/rename_bones"]) == false;
@@ -462,6 +463,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 		}
 
 		bool is_using_modifier = int(p_options["retarget/rest_fixer/retarget_method"]) == 2;
+		bool is_copying_bone_skin_scale = bool(p_options["retarget/rest_fixer/copy_bone_skin_scale"]);
 		bool is_using_global_pose = bool(p_options["retarget/rest_fixer/use_global_pose"]);
 		Skeleton3D *orig_skeleton = nullptr;
 		Skeleton3D *profile_skeleton = nullptr;
@@ -563,6 +565,7 @@ void PostImportPluginSkeletonRestFixer::internal_process(InternalImportCategory 
 				orig_skeleton->set_owner(owner);
 				orig_skeleton->set_unique_name_in_owner(true);
 
+				mod->set_copy_bone_skin_scale(is_copying_bone_skin_scale);
 				mod->set_use_global_pose(is_using_global_pose);
 				mod->set_profile(profile);
 

--- a/scene/3d/retarget_modifier_3d.cpp
+++ b/scene/3d/retarget_modifier_3d.cpp
@@ -206,7 +206,7 @@ void RetargetModifier3D::_reset_child_skeleton_poses() {
 			if (F.bone_id < 0) {
 				continue;
 			}
-			c->reset_bone_pose(F.bone_id);
+			c->reset_bone_pose(F.bone_id, copy_bone_skin_scale);
 		}
 	}
 }
@@ -261,6 +261,8 @@ void RetargetModifier3D::_validate_property(PropertyInfo &p_property) const {
 void RetargetModifier3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_profile", "profile"), &RetargetModifier3D::set_profile);
 	ClassDB::bind_method(D_METHOD("get_profile"), &RetargetModifier3D::get_profile);
+	ClassDB::bind_method(D_METHOD("set_copy_bone_skin_scale", "enabled"), &RetargetModifier3D::set_copy_bone_skin_scale);
+	ClassDB::bind_method(D_METHOD("is_copying_bone_skin_scale"), &RetargetModifier3D::is_copying_bone_skin_scale);
 	ClassDB::bind_method(D_METHOD("set_use_global_pose", "use_global_pose"), &RetargetModifier3D::set_use_global_pose);
 	ClassDB::bind_method(D_METHOD("is_using_global_pose"), &RetargetModifier3D::is_using_global_pose);
 	ClassDB::bind_method(D_METHOD("set_enable_flags", "enable_flags"), &RetargetModifier3D::set_enable_flags);
@@ -274,6 +276,7 @@ void RetargetModifier3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_scale_enabled"), &RetargetModifier3D::is_scale_enabled);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "profile", PROPERTY_HINT_RESOURCE_TYPE, SkeletonProfile::get_class_static()), "set_profile", "get_profile");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "copy_bone_skin_scale"), "set_copy_bone_skin_scale", "is_copying_bone_skin_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_global_pose"), "set_use_global_pose", "is_using_global_pose");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "enable", PROPERTY_HINT_FLAGS, "Position,Rotation,Scale"), "set_enable_flags", "get_enable_flags");
 
@@ -348,17 +351,13 @@ void RetargetModifier3D::_retarget_pose() {
 		float motion_scale_ratio = target_skeleton->get_motion_scale() / source_skeleton->get_motion_scale();
 		for (int i = 0; i < source_bone_ids.size(); i++) {
 			int target_bone_id = E.humanoid_bone_rests[i].bone_id;
-			if (target_bone_id < 0) {
-				continue;
-			}
-			int source_bone_id = source_bone_ids[i];
-			if (source_bone_id < 0) {
+			if (target_bone_id < 0 || source_bone_ids[i] < 0) {
 				continue;
 			}
 
 			Transform3D extracted_transform = source_poses[i];
 			extracted_transform.basis = E.humanoid_bone_rests[i].pre_basis * extracted_transform.basis * E.humanoid_bone_rests[i].post_basis;
-			extracted_transform.origin = E.humanoid_bone_rests[i].pre_basis.xform((extracted_transform.origin - source_skeleton->get_bone_rest(source_bone_id).origin) * motion_scale_ratio) + target_skeleton->get_bone_rest(target_bone_id).origin;
+			extracted_transform.origin = E.humanoid_bone_rests[i].pre_basis.xform((extracted_transform.origin - source_skeleton->get_bone_rest(source_bone_ids[i]).origin) * motion_scale_ratio) + target_skeleton->get_bone_rest(target_bone_id).origin;
 
 			if (enable_flags.has_flag(TRANSFORM_FLAG_POSITION)) {
 				target_skeleton->set_bone_pose_position(target_bone_id, extracted_transform.origin);
@@ -373,11 +372,51 @@ void RetargetModifier3D::_retarget_pose() {
 	}
 }
 
+void RetargetModifier3D::_retarget_skin_scale() {
+	Skeleton3D *source_skeleton = get_skeleton();
+	if (profile.is_null() || !source_skeleton) {
+		return;
+	}
+
+	LocalVector<Vector3> source_skin_scales;
+	for (int source_bone_id : source_bone_ids) {
+		Vector3 skin_scale = source_bone_id < 0 ? DEFAULT_SKIN_SCALE : source_skeleton->get_bone_skin_scale(source_bone_id);
+		source_skin_scales.push_back(influence < 1.0 ? DEFAULT_SKIN_SCALE.lerp(skin_scale, influence) : skin_scale);
+	}
+
+	for (const RetargetInfo &E : child_skeletons) {
+		Skeleton3D *target_skeleton = ObjectDB::get_instance<Skeleton3D>(E.skeleton_id);
+		if (!target_skeleton) {
+			continue;
+		}
+		for (int i = 0; i < source_bone_ids.size(); i++) {
+			int target_bone_id = E.humanoid_bone_rests[i].bone_id;
+			if (target_bone_id < 0 || source_bone_ids[i] < 0) {
+				continue;
+			}
+
+			Vector3 skin_scale = source_skin_scales[i];
+			if (!skin_scale.is_equal_approx(DEFAULT_SKIN_SCALE)) {
+				Basis to_target = E.humanoid_bone_rests[i].post_basis.orthonormalized();
+				if (!to_target.is_equal_approx(Basis())) {
+					skin_scale = (to_target.transposed() * Basis().scaled(skin_scale) * to_target).get_scale();
+				}
+			}
+			if (!target_skeleton->get_bone_skin_scale(target_bone_id).is_equal_approx(skin_scale)) {
+				target_skeleton->set_bone_skin_scale(target_bone_id, skin_scale);
+			}
+		}
+	}
+}
+
 void RetargetModifier3D::_process_modification(double p_delta) {
 	if (use_global_pose) {
 		_retarget_global_pose();
 	} else {
 		_retarget_pose();
+	}
+	if (copy_bone_skin_scale) {
+		_retarget_skin_scale();
 	}
 }
 
@@ -390,6 +429,17 @@ void RetargetModifier3D::set_profile(Ref<SkeletonProfile> p_profile) {
 
 Ref<SkeletonProfile> RetargetModifier3D::get_profile() const {
 	return profile;
+}
+
+void RetargetModifier3D::set_copy_bone_skin_scale(bool p_enabled) {
+	if (copy_bone_skin_scale != p_enabled) {
+		_reset_child_skeleton_poses();
+	}
+	copy_bone_skin_scale = p_enabled;
+}
+
+bool RetargetModifier3D::is_copying_bone_skin_scale() const {
+	return copy_bone_skin_scale;
 }
 
 void RetargetModifier3D::set_use_global_pose(bool p_use_global_pose) {

--- a/scene/3d/retarget_modifier_3d.h
+++ b/scene/3d/retarget_modifier_3d.h
@@ -36,6 +36,8 @@
 class RetargetModifier3D : public SkeletonModifier3D {
 	GDCLASS(RetargetModifier3D, SkeletonModifier3D);
 
+	const Vector3 DEFAULT_SKIN_SCALE = Vector3(1, 1, 1);
+
 public:
 	enum TransformFlag {
 		TRANSFORM_FLAG_POSITION = 1,
@@ -47,6 +49,7 @@ public:
 private:
 	Ref<SkeletonProfile> profile;
 
+	bool copy_bone_skin_scale = true;
 	bool use_global_pose = false;
 	BitField<TransformFlag> enable_flags = TRANSFORM_FLAG_ALL;
 
@@ -81,6 +84,7 @@ private:
 
 	void _retarget_global_pose();
 	void _retarget_pose();
+	void _retarget_skin_scale();
 
 protected:
 	virtual void _skeleton_changed(Skeleton3D *p_old, Skeleton3D *p_new) override;
@@ -101,6 +105,8 @@ protected:
 public:
 	virtual PackedStringArray get_configuration_warnings() const override;
 
+	void set_copy_bone_skin_scale(bool p_enabled);
+	bool is_copying_bone_skin_scale() const;
 	void set_use_global_pose(bool p_use_global_pose);
 	bool is_using_global_pose() const;
 	void set_enable_flags(BitField<TransformFlag> p_enable_flags);


### PR DESCRIPTION
- Prerequisite https://github.com/godotengine/godot/pull/120609

## What problem(s) does this PR solve?

When using RetargetModifier3D, if you want to scale a model’s skin using `skin_scale`, you’ll need to scale the skin of the `OriginalSkeleton` because the `GeneralSkeleton` does not have a skin. However, doing so causes a significant misalignment between the `GeneralSkeleton` and the `OriginalSkeleton`, making it difficult to view.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/e6918960-23d9-459d-b54c-08011ee300d1" />

If you apply `skin_scale` and `BoneSpreader` only to `GeneralSkeleton`, only the position animation will be retargeted, and the skin scaling will be ignored.

<img width="600" alt="image" src="https://github.com/user-attachments/assets/1825bc07-2c17-439c-be23-1f2612bdaf6e" />

We will add an option to RetargetModifier to copy the `skin_scale` from the GeneralSkeleton to the OriginalSkeleton. This automates the coordinate transformation, allowing `skin_scale` to be applied to both. The process is as follows:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/4208ed43-8cbe-426f-aac0-24ec704fb0bd" />

<img width="600" alt="image" src="https://github.com/user-attachments/assets/00a2c56e-84e8-41dd-997c-aec8a8e1c4bd" />

<img width="543" height="310" alt="image" src="https://github.com/user-attachments/assets/dc16368b-a8ff-4cda-98ee-4b207fc76da1" />


