### PR TITLE
Fix small typos in comments and internal method names

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -462,7 +462,7 @@ void ResourceLoader::_run_load_task(void *p_userdata) {
 
 			if (should_yield) {
 				// We need to make sure we yield on our actual current task. If we are
-				// waiting we are certainly not the the task being ran.
+				// waiting we are certainly not the task being ran.
 				yielders.push_back(WorkerThreadPool::get_singleton()->get_caller_task_id());
 			}
 

--- a/editor/script/script_editor_navigation_marker.cpp
+++ b/editor/script/script_editor_navigation_marker.cpp
@@ -88,7 +88,7 @@ bool ScriptEditorNavigationMarker::is_traversing() const {
 	return traverse_in_progress;
 }
 
-bool ScriptEditorNavigationMarker::is_locate_just_occured() const {
+bool ScriptEditorNavigationMarker::is_locate_just_occurred() const {
 	if (Engine::get_singleton()->is_in_physics_frame()) {
 		return locate_end_physics_frame == Engine::get_singleton()->get_physics_frames() || locate_end_physics_frame == Engine::get_singleton()->get_physics_frames() - 1;
 	} else {
@@ -96,7 +96,7 @@ bool ScriptEditorNavigationMarker::is_locate_just_occured() const {
 	}
 }
 
-bool ScriptEditorNavigationMarker::is_traverse_just_occured() const {
+bool ScriptEditorNavigationMarker::is_traverse_just_occurred() const {
 	if (Engine::get_singleton()->is_in_physics_frame()) {
 		return traverse_end_physics_frame == Engine::get_singleton()->get_physics_frames() || traverse_end_physics_frame == Engine::get_singleton()->get_physics_frames() - 1;
 	} else {

--- a/editor/script/script_editor_navigation_marker.h
+++ b/editor/script/script_editor_navigation_marker.h
@@ -61,6 +61,6 @@ public:
 	bool is_locating() const;
 	bool is_traversing() const;
 
-	bool is_locate_just_occured() const;
-	bool is_traverse_just_occured() const;
+	bool is_locate_just_occurred() const;
+	bool is_traverse_just_occurred() const;
 };

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1215,7 +1215,7 @@ void ScriptTextEditor::_breakpoint_toggled(int p_row) {
 }
 
 void ScriptTextEditor::_on_caret_moved() {
-	if (ScriptEditorNavigationMarker::get_singleton()->is_locate_just_occured() || ScriptEditorNavigationMarker::get_singleton()->is_traverse_just_occured() || ScriptEditorNavigationMarker::get_singleton()->is_locating() || ScriptEditorNavigationMarker::get_singleton()->is_traversing()) {
+	if (ScriptEditorNavigationMarker::get_singleton()->is_locate_just_occurred() || ScriptEditorNavigationMarker::get_singleton()->is_traverse_just_occurred() || ScriptEditorNavigationMarker::get_singleton()->is_locating() || ScriptEditorNavigationMarker::get_singleton()->is_traversing()) {
 		return;
 	}
 	if (code_editor->is_previewing_navigation_change()) {

--- a/servers/rendering/rendering_device_graph.cpp
+++ b/servers/rendering/rendering_device_graph.cpp
@@ -337,7 +337,7 @@ void RenderingDeviceGraph::_check_discardable_attachment_dependency(ResourceTrac
 		return;
 	}
 
-	// Check if the command is a a draw list that clears the attachment completely. If it is, we don't need to modify the previous draw list.
+	// Check if the command is a draw list that clears the attachment completely. If it is, we don't need to modify the previous draw list.
 	uint32_t command_offset = command_data_offsets[p_command_index];
 	RecordedDrawListCommand *draw_list_command = reinterpret_cast<RecordedDrawListCommand *>(&command_data[command_offset]);
 	if (draw_list_command->type == RecordedCommand::TYPE_DRAW_LIST) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.
-->

## What problem(s) does this PR solve?

This PR fixes a few small typos:

- Removes duplicated words in code comments:
  - `core/io/resource_loader.cpp`: "not the **the** task being ran"
  - `servers/rendering/rendering_device_graph.cpp`: "is **a a** draw list"
- Fixes misspelled "occured" -> "occurred" in `ScriptEditorNavigationMarker` internal method names (`is_locate_just_occured()` / `is_traverse_just_occured()`) and their call sites in `script_text_editor.cpp`. These methods are editor-internal and not exposed to scripting, so no compatibility impact.

No functional changes intended.

## Additional information

AI disclosure: an AI coding assistant was used to search the codebase for these typos and apply the mechanical fixes.