### PR TITLE
Use `SIZE_SHRINK_BEGIN` instead of `0` in `set_*_size_flags` calls

### DIFF
--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -587,7 +587,7 @@ void EditorAssetLibraryItemDescription::add_release(const String &p_url, const S
 
 void EditorAssetLibraryItemDescription::add_preview(int p_id, bool p_video, const String &p_url, const String &p_thumbnail) {
 	if (preview_images.is_empty()) {
-		desc_vbox->set_h_size_flags(0);
+		desc_vbox->set_h_size_flags(Control::SIZE_SHRINK_BEGIN);
 		previews_vbox->show();
 	}
 
@@ -965,7 +965,7 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 	panel->add_child(hb);
 	icon = memnew(TextureRect);
 	icon->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
-	icon->set_v_size_flags(0);
+	icon->set_v_size_flags(SIZE_SHRINK_BEGIN);
 	hb->add_child(icon);
 
 	VBoxContainer *vb = memnew(VBoxContainer);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -2320,7 +2320,7 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 
 		clear_button = memnew(Button);
 		clear_button->set_text(TTRC("Clear"));
-		clear_button->set_h_size_flags(0);
+		clear_button->set_h_size_flags(SIZE_SHRINK_BEGIN);
 		clear_button->set_disabled(true);
 		clear_button->connect(SceneStringName(pressed), callable_mp(this, &ScriptEditorDebugger::_clear_errors_list));
 		error_hbox->add_child(clear_button);

--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -1580,7 +1580,7 @@ Polygon2DEditor::Polygon2DEditor() {
 	bone_scroll_main_vb->set_custom_minimum_size(Size2(150 * EDSCALE, 0));
 	sync_bones = memnew(Button(TTR("Sync Bones to Polygon")));
 	bone_scroll_main_vb->add_child(sync_bones);
-	sync_bones->set_h_size_flags(0);
+	sync_bones->set_h_size_flags(SIZE_SHRINK_BEGIN);
 	sync_bones->connect(SceneStringName(pressed), callable_mp(this, &Polygon2DEditor::_sync_bones));
 	uv_main_hsc->add_child(bone_scroll_main_vb);
 	bone_scroll = memnew(ScrollContainer);

--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -6807,7 +6807,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 
 	view_display_menu = memnew(MenuButton);
 	view_display_menu->set_flat(false);
-	view_display_menu->set_h_size_flags(0);
+	view_display_menu->set_h_size_flags(SIZE_SHRINK_BEGIN);
 	view_display_menu->set_shortcut_context(this);
 	view_display_menu->set_accessibility_name(TTRC("View"));
 	view_display_menu->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);
@@ -6963,7 +6963,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	// Using Control even on macOS to avoid conflict with Quick Open shortcut.
 	preview_camera->set_shortcut(ED_SHORTCUT("spatial_editor/toggle_camera_preview", TTRC("Toggle Camera Preview"), KeyModifierMask::CTRL | Key::P));
 	vbox->add_child(preview_camera);
-	preview_camera->set_h_size_flags(0);
+	preview_camera->set_h_size_flags(SIZE_SHRINK_BEGIN);
 	preview_camera->set_theme_type_variation("CheckBoxNoIconTint");
 	preview_camera->hide();
 	preview_camera->connect(SceneStringName(toggled), callable_mp(this, &Node3DEditorViewport::_toggle_camera_preview));
@@ -6973,7 +6973,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	pilot_camera->set_tooltip_text(TTRC("Enable pilot mode for the preview camera.\nAllows WASD movement and mouse look when in preview mode."));
 	pilot_camera->set_shortcut(ED_SHORTCUT("spatial_editor/toggle_pilot_preview", TTRC("Toggle Pilot Mode in Preview")));
 	vbox->add_child(pilot_camera);
-	pilot_camera->set_h_size_flags(0);
+	pilot_camera->set_h_size_flags(SIZE_SHRINK_BEGIN);
 	pilot_camera->set_theme_type_variation("CheckBoxNoIconTint");
 	pilot_camera->hide();
 	pilot_camera->connect(SceneStringName(toggled), callable_mp(this, &Node3DEditorViewport::_toggle_pilot_preview));

--- a/editor/scene/sprite_frames_editor_plugin.cpp
+++ b/editor/scene/sprite_frames_editor_plugin.cpp
@@ -2592,8 +2592,8 @@ SpriteFramesEditor::SpriteFramesEditor() {
 
 	MarginContainer *split_sheet_zoom_margin = memnew(MarginContainer);
 	split_sheet_panel->add_child(split_sheet_zoom_margin);
-	split_sheet_zoom_margin->set_h_size_flags(0);
-	split_sheet_zoom_margin->set_v_size_flags(0);
+	split_sheet_zoom_margin->set_h_size_flags(SIZE_SHRINK_BEGIN);
+	split_sheet_zoom_margin->set_v_size_flags(SIZE_SHRINK_BEGIN);
 	split_sheet_zoom_margin->add_theme_constant_override("margin_top", 5);
 	split_sheet_zoom_margin->add_theme_constant_override("margin_left", 5);
 	HBoxContainer *split_sheet_zoom_hb = memnew(HBoxContainer);

--- a/editor/settings/editor_layouts_dialog.cpp
+++ b/editor/settings/editor_layouts_dialog.cpp
@@ -148,7 +148,7 @@ EditorLayoutsDialog::EditorLayoutsDialog() {
 	validation->add_line(0);
 	validation->set_update_callback(callable_mp(this, &EditorLayoutsDialog::_validate_name));
 	validation->set_accept_button(get_ok_button());
-	validation->set_v_size_flags(0);
+	validation->set_v_size_flags(Control::SIZE_SHRINK_BEGIN);
 
 	layout_names = memnew(ItemList);
 	layout_names->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED);

--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -290,6 +290,6 @@ void ProgressBar::_bind_methods() {
 }
 
 ProgressBar::ProgressBar() {
-	set_v_size_flags(0);
+	set_v_size_flags(SIZE_SHRINK_BEGIN);
 	set_step(0.01);
 }

--- a/scene/gui/scroll_bar.h
+++ b/scene/gui/scroll_bar.h
@@ -141,7 +141,7 @@ protected:
 
 public:
 	HScrollBar() :
-			ScrollBar(HORIZONTAL) { set_v_size_flags(0); }
+			ScrollBar(HORIZONTAL) { set_v_size_flags(SIZE_SHRINK_BEGIN); }
 };
 
 class VScrollBar : public ScrollBar {
@@ -152,5 +152,5 @@ protected:
 
 public:
 	VScrollBar() :
-			ScrollBar(VERTICAL) { set_h_size_flags(0); }
+			ScrollBar(VERTICAL) { set_h_size_flags(SIZE_SHRINK_BEGIN); }
 };

--- a/scene/gui/slider.h
+++ b/scene/gui/slider.h
@@ -118,7 +118,7 @@ class HSlider : public Slider {
 
 public:
 	HSlider() :
-			Slider(HORIZONTAL) { set_v_size_flags(0); }
+			Slider(HORIZONTAL) { set_v_size_flags(SIZE_SHRINK_BEGIN); }
 };
 
 class VSlider : public Slider {
@@ -126,5 +126,5 @@ class VSlider : public Slider {
 
 public:
 	VSlider() :
-			Slider(VERTICAL) { set_h_size_flags(0); }
+			Slider(VERTICAL) { set_h_size_flags(SIZE_SHRINK_BEGIN); }
 };


### PR DESCRIPTION
## What problem(s) does this PR solve?

Replaces all usages of `0` in `set_*_size_flags` calls with the corresponding enum `SIZE_SHRINK_BEGIN`