### PR TITLE
[.NET]: Embed custom types as grouped properties

### DIFF
--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/CodeAnalysisAttributes.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/CodeAnalysisAttributes.cs
@@ -4,4 +4,23 @@ namespace System.Diagnostics.CodeAnalysis
     public sealed class NotNullAttribute : Attribute
     {
     }
+
+    [AttributeUsage(AttributeTargets.Method | AttributeTargets.Property, Inherited = false, AllowMultiple = true)]
+    internal sealed class MemberNotNullWhenAttribute : Attribute
+    {
+        public MemberNotNullWhenAttribute(bool returnValue, string member)
+        {
+            ReturnValue = returnValue;
+            Members = new[] { member };
+        }
+
+        public MemberNotNullWhenAttribute(bool returnValue, params string[] members)
+        {
+            ReturnValue = returnValue;
+            Members = members;
+        }
+
+        public bool ReturnValue { get; }
+        public string[] Members { get; }
+    }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ExtensionMethods.cs
@@ -278,6 +278,9 @@ namespace Godot.SourceGenerators
         public static bool IsGodotExportAttribute(this INamedTypeSymbol symbol)
             => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.ExportAttr;
 
+        public static bool IsGodotExportEmbedAttribute(this INamedTypeSymbol symbol)
+            => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.ExportEmbedAttr;
+
         public static bool IsGodotSignalAttribute(this INamedTypeSymbol symbol)
             => symbol.FullQualifiedNameOmitGlobal() == GodotClasses.SignalAttr;
 
@@ -353,23 +356,29 @@ namespace Godot.SourceGenerators
 
         public static IEnumerable<GodotPropertyData> WhereIsGodotCompatibleType(
             this IEnumerable<IPropertySymbol> properties,
-            MarshalUtils.TypeCache typeCache
+            MarshalUtils.TypeCache typeCache,
+            GodotPropertyData? containingProperty,
+            bool createUnallowed = false
         )
         {
             foreach (var property in properties)
             {
                 var marshalType = MarshalUtils.ConvertManagedTypeToMarshalType(property.Type, typeCache);
 
+                if (createUnallowed && marshalType == null)
+                    yield return new GodotPropertyData(property, default, PropertyType.Unallowed, containingProperty);
                 if (marshalType == null)
                     continue;
 
-                yield return new GodotPropertyData(property, marshalType.Value);
+                yield return new GodotPropertyData(property, marshalType.Value, PropertyType.Property, containingProperty);
             }
         }
 
-        public static IEnumerable<GodotFieldData> WhereIsGodotCompatibleType(
+        public static IEnumerable<GodotPropertyData> WhereIsGodotCompatibleType(
             this IEnumerable<IFieldSymbol> fields,
-            MarshalUtils.TypeCache typeCache
+            MarshalUtils.TypeCache typeCache,
+            GodotPropertyData? containingProperty,
+            bool createUnallowed = false
         )
         {
             foreach (var field in fields)
@@ -377,11 +386,50 @@ namespace Godot.SourceGenerators
                 // TODO: We should still restore read-only fields after reloading assembly. Two possible ways: reflection or turn RestoreGodotObjectData into a constructor overload.
                 var marshalType = MarshalUtils.ConvertManagedTypeToMarshalType(field.Type, typeCache);
 
+                if (createUnallowed && marshalType == null)
+                    yield return new GodotPropertyData(field, default, PropertyType.Unallowed, containingProperty);
                 if (marshalType == null)
                     continue;
 
-                yield return new GodotFieldData(field, marshalType.Value);
+                yield return new GodotPropertyData(field, marshalType.Value, PropertyType.Field, containingProperty);
             }
+        }
+
+        public static IEnumerable<GodotPropertyData> WhereIsSortedGodotProperties(
+            this IEnumerable<ISymbol> members,
+            MarshalUtils.TypeCache typeCache,
+            Func<IEnumerable<ISymbol>, IEnumerable<IPropertySymbol>> propertiesFilter,
+            Func<IEnumerable<ISymbol>, IEnumerable<IFieldSymbol>> fieldsFilter,
+            bool createUnallowed = false,
+            GodotPropertyData? containingProperty = null
+        )
+        {
+            return Enumerable.Empty<GodotPropertyData>()
+                .Concat(propertiesFilter(members).WhereIsGodotCompatibleType(typeCache, containingProperty, createUnallowed))
+                .Concat(fieldsFilter(members).WhereIsGodotCompatibleType(typeCache, containingProperty, createUnallowed))
+                .Concat(members
+                    .Where(s => (s is IPropertySymbol || s is IFieldSymbol) && s.GetAttributes()
+                        .Any(a => a.AttributeClass?.IsGodotExportEmbedAttribute() ?? false))
+                    .Select(s => s switch
+                        {
+                            IPropertySymbol sp => new GodotPropertyData(sp, default, PropertyType.Embed, containingProperty),
+                            IFieldSymbol sf => new GodotPropertyData(sf, default, PropertyType.Embed, containingProperty),
+                            _ => throw new NotSupportedException(),
+                        }))
+                // To retain the definition order (and display categories correctly), we want to
+                //  iterate over fields and properties at the same time, sorted by line number.
+                .OrderBy(data => data.Symbol.Locations[0].Path())
+                .ThenBy(data => data.Symbol.Locations[0].StartLine())
+                // Gather Godot exports from embedded exports recursively.
+                .SelectMany(data => Enumerable
+                    .Repeat(data, 1)
+                    .Concat(data.PropertyType == PropertyType.Embed
+                        ? data.PropertyTypeSymbol
+                            .GetMembers()
+                            .Where(m => !m.GetAttributes()
+                                .Any(a => a.AttributeClass?.IsGodotIgnoreMemberAttribute() ?? false))
+                            .WhereIsSortedGodotProperties(typeCache, propertiesFilter, fieldsFilter, createUnallowed, data)
+                        : Enumerable.Empty<GodotPropertyData>()));
         }
 
         public static Location? FirstLocationWithSourceTreeOrDefault(this IEnumerable<Location> locations)

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotClasses.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotClasses.cs
@@ -7,6 +7,7 @@ namespace Godot.SourceGenerators
         public const string Callable = "Godot.Callable";
         public const string AssemblyHasScriptsAttr = "Godot.AssemblyHasScriptsAttribute";
         public const string ExportAttr = "Godot.ExportAttribute";
