### PR TITLE
CI: Migrate `static-checks` OS to `ubuntu-slim`

### DIFF
--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -13,8 +13,8 @@ on:
 jobs:
   static-checks:
     name: Code style, file formatting, and docs
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
+    runs-on: ubuntu-slim
+    timeout-minutes: 15
     outputs:
       changed-files: '"${{ steps.changed-files.outputs.clangd_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.
       sources-changed: ${{ steps.changed-files.outputs.sources_any_changed }}


### PR DESCRIPTION
## What problem(s) does this PR solve?

Expedites and simplifies our static checker action with a lightweight runner: [`ubuntu-slim`](https://docs.github.com/en/actions/reference/runners/github-hosted-runners#single-cpu-runners). This runner is designed specifically for the kind of small-scale automation checks this workflow already targets, and should help take a load off other runners fighting over resources when multiple static checks are underway.

## Additional information

As the single-CPU runners have a timeout of 15 minutes built-in, the `timeout-minutes` parameter was explicitly updated to reflect this upper limit. We should never reach this threshold in practice.