### PR TITLE
Clear translation domains when switching to English

### DIFF
--- a/editor/settings/editor_settings.cpp
+++ b/editor/settings/editor_settings.cpp
@@ -1508,6 +1508,11 @@ void EditorSettings::setup_language(bool p_initial_setup) {
 
 	if (lang == "en") {
 		TranslationServer::get_singleton()->set_locale(lang);
+
+		TranslationServer::get_singleton()->get_editor_domain()->clear();
+		TranslationServer::get_singleton()->get_property_domain()->clear();
+		TranslationServer::get_singleton()->get_doc_domain()->clear();
+
 		emit_signal("_translation_changed");
 		return; // Default, nothing to do.
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

When changing editor language, all editor translation domains are cleared and new translations are loaded. However, since English is not a Translation, the clear/load process was skipped.

This PR makes switching to English properly clear loaded translations.

## Additional information

Not sure why the clearing even happens tbh. Maybe it's to save memory? It causes problems when translating addons, because any translation injected to editor's domains have to be re-added, which is rather problematic (you have to propagate translation notification again, because UI updates before re-adding translations).
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
