### PR TITLE
Improve various dynamic method usages

### DIFF
--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -342,26 +342,7 @@ void InspectorDock::_prepare_history() {
 
 		Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(obj);
 
-		String text;
-		if (obj->has_method("_get_editor_name")) {
-			text = obj->call("_get_editor_name");
-		} else if (Object::cast_to<Resource>(obj)) {
-			Resource *r = Object::cast_to<Resource>(obj);
-			if (r->get_path().is_resource_file()) {
-				text = r->get_path().get_file();
-			} else if (!r->get_name().is_empty()) {
-				text = r->get_name();
-			} else {
-				text = r->get_class();
-			}
-		} else if (Object::cast_to<Node>(obj)) {
-			text = Object::cast_to<Node>(obj)->get_name();
-		} else if (obj->is_class("EditorDebuggerRemoteObjects")) {
-			text = obj->call("get_title");
-		} else {
-			text = obj->get_class();
-		}
-
+		String text = InspectorDock::get_object_display_name(obj);
 		if (i == editor_history->get_history_pos() && current) {
 			text += " " + TTR("(Current)");
 		}
@@ -528,6 +509,32 @@ void InspectorDock::_bind_methods() {
 	ClassDB::bind_method("apply_script_properties", &InspectorDock::apply_script_properties);
 
 	ADD_SIGNAL(MethodInfo("request_help"));
+}
+
+String InspectorDock::get_object_display_name(Object *p_object) {
+	Callable::CallError err;
+	const String editor_name = p_object->callp(SNAME("_get_editor_name"), nullptr, 0, err);
+
+	if (err.error == Callable::CallError::CALL_OK) {
+		return editor_name;
+	}
+	if (Object::cast_to<Resource>(p_object)) {
+		Resource *r = Object::cast_to<Resource>(p_object);
+		if (r->get_path().is_resource_file()) {
+			return r->get_path().get_file();
+		}
+		if (!r->get_name().is_empty()) {
+			return r->get_name();
+		}
+		return r->get_class();
+	}
+	if (Object::cast_to<Node>(p_object)) {
+		return Object::cast_to<Node>(p_object)->get_name();
+	}
+	if (Object::cast_to<EditorDebuggerRemoteObjects>(p_object)) {
+		return p_object->call(SNAME("get_title"));
+	}
+	return p_object->get_class();
 }
 
 void InspectorDock::edit_resource(const Ref<Resource> &p_resource) {

--- a/editor/docks/inspector_dock.h
+++ b/editor/docks/inspector_dock.h
@@ -145,6 +145,8 @@ protected:
 	void _notification(int p_what);
 
 public:
+	static String get_object_display_name(Object *p_object);
+
 	void edit_resource(const Ref<Resource> &p_resource);
 	void open_resource(const String &p_type);
 	void clear();

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1292,7 +1292,7 @@ void EditorSelection::add_node(Node *p_node) {
 	node_list_changed = true;
 	Object *meta = nullptr;
 	for (Object *E : editor_plugins) {
-		meta = E->call("_get_editor_data", p_node);
+		meta = E->call(SNAME("_get_editor_data"), p_node);
 		if (meta) {
 			break;
 		}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3186,17 +3186,15 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 		InspectorDock::get_inspector_singleton()->set_use_folding(!disable_folding, false);
 	}
 
-	bool is_resource = current_obj->is_class("Resource");
-	bool is_node = current_obj->is_class("Node");
+	bool is_resource = Object::cast_to<Resource>(current_obj);
+	bool is_node = Object::cast_to<Node>(current_obj);
 	bool skip_main_plugin = false;
 
 	String editable_info; // None by default.
 	bool info_is_warning = false;
 
-	if (current_obj->has_method("_is_read_only")) {
-		if (current_obj->call("_is_read_only")) {
-			editable_info = TTR("This object is marked as read-only, so it's not editable.");
-		}
+	if (current_obj->call(SNAME("_is_read_only")).operator bool()) {
+		editable_info = TTR("This object is marked as read-only, so it's not editable.");
 	}
 
 	if (is_resource) {
@@ -7192,9 +7190,7 @@ void EditorNode::_notify_nodes_scene_reimported(Node *p_node, Array p_reimported
 		}
 	}
 
-	if (p_node->has_method("_nodes_scene_reimported")) {
-		p_node->call("_nodes_scene_reimported", p_reimported_nodes);
-	}
+	p_node->call(SNAME("_nodes_scene_reimported"), p_reimported_nodes);
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		_notify_nodes_scene_reimported(p_node->get_child(i), p_reimported_nodes);

--- a/editor/export/dedicated_server_export_plugin.cpp
+++ b/editor/export/dedicated_server_export_plugin.cpp
@@ -119,7 +119,7 @@ Ref<Resource> DedicatedServerExportPlugin::_customize_resource(const Ref<Resourc
 		current_export_mode = _get_export_mode_for_path(p_path);
 	}
 
-	if (p_resource.is_valid() && current_export_mode == EditorExportPreset::MODE_FILE_STRIP && p_resource->has_method("create_placeholder")) {
+	if (p_resource.is_valid() && current_export_mode == EditorExportPreset::MODE_FILE_STRIP) {
 		Callable::CallError err;
 		Ref<Resource> result = p_resource->callp("create_placeholder", nullptr, 0, err);
 		if (err.error == Callable::CallError::CALL_OK) {

--- a/editor/gui/editor_object_selector.cpp
+++ b/editor/gui/editor_object_selector.cpp
@@ -31,6 +31,7 @@
 #include "editor_object_selector.h"
 
 #include "core/object/callable_mp.h"
+#include "editor/docks/inspector_dock.h"
 #include "editor/editor_data.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
@@ -130,30 +131,7 @@ void EditorObjectSelector::update_path() {
 		}
 
 		if (i == history->get_path_size() - 1) {
-			String name;
-			if (obj->has_method("_get_editor_name")) {
-				name = obj->call("_get_editor_name");
-			} else if (Object::cast_to<Resource>(obj)) {
-				Resource *r = Object::cast_to<Resource>(obj);
-				if (r->get_path().is_resource_file()) {
-					name = r->get_path().get_file();
-				} else {
-					name = r->get_name();
-				}
-
-				if (name.is_empty()) {
-					name = r->get_class();
-				}
-			} else if (obj->is_class("EditorDebuggerRemoteObjects")) {
-				name = obj->call("get_title");
-			} else if (Object::cast_to<Node>(obj)) {
-				name = Object::cast_to<Node>(obj)->get_name();
-			} else if (Object::cast_to<Resource>(obj) && !Object::cast_to<Resource>(obj)->get_name().is_empty()) {
-				name = Object::cast_to<Resource>(obj)->get_name();
-			} else {
-				name = obj->get_class();
-			}
-
+			const String name = InspectorDock::get_object_display_name(obj);
 			current_object_label->set_text(name);
 			set_tooltip_text(name + "\n" + vformat(TTR("Type: %s"), obj->get_class()) + "\n" + TTR("Click to open a list of sub-resources."));
 		}

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -301,6 +301,19 @@ Size2 EditorProperty::get_minimum_size() const {
 	return ms;
 }
 
+String EditorProperty::get_property_warning(Object *p_object, const StringName &p_property) {
+	Callable::CallError err;
+
+	const Variant v = p_property;
+	const Variant *argptrs[1] = { &v };
+
+	const String warning = p_object->callp(SNAME("_get_property_warning"), argptrs, 1, err);
+	if (err.error == Callable::CallError::CALL_OK) {
+		return warning;
+	}
+	return String();
+}
+
 void EditorProperty::emit_changed(const StringName &p_property, const Variant &p_value, const StringName &p_field, bool p_changing) {
 	Variant args[4] = { p_property, p_value, p_field, p_changing };
 	const Variant *argptrs[4] = { &args[0], &args[1], &args[2], &args[3] };
@@ -965,10 +978,7 @@ void EditorProperty::update_editor_property_status() {
 		new_pinned = node->is_property_pinned(property);
 	}
 
-	bool new_warning = false;
-	if (object->has_method("_get_property_warning")) {
-		new_warning = !String(object->call("_get_property_warning", property)).is_empty();
-	}
+	bool new_warning = object->call(SNAME("_get_property_warning")).operator bool();
 
 	// Check if the property is deprecated.
 	if (!new_warning && !doc_path.is_empty()) {
@@ -1551,11 +1561,9 @@ Control *EditorProperty::make_custom_tooltip(const String &p_text) const {
 	String symbol;
 	String prologue;
 
-	if (object->has_method("_get_property_warning")) {
-		const String custom_warning = object->call("_get_property_warning", property);
-		if (!custom_warning.is_empty()) {
-			prologue = "[b][color=" + theme_cache.warning_color.to_html(false) + "]" + custom_warning + "[/color][/b]";
-		}
+	const String custom_warning = EditorProperty::get_property_warning(object, property);
+	if (!custom_warning.is_empty()) {
+		prologue = "[b][color=" + theme_cache.warning_color.to_html(false) + "]" + custom_warning + "[/color][/b]";
 	}
 
 	if (has_doc_tooltip) {
@@ -2485,7 +2493,7 @@ void EditorInspectorSection::_notification(int p_what) {
 				if (rtl) {
 					text_offset.x = margin_end;
 				}
-				if (object->has_method("_get_property_warning") && !String(object->call("_get_property_warning", related_enable_property)).is_empty()) {
+				if (!EditorProperty::get_property_warning(object, related_enable_property).is_empty()) {
 					font_color = theme_cache.warning_color;
 				}
 				const Color string_color = header_hover ? theme_cache.font_hover_mono_color : font_color;
@@ -2589,11 +2597,9 @@ Control *EditorInspectorSection::make_custom_tooltip(const String &p_text) const
 	String symbol;
 	String prologue;
 
-	if (object->has_method("_get_property_warning")) {
-		const String custom_warning = object->call("_get_property_warning", related_enable_property);
-		if (!custom_warning.is_empty()) {
-			prologue = "[b][color=" + theme_cache.warning_color.to_html(false) + "]" + custom_warning + "[/color][/b]";
-		}
+	const String custom_warning = EditorProperty::get_property_warning(object, related_enable_property);
+	if (!custom_warning.is_empty()) {
+		prologue = "[b][color=" + theme_cache.warning_color.to_html(false) + "]" + custom_warning + "[/color][/b]";
 	}
 
 	symbol = p_text;
@@ -4436,9 +4442,7 @@ void EditorInspector::update_tree() {
 	bool draw_warning = false;
 	bool all_read_only = false;
 	if (is_inside_tree() && EditorNode::get_singleton()) {
-		if (object->has_method("_is_read_only")) {
-			all_read_only = object->call("_is_read_only");
-		}
+		all_read_only = object->call(SNAME("_is_read_only")).operator bool();
 
 		Node *nod = Object::cast_to<Node>(object);
 		Node *es = EditorNode::get_singleton()->get_edited_scene();
@@ -4644,7 +4648,7 @@ void EditorInspector::update_tree() {
 			continue;
 		}
 
-		if (p.name == "script" && (hide_script || bool(object->call("_hide_script_from_inspector")))) {
+		if (p.name == "script" && (hide_script || bool(object->call(SNAME("_hide_script_from_inspector"))))) {
 			// Hide script variables from inspector if required.
 			continue;
 		}
@@ -5334,7 +5338,7 @@ void EditorInspector::update_tree() {
 		}
 	}
 
-	if (!hide_metadata && !object->call("_hide_metadata_from_inspector")) {
+	if (!hide_metadata && !object->call(SNAME("_hide_metadata_from_inspector"))) {
 		// Add 4px of spacing between the "Add Metadata" button and the content above it.
 		Control *spacer = memnew(Control);
 		spacer->set_custom_minimum_size(Size2(0, 4) * EDSCALE);
@@ -5700,7 +5704,7 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 	}
 
 	EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
-	if (!undo_redo || bool(object->call("_dont_undo_redo"))) {
+	if (!undo_redo || bool(object->call(SNAME("_dont_undo_redo")))) {
 		object->set(p_name, p_value);
 		if (p_refresh_all) {
 			_edit_request_change(object, "");
@@ -5752,12 +5756,12 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 			}
 		}
 
-		PackedStringArray linked_properties_dynamic = object->call("_get_linked_undo_properties", p_name, p_value);
-		for (int i = 0; i < linked_properties_dynamic.size(); i++) {
+		const PackedStringArray linked_properties_dynamic = object->call(SNAME("_get_linked_undo_properties"), p_name, p_value);
+		for (const String &prop : linked_properties_dynamic) {
 			valid = false;
-			Variant undo_value = object->get(linked_properties_dynamic[i], &valid);
+			Variant undo_value = object->get(prop, &valid);
 			if (valid) {
-				undo_redo->add_undo_property(object, linked_properties_dynamic[i], undo_value);
+				undo_redo->add_undo_property(object, prop, undo_value);
 			}
 		}
 
@@ -5765,9 +5769,7 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 		Variant v_object = object;
 		Variant v_name = p_name;
 		const Vector<Callable> &callbacks = EditorNode::get_editor_data().get_undo_redo_inspector_hook_callback();
-		for (int i = 0; i < callbacks.size(); i++) {
-			const Callable &callback = callbacks[i];
-
+		for (const Callable &callback : callbacks) {
 			const Variant *p_arguments[] = { &v_undo_redo, &v_object, &v_name, &p_value };
 			Variant return_value;
 			Callable::CallError call_error;

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -239,6 +239,8 @@ protected:
 	void _accessibility_action_click(const Variant &p_data);
 
 public:
+	static String get_property_warning(Object *p_object, const StringName &p_property);
+
 	void emit_changed(const StringName &p_property, const Variant &p_value, const StringName &p_field = StringName(), bool p_changing = false);
 
 	String get_tooltip_string(const String &p_string) const;

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -3354,8 +3354,12 @@ Node *EditorPropertyNodePath::get_base_node() {
 		return base_node;
 	}
 
-	if (get_edited_object()->has_method("get_root_path")) {
-		return Object::cast_to<Node>(get_edited_object()->call("get_root_path"));
+	{
+		Callable::CallError err;
+		Object *root_node = get_edited_object()->callp(SNAME("get_root_path"), nullptr, 0, err);
+		if (err.error == Callable::CallError::CALL_OK) {
+			return Object::cast_to<Node>(root_node);
+		}
 	}
 
 	if (!base_node) {

--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -56,6 +56,7 @@
 #include "scene/gui/flow_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/texture_rect.h"
+#include "scene/main/canvas_layer.h"
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "scene/resources/packed_scene.h"
@@ -110,7 +111,7 @@ void SceneTreeEditor::_gui_input(const Ref<InputEvent> &p_event) {
 					NodePath node_path = tree_item->get_metadata(0);
 					Node *node = get_scene_node()->get_node_or_null(node_path);
 					if (node != nullptr) {
-						visibility_drag_value = !node->call("is_visible");
+						visibility_drag_value = !node->call(SceneStringName(is_visible));
 						visibility_drag_start_pos = tree_mouse_pos;
 						visibility_drag_start_node = node->get_instance_id();
 					}
@@ -150,7 +151,7 @@ void SceneTreeEditor::_gui_input(const Ref<InputEvent> &p_event) {
 			bool crossed_drag_threshold = visibility_drag_start_pos.distance_to(tree_mouse_pos) > get_viewport()->get_drag_threshold();
 			if (tree_button_id == BUTTON_VISIBILITY && (crossed_drag_threshold || !visibility_drag_nodes.is_empty())) {
 				Node *start_node = ObjectDB::get_instance<Node>(visibility_drag_start_node);
-				if (start_node != nullptr && (bool)start_node->call("is_visible") != visibility_drag_value) {
+				if (start_node != nullptr && (bool)start_node->call(SceneStringName(is_visible)) != visibility_drag_value) {
 					start_node->call("set_visible", visibility_drag_value);
 					visibility_drag_nodes.push_back(visibility_drag_start_node);
 				}
@@ -159,7 +160,7 @@ void SceneTreeEditor::_gui_input(const Ref<InputEvent> &p_event) {
 				ERR_FAIL_NULL(tree_item);
 				NodePath node_path = tree_item->get_metadata(0);
 				Node *node = get_scene_node()->get_node_or_null(node_path);
-				if (node != nullptr && (bool)node->call("is_visible") != visibility_drag_value) {
+				if (node != nullptr && (bool)node->call(SceneStringName(is_visible)) != visibility_drag_value) {
 					node->call("set_visible", visibility_drag_value);
 					visibility_drag_nodes.push_back(node->get_instance_id());
 				}
@@ -346,8 +347,8 @@ void SceneTreeEditor::_revoke_unique_name() {
 }
 
 void SceneTreeEditor::_toggle_visible(Node *p_node) {
-	if (p_node->has_method("is_visible") && p_node->has_method("set_visible")) {
-		bool v = bool(p_node->call("is_visible"));
+	if (p_node->has_method(SceneStringName(is_visible)) && p_node->has_method(SNAME("set_visible"))) {
+		bool v = bool(p_node->call(SceneStringName(is_visible)));
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 		undo_redo->add_do_method(p_node, "set_visible", !v);
 		undo_redo->add_undo_method(p_node, "set_visible", v);
@@ -714,8 +715,8 @@ void SceneTreeEditor::_update_node(Node *p_node, TreeItem *p_item, bool p_part_o
 			p_item->add_button(0, get_editor_theme_icon(SNAME("Group")), BUTTON_GROUP, false, TTR("Children are not selectable.\nClick to make them selectable."));
 		}
 
-		if (p_node->has_method("is_visible") && p_node->has_method("set_visible") && p_node->has_signal(SceneStringName(visibility_changed))) {
-			bool is_visible = p_node->call("is_visible");
+		if (p_node->has_method(SceneStringName(is_visible)) && p_node->has_method(SNAME("set_visible")) && p_node->has_signal(SceneStringName(visibility_changed))) {
+			bool is_visible = p_node->call(SceneStringName(is_visible));
 			if (is_visible) {
 				p_item->add_button(0, get_editor_theme_icon(SNAME("GuiVisibilityVisible")), BUTTON_VISIBILITY, false, TTR("Toggle Visibility"));
 			} else {
@@ -833,9 +834,9 @@ void SceneTreeEditor::_node_visibility_changed(Node *p_node) {
 
 	bool node_visible = false;
 
-	if (p_node->has_method("is_visible")) {
-		node_visible = p_node->call("is_visible");
-		if (p_node->is_class("CanvasItem") || p_node->is_class("CanvasLayer") || p_node->is_class("Window")) {
+	if (p_node->has_method(SceneStringName(is_visible))) {
+		node_visible = p_node->call(SceneStringName(is_visible));
+		if (Object::cast_to<CanvasItem>(p_node) || Object::cast_to<CanvasLayer>(p_node) || Object::cast_to<Window>(p_node)) {
 			CanvasItemEditor::get_singleton()->get_viewport_control()->queue_redraw();
 		}
 	}
@@ -850,7 +851,7 @@ void SceneTreeEditor::_node_visibility_changed(Node *p_node) {
 }
 
 void SceneTreeEditor::_update_visibility_color(Node *p_node, TreeItem *p_item) {
-	if (p_node->has_method("is_visible_in_tree")) {
+	if (p_node->has_method(SNAME("is_visible_in_tree"))) {
 		Color color(1, 1, 1, 1);
 		bool visible_on_screen = p_node->call("is_visible_in_tree");
 		if (!visible_on_screen) {

--- a/modules/gltf/editor/editor_scene_exporter_gltf_settings.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_settings.cpp
@@ -176,11 +176,10 @@ String get_friendly_config_prefix(Ref<GLTFDocumentExtension> p_extension) {
 }
 
 bool is_any_node_invisible(Node *p_node) {
-	if (p_node->has_method("is_visible")) {
-		bool visible = p_node->call("is_visible");
-		if (!visible) {
-			return true;
-		}
+	Callable::CallError err;
+	bool visible = p_node->callp(SceneStringName(is_visible), nullptr, 0, err);
+	if (err.error == Callable::CallError::CALL_OK && !visible) {
+		return true;
 	}
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		if (is_any_node_invisible(p_node->get_child(i))) {

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -4240,8 +4240,10 @@ void GLTFDocument::_convert_scene_node(Ref<GLTFState> p_state, Node *p_current, 
 #endif // TOOLS_ENABLED
 	Ref<GLTFNode> gltf_node;
 	gltf_node.instantiate();
-	if (p_current->has_method("is_visible")) {
-		bool visible = p_current->call("is_visible");
+
+	Callable::CallError err;
+	bool visible = p_current->callp(SceneStringName(is_visible), nullptr, 0, err);
+	if (err.error == Callable::CallError::CALL_OK) {
 		if (!visible && _visibility_mode == VISIBILITY_MODE_EXCLUDE) {
 			return;
 		}

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
@@ -2277,9 +2277,10 @@ Dictionary VisualShaderEditor::get_custom_node_data(Ref<VisualShaderNodeCustom> 
 	category = category.rstrip("/");
 	category = category.lstrip("/");
 	category = "Addons/" + category;
-	if (p_custom_node->has_method("_get_subcategory")) {
-		String subcategory = (String)p_custom_node->call("_get_subcategory");
-		if (!subcategory.is_empty()) {
+	{
+		Callable::CallError err;
+		const String subcategory = p_custom_node->callp("_get_subcategory", nullptr, 0, err);
+		if (err.error == Callable::CallError::CALL_OK && !subcategory.is_empty()) {
 			category += "/" + subcategory;
 		}
 	}

--- a/scene/debugger/scene_debugger_object.cpp
+++ b/scene/debugger/scene_debugger_object.cpp
@@ -297,7 +297,6 @@ SceneDebuggerTree::SceneDebuggerTree(Node *p_root) {
 	List<Node *> stack;
 	stack.push_back(p_root);
 	bool is_root = true;
-	const StringName &is_visible_sn = SNAME("is_visible");
 	const StringName &is_visible_in_tree_sn = SNAME("is_visible_in_tree");
 	while (stack.size()) {
 		Node *n = stack.front()->get();
@@ -312,8 +311,8 @@ SceneDebuggerTree::SceneDebuggerTree(Node *p_root) {
 		if (is_root) {
 			// Prevent root window visibility from being changed.
 			is_root = false;
-		} else if (n->has_method(is_visible_sn)) {
-			const Variant visible = n->call(is_visible_sn);
+		} else if (n->has_method(SceneStringName(is_visible))) {
+			const Variant visible = n->call(SceneStringName(is_visible));
 			if (visible.get_type() == Variant::BOOL) {
 				view_flags = RemoteNode::VIEW_HAS_VISIBLE_METHOD;
 				view_flags |= uint8_t(visible) * RemoteNode::VIEW_VISIBLE;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2871,12 +2871,10 @@ void Viewport::_push_text_input(const String &p_text, bool p_emit_signal) {
 		gui.subwindow_focused->push_text_input(p_text);
 		return;
 	}
-
-	StringName set_text_method = SNAME("_set_text");
-	if (!gui.key_focus || !gui.key_focus->has_method(set_text_method)) {
+	if (!gui.key_focus) {
 		return;
 	}
-	gui.key_focus->call(set_text_method, p_text, p_emit_signal);
+	gui.key_focus->call(SNAME("_set_text"), p_text, p_emit_signal);
 }
 
 void Viewport::push_text_input(const String &p_text) {

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -48,6 +48,7 @@ public:
 	const StringName draw = "draw";
 	const StringName hidden = "hidden";
 	const StringName visibility_changed = "visibility_changed";
+	const StringName is_visible = "is_visible";
 
 	const StringName input_event = "input_event";
 	const StringName gui_input = "gui_input";


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

I noticed editor code has many places where `call()` is used, preceded by `has_method()`. This is rather redundant, `call()` does not print any errors if it fails. For cases where `has_method()` affects behavior, one can use `callp()` and check if the call succeeded. This is what most of the changes in this PR are.

Other than that:
- Added `is_visible` SceneStringName
- Added `SNAME()` for some calls (`call()` takes StringName, not String)
- Replaced some `is_class()` calls with casting
- Deduplicated some code with static methods

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
