### PR TITLE
.NET: Exclude `.a` files from Android exports

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -365,6 +365,12 @@ namespace GodotTools.Export
                                                 path = newPath;
                                             }
 
+                                            if (fileName.EndsWith(".a"))
+                                            {
+                                                // Don't export static libraries for Android.
+                                                return;
+                                            }
+
                                             AddSharedObject(path, tags: new string[] { arch },
                                                 Path.Join(projectDataDirName,
                                                     Path.GetRelativePath(publishOutputDir,


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/115679

## Additional information

N/A
