### PR TITLE
Resource format text: Replace all instances of `_printerr` with `ERR_PRINT` directly

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -37,8 +37,8 @@
 #include "core/object/script_language.h"
 #include "scene/property_utils.h"
 
-void ResourceLoaderText::_printerr() {
-	ERR_PRINT(vformat("%s:%d - Parse Error: %s.", res_path, lines, error_text));
+String ResourceLoaderText::_get_error_string() {
+	return vformat("%s:%d - Parse Error: %s.", res_path, lines, error_text);
 }
 
 Ref<Resource> ResourceLoaderText::get_resource() {
@@ -151,7 +151,7 @@ Error ResourceLoaderText::_parse_ext_resource(VariantParser::Stream *p_stream, R
 					if (ResourceLoader::get_abort_on_missing_resources()) {
 						error = ERR_FILE_MISSING_DEPENDENCIES;
 						error_text = "[ext_resource] referenced non-existent resource at: " + path;
-						_printerr();
+						ERR_PRINT(_get_error_string());
 						err = error;
 					} else {
 						ResourceLoader::notify_dependency_error(local_path, path, type);
@@ -204,7 +204,7 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 			} else {
 				error = ERR_FILE_CORRUPT;
 				error_text = "Missing 'name' field from node tag";
-				_printerr();
+				ERR_PRINT(_get_error_string());
 				return Ref<PackedScene>();
 			}
 
@@ -253,7 +253,7 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 				if (packed_scene->get_state()->get_node_count() == 0) {
 					error = ERR_FILE_CORRUPT;
 					error_text = "Instance Placeholder can't be used for inheritance";
-					_printerr();
+					ERR_PRINT(_get_error_string());
 					return Ref<PackedScene>();
 				}
 
@@ -317,28 +317,28 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 			if (!next_tag.fields.has("from")) {
 				error = ERR_FILE_CORRUPT;
 				error_text = "Missing 'from' field from connection tag";
-				_printerr();
+				ERR_PRINT(_get_error_string());
 				return Ref<PackedScene>();
 			}
 
 			if (!next_tag.fields.has("to")) {
 				error = ERR_FILE_CORRUPT;
 				error_text = "Missing 'to' field from connection tag";
-				_printerr();
+				ERR_PRINT(_get_error_string());
 				return Ref<PackedScene>();
 			}
 
 			if (!next_tag.fields.has("signal")) {
 				error = ERR_FILE_CORRUPT;
 				error_text = "Missing 'signal' field from connection tag";
-				_printerr();
+				ERR_PRINT(_get_error_string());
 				return Ref<PackedScene>();
 			}
 
 			if (!next_tag.fields.has("method")) {
 				error = ERR_FILE_CORRUPT;
 				error_text = "Missing 'method' field from connection tag";
-				_printerr();
+				ERR_PRINT(_get_error_string());
 				return Ref<PackedScene>();
 			}
 
@@ -390,7 +390,7 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 
 			if (error) {
 				if (error != ERR_FILE_EOF) {
-					_printerr();
+					ERR_PRINT(_get_error_string());
 					return Ref<PackedScene>();
 				} else {
 					error = OK;
@@ -401,7 +401,7 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 			if (!next_tag.fields.has("path")) {
 				error = ERR_FILE_CORRUPT;
 				error_text = "Missing 'path' field from editable tag";
-				_printerr();
+				ERR_PRINT(_get_error_string());
 				return Ref<PackedScene>();
 			}
 
@@ -413,7 +413,7 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 
 			if (error) {
 				if (error != ERR_FILE_EOF) {
-					_printerr();
+					ERR_PRINT(_get_error_string());
 					return Ref<PackedScene>();
 				} else {
 					error = OK;
@@ -423,7 +423,7 @@ Ref<PackedScene> ResourceLoaderText::_parse_node_tag(VariantParser::ResourcePars
 		} else {
 			error = ERR_FILE_CORRUPT;
 			error_text = vformat("Unknown tag '%s' in file", next_tag.name);
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			return Ref<PackedScene>();
 		}
 	}
@@ -475,21 +475,21 @@ Error ResourceLoaderText::load() {
 		if (!next_tag.fields.has("path")) {
 			error = ERR_FILE_CORRUPT;
 			error_text = "Missing 'path' in external resource tag";
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			return error;
 		}
 
 		if (!next_tag.fields.has("type")) {
 			error = ERR_FILE_CORRUPT;
 			error_text = "Missing 'type' in external resource tag";
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			return error;
 		}
 
 		if (!next_tag.fields.has("id")) {
 			error = ERR_FILE_CORRUPT;
 			error_text = "Missing 'id' in external resource tag";
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			return error;
 		}
 
@@ -531,7 +531,7 @@ Error ResourceLoaderText::load() {
 			if (ResourceLoader::get_abort_on_missing_resources()) {
 				error = ERR_FILE_CORRUPT;
 				error_text = "[ext_resource] referenced non-existent resource at: " + path;
-				_printerr();
+				ERR_PRINT(_get_error_string());
 				return error;
 			} else {
 				ResourceLoader::notify_dependency_error(local_path, path, type);
@@ -541,7 +541,7 @@ Error ResourceLoaderText::load() {
 		error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp);
 
 		if (error) {
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			return error;
 		}
 	}
@@ -561,14 +561,14 @@ Error ResourceLoaderText::load() {
 		if (!next_tag.fields.has("type")) {
 			error = ERR_FILE_CORRUPT;
 			error_text = "Missing 'type' in external resource tag";
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			return error;
 		}
 
 		if (!next_tag.fields.has("id")) {
 			error = ERR_FILE_CORRUPT;
 			error_text = "Missing 'id' in external resource tag";
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			return error;
 		}
 
@@ -611,7 +611,7 @@ Error ResourceLoaderText::load() {
 						obj = missing_resource.ptr();
 					} else {
 						error_text = vformat("Can't create sub resource of type '%s'", type);
-						_printerr();
+						ERR_PRINT(_get_error_string());
 						error = ERR_FILE_CORRUPT;
 						return error;
 					}
@@ -620,7 +620,7 @@ Error ResourceLoaderText::load() {
 				Resource *r = Object::cast_to<Resource>(obj);
 				if (!r) {
 					error_text = vformat("Can't create sub resource of type '%s' as it's not a resource type", type);
-					_printerr();
+					ERR_PRINT(_get_error_string());
 					error = ERR_FILE_CORRUPT;
 					return error;
 				}
@@ -655,7 +655,7 @@ Error ResourceLoaderText::load() {
 			error = VariantParser::parse_tag_assign_eof(&stream, lines, error_text, next_tag, assign, value, &rp);
 
 			if (error) {
-				_printerr();
+				ERR_PRINT(_get_error_string());
 				return error;
 			}
 
@@ -711,7 +711,7 @@ Error ResourceLoaderText::load() {
 			} else {
 				error = ERR_FILE_CORRUPT;
 				error_text = "Premature end of file while parsing [sub_resource]";
-				_printerr();
+				ERR_PRINT(_get_error_string());
 				return error;
 			}
 		}
@@ -732,7 +732,7 @@ Error ResourceLoaderText::load() {
 
 		if (is_scene) {
 			error_text = "Unexpected 'resource' tag in a scene file";
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			error = ERR_FILE_CORRUPT;
 			return error;
 		}
@@ -757,7 +757,7 @@ Error ResourceLoaderText::load() {
 						obj = missing_resource.ptr();
 					} else {
 						error_text = vformat("Can't create sub resource of type '%s'", res_type);
-						_printerr();
+						ERR_PRINT(_get_error_string());
 						error = ERR_FILE_CORRUPT;
 						return error;
 					}
@@ -766,7 +766,7 @@ Error ResourceLoaderText::load() {
 				Resource *r = Object::cast_to<Resource>(obj);
 				if (!r) {
 					error_text = vformat("Can't create sub resource of type '%s' as it's not a resource type", res_type);
-					_printerr();
+					ERR_PRINT(_get_error_string());
 					error = ERR_FILE_CORRUPT;
 					return error;
 				}
@@ -785,7 +785,7 @@ Error ResourceLoaderText::load() {
 
 			if (error) {
 				if (error != ERR_FILE_EOF) {
-					_printerr();
+					ERR_PRINT(_get_error_string());
 					return error;
 				}
 				// EOF, Done parsing.
@@ -848,7 +848,7 @@ Error ResourceLoaderText::load() {
 			} else if (!next_tag.name.is_empty()) {
 				error = ERR_FILE_CORRUPT;
 				error_text = "Extra tag found when parsing main resource file";
-				_printerr();
+				ERR_PRINT(_get_error_string());
 				return error;
 			} else {
 				break;
@@ -879,7 +879,7 @@ Error ResourceLoaderText::load() {
 	if (next_tag.name == "node") {
 		if (!is_scene) {
 			error_text = "Unexpected 'node' tag in a resource file";
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			error = ERR_FILE_CORRUPT;
 			return error;
 		}
@@ -911,7 +911,7 @@ Error ResourceLoaderText::load() {
 		return error;
 	} else {
 		error_text = vformat("Unknown tag '%s' in file", next_tag.name);
-		_printerr();
+		ERR_PRINT(_get_error_string());
 		error = ERR_FILE_CORRUPT;
 		return error;
 	}
@@ -941,14 +941,14 @@ void ResourceLoaderText::get_dependencies(Ref<FileAccess> p_f, List<String> *p_d
 		if (!next_tag.fields.has("type")) {
 			error = ERR_FILE_CORRUPT;
 			error_text = "Missing 'type' in external resource tag";
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			return;
 		}
 
 		if (!next_tag.fields.has("id")) {
 			error = ERR_FILE_CORRUPT;
 			error_text = "Missing 'id' in external resource tag";
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			return;
 		}
 
@@ -990,7 +990,7 @@ void ResourceLoaderText::get_dependencies(Ref<FileAccess> p_f, List<String> *p_d
 		if (err) {
 			print_line(error_text + " - " + itos(lines));
 			error_text = "Unexpected end of file";
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			error = ERR_FILE_CORRUPT;
 			return;
 		}
@@ -1014,7 +1014,7 @@ Error ResourceLoaderText::rename_dependencies(Ref<FileAccess> p_f, const String 
 
 		if (err != OK) {
 			error = ERR_FILE_CORRUPT;
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			ERR_FAIL_V(error);
 		}
 
@@ -1154,7 +1154,7 @@ void ResourceLoaderText::open(Ref<FileAccess> p_f, bool p_skip_first_tag) {
 
 	if (err) {
 		error = err;
-		_printerr();
+		ERR_PRINT(_get_error_string());
 		return;
 	}
 
@@ -1162,7 +1162,7 @@ void ResourceLoaderText::open(Ref<FileAccess> p_f, bool p_skip_first_tag) {
 		format_version = tag.fields["format"];
 		if (format_version > FORMAT_VERSION) {
 			error_text = "Saved with newer format version";
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			error = ERR_FILE_UNRECOGNIZED;
 			return;
 		}
@@ -1176,7 +1176,7 @@ void ResourceLoaderText::open(Ref<FileAccess> p_f, bool p_skip_first_tag) {
 	} else if (tag.name == "gd_resource") {
 		if (!tag.fields.has("type")) {
 			error_text = "Missing 'type' field in 'gd_resource' tag";
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			error = ERR_PARSE_ERROR;
 			return;
 		}
@@ -1189,7 +1189,7 @@ void ResourceLoaderText::open(Ref<FileAccess> p_f, bool p_skip_first_tag) {
 
 	} else {
 		error_text = vformat("Unrecognized file type '%s'", tag.name);
-		_printerr();
+		ERR_PRINT(_get_error_string());
 		error = ERR_PARSE_ERROR;
 		return;
 	}
@@ -1205,7 +1205,7 @@ void ResourceLoaderText::open(Ref<FileAccess> p_f, bool p_skip_first_tag) {
 
 		if (err) {
 			error_text = "Unexpected end of file";
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			error = ERR_FILE_CORRUPT;
 		}
 	}
@@ -1233,7 +1233,7 @@ Error ResourceLoaderText::get_classes_used(HashSet<StringName> *r_classes) {
 		error = VariantParser::parse_tag(&stream, lines, error_text, next_tag, &rp_new);
 
 		if (error) {
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			return error;
 		}
 	}
@@ -1243,7 +1243,7 @@ Error ResourceLoaderText::get_classes_used(HashSet<StringName> *r_classes) {
 			if (!next_tag.fields.has("type")) {
 				error = ERR_FILE_CORRUPT;
 				error_text = "Missing 'type' in external resource tag";
-				_printerr();
+				ERR_PRINT(_get_error_string());
 				return error;
 			}
 
@@ -1264,7 +1264,7 @@ Error ResourceLoaderText::get_classes_used(HashSet<StringName> *r_classes) {
 					return OK;
 				}
 
-				_printerr();
+				ERR_PRINT(_get_error_string());
 				return error;
 			}
 
@@ -1276,7 +1276,7 @@ Error ResourceLoaderText::get_classes_used(HashSet<StringName> *r_classes) {
 			} else {
 				error = ERR_FILE_CORRUPT;
 				error_text = "Premature end of file while parsing [sub_resource]";
-				_printerr();
+				ERR_PRINT(_get_error_string());
 				return error;
 			}
 		}
@@ -1288,7 +1288,7 @@ Error ResourceLoaderText::get_classes_used(HashSet<StringName> *r_classes) {
 		if (!is_scene) {
 			error = ERR_FILE_CORRUPT;
 			error_text = "Unexpected 'node' tag in a resource file";
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			return error;
 		}
 
@@ -1306,7 +1306,7 @@ Error ResourceLoaderText::get_classes_used(HashSet<StringName> *r_classes) {
 				if (error == ERR_FILE_MISSING_DEPENDENCIES) {
 					// Resource loading error, just skip it.
 				} else if (error != ERR_FILE_EOF) {
-					_printerr();
+					ERR_PRINT(_get_error_string());
 					return error;
 				} else {
 					return OK;
@@ -1321,7 +1321,7 @@ Error ResourceLoaderText::get_classes_used(HashSet<StringName> *r_classes) {
 			} else {
 				error = ERR_FILE_CORRUPT;
 				error_text = "Premature end of file while parsing [sub_resource]";
-				_printerr();
+				ERR_PRINT(_get_error_string());
 				return error;
 			}
 		}
@@ -1344,7 +1344,7 @@ String ResourceLoaderText::recognize_script_class(Ref<FileAccess> p_f) {
 	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag);
 
 	if (err) {
-		_printerr();
+		ERR_PRINT(_get_error_string());
 		return "";
 	}
 
@@ -1352,7 +1352,7 @@ String ResourceLoaderText::recognize_script_class(Ref<FileAccess> p_f) {
 		int fmt = tag.fields["format"];
 		if (fmt > FORMAT_VERSION) {
 			error_text = "Saved with newer format version";
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			return "";
 		}
 	}
@@ -1382,7 +1382,7 @@ String ResourceLoaderText::recognize(Ref<FileAccess> p_f) {
 	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag);
 
 	if (err) {
-		_printerr();
+		ERR_PRINT(_get_error_string());
 		return "";
 	}
 
@@ -1390,7 +1390,7 @@ String ResourceLoaderText::recognize(Ref<FileAccess> p_f) {
 		int fmt = tag.fields["format"];
 		if (fmt > FORMAT_VERSION) {
 			error_text = "Saved with newer format version";
-			_printerr();
+			ERR_PRINT(_get_error_string());
 			return "";
 		}
 	}
@@ -1405,7 +1405,7 @@ String ResourceLoaderText::recognize(Ref<FileAccess> p_f) {
 
 	if (!tag.fields.has("type")) {
 		error_text = "Missing 'type' field in 'gd_resource' tag";
-		_printerr();
+		ERR_PRINT(_get_error_string());
 		return "";
 	}
 
@@ -1426,7 +1426,7 @@ ResourceUID::ID ResourceLoaderText::get_uid(Ref<FileAccess> p_f) {
 	Error err = VariantParser::parse_tag(&stream, lines, error_text, tag);
 
 	if (err) {
-		_printerr();
+		ERR_PRINT(_get_error_string());
 		return ResourceUID::INVALID_ID;
 	}
 

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -113,7 +113,7 @@ private:
 
 	static Error _parse_sub_resource_dummy(DummyReadData *p_data, VariantParser::Stream *p_stream, Ref<Resource> &r_res, int &line, String &r_err_str);
 	static Error _parse_ext_resource_dummy(DummyReadData *p_data, VariantParser::Stream *p_stream, Ref<Resource> &r_res, int &line, String &r_err_str);
-	void _printerr();
+	String _get_error_string();
 
 	VariantParser::ResourceParser rp;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- First step of https://github.com/godotengine/godot-proposals/issues/15411

## Additional information

Done by creating a function
```cpp
String ResourceLoaderText::_error_string() {
	return vformat("%s:%d - Parse Error: %s.", res_path, lines, error_text);
}
```
And doing a search for `_printerr();` and replacing with `ERR_PRINT(_error_string());`