### PR TITLE
Display the .gd file that had an error when running completion tests

### DIFF
--- a/modules/gdscript/tests/test_completion.h
+++ b/modules/gdscript/tests/test_completion.h
@@ -103,8 +103,12 @@ static void test_directory(const String &p_dir) {
 			test_directory(path.path_join(next));
 		} else if (next.ends_with(".gd") && !next.ends_with(".notest.gd")) {
 			Ref<FileAccess> acc = FileAccess::open(path.path_join(next), FileAccess::READ, &err);
+			String test_case_path = path.path_join(next);
+			int test_word_pos = test_case_path.rfind("/tests/");
+			test_case_path = test_case_path.substr(test_word_pos);
 
 			if (err != OK) {
+				CHECK_MESSAGE(err == OK, "error running file '", test_case_path, "'");
 				next = dir->get_next();
 				continue;
 			}
@@ -114,7 +118,7 @@ static void test_directory(const String &p_dir) {
 			code = code.replace_first(String::chr(0x27A1), String::chr(0xFFFF));
 			// Require pointer sentinel char in scripts.
 			int location = code.find_char(0xFFFF);
-			CHECK(location != -1);
+			CHECK_MESSAGE(location != -1, "Caret was not found for '", test_case_path, "'.");
 
 			String res_path = ProjectSettings::get_singleton()->localize_path(path.path_join(next));
 
@@ -213,8 +217,8 @@ static void test_directory(const String &p_dir) {
 			String expected_call_hint = conf.get_value("output", "call_hint", call_hint);
 			bool expected_forced = conf.get_value("output", "forced", forced);
 
-			CHECK(expected_call_hint == call_hint);
-			CHECK(expected_forced == forced);
+			CHECK_MESSAGE(expected_call_hint == call_hint, "Unexpected call hint '", call_hint, "' for '", test_case_path, "'.");
+			CHECK_MESSAGE(expected_forced == forced, "Unexpected `forced` value '", forced, "' for '", test_case_path, "'.");
 
 			memdelete(scene);
 		}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Before this PR, if a `.gd` file failed in the completion test cases, there was no way to know which .gd file had failed. This PR adds logging which displays the path of the `.gd` file. The `--verbose` flag does not affect whether this shows or not. Images are not quite apples to apples as there was only one failing test in the first one, and three in the second

Before:
<img width="1554" height="407" alt="image" src="https://github.com/user-attachments/assets/f07b9825-ae80-4ef6-87a3-fa7d77e0845e" />

After:
<img width="1597" height="797" alt="image" src="https://github.com/user-attachments/assets/b41a4a9c-9e91-446e-9e15-c658986aa0b9" />


## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
Discussed with @HolonProduction in Rocket Chat https://chat.godotengine.org/channel/general?msg=X5KCGbh7k36tZ9FSP, and this problem was discovered when I encountered it while making this pr: https://github.com/godotengine/godot/pull/122398