### PR TITLE
Deprecate internal `collider` field on physics query results

### DIFF
--- a/modules/godot_physics_2d/godot_space_2d.cpp
+++ b/modules/godot_physics_2d/godot_space_2d.cpp
@@ -103,9 +103,6 @@ int GodotPhysicsDirectSpaceState2D::intersect_point(const PS2DT::PointParameters
 		}
 
 		r_results[cc].collider_id = col_obj->get_instance_id();
-		if (r_results[cc].collider_id.is_valid()) {
-			r_results[cc].collider = ObjectDB::get_instance(r_results[cc].collider_id);
-		}
 		r_results[cc].rid = col_obj->get_self();
 		r_results[cc].shape = shape_idx;
 
@@ -194,9 +191,6 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray(const PS2DT::RayParameters &p
 	ERR_FAIL_NULL_V(res_obj, false); // Shouldn't happen but silences warning.
 
 	r_result.collider_id = res_obj->get_instance_id();
-	if (r_result.collider_id.is_valid()) {
-		r_result.collider = ObjectDB::get_instance(r_result.collider_id);
-	}
 	r_result.normal = res_normal;
 	r_result.position = res_point;
 	r_result.rid = res_obj->get_self();
@@ -242,9 +236,6 @@ int GodotPhysicsDirectSpaceState2D::intersect_shape(const PS2DT::ShapeParameters
 		}
 
 		r_results[cc].collider_id = col_obj->get_instance_id();
-		if (r_results[cc].collider_id.is_valid()) {
-			r_results[cc].collider = ObjectDB::get_instance(r_results[cc].collider_id);
-		}
 		r_results[cc].rid = col_obj->get_self();
 		r_results[cc].shape = shape_idx;
 

--- a/modules/godot_physics_3d/godot_space_3d.cpp
+++ b/modules/godot_physics_3d/godot_space_3d.cpp
@@ -93,11 +93,6 @@ int GodotPhysicsDirectSpaceState3D::intersect_point(const PS3DT::PointParameters
 		}
 
 		r_results[cc].collider_id = col_obj->get_instance_id();
-		if (r_results[cc].collider_id.is_valid()) {
-			r_results[cc].collider = ObjectDB::get_instance(r_results[cc].collider_id);
-		} else {
-			r_results[cc].collider = nullptr;
-		}
 		r_results[cc].rid = col_obj->get_self();
 		r_results[cc].shape = shape_idx;
 
@@ -193,11 +188,6 @@ bool GodotPhysicsDirectSpaceState3D::intersect_ray(const PS3DT::RayParameters &p
 	ERR_FAIL_NULL_V(res_obj, false); // Shouldn't happen but silences warning.
 
 	r_result.collider_id = res_obj->get_instance_id();
-	if (r_result.collider_id.is_valid()) {
-		r_result.collider = ObjectDB::get_instance(r_result.collider_id);
-	} else {
-		r_result.collider = nullptr;
-	}
 	r_result.normal = res_normal;
 	r_result.face_index = res_face_index;
 	r_result.position = res_point;
@@ -247,11 +237,6 @@ int GodotPhysicsDirectSpaceState3D::intersect_shape(const PS3DT::ShapeParameters
 
 		if (r_results) {
 			r_results[cc].collider_id = col_obj->get_instance_id();
-			if (r_results[cc].collider_id.is_valid()) {
-				r_results[cc].collider = ObjectDB::get_instance(r_results[cc].collider_id);
-			} else {
-				r_results[cc].collider = nullptr;
-			}
 			r_results[cc].rid = col_obj->get_self();
 			r_results[cc].shape = shape_idx;
 		}

--- a/modules/jolt_physics/objects/jolt_object_3d.cpp
+++ b/modules/jolt_physics/objects/jolt_object_3d.cpp
@@ -74,10 +74,6 @@ JoltObject3D::JoltObject3D(ObjectType p_object_type) :
 
 JoltObject3D::~JoltObject3D() = default;
 
-Object *JoltObject3D::get_instance() const {
-	return ObjectDB::get_instance(instance_id);
-}
-
 void JoltObject3D::set_space(JoltSpace3D *p_space) {
 	if (space == p_space) {
 		return;
@@ -141,6 +137,6 @@ String JoltObject3D::to_string() const {
 		return fallback_name; // Calling `Object::to_string` is not thread-safe.
 	}
 
-	Object *instance = get_instance();
+	Object *instance = get_instance_id().is_valid() ? ObjectDB::get_instance(get_instance_id()) : nullptr;
 	return instance != nullptr ? instance->to_string() : fallback_name;
 }

--- a/modules/jolt_physics/objects/jolt_object_3d.h
+++ b/modules/jolt_physics/objects/jolt_object_3d.h
@@ -116,7 +116,6 @@ public:
 
 	ObjectID get_instance_id() const { return instance_id; }
 	void set_instance_id(ObjectID p_id) { instance_id = p_id; }
-	Object *get_instance() const;
 
 	JPH::Body *get_jolt_body() const { return jolt_body; }
 	JPH::BodyID get_jolt_id() const { return jolt_body->GetID(); }

--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -498,7 +498,6 @@ bool JoltPhysicsDirectSpaceState3D::intersect_ray(const PS3DT::RayParameters &p_
 	r_result.normal = to_godot(normal);
 	r_result.rid = object->get_rid();
 	r_result.collider_id = object->get_instance_id();
-	r_result.collider = object->get_instance();
 	r_result.shape = 0;
 
 	if (const JoltShapedObject3D *shaped_object = object->as_shaped()) {
@@ -543,7 +542,6 @@ int JoltPhysicsDirectSpaceState3D::intersect_point(const PS3DT::PointParameters 
 
 		result.rid = object->get_rid();
 		result.collider_id = object->get_instance_id();
-		result.collider = object->get_instance();
 	}
 
 	return hit_count;
@@ -615,7 +613,6 @@ int JoltPhysicsDirectSpaceState3D::intersect_shape(const PS3DT::ShapeParameters 
 
 			result.rid = object->get_rid();
 			result.collider_id = object->get_instance_id();
-			result.collider = object->get_instance();
 
 			hit_count++;
 			if (hit_count >= p_result_max) {

--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -106,7 +106,10 @@ StringName AudioStreamPlayer2D::_get_actual_bus() {
 
 	int areas = space_state->intersect_point(point_params, sr, MAX_INTERSECT_AREAS);
 	for (int i = 0; i < areas; i++) {
-		Area2D *area2d = Object::cast_to<Area2D>(sr[i].collider);
+		if (!sr[i].collider_id.is_valid()) {
+			continue;
+		}
+		Area2D *area2d = ObjectDB::get_instance<Area2D>(sr[i].collider_id);
 		if (!area2d) {
 			continue;
 		}

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -331,11 +331,10 @@ Area3D *AudioStreamPlayer3D::_get_overriding_area() {
 	int areas = space_state->intersect_point(point_params, sr, MAX_INTERSECT_AREAS);
 
 	for (int i = 0; i < areas; i++) {
-		if (!sr[i].collider) {
+		if (!sr[i].collider_id.is_valid()) {
 			continue;
 		}
-
-		Area3D *tarea = Object::cast_to<Area3D>(sr[i].collider);
+		Area3D *tarea = ObjectDB::get_instance<Area3D>(sr[i].collider_id);
 		if (!tarea) {
 			continue;
 		}

--- a/scene/3d/physics/vehicle_body_3d.cpp
+++ b/scene/3d/physics/vehicle_body_3d.cpp
@@ -490,8 +490,8 @@ real_t VehicleBody3D::_ray_cast(int p_idx, PhysicsDirectBodyState3D *s) {
 		wheel.m_raycastInfo.m_contactNormalWS = rr.normal;
 
 		wheel.m_raycastInfo.m_isInContact = true;
-		if (rr.collider) {
-			wheel.m_raycastInfo.m_groundObject = Object::cast_to<PhysicsBody3D>(rr.collider);
+		if (rr.collider_id.is_valid()) {
+			wheel.m_raycastInfo.m_groundObject = ObjectDB::get_instance<PhysicsBody3D>(rr.collider_id);
 		}
 
 		real_t hitDistance = param * raylen;

--- a/scene/debugger/runtime_node_select.cpp
+++ b/scene/debugger/runtime_node_select.cpp
@@ -1241,11 +1241,11 @@ void RuntimeNodeSelect::_find_3d_items_at_pos(const Point2 &p_pos, Vector<Select
 		ray_params.exclude = excluded;
 		if (ss->intersect_ray(ray_params, result)) {
 			SelectResult res;
-			res.item = Object::cast_to<Node>(result.collider);
+			res.item = result.collider_id.is_valid() ? ObjectDB::get_instance<Node>(result.collider_id) : nullptr;
 			res.order = -pos.distance_to(result.position);
 
 			// Fetch collision shapes.
-			CollisionObject3D *collision = Object::cast_to<CollisionObject3D>(result.collider);
+			CollisionObject3D *collision = result.collider_id.is_valid() ? ObjectDB::get_instance<CollisionObject3D>(result.collider_id) : nullptr;
 			if (collision) {
 				List<uint32_t> owners;
 				collision->get_shape_owners(&owners);
@@ -1364,16 +1364,15 @@ void RuntimeNodeSelect::_find_3d_items_at_rect(const Rect2 &p_rect, Vector<Selec
 	const int num_hits = ss->intersect_shape(shape_params, results, 32);
 	for (int i = 0; i < num_hits; i++) {
 		const PS3DT::ShapeResult &result = results[i];
-		if (!result.collider) {
+		SelectResult res;
+		res.item = result.collider_id.is_valid() ? ObjectDB::get_instance<Node>(result.collider_id) : nullptr;
+		if (!res.item) {
 			continue;
 		}
-
-		SelectResult res;
-		res.item = Object::cast_to<Node>(result.collider);
 		res.order = -dist_pos.distance_to(Object::cast_to<Node3D>(res.item)->get_global_transform().origin);
 
 		// Fetch collision shapes.
-		CollisionObject3D *collision = Object::cast_to<CollisionObject3D>(result.collider);
+		CollisionObject3D *collision = result.collider_id.is_valid() ? ObjectDB::get_instance<CollisionObject3D>(result.collider_id) : nullptr;
 		if (collision) {
 			List<uint32_t> owners;
 			collision->get_shape_owners(&owners);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -932,8 +932,11 @@ void Viewport::_process_picking() {
 				if (physics_object_picking_sort) {
 					struct ComparatorCollisionObjects {
 						bool operator()(const PS2DT::ShapeResult &p_a, const PS2DT::ShapeResult &p_b) const {
-							CollisionObject2D *a = Object::cast_to<CollisionObject2D>(p_a.collider);
-							CollisionObject2D *b = Object::cast_to<CollisionObject2D>(p_b.collider);
+							if (!p_a.collider_id.is_valid() || !p_b.collider_id.is_valid()) {
+								return false;
+							}
+							CollisionObject2D *a = ObjectDB::get_instance<CollisionObject2D>(p_a.collider_id);
+							CollisionObject2D *b = ObjectDB::get_instance<CollisionObject2D>(p_b.collider_id);
 							if (!a || !b) {
 								return false;
 							}
@@ -952,8 +955,8 @@ void Viewport::_process_picking() {
 					if (is_input_handled()) {
 						break;
 					}
-					if (res[i].collider_id.is_valid() && res[i].collider) {
-						CollisionObject2D *co = Object::cast_to<CollisionObject2D>(res[i].collider);
+					if (res[i].collider_id.is_valid()) {
+						CollisionObject2D *co = ObjectDB::get_instance<CollisionObject2D>(res[i].collider_id);
 						if (co && co->can_process()) {
 							bool send_event = true;
 							if (is_mouse) {
@@ -1040,7 +1043,7 @@ void Viewport::_process_picking() {
 
 					bool col = space->intersect_ray(ray_params, result);
 					ObjectID new_collider;
-					CollisionObject3D *co = col ? Object::cast_to<CollisionObject3D>(result.collider) : nullptr;
+					CollisionObject3D *co = col && result.collider_id.is_valid() ? ObjectDB::get_instance<CollisionObject3D>(result.collider_id) : nullptr;
 					if (co && co->can_process()) {
 						new_collider = result.collider_id;
 						if (!capture_object) {

--- a/servers/physics_2d/direct_states/physics_direct_space_state_2d.cpp
+++ b/servers/physics_2d/direct_states/physics_direct_space_state_2d.cpp
@@ -47,7 +47,20 @@ Dictionary PhysicsDirectSpaceState2D::_intersect_ray(RequiredParam<PhysicsRayQue
 	d["position"] = result.position;
 	d["normal"] = result.normal;
 	d["collider_id"] = result.collider_id;
-	d["collider"] = result.collider;
+
+#ifndef DISABLE_DEPRECATED
+	GODOT_PUSH_IGNORE_DEPRECATION()
+	if (result.collider != nullptr) {
+		d["collider"] = result.collider;
+	} else if (result.collider_id.is_valid()) {
+		d["collider"] = ObjectDB::get_instance(result.collider_id);
+	} else {
+		d["collider"] = (Object *)nullptr;
+	}
+	GODOT_POP_IGNORE_DEPRECATION()
+#else
+	d["collider"] = result.collider_id.is_valid() ? ObjectDB::get_instance(result.collider_id) : (Object *)nullptr;
+#endif // !DISABLE_DEPRECATED
 	d["shape"] = result.shape;
 	d["rid"] = result.rid;
 
@@ -72,10 +85,23 @@ TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_point(RequiredParam
 		Dictionary d;
 		d["rid"] = ret[i].rid;
 		d["collider_id"] = ret[i].collider_id;
-		d["collider"] = ret[i].collider;
+#ifndef DISABLE_DEPRECATED
+		GODOT_PUSH_IGNORE_DEPRECATION()
+		if (ret[i].collider != nullptr) {
+			d["collider"] = ret[i].collider;
+		} else if (ret[i].collider_id.is_valid()) {
+			d["collider"] = ObjectDB::get_instance(ret[i].collider_id);
+		} else {
+			d["collider"] = (Object *)nullptr;
+		}
+		GODOT_POP_IGNORE_DEPRECATION()
+#else
+		d["collider"] = ret[i].collider_id.is_valid() ? ObjectDB::get_instance(ret[i].collider_id) : (Object *)nullptr;
+#endif // !DISABLE_DEPRECATED
 		d["shape"] = ret[i].shape;
 		r[i] = d;
 	}
+
 	return r;
 }
 
@@ -91,7 +117,19 @@ TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_shape(RequiredParam
 		Dictionary d;
 		d["rid"] = sr[i].rid;
 		d["collider_id"] = sr[i].collider_id;
-		d["collider"] = sr[i].collider;
+#ifndef DISABLE_DEPRECATED
+		GODOT_PUSH_IGNORE_DEPRECATION()
+		if (sr[i].collider != nullptr) {
+			d["collider"] = sr[i].collider;
+		} else if (sr[i].collider_id.is_valid()) {
+			d["collider"] = ObjectDB::get_instance(sr[i].collider_id);
+		} else {
+			d["collider"] = (Object *)nullptr;
+		}
+		GODOT_POP_IGNORE_DEPRECATION()
+#else
+		d["collider"] = sr[i].collider_id.is_valid() ? ObjectDB::get_instance(sr[i].collider_id) : (Object *)nullptr;
+#endif // !DISABLE_DEPRECATED
 		d["shape"] = sr[i].shape;
 		ret[i] = d;
 	}

--- a/servers/physics_2d/physics_server_2d_types.h
+++ b/servers/physics_2d/physics_server_2d_types.h
@@ -49,21 +49,25 @@ struct RayParameters {
 	bool hit_from_inside = false;
 };
 
+GODOT_PUSH_IGNORE_DEPRECATION() // For implicit constructors etc.
 struct RayResult {
 	Vector2 position;
 	Vector2 normal;
 	RID rid;
 	ObjectID collider_id;
-	Object *collider = nullptr;
+	[[deprecated("Use `collider_id` instead.")]] Object *collider = nullptr;
 	int shape = 0;
 };
+GODOT_POP_IGNORE_DEPRECATION()
 
+GODOT_PUSH_IGNORE_DEPRECATION() // For implicit constructors etc.
 struct ShapeResult {
 	RID rid;
 	ObjectID collider_id;
-	Object *collider = nullptr;
+	[[deprecated("Use `collider_id` instead.")]] Object *collider = nullptr;
 	int shape = 0;
 };
+GODOT_POP_IGNORE_DEPRECATION()
 
 struct PointParameters {
 	Vector2 position;

--- a/servers/physics_3d/direct_states/physics_direct_space_state_3d.cpp
+++ b/servers/physics_3d/direct_states/physics_direct_space_state_3d.cpp
@@ -48,7 +48,19 @@ Dictionary PhysicsDirectSpaceState3D::_intersect_ray(RequiredParam<PhysicsRayQue
 	d["normal"] = result.normal;
 	d["face_index"] = result.face_index;
 	d["collider_id"] = result.collider_id;
-	d["collider"] = result.collider;
+#ifndef DISABLE_DEPRECATED
+	GODOT_PUSH_IGNORE_DEPRECATION()
+	if (result.collider != nullptr) {
+		d["collider"] = result.collider;
+	} else if (result.collider_id.is_valid()) {
+		d["collider"] = ObjectDB::get_instance(result.collider_id);
+	} else {
+		d["collider"] = (Object *)nullptr;
+	}
+	GODOT_POP_IGNORE_DEPRECATION()
+#else
+	d["collider"] = result.collider_id.is_valid() ? ObjectDB::get_instance(result.collider_id) : (Object *)nullptr;
+#endif // !DISABLE_DEPRECATED
 	d["shape"] = result.shape;
 	d["rid"] = result.rid;
 
@@ -73,7 +85,19 @@ TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_point(RequiredParam
 		Dictionary d;
 		d["rid"] = ret[i].rid;
 		d["collider_id"] = ret[i].collider_id;
-		d["collider"] = ret[i].collider;
+#ifndef DISABLE_DEPRECATED
+		GODOT_PUSH_IGNORE_DEPRECATION()
+		if (ret[i].collider != nullptr) {
+			d["collider"] = ret[i].collider;
+		} else if (ret[i].collider_id.is_valid()) {
+			d["collider"] = ObjectDB::get_instance(ret[i].collider_id);
+		} else {
+			d["collider"] = (Object *)nullptr;
+		}
+		GODOT_POP_IGNORE_DEPRECATION()
+#else
+		d["collider"] = ret[i].collider_id.is_valid() ? ObjectDB::get_instance(ret[i].collider_id) : (Object *)nullptr;
+#endif // !DISABLE_DEPRECATED
 		d["shape"] = ret[i].shape;
 		r[i] = d;
 	}
@@ -92,7 +116,19 @@ TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_shape(RequiredParam
 		Dictionary d;
 		d["rid"] = sr[i].rid;
 		d["collider_id"] = sr[i].collider_id;
-		d["collider"] = sr[i].collider;
+#ifndef DISABLE_DEPRECATED
+		GODOT_PUSH_IGNORE_DEPRECATION()
+		if (sr[i].collider != nullptr) {
+			d["collider"] = sr[i].collider;
+		} else if (sr[i].collider_id.is_valid()) {
+			d["collider"] = ObjectDB::get_instance(sr[i].collider_id);
+		} else {
+			d["collider"] = (Object *)nullptr;
+		}
+		GODOT_POP_IGNORE_DEPRECATION()
+#else
+		d["collider"] = sr[i].collider_id.is_valid() ? ObjectDB::get_instance(sr[i].collider_id) : (Object *)nullptr;
+#endif // !DISABLE_DEPRECATED
 		d["shape"] = sr[i].shape;
 		ret[i] = d;
 	}

--- a/servers/physics_3d/physics_server_3d_types.h
+++ b/servers/physics_3d/physics_server_3d_types.h
@@ -52,22 +52,26 @@ struct RayParameters {
 	bool pick_ray = false;
 };
 
+GODOT_PUSH_IGNORE_DEPRECATION() // For implicit constructors etc.
 struct RayResult {
 	Vector3 position;
 	Vector3 normal;
 	RID rid;
 	ObjectID collider_id;
-	Object *collider = nullptr;
+	[[deprecated("Use `collider_id` instead.")]] Object *collider = nullptr;
 	int shape = 0;
 	int face_index = -1;
 };
+GODOT_POP_IGNORE_DEPRECATION()
 
+GODOT_PUSH_IGNORE_DEPRECATION() // For implicit constructors etc.
 struct ShapeResult {
 	RID rid;
 	ObjectID collider_id;
-	Object *collider = nullptr;
+	[[deprecated("Use `collider_id` instead.")]] Object *collider = nullptr;
 	int shape = 0;
 };
+GODOT_POP_IGNORE_DEPRECATION()
 
 struct PointParameters {
 	Vector3 position;


### PR DESCRIPTION
## What problem(s) does this PR solve?

This removes `ObjectDB::get_instance` calls in physics query internals, to avoid [taking the global lock there](https://github.com/godotengine/godot/blob/893cf5cbfe789ae67c9389708e1428141bb39b18/core/object/object.h#L914-L934), which @mihe has mentioned is incredibly costly in threaded contexts.

## Additional information

Deprecates `RayResult::collider` and `ShapeResult::collider` in `PhysicsServer2DTypes` and `PhysicsServer3DTypes`. 

Where the `Object` pointer is needed, the calls to `get_instance` are moved to the call site. In particular, this is done for the currently exposed query API in `PhysicsDirectSpaceState2D` and `PhysicsDirectSpaceState3D` (e.g. returning dictionaries containing a `"collider"` key), so *compatibility on the scripting layer is preserved*.

(For e.g. ray casts it is common to need only the intersection point and not the collider. In a future improved query API, we could avoid doing the `get_instance` call by default, and users would be able to use e.g. `instance_from_id(result.collider_id)` in GDScript to get the `Object` if needed. Or alternatively, we could keep the collider properties and getters, but only call `ObjectDB::get_instance` in the functions where it is needed, similarly to what `RayCast2D`, `RayCast3D`, `KinematicCollision2D` and `KinematicCollision3D` currently already do in their `get_collider`.)

**Notes:**

- **Physics server GDExtensions** can skip setting the `collider` field, in a version of Godot with this PR merged.

- To avoid duplicated `ObjectDB::get_instance` calls for current/old physics server GDExtensions that do populate the `collider` struct field, (kind of ugly) compatibility code has been added. **Edit**: This de-duplication attempt has been removed from `VehicleBody`, `AudioStreamPlayer2D`, `AudioStreamPlayer3D`, `Viewport`, and `RuntimeNodeSelect` (left only in the physics queries).

- We could consider actually removing the struct field by wrapping it in `#ifndef DISABLE_DEPRECATED`, but that would break binary compatibility with GDExtensions (what's the policy for that?).

- Not yet tested. The potential performance impact could be tested e.g. by commenting out the `d["collider"] = ...` lines from physics queries and doing many threaded queries. **Edit:** Notably also the `RayCast2D` and `RayCast3D` nodes use the internal query API without calling `ObjectDB::get_instance` at query time (that only happens in the `get_collider` getter), so using those nodes would be an easier way to test ray query performance. **Edit 2:** Never mind, `RayCast2D` and `RayCast3D` can't be used in thread groups currently.