### PR TITLE
Change PhysicsDirectSpaceState3D.cast_motion return type to Vector2

### DIFF
--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -13,11 +13,11 @@
 	</tutorials>
 	<methods>
 		<method name="cast_motion">
-			<return type="PackedFloat32Array" />
+			<return type="Vector2" />
 			<param index="0" name="parameters" type="PhysicsShapeQueryParameters3D" />
 			<description>
 				Checks how far a [Shape3D] can move without colliding. All the parameters for the query, including the shape and the motion, are supplied through a [PhysicsShapeQueryParameters3D] object.
-				Returns an array with the safe and unsafe proportions (between 0 and 1) of the motion. The safe proportion is the maximum fraction of the motion that can be made without a collision. The unsafe proportion is the minimum fraction of the distance that must be moved for a collision. If no collision is detected a result of [code][1.0, 1.0][/code] will be returned.
+				Returns a [Vector2] with the safe and unsafe proportions (between 0 and 1) of the motion. The safe proportion is stored in [member Vector2.x] and is the maximum fraction of the motion that can be made without a collision. The unsafe proportion is stored in [member Vector2.y] and is the minimum fraction of the distance that must be moved for a collision. If no collision is detected, [code]Vector2(1.0, 1.0)[/code] is returned.
 				[b]Note:[/b] Any [Shape3D]s that the shape is already colliding with e.g. inside of, will be ignored. Use [method collide_shape] to determine the [Shape3D]s that the shape is already colliding with.
 			</description>
 		</method>

--- a/servers/physics_3d/direct_states/physics_direct_space_state_3d.cpp
+++ b/servers/physics_3d/direct_states/physics_direct_space_state_3d.cpp
@@ -100,19 +100,15 @@ TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_shape(RequiredParam
 	return ret;
 }
 
-Vector<real_t> PhysicsDirectSpaceState3D::_cast_motion(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query) {
-	EXTRACT_PARAM_OR_FAIL_V(shape_query, p_shape_query, Vector<real_t>());
+Vector2 PhysicsDirectSpaceState3D::_cast_motion(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query) {
+	EXTRACT_PARAM_OR_FAIL_V(shape_query, p_shape_query, Vector2(1.0f, 1.0f));
 
 	real_t closest_safe = 1.0f, closest_unsafe = 1.0f;
 	bool res = cast_motion(shape_query->get_parameters(), closest_safe, closest_unsafe);
 	if (!res) {
-		return Vector<real_t>();
+		return Vector2(1.0f, 1.0f);
 	}
-	Vector<real_t> ret;
-	ret.resize(2);
-	ret.write[0] = closest_safe;
-	ret.write[1] = closest_unsafe;
-	return ret;
+	return Vector2(closest_safe, closest_unsafe);
 }
 
 TypedArray<Vector3> PhysicsDirectSpaceState3D::_collide_shape(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query, int p_max_results) {

--- a/servers/physics_3d/direct_states/physics_direct_space_state_3d.h
+++ b/servers/physics_3d/direct_states/physics_direct_space_state_3d.h
@@ -43,7 +43,7 @@ private:
 	Dictionary _intersect_ray(RequiredParam<PhysicsRayQueryParameters3D> p_ray_query);
 	TypedArray<Dictionary> _intersect_point(RequiredParam<PhysicsPointQueryParameters3D> p_point_query, int p_max_results = 32);
 	TypedArray<Dictionary> _intersect_shape(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query, int p_max_results = 32);
-	Vector<real_t> _cast_motion(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query);
+	Vector2 _cast_motion(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query);
 	TypedArray<Vector3> _collide_shape(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query, int p_max_results = 32);
 	Dictionary _get_rest_info(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query);
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

Original cast_motion returns PackedFloat32Array which creates managed allocations, in C#, this creates a managed array for every call, causing avoidable allocations when the method is repeatedly used during physics processing, this PR target is to solve this with minimun API changes

## Additional information

This PR changes the return type to Vector2,  the safe fraction is stored in Vector2.x, and the unsafe fraction is stored in Vector2.y
If no collision is detected, the method returns Vector2(1.0, 1.0), this preserves the existing no-collision behavior because original method also did return 1.0, 1.0. The change removes the per-call managed allocation caused by the return value.

This is a compatibility-breaking API change, existing code must migrate from result[0] and result[1] to result.x and result.y

This addresses the first problem described in the proposal. It is a small and independent change from the more comprehensive solution to the second problem, which also removes this allocation.
- Related proposal godotengine/godot-proposals#15430