### PR TITLE
Fix tooltip reappearing after being dismissed with Escape

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2307,11 +2307,13 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 
 		if (p_event->is_action_pressed(SNAME("ui_cancel"))) {
 			// Cancel tooltip timer or hide tooltip when pressing Escape (this is standard behavior in most applications).
+			Control *tooltip_control = gui.tooltip_control;
 			_gui_cancel_tooltip();
 			if (gui.tooltip_popup) {
 				// If a tooltip was hidden, prevent other actions associated with `ui_cancel` from occurring.
 				// For instance, this prevents the node from being deselected when pressing Escape
 				// to hide a documentation tooltip in the inspector.
+				gui.tooltip_control = tooltip_control;
 				set_input_as_handled();
 				return;
 			}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/104205

## Additional information

Keeps the hovered control remembered when the tooltip is dismissed with Escape. Therefore stops the tooltip timer from immediately being restarted, unless the mouse actually moves again.

Before:
<img width="1720" height="1300" alt="godot windows editor x86_64_AnOObLhBkU" src="https://github.com/user-attachments/assets/d4a58567-eb66-4d30-8c94-3f60c00bf310" />
After:
<img width="1720" height="1300" alt="godot windows editor x86_64_9PofKujRg9" src="https://github.com/user-attachments/assets/2c358baf-8cb6-4453-94ed-d3641f915aa2" />