+        public const string ExportEmbedAttr = "Godot.ExportEmbedAttribute";
         public const string ExportCategoryAttr = "Godot.ExportCategoryAttribute";
         public const string ExportGroupAttr = "Godot.ExportGroupAttribute";
         public const string ExportSubgroupAttr = "Godot.ExportSubgroupAttribute";

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotEnums.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotEnums.cs
@@ -90,7 +90,11 @@ namespace Godot.SourceGenerators
         LayersAvoidance = 37,
         DictionaryType = 38,
         ToolButton = 39,
-        Max = 40
+        OneShot = 40,
+        GroupEnable = 42,
+        InputName = 43,
+        FilePath = 44,
+        Max = 45
     }
 
     [Flags]

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotMemberData.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/GodotMemberData.cs
@@ -34,55 +34,66 @@ namespace Godot.SourceGenerators
         public GodotMethodData InvokeMethodData { get; }
     }
 
-    public readonly struct GodotPropertyData
+    public enum PropertyType
     {
-        public GodotPropertyData(IPropertySymbol propertySymbol, MarshalType type)
-        {
-            PropertySymbol = propertySymbol;
-            Type = type;
-        }
-
-        public IPropertySymbol PropertySymbol { get; }
-        public MarshalType Type { get; }
-
-        public bool IsReadOnly => PropertySymbol.IsReadOnly ||
-                                  PropertySymbol.SetMethodOrBaseSetMethod() is { IsInitOnly: true };
-        public bool IsWriteOnly => PropertySymbol.IsWriteOnly;
+        Unallowed,
+        Field,
+        Property,
+        Embed,
     }
 
-    public readonly struct GodotFieldData
+    public class GodotPropertyData
     {
-        public GodotFieldData(IFieldSymbol fieldSymbol, MarshalType type)
-        {
-            FieldSymbol = fieldSymbol;
-            Type = type;
-        }
-
-        public IFieldSymbol FieldSymbol { get; }
-        public MarshalType Type { get; }
-
-        public bool IsReadOnly => FieldSymbol.IsReadOnly;
-    }
-
-    public struct GodotPropertyOrFieldData
-    {
-        public GodotPropertyOrFieldData(ISymbol symbol, MarshalType type)
+        public GodotPropertyData(
+            ISymbol symbol,
+            ITypeSymbol typeSymbol,
+            MarshalType marshalType,
+            PropertyType propertyType,
+            GodotPropertyData? containingProperty,
+            bool isReadOnly,
+            bool isWriteOnly)
         {
             Symbol = symbol;
-            Type = type;
+            PropertyTypeSymbol = typeSymbol;
+            MarshalType = marshalType;
+            PropertyType = propertyType;
+            ContainingProperty = containingProperty;
+            IsReadOnly = isReadOnly;
+            IsWriteOnly = isWriteOnly;
         }
 
-        public GodotPropertyOrFieldData(GodotPropertyData propertyData)
-            : this(propertyData.PropertySymbol, propertyData.Type)
+        public GodotPropertyData(IPropertySymbol propertySymbol, MarshalType type, PropertyType propertyType, GodotPropertyData? containingProperty)
+            : this(propertySymbol, propertySymbol.Type, type, propertyType, containingProperty,
+                propertySymbol.IsReadOnly || propertySymbol.SetMethodOrBaseSetMethod() is { IsInitOnly: true }, propertySymbol.IsWriteOnly)
         {
         }
 
-        public GodotPropertyOrFieldData(GodotFieldData fieldData)
-            : this(fieldData.FieldSymbol, fieldData.Type)
+        public GodotPropertyData(IFieldSymbol fieldSymbol, MarshalType type, PropertyType propertyType, GodotPropertyData? containingProperty)
+            : this(fieldSymbol, fieldSymbol.Type, type, propertyType, containingProperty, fieldSymbol.IsReadOnly, false)
         {
         }
 
+        public GodotPropertyData? ContainingProperty { get; }
         public ISymbol Symbol { get; }
-        public MarshalType Type { get; }
+        public ITypeSymbol PropertyTypeSymbol { get; }
+        public MarshalType MarshalType { get; }
+        public PropertyType PropertyType { get; }
+        [System.Diagnostics.CodeAnalysis.MemberNotNullWhen(true, nameof(ContainingProperty))]
+        public bool InNullable => ContainingProperty is not null && (ContainingProperty.InNullable || ContainingProperty.PropertyTypeSymbol.IsReferenceType);
+        public string MemberName => string.Concat(ContainingProperty is not null ? $"{ContainingProperty.MemberName}.@" : "", Symbol.Name);
+        public string MemberNameNullable => string.Concat(
+            ContainingProperty is not null
+            ? string.Concat(ContainingProperty.MemberNameNullable, ContainingProperty.PropertyTypeSymbol.IsReferenceType ? $"?" : "", ".@")
+            : "", Symbol.Name);
+        public string PropertyName => string.Concat(ContainingProperty is not null ? $"{ContainingProperty.PropertyName}_" : "", Symbol.Name);
+        public string PropertyNameHint => string.Concat(ContainingProperty is not null ? $"{ContainingProperty.PropertyGroupName}/" : "", Symbol.Name);
+        public string PropertyGroupName => string.Concat(ContainingProperty is not null ? $"{ContainingProperty.PropertyGroupName}/" : "", Capitalize(Symbol.Name));
+        public bool IsReadOnly { get; }
+        public bool IsWriteOnly { get; }
+
+        private static string Capitalize(string input)
+        {
+            return input[0].ToString().ToUpper() + input.Substring(1);
+        }
     }
 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertiesGenerator.cs
