### PR TITLE
GDScript: Prevent code completion from suggesting enum values on global enum value

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1526,7 +1526,7 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 				return;
 			} break;
 			case GDScriptParser::DataType::ENUM: {
-				if (p_types_only) {
+				if (p_types_only || !base_type.is_meta_type) {
 					return;
 				}
 

--- a/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_no_autocomplete_on_value_explicit_metatype.cfg
+++ b/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_no_autocomplete_on_value_explicit_metatype.cfg
@@ -1,0 +1,2 @@
+[output]
+exclude=[{"display": "ANCHOR_BEGIN"}]

--- a/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_no_autocomplete_on_value_explicit_metatype.gd
+++ b/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_no_autocomplete_on_value_explicit_metatype.gd
@@ -1,0 +1,5 @@
+extends Control
+
+func _ready():
+    var t = Anchor.ANCHOR_BEGIN.➡
+    pass

--- a/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_no_autocomplete_on_value_inferred_metatype.cfg
+++ b/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_no_autocomplete_on_value_inferred_metatype.cfg
@@ -1,0 +1,2 @@
+[output]
+exclude=[{"display": "ANCHOR_BEGIN"}]

--- a/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_no_autocomplete_on_value_inferred_metatype.gd
+++ b/modules/gdscript/tests/scripts/completion/builtin_enum/builtin_enum_no_autocomplete_on_value_inferred_metatype.gd
@@ -1,0 +1,5 @@
+extends Control
+
+func _ready():
+    var t = ANCHOR_BEGIN.➡
+    pass

--- a/modules/gdscript/tests/scripts/completion/global_enum/global_enum_no_autocomplete_on_value_explicit_metatype.cfg
+++ b/modules/gdscript/tests/scripts/completion/global_enum/global_enum_no_autocomplete_on_value_explicit_metatype.cfg
@@ -1,0 +1,2 @@
+[output]
+exclude=[{"display": "KEY_0"}]

--- a/modules/gdscript/tests/scripts/completion/global_enum/global_enum_no_autocomplete_on_value_explicit_metatype.gd
+++ b/modules/gdscript/tests/scripts/completion/global_enum/global_enum_no_autocomplete_on_value_explicit_metatype.gd
@@ -1,0 +1,5 @@
+extends Control
+
+func _ready():
+    var t = Key.KEY_0.➡
+    pass

--- a/modules/gdscript/tests/scripts/completion/global_enum/global_enum_no_autocomplete_on_value_inferred_metatype.cfg
+++ b/modules/gdscript/tests/scripts/completion/global_enum/global_enum_no_autocomplete_on_value_inferred_metatype.cfg
@@ -1,0 +1,2 @@
+[output]
+exclude=[{"display": "KEY_0"}]

--- a/modules/gdscript/tests/scripts/completion/global_enum/global_enum_no_autocomplete_on_value_inferred_metatype.gd
+++ b/modules/gdscript/tests/scripts/completion/global_enum/global_enum_no_autocomplete_on_value_inferred_metatype.gd
@@ -1,0 +1,5 @@
+extends Control
+
+func _ready():
+    var t = KEY_0.➡
+    pass

--- a/modules/gdscript/tests/scripts/completion/script_enum/script_enum_no_autocomplete_on_value_explicit_metatype.cfg
+++ b/modules/gdscript/tests/scripts/completion/script_enum/script_enum_no_autocomplete_on_value_explicit_metatype.cfg
@@ -1,0 +1,2 @@
+[output]
+exclude=[{"display": "ONE"}, {"display": "TWO"}]

--- a/modules/gdscript/tests/scripts/completion/script_enum/script_enum_no_autocomplete_on_value_explicit_metatype.gd
+++ b/modules/gdscript/tests/scripts/completion/script_enum/script_enum_no_autocomplete_on_value_explicit_metatype.gd
@@ -1,0 +1,7 @@
+extends Control
+
+enum MyEnum { ONE, TWO }
+
+func _ready():
+    var t = MyEnum.ONE.➡
+    pass


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #122761

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

As described in [my comment on the issue](https://github.com/godotengine/godot/issues/122761#issuecomment-5398311065), it seems that global enum _values_ (like `KEY_0`) were being inferred/guessed to be their parent enum _type_, which was causing code completion to suggest using them as if they were their type. This PR adds a check to this process: if the actual item we're getting code completion for is an `int` (as is the case for global enum _values_), we avoid this inference/guessing.

This gives the expected behavior for all of the test cases I ran:

https://github.com/user-attachments/assets/11b1a76e-8f67-45ee-9983-edfa2a9676a4


