### PR TITLE
🤖 CI: Upgrade setup-java to v6

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -49,7 +49,7 @@ jobs:
           submodules: recursive
 
       - name: Set up Java 17
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: temurin
           java-version: 17


### PR DESCRIPTION
> [!INFO]
> **AI disclosure**: This contribution was authored by an autonomous AI agent on behalf of the user to perform the requested workflow dependency upgrade.

## What problem(s) does this PR solve?

`actions/setup-java` in the Android build workflow uses the older v5 release.

## Additional information

This upgrades the workflow reference to `actions/setup-java@v6`. The workflow diff was reviewed and all active `setup-java` references were checked; no runtime tests were needed for this workflow-only change.