@@ -116,17 +116,18 @@ namespace Godot.SourceGenerators
                 .Where(m => !m.GetAttributes()
                     .Any(a => a.AttributeClass?.IsGodotIgnoreMemberAttribute() ?? false));
 
-            var propertySymbols = members
-                .Where(s => !s.IsStatic && s.Kind == SymbolKind.Property)
-                .Cast<IPropertySymbol>()
-                .Where(s => !s.IsIndexer && s.ExplicitInterfaceImplementations.Length == 0);
-
-            var fieldSymbols = members
-                .Where(s => !s.IsStatic && s.Kind == SymbolKind.Field && !s.IsImplicitlyDeclared)
-                .Cast<IFieldSymbol>();
-
-            var godotClassProperties = propertySymbols.WhereIsGodotCompatibleType(typeCache).ToArray();
-            var godotClassFields = fieldSymbols.WhereIsGodotCompatibleType(typeCache).ToArray();
+            var godotProperties = members
+                .WhereIsSortedGodotProperties(
+                    typeCache,
+                    static members => members
+                        .Where(s => !s.IsStatic && s.Kind == SymbolKind.Property)
+                        .Cast<IPropertySymbol>()
+                        .Where(s => !s.IsIndexer && s.ExplicitInterfaceImplementations.Length == 0)
+                    ,
+                    static members => members
+                        .Where(s => !s.IsStatic && s.Kind == SymbolKind.Field && !s.IsImplicitlyDeclared)
+                        .Cast<IFieldSymbol>())
+                .ToArray();
 
             source.Append("#pragma warning disable CS0109 // Disable warning about redundant 'new' keyword\n");
 
@@ -139,48 +140,60 @@ namespace Godot.SourceGenerators
 
             // Generate cached StringNames for methods and properties, for fast lookup
 
-            foreach (var property in godotClassProperties)
+            foreach (var embed in godotProperties.Where(prop => prop.PropertyType == PropertyType.Embed))
             {
-                string propertyName = property.PropertySymbol.Name;
+                if (!embed.PropertyTypeSymbol.IsReferenceType)
+                    continue;
 
                 source.Append("        /// <summary>\n")
                     .Append("        /// Cached name for the '")
-                    .Append(propertyName)
+                    .Append(embed.MemberName)
+                    .Append("' embedded.\n")
+                    .Append("        /// </summary>\n");
+
+                source.Append("        public new static readonly global::Godot.StringName @").Append(embed.PropertyName).Append("_nonnull = \"");
+                source.Append($"{embed.PropertyGroupName}/#nonnull");
+                source.Append("\";\n");
+            }
+
+            foreach (var property in godotProperties.Where(prop => prop.PropertyType == PropertyType.Property))
+            {
+                source.Append("        /// <summary>\n")
+                    .Append("        /// Cached name for the '")
+                    .Append(property.MemberName)
                     .Append("' property.\n")
                     .Append("        /// </summary>\n");
 
                 source.Append("        public new static readonly global::Godot.StringName @");
-                source.Append(propertyName);
+                source.Append(property.PropertyName);
                 source.Append(" = \"");
-                source.Append(propertyName);
+                source.Append(property.PropertyNameHint);
                 source.Append("\";\n");
             }
 
-            foreach (var field in godotClassFields)
+            foreach (var field in godotProperties.Where(prop => prop.PropertyType == PropertyType.Field))
             {
-                string fieldName = field.FieldSymbol.Name;
-
                 source.Append("        /// <summary>\n")
                     .Append("        /// Cached name for the '")
-                    .Append(fieldName)
+                    .Append(field.MemberName)
                     .Append("' field.\n")
                     .Append("        /// </summary>\n");
 
                 source.Append("        public new static readonly global::Godot.StringName @");
-                source.Append(fieldName);
+                source.Append(field.PropertyName);
                 source.Append(" = \"");
-                source.Append(fieldName);
+                source.Append(field.PropertyNameHint);
                 source.Append("\";\n");
             }
 
             source.Append("    }\n"); // class GodotInternal
 
