### PR TITLE
Fix GDScriptDocGen not handling named enums properly

### DIFF
--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -647,6 +647,7 @@ public:
 		String deprecated_message;
 		bool is_experimental = false;
 		String experimental_message;
+		Vector<ConstantDoc> constants;
 		static EnumDoc from_dict(const Dictionary &p_dict) {
 			EnumDoc doc;
 
@@ -674,6 +675,14 @@ public:
 				doc.experimental_message = p_dict["experimental"];
 			}
 
+			Array constants;
+			if (p_dict.has("constants")) {
+				constants = p_dict["constants"];
+			}
+			for (int i = 0; i < constants.size(); i++) {
+				doc.constants.push_back(ConstantDoc::from_dict(constants[i]));
+			}
+
 			return doc;
 		}
 		static Dictionary to_dict(const EnumDoc &p_doc) {
@@ -689,6 +698,14 @@ public:
 
 			if (p_doc.is_experimental) {
 				dict["experimental"] = p_doc.experimental_message;
+			}
+
+			if (!p_doc.constants.is_empty()) {
+				Array constants;
+				for (int i = 0; i < p_doc.constants.size(); i++) {
+					constants.push_back(ConstantDoc::to_dict(p_doc.constants[i]));
+				}
+				dict["constants"] = constants;
 			}
 
 			return dict;

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -3711,6 +3711,54 @@ EditorHelpBit::HelpData EditorHelpBit::_get_constant_help_data(const StringName 
 				doc_constant_cache[p_class_name][constant.name] = current;
 			}
 		}
+	} else { // Check if "class" is named enum
+		String class_name_and_enum = p_class_name.string();
+		int sep_idx = class_name_and_enum.rfind(".");
+		if (sep_idx >= 0) {
+			String enum_name = class_name_and_enum.substr(sep_idx + 1, class_name_and_enum.size() - sep_idx - 1);
+			String class_name = class_name_and_enum.substr(0, sep_idx);
+			const DocData::ClassDoc *parent_class_doc = EditorHelp::get_doc(class_name);
+			if (parent_class_doc) {
+				const bool is_native = !parent_class_doc->is_script_doc;
+
+				if (parent_class_doc->enums.has(enum_name)) {
+					for (const DocData::ConstantDoc &constant : parent_class_doc->enums[enum_name].constants) {
+						HelpData current;
+						current.description = HANDLE_DOC(constant.description);
+						if (constant.is_deprecated) {
+							if (constant.deprecated_message.is_empty()) {
+								current.deprecated_message = TTR("This constant may be changed or removed in future versions.");
+							} else {
+								current.deprecated_message = HANDLE_DOC(constant.deprecated_message);
+							}
+						}
+						if (constant.is_experimental) {
+							if (constant.experimental_message.is_empty()) {
+								current.experimental_message = TTR("This constant may be changed or removed in future versions.");
+							} else {
+								current.experimental_message = HANDLE_DOC(constant.experimental_message);
+							}
+						}
+						current.doc_type = { constant.type, constant.enumeration, constant.is_bitfield };
+						if (constant.is_value_valid) {
+							current.value = constant.value;
+						}
+
+						if (constant.name == p_constant_name) {
+							result = current;
+
+							if (!is_native) {
+								break;
+							}
+						}
+
+						if (is_native) {
+							doc_constant_cache[p_class_name][constant.name] = current;
+						}
+					}
+				}
+			}
+		}
 	}
 
 	return result;

--- a/modules/gdscript/editor/gdscript_docgen.cpp
+++ b/modules/gdscript/editor/gdscript_docgen.cpp
@@ -544,7 +544,6 @@ void GDScriptDocGen::_generate_docs(GDScript *p_script, const GDP::ClassNode *p_
 				enum_doc.deprecated_message = m_enum->doc_data.deprecated_message;
 				enum_doc.is_experimental = m_enum->doc_data.is_experimental;
 				enum_doc.experimental_message = m_enum->doc_data.experimental_message;
-				doc.enums[name] = enum_doc;
 
 				for (const GDP::EnumNode::Value &val : m_enum->values) {
 					DocData::ConstantDoc const_doc;
@@ -559,9 +558,10 @@ void GDScriptDocGen::_generate_docs(GDScript *p_script, const GDP::ClassNode *p_
 					const_doc.is_experimental = val.doc_data.is_experimental;
 					const_doc.experimental_message = val.doc_data.experimental_message;
 
-					doc.constants.push_back(const_doc);
+					enum_doc.constants.push_back(const_doc);
 				}
 
+				doc.enums[name] = enum_doc;
 			} break;
 
 			case GDP::ClassNode::Member::ENUM_VALUE: {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #122585 #122737
#122633 #122584

## Additional information
This PR changes/fixes how `GDScriptDocGen` stores the constants of named enums. `EnumDoc` now stores its associated constants instead them being added to the parent class constants. This also fixes a bug that allowed named enums to shadow the doc data of constants of the same name in the parent class.

It also adds a second code path in `EditorHelpBit::_get_constant_help_data` to check if the `p_class_name` refers to a named enum. This is a bit ugly but likely the easiest solution. Things could probably be reshuffled a bit to reduce the code duplication in the function but at the cost of being harder to follow.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
