### PR TITLE
Fix issue where certain types could not be edited from remote or multi-node edit.

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -92,13 +92,7 @@ void EditorDebuggerRemoteObjects::_get_property_list(List<PropertyInfo> *p_list)
 }
 
 void EditorDebuggerRemoteObjects::set_property_field(const StringName &p_property, const Variant &p_value, const String &p_field) {
-	// Ignore the field with arrays and dictionaries, as they are passed whole when edited.
-	Variant::Type type = p_value.get_type();
-	if (type == Variant::ARRAY || type == Variant::DICTIONARY) {
-		_set_impl(p_property, p_value, "");
-	} else {
-		_set_impl(p_property, p_value, p_field);
-	}
+	_set_impl(p_property, p_value, p_field);
 }
 
 String EditorDebuggerRemoteObjects::get_title() {

--- a/editor/inspector/editor_properties_array_dict.cpp
+++ b/editor/inspector/editor_properties_array_dict.cpp
@@ -284,7 +284,7 @@ void EditorPropertyArray::_property_changed(const String &p_property, Variant p_
 
 	Variant array = object->get_array().duplicate();
 	array.set(index, p_value);
-	emit_changed(get_edited_property(), array, p_name, p_changing);
+	emit_changed(get_edited_property(), array, "", p_changing);
 	if (p_changing) {
 		object->set_array(array);
 	}
@@ -1070,7 +1070,7 @@ void EditorPropertyDictionary::_property_changed(const String &p_property, Varia
 
 	object->set(p_property, p_value);
 	bool new_item_or_key = !p_property.begins_with("indices");
-	emit_changed(get_edited_property(), object->get_dict(), p_name, p_changing || new_item_or_key);
+	emit_changed(get_edited_property(), object->get_dict(), "", p_changing || new_item_or_key);
 	if (new_item_or_key) {
 		update_property();
 	}

--- a/editor/inspector/multi_node_edit.cpp
+++ b/editor/inspector/multi_node_edit.cpp
@@ -368,13 +368,7 @@ StringName MultiNodeEdit::get_edited_class_name() const {
 }
 
 void MultiNodeEdit::set_property_field(const StringName &p_property, const Variant &p_value, const String &p_field) {
-	// Ignore the field with arrays and dictionaries, as they are passed whole when edited.
-	Variant::Type type = p_value.get_type();
-	if (type == Variant::ARRAY || type == Variant::DICTIONARY) {
-		_set_impl(p_property, p_value, "");
-	} else {
-		_set_impl(p_property, p_value, p_field);
-	}
+	_set_impl(p_property, p_value, p_field);
 }
 
 void MultiNodeEdit::_bind_methods() {


### PR DESCRIPTION


AI use:
Copilot was used as a soft sanity check in addition to print tracing to see if any of the proposed changes would introduce unforseen consequences such as modifying fields that the user may not expect to be modified. All of the code in this commit is human-generated.

## What problem(s) does this PR solve?

- Closes #122586 
- Supercedes #122678 

## Additional information
My orginal diagnosis of the issue ended up lying downstream of the actual issue, which was that 'EditorPropertyArray' and 'EditorPropertyDictionary' were passing along field information which were unused but needed to be treated as special cases for remote and multi node edits.

The simplest solution (and the one that other inheritors of 'EditorProperty' use) is to simply pass an empty field string down the signal chain. This ultimately has the same effect as the if clause in 'set_property_field()' but moves the type checking into the functions responsible for initiating the signal chain.  This also automatically fixes the corresponding issue in 'MultiNodeEdit'.

The added benefit of this solution over my previous one is that it decouples 'MultiNodeEdit' and 'EditorDebuggerRemoteObjects' from 'EditorProperty.' If an array-like type is added in the future, it will now be the responsibility of the person introducing the type to ensure its '_property_changed()' function does not pass along field information. This is in contrast to how it is now, where such additions will result in the bug described in #122586 until someone adds a clause to the if statement in 'set_property_field()'. 

Potential improvements include finding a way to pass field information to prevent unecessary copying, but this would be a considerably larger commit and constitute a minor refactor. Once I have contributed more, I may discuss such a change if it is deemed to be a worthwhile optimization task.