-            if (godotClassProperties.Length > 0 || godotClassFields.Length > 0)
+            if (godotProperties.Length > 0)
             {
 
                 // Generate SetGodotClassPropertyValue
 
-                bool allPropertiesAreReadOnly = godotClassFields.All(fi => fi.IsReadOnly) && godotClassProperties.All(pi => pi.IsReadOnly);
+                bool allPropertiesAreReadOnly = godotProperties.All(pi => pi.IsReadOnly || (pi.PropertyType == PropertyType.Embed && !pi.PropertyTypeSymbol.IsReferenceType));
 
                 if (!allPropertiesAreReadOnly)
                 {
@@ -189,22 +202,45 @@ namespace Godot.SourceGenerators
                     source.Append("    protected override bool SetGodotClassPropertyValue(in godot_string_name name, ");
                     source.Append("in godot_variant value)\n    {\n");
 
-                    foreach (var property in godotClassProperties)
+                    foreach (var embed in godotProperties.Where(prop => prop.PropertyType == PropertyType.Embed))
+                    {
+                        if (!embed.PropertyTypeSymbol.IsReferenceType)
+                            continue;
+
+                        source
+                            .Append("        if (name == PropertyName.@")
+                            .Append(embed.PropertyName)
+                            .Append("_nonnull) {\n");
+                        if (embed.InNullable)
+                            source.Append("            if (").Append("this.@").Append(embed.ContainingProperty.MemberNameNullable).Append(" is not null) {\n    ");
+                        source.Append("            this.@")
+                            .Append(embed.MemberName)
+                            .Append(" = ")
+                            .AppendNativeVariantToManagedExpr("value", context.Compilation.GetSpecialType(SpecialType.System_Boolean), MarshalType.Boolean)
+                            .Append(" ? ")
+                            .Append("this.@")
+                            .Append(embed.MemberName)
+                            .Append(" ?? new() : null;\n");
+                        if (embed.InNullable)
+                            source.Append("            }\n");
+                        source.Append("            return true;\n")
+                            .Append("        }\n");
+                    }
+
+                    foreach (var property in godotProperties.Where(prop => prop.PropertyType == PropertyType.Property))
                     {
                         if (property.IsReadOnly)
                             continue;
 
-                        GeneratePropertySetter(property.PropertySymbol.Name,
-                            property.PropertySymbol.Type, property.Type, source);
+                        GeneratePropertySetter(property, source);
                     }
 
-                    foreach (var field in godotClassFields)
+                    foreach (var field in godotProperties.Where(prop => prop.PropertyType == PropertyType.Field))
                     {
                         if (field.IsReadOnly)
                             continue;
 
-                        GeneratePropertySetter(field.FieldSymbol.Name,
-                            field.FieldSymbol.Type, field.Type, source);
+                        GeneratePropertySetter(field, source);
                     }
 
                     source.Append("        return base.SetGodotClassPropertyValue(name, value);\n");
@@ -213,7 +249,7 @@ namespace Godot.SourceGenerators
                 }
 
                 // Generate GetGodotClassPropertyValue
-                bool allPropertiesAreWriteOnly = godotClassFields.Length == 0 && godotClassProperties.All(pi => pi.IsWriteOnly);
+                bool allPropertiesAreWriteOnly = godotProperties.All(pi => pi.IsWriteOnly || (pi.PropertyType == PropertyType.Embed && !pi.PropertyTypeSymbol.IsReferenceType));
 
                 if (!allPropertiesAreWriteOnly)
                 {
@@ -222,19 +258,32 @@ namespace Godot.SourceGenerators
                     source.Append("    protected override bool GetGodotClassPropertyValue(in godot_string_name name, ");
                     source.Append("out godot_variant value)\n    {\n");
 
-                    foreach (var property in godotClassProperties)
+                    foreach (var embed in godotProperties.Where(prop => prop.PropertyType == PropertyType.Embed))
                     {
-                        if (property.PropertySymbol.IsWriteOnly)
+                        if (!embed.PropertyTypeSymbol.IsReferenceType)
                             continue;
 
-                        GeneratePropertyGetter(property.PropertySymbol.Name,
-                            property.PropertySymbol.Type, property.Type, source);
+                        source.Append("        if (name == PropertyName.@").Append(embed.PropertyName).Append("_nonnull) {\n");
+                        source.Append("            value = ").AppendManagedToNativeVariantExpr($"this.@{embed.MemberNameNullable} is not null",
+                            context.Compilation.GetSpecialType(SpecialType.System_Boolean), MarshalType.Boolean).Append(";\n");
+                        source.Append("            return true;\n");
+                        source.Append("        }\n");
                     }
 
-                    foreach (var field in godotClassFields)
+                    foreach (var property in godotProperties.Where(prop => prop.PropertyType == PropertyType.Property))
                     {
-                        GeneratePropertyGetter(field.FieldSymbol.Name,
-                            field.FieldSymbol.Type, field.Type, source);
+                        if (property.IsWriteOnly)
+                            continue;
+
+                        GeneratePropertyGetter(property, source);
+                    }
+
+                    foreach (var field in godotProperties.Where(prop => prop.PropertyType == PropertyType.Field))
+                    {
+                        if (field.IsWriteOnly)
+                            continue;
+
+                        GeneratePropertyGetter(field, source);
                     }
 
                     source.Append("        return base.GetGodotClassPropertyValue(name, out value);\n");
@@ -261,21 +310,31 @@ namespace Godot.SourceGenerators
                     .Append(DictionaryType)
                     .Append("();\n");
 
-                // To retain the definition order (and display categories correctly), we want to
-                //  iterate over fields and properties at the same time, sorted by line number.
-                var godotClassPropertiesAndFields = Enumerable.Empty<GodotPropertyOrFieldData>()
-                    .Concat(godotClassProperties.Select(propertyData => new GodotPropertyOrFieldData(propertyData)))
-                    .Concat(godotClassFields.Select(fieldData => new GodotPropertyOrFieldData(fieldData)))
-                    .OrderBy(data => data.Symbol.Locations[0].Path())
-                    .ThenBy(data => data.Symbol.Locations[0].StartLine());
 
-                foreach (var member in godotClassPropertiesAndFields)
+                foreach (var member in godotProperties)
                 {
-                    foreach (var groupingInfo in DetermineGroupingPropertyInfo(member.Symbol))
+                    if (member.PropertyType == PropertyType.Embed)
+                    {
+                        string memberGroupName = member.PropertyGroupName;
+                        AppendGroupingPropertyInfo(source, new PropertyInfo(
+                            VariantType.Nil,
+                            member.ContainingProperty is null ? memberGroupName : memberGroupName.Substring(memberGroupName.IndexOf("/") + 1),
+                            PropertyHint.None,
+                            $"{memberGroupName}/",
+                            member.ContainingProperty is null ? PropertyUsageFlags.Group : PropertyUsageFlags.Subgroup,
+                            true
+                        ));
+                        if (member.PropertyTypeSymbol.IsReferenceType)
+                        {
+                            AppendPropertyInfo(source, new PropertyInfo(VariantType.Bool, $"{member.PropertyName}_nonnull", PropertyHint.GroupEnable, "", PropertyUsageFlags.Default, true));
+                        }
+                        continue;
+                    }
+
+                    foreach (var groupingInfo in DetermineGroupingPropertyInfo(member))
                         AppendGroupingPropertyInfo(source, groupingInfo);
 
-                    var propertyInfo = DeterminePropertyInfo(context, typeCache,
-                        member.Symbol, member.Type);
+                    var propertyInfo = DeterminePropertyInfo(context, typeCache, member);
 
                     if (propertyInfo == null)
                         continue;
@@ -321,42 +380,39 @@ namespace Godot.SourceGenerators
             context.AddSource(uniqueHint, SourceText.From(source.ToString(), Encoding.UTF8));
         }
 
-        private static void GeneratePropertySetter(
-            string propertyMemberName,
-            ITypeSymbol propertyTypeSymbol,
-            MarshalType propertyMarshalType,
-            StringBuilder source
-        )
+        private static void GeneratePropertySetter(GodotPropertyData property, StringBuilder source)
         {
             source.Append("        ");
 
             source.Append("if (name == PropertyName.@")
-                .Append(propertyMemberName)
-                .Append(") {\n")
-                .Append("            this.@")
-                .Append(propertyMemberName)
+                .Append(property.PropertyName)
+                .Append(") {\n");
+            if (property.InNullable)
+                source.Append("            if (this.@")
+                    .Append(property.ContainingProperty.MemberNameNullable)
+                    .Append(" is not null) {\n    ");
+            source.Append("            this.@")
+                .Append(property.MemberName)
                 .Append(" = ")
-                .AppendNativeVariantToManagedExpr("value", propertyTypeSymbol, propertyMarshalType)
-                .Append(";\n")
-                .Append("            return true;\n")
+                .AppendNativeVariantToManagedExpr("value", property.PropertyTypeSymbol, property.MarshalType)
+                .Append(";\n");
+            if (property.InNullable)
+                source.Append("            }\n");
+            source.Append("            return true;\n")
                 .Append("        }\n");
         }
 
-        private static void GeneratePropertyGetter(
-            string propertyMemberName,
-            ITypeSymbol propertyTypeSymbol,
-            MarshalType propertyMarshalType,
-            StringBuilder source
-        )
+        private static void GeneratePropertyGetter(GodotPropertyData property, StringBuilder source)
         {
             source.Append("        ");
 
             source.Append("if (name == PropertyName.@")
-                .Append(propertyMemberName)
+                .Append(property.PropertyName)
                 .Append(") {\n")
                 .Append("            value = ")
-                .AppendManagedToNativeVariantExpr("this.@" + propertyMemberName,
-                    propertyTypeSymbol, propertyMarshalType)
+                .AppendManagedToNativeVariantExpr(
+                    string.Concat("this.@", property.MemberNameNullable, property.InNullable ? " ?? default" : ""),
+                    property.PropertyTypeSymbol, property.MarshalType)
                 .Append(";\n")
                 .Append("            return true;\n")
                 .Append("        }\n");
@@ -394,9 +450,9 @@ namespace Godot.SourceGenerators
                 .Append("));\n");
         }
 
-        private static IEnumerable<PropertyInfo> DetermineGroupingPropertyInfo(ISymbol memberSymbol)
+        private static IEnumerable<PropertyInfo> DetermineGroupingPropertyInfo(GodotPropertyData property)
         {
-            foreach (var attr in memberSymbol.GetAttributes())
+            foreach (var attr in property.Symbol.GetAttributes())
             {
                 PropertyUsageFlags? propertyUsage = attr.AttributeClass?.FullQualifiedNameOmitGlobal() switch
                 {
@@ -415,6 +471,19 @@ namespace Godot.SourceGenerators
                     if (propertyUsage != PropertyUsageFlags.Category && attr.ConstructorArguments.Length > 1)
                         hintString = attr.ConstructorArguments[1].Value?.ToString();
 
+                    if (propertyUsage != PropertyUsageFlags.Category && property.ContainingProperty is not null)
+                    {
+                        string groupName = property.ContainingProperty.PropertyGroupName;
+                        hintString = $"{groupName}/{hintString}";
+                        int slashIndex = groupName.IndexOf("/");
+                        if (slashIndex != -1)
+                            groupName = groupName.Substring(slashIndex + 1);
+                        else
+                            groupName = "";
+                        name = string.Join("/", new[] { groupName, name }.Where(s => !string.IsNullOrWhiteSpace(s)));
+                        propertyUsage = PropertyUsageFlags.Subgroup;
+                    }
+
                     yield return new PropertyInfo(VariantType.Nil, name, PropertyHint.None, hintString,
                         propertyUsage.Value, true);
                 }
@@ -424,28 +493,27 @@ namespace Godot.SourceGenerators
         private static PropertyInfo? DeterminePropertyInfo(
             GeneratorExecutionContext context,
             MarshalUtils.TypeCache typeCache,
-            ISymbol memberSymbol,
-            MarshalType marshalType
+            GodotPropertyData property
         )
         {
-            var exportAttr = memberSymbol.GetAttributes()
+            var exportAttr = property.Symbol.GetAttributes()
                 .FirstOrDefault(a => a.AttributeClass?.IsGodotExportAttribute() ?? false);
 
-            var exportToolButtonAttr = memberSymbol.GetAttributes()
+            var exportToolButtonAttr = property.Symbol.GetAttributes()
                 .FirstOrDefault(a => a.AttributeClass?.IsGodotExportToolButtonAttribute() ?? false);
 
             if (exportAttr != null && exportToolButtonAttr != null)
             {
                 context.ReportDiagnostic(Diagnostic.Create(
                     Common.ExportToolButtonShouldNotBeUsedWithExportRule,
-                    memberSymbol.Locations.FirstLocationWithSourceTreeOrDefault(),
-                    memberSymbol.ToDisplayString()
+                    property.Symbol.Locations.FirstLocationWithSourceTreeOrDefault(),
+                    property.Symbol.ToDisplayString()
                 ));
                 return null;
             }
 
-            var propertySymbol = memberSymbol as IPropertySymbol;
-            var fieldSymbol = memberSymbol as IFieldSymbol;
+            var propertySymbol = property.Symbol as IPropertySymbol;
+            var fieldSymbol = property.Symbol as IFieldSymbol;
 
             if (exportAttr != null && propertySymbol != null)
             {
@@ -557,8 +625,8 @@ namespace Godot.SourceGenerators
 
             var memberType = propertySymbol?.Type ?? fieldSymbol!.Type;
 
-            var memberVariantType = MarshalUtils.ConvertMarshalTypeToVariantType(marshalType)!.Value;
-            string memberName = memberSymbol.Name;
+            var memberVariantType = MarshalUtils.ConvertMarshalTypeToVariantType(property.MarshalType)!.Value;
+            string memberName = property.PropertyName;
 
             string? hintString = null;
 
@@ -568,8 +636,8 @@ namespace Godot.SourceGenerators
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         Common.ExportToolButtonIsNotCallableRule,
-                        memberSymbol.Locations.FirstLocationWithSourceTreeOrDefault(),
-                        memberSymbol.ToDisplayString()
+                        property.Symbol.Locations.FirstLocationWithSourceTreeOrDefault(),
+                        property.Symbol.ToDisplayString()
                     ));
                     return null;
                 }

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptPropertyDefValGenerator.cs
@@ -115,22 +115,42 @@ namespace Godot.SourceGenerators
                 .Where(m => !m.GetAttributes()
                     .Any(a => a.AttributeClass?.IsGodotIgnoreMemberAttribute() ?? false));
 
-            var exportedProperties = members
-                .Where(s => s.Kind == SymbolKind.Property)
-                .Cast<IPropertySymbol>()
-                .Where(s => s.GetAttributes()
-                    .Any(a => a.AttributeClass?.IsGodotExportAttribute() ?? false))
+            var godotProperties = members
+                .WhereIsSortedGodotProperties(
+                    typeCache,
+                    static members => members
+                        .Where(s => s.Kind == SymbolKind.Property)
+                        .Cast<IPropertySymbol>()
+                        .Where(s => s.GetAttributes()
+                            .Any(a => a.AttributeClass?.IsGodotExportAttribute() ?? false))
+                    ,
+                    static members => members
+                        .Where(s => s.Kind == SymbolKind.Field && !s.IsImplicitlyDeclared)
+                        .Cast<IFieldSymbol>()
+                        .Where(s => s.GetAttributes()
+                            .Any(a => a.AttributeClass?.IsGodotExportAttribute() ?? false))
+                    ,
+                    true)
                 .ToArray();
 
-            var exportedFields = members
-                .Where(s => s.Kind == SymbolKind.Field && !s.IsImplicitlyDeclared)
-                .Cast<IFieldSymbol>()
-                .Where(s => s.GetAttributes()
-                    .Any(a => a.AttributeClass?.IsGodotExportAttribute() ?? false))
-                .ToArray();
-
-            foreach (var property in exportedProperties)
+            foreach (var embed in godotProperties.Where(data => data.PropertyType == PropertyType.Embed))
             {
+                if (!embed.PropertyTypeSymbol.IsReferenceType)
+                    continue;
+
+                exportedMembers.Add(new ExportedPropertyMetadata(
+                    $"{embed.PropertyName}_nonnull",
+                    MarshalType.Boolean,
+                    context.Compilation.GetSpecialType(SpecialType.System_Boolean),
+                    null
+                ));
+            }
+
+            foreach (var godotProperty in godotProperties.Where(data => data.PropertyType == PropertyType.Property || data.PropertyType == PropertyType.Unallowed))
+            {
+                if (godotProperty.Symbol is not IPropertySymbol property)
+                    continue;
+
                 if (property.IsStatic)
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
@@ -186,9 +206,9 @@ namespace Godot.SourceGenerators
                 }
 
                 var propertyType = property.Type;
-                var marshalType = MarshalUtils.ConvertManagedTypeToMarshalType(propertyType, typeCache);
+                var marshalType = godotProperty.MarshalType;
 
-                if (marshalType == null)
+                if (godotProperty.PropertyType == PropertyType.Unallowed || godotProperty.PropertyType == PropertyType.Embed)
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         Common.ExportedMemberTypeIsNotSupportedRule,
@@ -198,7 +218,7 @@ namespace Godot.SourceGenerators
                     continue;
                 }
 
-                if (!isNode && MemberHasNodeType(propertyType, marshalType.Value))
+                if (!isNode && MemberHasNodeType(propertyType, marshalType))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         Common.OnlyNodesShouldExportNodesRule,
@@ -278,11 +298,14 @@ namespace Godot.SourceGenerators
                 }
 
                 exportedMembers.Add(new ExportedPropertyMetadata(
-                    property.Name, marshalType.Value, propertyType, value));
+                    godotProperty.PropertyName, marshalType, propertyType, value));
             }
 
