### PR TITLE
LSP: Display warning code in diagnostic "code" field instead of message

### DIFF
--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -81,8 +81,9 @@ void ExtendGDScriptParser::update_diagnostics() {
 	for (const GDScriptWarning &warning : parser_warnings) {
 		LSP::Diagnostic diagnostic;
 		diagnostic.severity = LSP::DiagnosticSeverity::Warning;
-		diagnostic.message = "(" + warning.get_name() + "): " + warning.get_message();
+		diagnostic.message = warning.get_message();
 		diagnostic.source = "gdscript";
+		diagnostic.code = warning.get_name();
 
 		GodotRange godot_range(
 				GodotPosition(warning.start_line, warning.start_column),

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -774,7 +774,7 @@ struct Diagnostic {
 	/**
 	 * The diagnostic's code, which might appear in the user interface.
 	 */
-	int code = 0;
+	String code;
 
 	/**
 	 * A human-readable string describing the source of this


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

No issue or proposal exists for this change, to my knowledge.

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

The LSP includes a `Diagnostic.code` field, which is intended for "the diagnostic's code, which might appear in the user interface". GDScript warning names like `UNTYPED_DECLARATION` or `UNUSED_VARIABLE` should fall under this category.

This PR removes the warning name from the `message` field and into the `code` field, so that it displays consistently in IDEs supporting the LSP with the experience from other language servers.

<img width="1919" height="419" alt="CleanShot 2026-08-23 at 20 46 00@2x" src="https://github.com/user-attachments/assets/6c998606-acaa-46ff-bc10-8412b450d410" />
