### PR TITLE
Remove unused `AcceptDialog` in `ScriptEditorDebugger`

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -2520,9 +2520,6 @@ Instead, use the monitors tab to obtain more precise VRAM usage.
 		misc->add_child(buttons);
 	}
 
-	msgdialog = memnew(AcceptDialog);
-	add_child(msgdialog);
-
 	_update_buttons_state();
 }
 

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -89,8 +89,6 @@ private:
 		VMEM_MENU_OWNERS,
 	};
 
-	AcceptDialog *msgdialog = nullptr;
-
 	LineEdit *clicked_ctrl = nullptr;
 	LineEdit *clicked_ctrl_type = nullptr;
 	LineEdit *live_edit_root = nullptr;


### PR DESCRIPTION
## What problem(s) does this PR solve?

Not really a problem, but it's simply an unused variable. There's really no defense for why it should be there. Doesn't create much noise.

## Additional information

Note that an `AcceptDialog` is hidden by defualt.

Seems like no open PR relies on it (should probably use `EditorNode::get_singleton()->show_warning()` anyway).