-            foreach (var field in exportedFields)
+            foreach (var godotField in godotProperties.Where(data => data.PropertyType == PropertyType.Field || data.PropertyType == PropertyType.Unallowed))
             {
+                if (godotField.Symbol is not IFieldSymbol field)
+                    continue;
+
                 if (field.IsStatic)
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
@@ -306,9 +329,9 @@ namespace Godot.SourceGenerators
                 }
 
                 var fieldType = field.Type;
-                var marshalType = MarshalUtils.ConvertManagedTypeToMarshalType(fieldType, typeCache);
+                var marshalType = godotField.MarshalType;
 
-                if (marshalType == null)
+                if (godotField.PropertyType == PropertyType.Unallowed || godotField.PropertyType == PropertyType.Embed)
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         Common.ExportedMemberTypeIsNotSupportedRule,
@@ -318,7 +341,7 @@ namespace Godot.SourceGenerators
                     continue;
                 }
 
-                if (!isNode && MemberHasNodeType(fieldType, marshalType.Value))
+                if (!isNode && MemberHasNodeType(fieldType, marshalType))
                 {
                     context.ReportDiagnostic(Diagnostic.Create(
                         Common.OnlyNodesShouldExportNodesRule,
@@ -346,7 +369,7 @@ namespace Godot.SourceGenerators
                 }
 
                 exportedMembers.Add(new ExportedPropertyMetadata(
-                    field.Name, marshalType.Value, fieldType, value));
+                    godotField.PropertyName, marshalType, fieldType, value));
             }
 
             // Generate GetGodotExportedProperties

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSerializationGenerator.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators/ScriptSerializationGenerator.cs
@@ -114,25 +114,24 @@ namespace Godot.SourceGenerators
                 .Where(m => !m.GetAttributes()
                     .Any(a => a.AttributeClass?.IsGodotIgnoreMemberAttribute() ?? false));
 
