### PR TITLE
Add optional names to tests/signal_watcher

### DIFF
--- a/tests/signal_watcher.cpp
+++ b/tests/signal_watcher.cpp
@@ -60,21 +60,21 @@ void SignalWatcher::_signal_callback_three(Variant p_arg1, Variant p_arg2, Varia
 	_add_signal_entry(args, p_name);
 }
 
-void SignalWatcher::watch_signal(Object *p_object, const String &p_signal) {
+void SignalWatcher::watch_signal_named(Object *p_object, const String &p_signal, const String &p_name) {
 	MethodInfo method_info;
 	ClassDB::get_signal(p_object->get_class(), p_signal, &method_info);
 	switch (method_info.arguments.size()) {
 		case 0: {
-			p_object->connect(p_signal, callable_mp(this, &SignalWatcher::_signal_callback_zero).bind(p_signal));
+			p_object->connect(p_signal, callable_mp(this, &SignalWatcher::_signal_callback_zero).bind(p_name));
 		} break;
 		case 1: {
-			p_object->connect(p_signal, callable_mp(this, &SignalWatcher::_signal_callback_one).bind(p_signal));
+			p_object->connect(p_signal, callable_mp(this, &SignalWatcher::_signal_callback_one).bind(p_name));
 		} break;
 		case 2: {
-			p_object->connect(p_signal, callable_mp(this, &SignalWatcher::_signal_callback_two).bind(p_signal));
+			p_object->connect(p_signal, callable_mp(this, &SignalWatcher::_signal_callback_two).bind(p_name));
 		} break;
 		case 3: {
-			p_object->connect(p_signal, callable_mp(this, &SignalWatcher::_signal_callback_three).bind(p_signal));
+			p_object->connect(p_signal, callable_mp(this, &SignalWatcher::_signal_callback_three).bind(p_name));
 		} break;
 		default: {
 			MESSAGE("Signal ", p_signal, " arg count not supported.");

--- a/tests/signal_watcher.h
+++ b/tests/signal_watcher.h
@@ -63,7 +63,8 @@ class SignalWatcher : public Object {
 public:
 	static SignalWatcher *get_singleton() { return singleton; }
 
-	void watch_signal(Object *p_object, const String &p_signal);
+	inline void watch_signal(Object *p_object, const String &p_signal) { watch_signal_named(p_object, p_signal, p_signal); }
+	void watch_signal_named(Object *p_object, const String &p_signal, const String &p_name);
 	void unwatch_signal(Object *p_object, const String &p_signal);
 	bool check(const String &p_name, const Array &p_args);
 	bool check_false(const String &p_name);
@@ -76,6 +77,7 @@ public:
 };
 
 #define SIGNAL_WATCH(m_object, m_signal) SignalWatcher::get_singleton()->watch_signal(m_object, m_signal);
+#define SIGNAL_WATCH_NAMED(m_object, m_signal, m_name) SignalWatcher::get_singleton()->watch_signal_named(m_object, m_signal, m_name);
 #define SIGNAL_UNWATCH(m_object, m_signal) SignalWatcher::get_singleton()->unwatch_signal(m_object, m_signal);
 
 #define SIGNAL_CHECK(m_signal, m_args) CHECK(SignalWatcher::get_singleton()->check(m_signal, m_args));


### PR DESCRIPTION
Support custom names allowing for listening to the same signal across multiple objects simultaneously. Otherwise, the SignalWatcher singleton overlaps the caught signals.

## What problem(s) does this PR solve?

Test environments using SIGNAL_WATCHER can only watch signals of a single name from one object at a time, as the signal name is used as the key to the table of tracked signal events.

This PR includes an optional SIGNAL_WATCH_NAMED macro that allows for a unique name separate from the signal
to be used for all related operations.

## Additional information

No change on existing test suites at this time.