### PR TITLE
Fix remote deploy with network filesystem not detecting resource UIDs.

### DIFF
--- a/editor/debugger/editor_file_server.cpp
+++ b/editor/debugger/editor_file_server.cpp
@@ -206,6 +206,8 @@ void EditorFileServer::poll() {
 	}
 
 	_add_custom_file("res://project.godot", files_to_send, cached_files);
+	_add_custom_file("res://.godot/uid_cache.bin", files_to_send, cached_files);
+
 	// Check which files were removed and also add them
 	for (KeyValue<String, uint64_t> K : cached_files) {
 		if (!files_to_send.has(K.key)) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/122668

