### PR TITLE
Linux, Windows: Expand `.debugsymbols` search in crash handler

### DIFF
--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -78,6 +78,139 @@ inline String find_addr2line_executable() {
 	return String("addr2line");
 }
 
+static String get_gnu_debuglink(const String &p_exec_path) {
+	Ref<FileAccess> f = FileAccess::open(p_exec_path, FileAccess::READ);
+	if (f.is_null()) {
+		return String();
+	}
+
+	// Read and check ELF magic number.
+	{
+		uint32_t magic = f->get_32();
+		if (magic != 0x464c457f) { // 0x7F + "ELF"
+			return String();
+		}
+	}
+
+	// Read program architecture bits from class field.
+	int bits = f->get_8() * 32;
+
+	// Get info about the section header table.
+	int64_t section_table_pos;
+	int64_t section_header_size;
+	if (bits == 32) {
+		section_header_size = 40;
+		f->seek(0x20);
+		section_table_pos = f->get_32();
+		f->seek(0x30);
+	} else { // 64
+		section_header_size = 64;
+		f->seek(0x28);
+		section_table_pos = f->get_64();
+		f->seek(0x3c);
+	}
+	int num_sections = f->get_16();
+
+	// Load the strings table.
+	uint8_t *strings;
+	{
+		int string_section_idx = f->get_16();
+
+		// Jump to the strings section header.
+		f->seek(section_table_pos + string_section_idx * section_header_size);
+
+		// Read strings data size and offset.
+		int64_t string_data_pos;
+		int64_t string_data_size;
+		if (bits == 32) {
+			f->seek(f->get_position() + 0x10);
+			string_data_pos = f->get_32();
+			string_data_size = f->get_32();
+		} else { // 64
+			f->seek(f->get_position() + 0x18);
+			string_data_pos = f->get_64();
+			string_data_size = f->get_64();
+		}
+
+		// Read strings data.
+		f->seek(string_data_pos);
+		strings = (uint8_t *)memalloc(string_data_size);
+		if (!strings) {
+			return String();
+		}
+		f->get_buffer(strings, string_data_size);
+	}
+
+	// Search for the ".gnu_debuglink" section.
+	String ret;
+	for (int i = 0; i < num_sections; ++i) {
+		int64_t section_header_pos = section_table_pos + i * section_header_size;
+		f->seek(section_header_pos);
+
+		uint32_t name_offset = f->get_32();
+		if (strcmp((char *)strings + name_offset, ".gnu_debuglink") == 0) {
+			// ".gnu_debuglink" section found.
+
+			int64_t section_start = 0;
+			int64_t section_size = 0;
+			if (bits == 32) {
+				f->seek(section_header_pos + 0x10);
+				section_start = f->get_32();
+				section_size = f->get_32();
+			} else { // 64
+				f->seek(section_header_pos + 0x18);
+				section_start = f->get_64();
+				section_size = f->get_64();
+			}
+
+			f->seek(section_start);
+
+			// Extract the value as a UTF-8 string.
+			uint8_t *str = (uint8_t *)memalloc(section_size);
+
+			f->get_buffer(str, section_size);
+
+			ret = String::utf8((const char *)str, section_size);
+
+			memfree(str);
+
+			break;
+		}
+	}
+	memfree(strings);
+
+	return ret;
+}
+
+static String find_debugsymbols(const String &p_exec_path) {
+	const String base_dir = p_exec_path.get_base_dir() + "/";
+	const String exec_file = p_exec_path.get_file() + ".debugsymbols";
+
+	// TODO: Additional paths? e.g. `/usr/lib/debug` and similar.
+	// TODO: Integrate directly with debuginfod-find?
+
+	// First try the current executable name plus `.debugsymbols`, possibly in a `.debug` folder.
+	if (FileAccess::exists(p_exec_path + ".debugsymbols")) {
+		return p_exec_path + ".debugsymbols";
+	} else if (FileAccess::exists(base_dir + ".debug/" + exec_file)) {
+		return base_dir + ".debug/" + exec_file;
+	}
+
+	// Otherwise try using the `.gnu_debuglink` section, and try it in the same places if non-empty.
+	const String debuglink_value = get_gnu_debuglink(p_exec_path);
+	if (debuglink_value.is_empty()) {
+		return p_exec_path;
+	}
+
+	if (FileAccess::exists(base_dir + debuglink_value)) {
+		return base_dir + debuglink_value;
+	} else if (FileAccess::exists(base_dir + ".debug/" + debuglink_value)) {
+		return base_dir + ".debug/" + debuglink_value;
+	}
+
+	return p_exec_path;
+}
+
 static void handle_crash(int sig) {
 	signal(SIGSEGV, SIG_DFL);
 	signal(SIGFPE, SIG_DFL);
@@ -93,11 +226,7 @@ static void handle_crash(int sig) {
 
 	void *bt_buffer[256];
 	size_t size = backtrace(bt_buffer, 256);
-	String exec_path = OS::get_singleton()->get_executable_path();
-
-	if (FileAccess::exists(exec_path + ".debugsymbols")) {
-		exec_path = exec_path + ".debugsymbols";
-	}
+	String exec_path = find_debugsymbols(OS::get_singleton()->get_executable_path());
 
 	String msg;
 	if (ProjectSettings::get_singleton()) {

--- a/platform/windows/crash_handler_windows_signal.cpp
+++ b/platform/windows/crash_handler_windows_signal.cpp
@@ -209,6 +209,133 @@ int64_t get_image_base(const String &p_path) {
 	}
 }
 
+static String get_gnu_debuglink(const String &p_exec_path) {
+	Ref<FileAccess> f = FileAccess::open(p_exec_path, FileAccess::READ);
+	if (f.is_null()) {
+		return String();
+	}
+
+	// Jump to the PE header and check the magic number.
+	{
+		f->seek(0x3c);
+		uint32_t pe_pos = f->get_32();
+
+		f->seek(pe_pos);
+		uint32_t magic = f->get_32();
+		if (magic != 0x00004550) {
+			return String();
+		}
+	}
+
+	// Process header.
+	int num_sections;
+	uint64_t string_table_pos = 0;
+
+	int64_t section_table_pos = 0;
+	{
+		int64_t header_pos = f->get_position();
+		f->seek(header_pos + 2);
+		num_sections = f->get_16();
+		f->seek(header_pos + 8);
+		string_table_pos += f->get_32();
+		f->seek(header_pos + 12);
+		string_table_pos += f->get_32() * 18;
+		f->seek(header_pos + 16);
+		uint16_t opt_header_size = f->get_16();
+		int64_t opt_header_pos = f->get_position() + 2;
+
+		// Skip rest of header + optional header to go to the section headers.
+		f->seek(opt_header_pos + opt_header_size);
+		section_table_pos = f->get_position();
+	}
+
+	if (string_table_pos == 0) {
+		return String();
+	}
+
+	// Load the strings table.
+	uint8_t *strings = nullptr;
+	{
+		f->seek(string_table_pos);
+		uint32_t string_data_size = f->get_32();
+
+		// Read strings data.
+		f->seek(string_table_pos);
+		strings = (uint8_t *)memalloc(string_data_size);
+		if (!strings) {
+			return String();
+		}
+		f->get_buffer(strings, string_data_size);
+	}
+
+	// Search for the ".gnu_debuglink" section.
+	String ret;
+
+	for (int i = 0; i < num_sections; ++i) {
+		int64_t section_header_pos = section_table_pos + i * 40;
+		f->seek(section_header_pos);
+
+		uint8_t section_name[9];
+		f->get_buffer(section_name, 8);
+		section_name[8] = '\0';
+
+		if (section_name[0] == '/') {
+			uint32_t string_table_off = String::utf8((const char *)&section_name[1], 7).to_int();
+			if (strcmp((char *)strings + string_table_off, ".gnu_debuglink") == 0) {
+				// ".gnu_debuglink" section found.
+
+				f->seek(section_table_pos + i * 40 + 8);
+				uint32_t section_size = f->get_32();
+				f->seek(section_table_pos + i * 40 + 20);
+				uint32_t section_start = f->get_32();
+
+				f->seek(section_start);
+
+				// Extract the value as a UTF-8 string.
+				uint8_t *str = (uint8_t *)memalloc(section_size);
+
+				f->get_buffer(str, section_size);
+
+				ret = String::utf8((const char *)str, section_size);
+
+				memfree(str);
+
+				break;
+			}
+		}
+	}
+
+	memfree(strings);
+
+	return ret;
+}
+
+static String find_debugsymbols(const String &p_exec_path) {
+	const String base_dir = p_exec_path.get_base_dir() + "/";
+	const String exec_file = p_exec_path.get_file() + ".debugsymbols";
+
+	// First try the current executable name plus `.debugsymbols`, possibly in a `.debug` folder.
+	if (FileAccess::exists(p_exec_path + ".debugsymbols")) {
+		return p_exec_path + ".debugsymbols";
+	} else if (FileAccess::exists(base_dir + ".debug/" + exec_file)) {
+		return base_dir + ".debug/" + exec_file;
+	}
+
+	// Otherwise try using the `.gnu_debuglink` section, and try it in the same places if non-empty.
+	const String debuglink_value = get_gnu_debuglink(p_exec_path);
+	if (debuglink_value.is_empty()) {
+		return p_exec_path;
+	}
+
+	if (FileAccess::exists(base_dir + debuglink_value)) {
+		return base_dir + debuglink_value;
+	} else if (FileAccess::exists(base_dir + ".debug/" + debuglink_value)) {
+		return base_dir + ".debug/" + debuglink_value;
+	}
+
+	return p_exec_path;
+}
+
 extern void CrashHandlerException(int signal) {
 	CrashHandlerData data;
 
@@ -268,10 +395,7 @@ extern void CrashHandlerException(int signal) {
 
 	print_error(vformat("Load address: %x\n", (uint64_t)data.offset));
 
-	if (FileAccess::exists(exec_path + ".debugsymbols")) {
-		exec_path = exec_path + ".debugsymbols";
-	}
-	exec_path = exec_path.replace_char('/', '\\');
+	exec_path = find_debugsymbols(exec_path).replace_char('/', '\\');
 
 	CharString cs = exec_path.utf8(); // Note: should remain in scope during backtrace_simple call.
 	data.state = backtrace_create_state(cs.get_data(), 0, &error_callback, reinterpret_cast<void *>(&data));


### PR DESCRIPTION

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Searches in a `.debug` folder as well as searching for the file referenced in `.gnu_debuglink`

The central goal is to:
* Make the crash handler more flexible to changes, and more portable
* Improve parity between using gdb and the crash handler, with the long term goal being that if gdb finds the symbols then the crash handler should too (gdb probably can't be made to match in the other direction, i.e. we probably can't make it find the symbols if they have been renamed, at least from my testing that's not the case)

Related to discussion in:
* https://github.com/godotengine/godot/pull/114924

## Additional information

Some notes in the code explain some of the potential future additions to consider, they might only be really relevant on Linux, but I've done some preliminary testing separate from this (and only with the gdb side) and it should be feasible to provide `debuginfod` support with some minor adjustments on the build server side (we currently don't generate a `.note.gnu.build-id` entry but it's trivial to force it) to be able to provide server hosted debug files for download. That would require further changes to this code however to make it look up that file in the right place, but I will do further testing on that later if we go ahead with this one

Looking up `.gnu_debuglink` is currently only implemented on Linux, will implement and test on Windows as well, should be trivial to do as well but my turnaround time for testing on Windows is longer so wanted to start with this

The current implementation is confirmed to work on both Linux and Windows (for windows just the relocation support, i.e. moving the file into `.debug`, tested only on Wine for now but will verify both solutions on a Windows machine when I've implemented the full feature)

The lookup code for Linux is adjusted from the existing `get_embedded_pck_offset` code, will look at some general cleaning up and merging of code when it is finalized

Todo:
* [x] Implement support for `.gnu_debuglink` on Windows
* [x] Verify both cases on an actual Windows machine

No AI used what so ever.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
