### PR TITLE
Audio: Fix stream playbacks leaking at exit

### DIFF
--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -1476,10 +1476,6 @@ void AudioServer::finish() {
 		AudioDriverManager::get_driver(i)->finish();
 	}
 
-	// The mix step is the only thing that takes playbacks off the list, and the
-	// drivers are stopped by now, so no further mix step will run. A playback left
-	// on the list would keep its reference and get reported as a leaked instance
-	// at exit.
 	for (AudioStreamPlaybackListNode *playback : playback_list) {
 		_delete_stream_playback_list_node(playback);
 	}

--- a/servers/audio/audio_server.cpp
+++ b/servers/audio/audio_server.cpp
@@ -1476,6 +1476,15 @@ void AudioServer::finish() {
 		AudioDriverManager::get_driver(i)->finish();
 	}
 
+	// The mix step is the only thing that takes playbacks off the list, and the
+	// drivers are stopped by now, so no further mix step will run. A playback left
+	// on the list would keep its reference and get reported as a leaked instance
+	// at exit.
+	for (AudioStreamPlaybackListNode *playback : playback_list) {
+		_delete_stream_playback_list_node(playback);
+	}
+	_cleanup_lists();
+
 	for (int i = 0; i < buses.size(); i++) {
 		memdelete(buses[i]);
 	}


### PR DESCRIPTION
Fixes #76745

Quitting the game while a sound is playing leaks the playback object:

```
WARNING: 4 ObjectDB instances were leaked at exit (run with `--verbose` for details).
ERROR: 2 resources still in use at exit (run with --verbose for details).
```

With `--verbose` the four are AudioStreamPlaybackOggVorbis, OggPacketSequencePlayback, OggPacketSequence and AudioStreamOggVorbis, the same list as in the issue.

AudioServer only takes a playback off its list during a mix step. On shutdown the audio drivers stop first, so no mix step runs after that, and whatever is left in the list keeps its reference. Calling `stop()` before quitting does not help either: `stop_playback_stream()` only sets the state to `FADE_OUT_TO_DELETION` and leaves the removal to the next mix step.

`AudioServer::finish()` now empties the list itself, right after the drivers are stopped. It uses the same two calls the mix step uses, and nothing can be mixing at that point.

To reproduce, put this on the root node of the main scene, with any short sound file:

```gdscript
extends Node

func _ready():
	var player := AudioStreamPlayer.new()
	player.stream = load("res://tone.ogg")
	add_child(player)
	player.play()
	await get_tree().create_timer(0.3).timeout
	get_tree().quit()
```

Run it from the command line and the messages above show up. It also happens with no sound file at all, and then a single frame is enough:

```gdscript
extends Node

func _ready():
	var player := AudioStreamPlayer.new()
	player.stream = AudioStreamGenerator.new()
	add_child(player)
	player.play()
	get_tree().quit()
```

This is not specific to the dummy audio driver. I get the same leak with CoreAudio, headless or in a window. On a real audio device a mix step sometimes still runs in time and hides it, which is probably why the issue says it happens about half the time.

Tested on macOS 26.5 arm64 with an editor build of master. Both scripts leak before the patch and print nothing after it. AudioStreamWAV leaks the same way. `--test` gives the same results before and after.

> An LLM was used to translate and reformulate the PR description text. Not the code.