-            var propertySymbols = members
-                .Where(s => !s.IsStatic && s.Kind == SymbolKind.Property)
-                .Cast<IPropertySymbol>()
-                .Where(s => !s.IsIndexer && s.ExplicitInterfaceImplementations.Length == 0);
-
-            var fieldSymbols = members
-                .Where(s => !s.IsStatic && s.Kind == SymbolKind.Field && !s.IsImplicitlyDeclared)
-                .Cast<IFieldSymbol>();
-
-            // TODO: We should still restore read-only properties after reloading assembly. Two possible ways: reflection or turn RestoreGodotObjectData into a constructor overload.
-            // Ignore properties without a getter, without a setter or with an init-only setter. Godot properties must be both readable and writable.
-            var godotClassProperties = propertySymbols
-                .Where(property => !(property.IsReadOnly || property.IsWriteOnly) && property.SetMethodOrBaseSetMethod() is { IsInitOnly: false })
-                .WhereIsGodotCompatibleType(typeCache)
+            var godotProperties = members
+                .WhereIsSortedGodotProperties(
+                    typeCache,
+                    static members => members
+                        .Where(s => !s.IsStatic && s.Kind == SymbolKind.Property)
+                        .Cast<IPropertySymbol>()
+                        .Where(s => !s.IsIndexer && s.ExplicitInterfaceImplementations.Length == 0)
+                        // TODO: We should still restore read-only properties after reloading assembly. Two possible ways: reflection or turn RestoreGodotObjectData into a constructor overload.
+                        // Ignore properties without a getter, without a setter or with an init-only setter. Godot properties must be both readable and writable.
+                        .Where(property => !(property.IsReadOnly || property.IsWriteOnly) && property.SetMethodOrBaseSetMethod() is { IsInitOnly: false })
+                    ,
+                    static members => members
+                        .Where(s => !s.IsStatic && s.Kind == SymbolKind.Field && !s.IsImplicitlyDeclared)
+                        .Cast<IFieldSymbol>()
+                        // TODO: Restore read-only properties.
+                        .Where(property => !property.IsReadOnly))
                 .ToArray();
