### PR TITLE
Editor quick open: Use defined but unused `MarginContainer`

### DIFF
--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -398,7 +398,7 @@ QuickOpenResultContainer::QuickOpenResultContainer() {
 			scroll_container->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 			scroll_container->set_scroll_hint_mode(ScrollContainer::SCROLL_HINT_MODE_ALL);
 			scroll_container->hide();
-			panel_container->add_child(scroll_container);
+			mc->add_child(scroll_container);
 
 			list = memnew(VBoxContainer);
 			list->set_h_size_flags(Control::SIZE_EXPAND_FILL);


### PR DESCRIPTION
## What problem(s) does this PR solve?

Makes use of an unused `MarginContainer` from https://github.com/godotengine/godot/pull/113816 CC @YeldhamDev