### PR TITLE
ScriptCreateDialog: Replace `alert` dialog with `show_warning()`

### DIFF
--- a/editor/script/script_create_dialog.cpp
+++ b/editor/script/script_create_dialog.cpp
@@ -380,8 +380,7 @@ void ScriptCreateDialog::_create_new() {
 		scr->set_path(lpath);
 		Error err = ResourceSaver::save(scr, lpath, ResourceSaver::FLAG_CHANGE_PATH);
 		if (err != OK) {
-			alert->set_text(TTR("Error - Could not create script in filesystem."));
-			alert->popup_centered();
+			EditorNode::get_singleton()->show_warning(TTR("Failed to create Script in the filesystem."), TTR("Error!"));
 			return;
 		}
 	}
@@ -394,8 +393,7 @@ void ScriptCreateDialog::_load_exist() {
 	String path = file_path->get_text();
 	Ref<Resource> p_script = ResourceLoader::load(path, "Script");
 	if (p_script.is_null()) {
-		alert->set_text(vformat(TTR("Error loading script from %s"), path));
-		alert->popup_centered();
+		EditorNode::get_singleton()->show_warning(vformat(TTR("Failed to load Script from \"%s\"."), path), TTR("Error!"));
 		return;
 	}
 
@@ -1006,13 +1004,6 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	file_browse->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	add_child(file_browse);
 	set_ok_button_text(TTR("Create"));
-	alert = memnew(AcceptDialog);
-	alert->set_flag(Window::FLAG_RESIZE_DISABLED, true);
-	alert->get_label()->set_autowrap_mode(TextServer::AUTOWRAP_WORD_SMART);
-	alert->get_label()->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
-	alert->get_label()->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
-	alert->get_label()->set_custom_minimum_size(Size2(325, 60) * EDSCALE);
-	add_child(alert);
 
 	set_hide_on_ok(false);
 	set_title(TTR("Attach Node Script"));

--- a/editor/script/script_create_dialog.h
+++ b/editor/script/script_create_dialog.h
@@ -62,7 +62,6 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	EditorFileDialog *file_browse = nullptr;
 	CheckBox *built_in = nullptr;
 	CheckBox *use_templates = nullptr;
-	AcceptDialog *alert = nullptr;
 	CreateDialog *select_class = nullptr;
 
 	bool is_browsing_parent = false;


### PR DESCRIPTION
## What problem(s) does this PR solve?

After https://github.com/godotengine/godot/pull/117849 this dialog cannot be resized, but it has a minimum size, so stuff like this can happen:

<img width="365" height="173" alt="image" src="https://github.com/user-attachments/assets/3f04fb78-7ba3-42dc-bf4e-f377ff81a450" />

↑ cannot be resized, and the empty space looks weird.

This solves that problem by using `EditorNode::show_warning()` instead of a custom `AcceptDialog:`

<img width="309" height="137" alt="image" src="https://github.com/user-attachments/assets/85eb1190-881b-49d5-ac85-3135217e5b3b" />

## Additional information

Also changed/improved the error messages.

Note that now it can be resized (I have the PR already ready for many more cases of this in the Editor, just doing some final testing).

No AI was used.

Supersedes https://github.com/godotengine/godot/pull/122747