-            var godotClassFields = fieldSymbols
-                .Where(property => !property.IsReadOnly)
-                .WhereIsGodotCompatibleType(typeCache)
-                .ToArray();
+
 
             var signalDelegateSymbols = members
                 .Where(s => s.Kind == SymbolKind.NamedType)
@@ -167,31 +166,45 @@ namespace Godot.SourceGenerators
                 "    protected override void SaveGodotObjectData(global::Godot.Bridge.GodotSerializationInfo info)\n    {\n");
             source.Append("        base.SaveGodotObjectData(info);\n");
 
+            // Save embedded nullables
+
+            foreach (var embed in godotProperties.Where(data => data.PropertyType == PropertyType.Embed))
+            {
+                if (!embed.PropertyTypeSymbol.IsReferenceType)
+                    continue;
+                {
+                    source.Append("        info.AddProperty(PropertyName.@")
+                        .Append(embed.PropertyName)
+                        .Append("_nonnull, ")
+                        .AppendManagedToVariantExpr(string.Concat("this.@", embed.MemberNameNullable, " is not null"),
+                            context.Compilation.GetSpecialType(SpecialType.System_Boolean), MarshalType.Boolean)
+                        .Append(");\n");
+                }
+            }
+
             // Save properties
 
-            foreach (var property in godotClassProperties)
+            foreach (var property in godotProperties.Where(data => data.PropertyType == PropertyType.Property))
             {
-                string propertyName = property.PropertySymbol.Name;
-
                 source.Append("        info.AddProperty(PropertyName.@")
-                    .Append(propertyName)
+                    .Append(property.PropertyName)
                     .Append(", ")
-                    .AppendManagedToVariantExpr(string.Concat("this.@", propertyName),
-                        property.PropertySymbol.Type, property.Type)
+                    .AppendManagedToVariantExpr(
+                        string.Concat("this.@", property.MemberNameNullable, property.InNullable ? " ?? default" : ""),
+                        property.PropertyTypeSymbol, property.MarshalType)
                     .Append(");\n");
             }
 
             // Save fields
 
-            foreach (var field in godotClassFields)
+            foreach (var field in godotProperties.Where(data => data.PropertyType == PropertyType.Field))
             {
-                string fieldName = field.FieldSymbol.Name;
-
                 source.Append("        info.AddProperty(PropertyName.@")
-                    .Append(fieldName)
+                    .Append(field.PropertyName)
                     .Append(", ")
-                    .AppendManagedToVariantExpr(string.Concat("this.@", fieldName),
-                        field.FieldSymbol.Type, field.Type)
+                    .AppendManagedToVariantExpr(
+                        string.Concat("this.@", field.MemberNameNullable, field.InNullable ? " ?? default" : ""),
+                        field.PropertyTypeSymbol, field.MarshalType)
                     .Append(");\n");
             }
 
