### PR TITLE
CI: Bump Ubuntu versions to next LTS

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build-android:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     name: ${{ matrix.name }}
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -24,7 +24,7 @@ env:
 jobs:
   build-linux:
     # Stay one LTS before latest to increase portability of Linux artifacts.
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: ${{ matrix.name }}
     timeout-minutes: 120
     strategy:

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   static-checks:
     name: Code style, file formatting, and docs
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 30
     outputs:
       changed-files: '"${{ steps.changed-files.outputs.clangd_all_changed_files }}"' # Wrap with quotes to bookend internal quote separators.

--- a/.github/workflows/web_builds.yml
+++ b/.github/workflows/web_builds.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   web-template:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     name: ${{ matrix.name }}
     timeout-minutes: 60
     strategy:

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -493,7 +493,9 @@ public:
 		}
 
 		call_level->prev = _call_stack;
+		GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wdangling-pointer=") // False positive on GCC 13/14.
 		_call_stack = call_level;
+		GODOT_GCC_WARNING_POP
 		call_level->stack = p_stack;
 		call_level->instance = p_instance;
 		call_level->function = p_function;


### PR DESCRIPTION
## What problem(s) does this PR solve?

In a little less than a month, Ubuntu 22 runners are set to be deprecated, with them being outright removed the following April[^1]. In the interest of staying ahead of the curve, this PR bumps all relevant Ubuntu runners to the next LTS versions. That puts the Linux-build runner at Ubuntu 24 & all other Ubuntu runners at Ubuntu 26[^2].

Marking as a draft for the time being, as there are some lsan-related warnings that go a bit over my head.

## Additional information

[^1]: actions/runner-images#14254
[^2]: actions/runner-images#14226