### PR TITLE
ScriptCreateDialog: Fix `alert` dialog size

### DIFF
--- a/editor/script/script_create_dialog.cpp
+++ b/editor/script/script_create_dialog.cpp
@@ -381,6 +381,7 @@ void ScriptCreateDialog::_create_new() {
 		Error err = ResourceSaver::save(scr, lpath, ResourceSaver::FLAG_CHANGE_PATH);
 		if (err != OK) {
 			alert->set_text(TTR("Error - Could not create script in filesystem."));
+			alert->reset_size();
 			alert->popup_centered();
 			return;
 		}
@@ -395,6 +396,7 @@ void ScriptCreateDialog::_load_exist() {
 	Ref<Resource> p_script = ResourceLoader::load(path, "Script");
 	if (p_script.is_null()) {
 		alert->set_text(vformat(TTR("Error loading script from %s"), path));
+		alert->reset_size();
 		alert->popup_centered();
 		return;
 	}
@@ -1006,12 +1008,9 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	file_browse->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	add_child(file_browse);
 	set_ok_button_text(TTR("Create"));
+
 	alert = memnew(AcceptDialog);
 	alert->set_flag(Window::FLAG_RESIZE_DISABLED, true);
-	alert->get_label()->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
-	alert->get_label()->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
-	alert->get_label()->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
-	alert->get_label()->set_custom_minimum_size(Size2(325, 60) * EDSCALE);
 	add_child(alert);
 
 	set_hide_on_ok(false);


### PR DESCRIPTION
## What problem(s) does this PR solve?

After https://github.com/godotengine/godot/pull/117849 this dialog cannot be resized, but it has a minimum size, so stuff like this can happen:

<img width="365" height="173" alt="image" src="https://github.com/user-attachments/assets/3f04fb78-7ba3-42dc-bf4e-f377ff81a450" />

↑ cannot be resized, and the empty space looks weird.

This makes them the right size:

<img width="325" height="161" alt="image" src="https://github.com/user-attachments/assets/e8c56e08-ea4b-4b39-8836-c41b4c73f541" />

## Additional information

The message in the second screenshot doesn't exist, as I also changed the error texts, but then decided to split it into a separate PR.

No AI was used.