@@ -216,41 +229,69 @@ namespace Godot.SourceGenerators
                 "    protected override void RestoreGodotObjectData(global::Godot.Bridge.GodotSerializationInfo info)\n    {\n");
             source.Append("        base.RestoreGodotObjectData(info);\n");
 
+            // Restore embedded nullables
+
+            foreach (var embed in godotProperties.Where(data => data.PropertyType == PropertyType.Embed))
+            {
+                if (!embed.PropertyTypeSymbol.IsReferenceType)
+                    continue;
+                source.Append("        if (");
+                if (embed.InNullable)
+                    source.Append("this.@").Append(embed.ContainingProperty.MemberNameNullable).Append(" is not null && ");
+                source.Append("info.TryGetProperty(PropertyName.@")
+                    .Append(embed.PropertyName)
+                    .Append("_nonnull, out var _value_")
+                    .Append(embed.PropertyName)
+                    .Append("_nonnull))\n")
+                    .Append("            this.@")
+                    .Append(embed.MemberName)
+                    .Append(" = ")
+                    .AppendVariantToManagedExpr(string.Concat("_value_", embed.PropertyName, "_nonnull"),
+                        context.Compilation.GetSpecialType(SpecialType.System_Boolean), MarshalType.Boolean)
+                    .Append(" ? ")
+                    .Append("this.@")
+                    .Append(embed.MemberName)
+                    .Append(" ?? new() : null;\n");
+            }
+
             // Restore properties
 
-            foreach (var property in godotClassProperties)
+            foreach (var property in godotProperties.Where(data => data.PropertyType == PropertyType.Property))
             {
-                string propertyName = property.PropertySymbol.Name;
-
-                source.Append("        if (info.TryGetProperty(PropertyName.@")
-                    .Append(propertyName)
+                source.Append("        if (");
+                if (property.InNullable)
+                    source.Append("this.@").Append(property.ContainingProperty.MemberNameNullable).Append(" is not null && ");
+                source.Append("info.TryGetProperty(PropertyName.@")
+                    .Append(property.PropertyName)
                     .Append(", out var _value_")
-                    .Append(propertyName)
-                    .Append("))\n")
+                    .Append(property.PropertyName)
+                    .Append(")");
+                source.Append(")\n")
                     .Append("            this.@")
-                    .Append(propertyName)
+                    .Append(property.MemberName)
                     .Append(" = ")
-                    .AppendVariantToManagedExpr(string.Concat("_value_", propertyName),
-                        property.PropertySymbol.Type, property.Type)
+                    .AppendVariantToManagedExpr(string.Concat("_value_", property.PropertyName),
+                        property.PropertyTypeSymbol, property.MarshalType)
                     .Append(";\n");
             }
 
             // Restore fields
 
-            foreach (var field in godotClassFields)
+            foreach (var field in godotProperties.Where(data => data.PropertyType == PropertyType.Field))
             {
-                string fieldName = field.FieldSymbol.Name;
-
-                source.Append("        if (info.TryGetProperty(PropertyName.@")
-                    .Append(fieldName)
+                source.Append("        if (");
+                if (field.InNullable)
+                    source.Append("this.@").Append(field.ContainingProperty.MemberNameNullable).Append(" is not null && ");
+                source.Append("info.TryGetProperty(PropertyName.@")
+                    .Append(field.PropertyName)
                     .Append(", out var _value_")
-                    .Append(fieldName)
+                    .Append(field.PropertyName)
                     .Append("))\n")
                     .Append("            this.@")
-                    .Append(fieldName)
+                    .Append(field.MemberName)
                     .Append(" = ")
-                    .AppendVariantToManagedExpr(string.Concat("_value_", fieldName),
-                        field.FieldSymbol.Type, field.Type)
+                    .AppendVariantToManagedExpr(string.Concat("_value_", field.PropertyName),
+                        field.PropertyTypeSymbol, field.MarshalType)
                     .Append(";\n");
             }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportEmbedAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportEmbedAttribute.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Godot
+{
+    /// <summary>
+    /// Embeds the properties of annotated member as a properties of the Godot Object.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
+    public sealed class ExportEmbedAttribute : Attribute { }
+}

--- a/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
+++ b/modules/mono/glue/GodotSharp/GodotSharp/GodotSharp.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Core\Array.cs" />
     <Compile Include="Core\Attributes\AssemblyHasScriptsAttribute.cs" />
     <Compile Include="Core\Attributes\ExportAttribute.cs" />
+    <Compile Include="Core\Attributes\ExportEmbedAttribute.cs" />
     <Compile Include="Core\Attributes\ExportCategoryAttribute.cs" />
     <Compile Include="Core\Attributes\ExportGroupAttribute.cs" />
     <Compile Include="Core\Attributes\ExportSubgroupAttribute.cs" />


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes: https://github.com/godotengine/godot-proposals/issues/438
- Closes: https://github.com/godotengine/godot-proposals/issues/997

## Additional information

Currently just a proof of concept.

Not sure if there is interest for this, seeing as structs are being hypothetically worked on, but I just had an idea that I thought is possible with already existing systems. Should be even more lightweight than hypothetical structs, seeing that these properties don't actually exist :V

<img width="1786" height="990" alt="image" src="https://github.com/user-attachments/assets/334990e3-2b83-4ce7-9c22-2f93a3e81cb9" />

## Limitations

- You can't use `[ExportEmbed]` in the middle of the group or a subgroup (well you can if you like seeing broken grouping I guess).
- Pretty sure `[ExportCategory]` won't work (breaks `PROPERTY_HINT_GROUP_ENABLE` that is used as null set).
- Treats `[ExportGroup]` as `[ExportSubgroup]` inside the embedded class, otherwise it was too messy.
- If you null a class value in `[Tool]` script , you won't be able to restore its values.
- Bloat of properties, embedded types work by embedding properties as part of the Godot Object.

No AI used.