### PR TITLE
Add reusable result object to PhysicsDirectSpaceState3D.cast_motion

### DIFF
--- a/doc/classes/PhysicsCastMotionResult3D.xml
+++ b/doc/classes/PhysicsCastMotionResult3D.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PhysicsCastMotionResult3D" inherits="RefCounted" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Describes the result of [method PhysicsDirectSpaceState3D.cast_motion].
+	</brief_description>
+	<description>
+		This class stores the result of a 3D shape motion query from [PhysicsDirectSpaceState3D]. Its properties are only valid if [method PhysicsDirectSpaceState3D.cast_motion] returns [code]true[/code].
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="collider_id" type="int" setter="" getter="get_collider_id">
+			The unique instance ID of the colliding object's attached [Object]. See [method Object.get_instance_id].
+		</member>
+		<member name="collider_rid" type="RID" setter="" getter="get_collider_rid">
+			The colliding object's [RID] used by the [PhysicsServer3D].
+		</member>
+		<member name="collider_shape" type="int" setter="" getter="get_collider_shape">
+			The colliding object's shape index. See [CollisionObject3D].
+		</member>
+		<member name="collider_velocity" type="Vector3" setter="" getter="get_collider_velocity">
+			The colliding object's velocity at the collision point.
+		</member>
+		<member name="collision_normal" type="Vector3" setter="" getter="get_collision_normal">
+			The collision normal of the query shape at the collision point, pointing away from the colliding object.
+		</member>
+		<member name="collision_point" type="Vector3" setter="" getter="get_collision_point">
+			The point of collision in global coordinates.
+		</member>
+		<member name="collision_safe_fraction" type="float" setter="" getter="get_collision_safe_fraction">
+			The maximum fraction of the motion that can occur without a collision, between [code]0[/code] and [code]1[/code].
+		</member>
+		<member name="collision_unsafe_fraction" type="float" setter="" getter="get_collision_unsafe_fraction">
+			The minimum fraction of the motion needed to collide, between [code]0[/code] and [code]1[/code].
+		</member>
+	</members>
+</class>

--- a/doc/classes/PhysicsDirectSpaceState3D.xml
+++ b/doc/classes/PhysicsDirectSpaceState3D.xml
@@ -13,11 +13,11 @@
 	</tutorials>
 	<methods>
 		<method name="cast_motion">
-			<return type="PackedFloat32Array" />
+			<return type="bool" />
 			<param index="0" name="parameters" type="PhysicsShapeQueryParameters3D" />
+			<param index="1" name="result" type="PhysicsCastMotionResult3D" default="null" />
 			<description>
-				Checks how far a [Shape3D] can move without colliding. All the parameters for the query, including the shape and the motion, are supplied through a [PhysicsShapeQueryParameters3D] object.
-				Returns an array with the safe and unsafe proportions (between 0 and 1) of the motion. The safe proportion is the maximum fraction of the motion that can be made without a collision. The unsafe proportion is the minimum fraction of the distance that must be moved for a collision. If no collision is detected a result of [code][1.0, 1.0][/code] will be returned.
+				Returns [code]true[/code] if a collision would result from moving a [Shape3D] along a motion vector. See [PhysicsShapeQueryParameters3D] for the available query parameters. Optionally, a [PhysicsCastMotionResult3D] object can be passed, which will be used to store the safe and unsafe fractions of the motion and additional collision information.
 				[b]Note:[/b] Any [Shape3D]s that the shape is already colliding with e.g. inside of, will be ignored. Use [method collide_shape] to determine the [Shape3D]s that the shape is already colliding with.
 			</description>
 		</method>

--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.cpp
@@ -55,7 +55,7 @@
 #include <Jolt/Physics/Collision/Shape/MeshShape.h>
 #include <Jolt/Physics/PhysicsSystem.h>
 
-bool JoltPhysicsDirectSpaceState3D::_cast_motion_impl(const JPH::Shape &p_jolt_shape, const Transform3D &p_transform_com, const Vector3 &p_scale, const Vector3 &p_motion, bool p_use_edge_removal, bool p_ignore_overlaps, const JPH::CollideShapeSettings &p_settings, const JPH::BroadPhaseLayerFilter &p_broad_phase_layer_filter, const JPH::ObjectLayerFilter &p_object_layer_filter, const JPH::BodyFilter &p_body_filter, const JPH::ShapeFilter &p_shape_filter, real_t &r_closest_safe, real_t &r_closest_unsafe) const {
+bool JoltPhysicsDirectSpaceState3D::_cast_motion_impl(const JPH::Shape &p_jolt_shape, const Transform3D &p_transform_com, const Vector3 &p_scale, const Vector3 &p_motion, bool p_use_edge_removal, bool p_ignore_overlaps, const JPH::CollideShapeSettings &p_settings, const JPH::BroadPhaseLayerFilter &p_broad_phase_layer_filter, const JPH::ObjectLayerFilter &p_object_layer_filter, const JPH::BodyFilter &p_body_filter, const JPH::ShapeFilter &p_shape_filter, real_t &r_closest_safe, real_t &r_closest_unsafe, JPH::CollideShapeResult *r_hit) const {
 	r_closest_safe = 1.0f;
 	r_closest_unsafe = 1.0f;
 
@@ -88,7 +88,7 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion_impl(const JPH::Shape &p_jolt_s
 
 	JoltCustomMotionShape motion_shape(static_cast<const JPH::ConvexShape &>(p_jolt_shape));
 
-	auto collides = [&](const JPH::Body &p_other_body, float p_fraction) {
+	auto collides = [&](const JPH::Body &p_other_body, float p_fraction, JPH::CollideShapeResult *r_result) {
 		motion_shape.set_motion(motion_local * p_fraction);
 
 		const JPH::TransformedShape other_shape = p_other_body.GetTransformedShape();
@@ -107,7 +107,15 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion_impl(const JPH::Shape &p_jolt_s
 			other_shape.CollideShape(&motion_shape, scale, transform_com, p_settings, base_offset, collector, p_shape_filter);
 		}
 
-		return collector.had_hit();
+		if (!collector.had_hit()) {
+			return false;
+		}
+
+		if (r_result != nullptr) {
+			*r_result = collector.get_hit();
+		}
+
+		return true;
 	};
 
 	// Figure out the number of steps we need in our binary search in order to achieve millimeter precision, within reason.
@@ -126,11 +134,18 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion_impl(const JPH::Shape &p_jolt_s
 			continue;
 		}
 
-		if (!collides(*other_jolt_body, 1.0f)) {
+		JPH::CollideShapeResult body_hit;
+		JPH::CollideShapeResult *body_hit_ptr = nullptr;
+
+		if (r_hit != nullptr) {
+			body_hit_ptr = &body_hit;
+		}
+
+		if (!collides(*other_jolt_body, 1.0f, body_hit_ptr)) {
 			continue;
 		}
 
-		if (p_ignore_overlaps && collides(*other_jolt_body, 0.0f)) {
+		if (p_ignore_overlaps && collides(*other_jolt_body, 0.0f, nullptr)) {
 			continue;
 		}
 
@@ -141,7 +156,7 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion_impl(const JPH::Shape &p_jolt_s
 		for (int j = 0; j < step_count; ++j) {
 			const float fraction = lo + (hi - lo) * coeff;
 
-			if (collides(*other_jolt_body, fraction)) {
+			if (collides(*other_jolt_body, fraction, body_hit_ptr)) {
 				collided = true;
 
 				hi = fraction;
@@ -165,6 +180,10 @@ bool JoltPhysicsDirectSpaceState3D::_cast_motion_impl(const JPH::Shape &p_jolt_s
 		if (lo < r_closest_safe) {
 			r_closest_safe = lo;
 			r_closest_unsafe = hi;
+
+			if (r_hit != nullptr) {
+				*r_hit = body_hit;
+			}
 		}
 	}
 
@@ -629,7 +648,6 @@ int JoltPhysicsDirectSpaceState3D::intersect_shape(const PS3DT::ShapeParameters 
 
 bool JoltPhysicsDirectSpaceState3D::cast_motion(const PS3DT::ShapeParameters &p_parameters, real_t &r_closest_safe, real_t &r_closest_unsafe, PS3DT::ShapeRestInfo *r_info) {
 	ERR_FAIL_COND_V_MSG(space->is_stepping(), false, "cast_motion must not be called while the physics space is being stepped.");
-	ERR_FAIL_COND_V_MSG(r_info != nullptr, false, "Providing rest info as part of cast_motion is not supported when using Jolt Physics.");
 
 	space->flush_pending_objects();
 
@@ -653,7 +671,38 @@ bool JoltPhysicsDirectSpaceState3D::cast_motion(const PS3DT::ShapeParameters &p_
 	settings.mMaxSeparationDistance = (float)p_parameters.margin;
 
 	const JoltQueryFilter3D query_filter(*this, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.exclude);
-	_cast_motion_impl(*jolt_shape, transform_com, scale, p_parameters.motion, JoltProjectSettings::use_enhanced_internal_edge_removal_for_queries, true, settings, query_filter, query_filter, query_filter, JPH::ShapeFilter(), r_closest_safe, r_closest_unsafe);
+
+	JPH::CollideShapeResult hit;
+	JPH::CollideShapeResult *hit_ptr = nullptr;
+
+	if (r_info != nullptr) {
+		hit_ptr = &hit;
+	}
+
+	_cast_motion_impl(*jolt_shape, transform_com, scale, p_parameters.motion, JoltProjectSettings::use_enhanced_internal_edge_removal_for_queries, true, settings, query_filter, query_filter, query_filter, JPH::ShapeFilter(), r_closest_safe, r_closest_unsafe, hit_ptr);
+
+	if (r_info == nullptr || r_closest_safe >= 1.0) {
+		return true;
+	}
+
+	const JoltObject3D *object = space->try_get_object(hit.mBodyID2);
+	ERR_FAIL_NULL_V(object, false);
+
+	r_info->shape = 0;
+
+	if (const JoltShapedObject3D *shaped_object = object->as_shaped()) {
+		const int shape_index = shaped_object->find_shape_index(hit.mSubShapeID2);
+		ERR_FAIL_COND_V(shape_index == -1, false);
+		r_info->shape = shape_index;
+	}
+
+	const Vector3 hit_point = transform_com.origin + to_godot(hit.mContactPointOn2);
+
+	r_info->point = hit_point;
+	r_info->normal = to_godot(-hit.mPenetrationAxis.Normalized());
+	r_info->rid = object->get_rid();
+	r_info->collider_id = object->get_instance_id();
+	r_info->linear_velocity = object->get_velocity_at_position(hit_point);
 
 	return true;
 }

--- a/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.h
+++ b/modules/jolt_physics/spaces/jolt_physics_direct_space_state_3d.h
@@ -53,7 +53,7 @@ class JoltPhysicsDirectSpaceState3D final : public PhysicsDirectSpaceState3D {
 
 	static void _bind_methods() {}
 
-	bool _cast_motion_impl(const JPH::Shape &p_jolt_shape, const Transform3D &p_transform_com, const Vector3 &p_scale, const Vector3 &p_motion, bool p_use_edge_removal, bool p_ignore_overlaps, const JPH::CollideShapeSettings &p_settings, const JPH::BroadPhaseLayerFilter &p_broad_phase_layer_filter, const JPH::ObjectLayerFilter &p_object_layer_filter, const JPH::BodyFilter &p_body_filter, const JPH::ShapeFilter &p_shape_filter, real_t &r_closest_safe, real_t &r_closest_unsafe) const;
+	bool _cast_motion_impl(const JPH::Shape &p_jolt_shape, const Transform3D &p_transform_com, const Vector3 &p_scale, const Vector3 &p_motion, bool p_use_edge_removal, bool p_ignore_overlaps, const JPH::CollideShapeSettings &p_settings, const JPH::BroadPhaseLayerFilter &p_broad_phase_layer_filter, const JPH::ObjectLayerFilter &p_object_layer_filter, const JPH::BodyFilter &p_body_filter, const JPH::ShapeFilter &p_shape_filter, real_t &r_closest_safe, real_t &r_closest_unsafe, JPH::CollideShapeResult *r_hit = nullptr) const;
 
 	bool _body_motion_recover(const JoltBody3D &p_body, const Transform3D &p_transform, float p_margin, const HashSet<RID> &p_excluded_bodies, const HashSet<ObjectID> &p_excluded_objects, Vector3 &r_recovery) const;
 	bool _body_motion_cast(const JoltBody3D &p_body, const Transform3D &p_transform, const Vector3 &p_scale, const Vector3 &p_motion, bool p_collide_separation_ray, const HashSet<RID> &p_excluded_bodies, const HashSet<ObjectID> &p_excluded_objects, real_t &r_safe_fraction, real_t &r_unsafe_fraction) const;

--- a/servers/physics_3d/direct_states/physics_direct_space_state_3d.cpp
+++ b/servers/physics_3d/direct_states/physics_direct_space_state_3d.cpp
@@ -100,19 +100,31 @@ TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_shape(RequiredParam
 	return ret;
 }
 
-Vector<real_t> PhysicsDirectSpaceState3D::_cast_motion(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query) {
-	EXTRACT_PARAM_OR_FAIL_V(shape_query, p_shape_query, Vector<real_t>());
+bool PhysicsDirectSpaceState3D::_cast_motion(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query, const Ref<PhysicsCastMotionResult3D> &p_result) {
+	EXTRACT_PARAM_OR_FAIL_V(shape_query, p_shape_query, false);
 
-	real_t closest_safe = 1.0f, closest_unsafe = 1.0f;
-	bool res = cast_motion(shape_query->get_parameters(), closest_safe, closest_unsafe);
-	if (!res) {
-		return Vector<real_t>();
+	real_t closest_safe = 1.0;
+	real_t closest_unsafe = 1.0;
+	PS3DT::ShapeRestInfo *rest_info_ptr = nullptr;
+
+	if (p_result.is_valid()) {
+		p_result->_reset();
+		rest_info_ptr = p_result->_get_rest_info_ptr();
 	}
-	Vector<real_t> ret;
-	ret.resize(2);
-	ret.write[0] = closest_safe;
-	ret.write[1] = closest_unsafe;
-	return ret;
+
+	if (!cast_motion(shape_query->get_parameters(), closest_safe, closest_unsafe, rest_info_ptr)) {
+		return false;
+	}
+
+	if (closest_safe >= 1.0) {
+		return false;
+	}
+
+	if (rest_info_ptr != nullptr) {
+		p_result->_set_fractions(closest_safe, closest_unsafe);
+	}
+
+	return true;
 }
 
 TypedArray<Vector3> PhysicsDirectSpaceState3D::_collide_shape(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query, int p_max_results) {
@@ -161,7 +173,7 @@ void PhysicsDirectSpaceState3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("intersect_point", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_point, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("intersect_ray", "parameters"), &PhysicsDirectSpaceState3D::_intersect_ray);
 	ClassDB::bind_method(D_METHOD("intersect_shape", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_intersect_shape, DEFVAL(32));
-	ClassDB::bind_method(D_METHOD("cast_motion", "parameters"), &PhysicsDirectSpaceState3D::_cast_motion);
+	ClassDB::bind_method(D_METHOD("cast_motion", "parameters", "result"), &PhysicsDirectSpaceState3D::_cast_motion, DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("collide_shape", "parameters", "max_results"), &PhysicsDirectSpaceState3D::_collide_shape, DEFVAL(32));
 	ClassDB::bind_method(D_METHOD("get_rest_info", "parameters"), &PhysicsDirectSpaceState3D::_get_rest_info);
 }

--- a/servers/physics_3d/queries/physics_cast_motion_result_3d.cpp
+++ b/servers/physics_3d/queries/physics_cast_motion_result_3d.cpp
@@ -1,0 +1,96 @@
+/**************************************************************************/
+/*  physics_cast_motion_result_3d.cpp                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "physics_cast_motion_result_3d.h"
+
+#include "core/object/class_db.h"
+
+void PhysicsCastMotionResult3D::_reset() {
+	collision_safe_fraction = 1.0;
+	collision_unsafe_fraction = 1.0;
+	rest_info = PS3DT::ShapeRestInfo();
+}
+
+void PhysicsCastMotionResult3D::_set_fractions(real_t p_safe_fraction, real_t p_unsafe_fraction) {
+	collision_safe_fraction = p_safe_fraction;
+	collision_unsafe_fraction = p_unsafe_fraction;
+}
+
+real_t PhysicsCastMotionResult3D::get_collision_safe_fraction() const {
+	return collision_safe_fraction;
+}
+
+real_t PhysicsCastMotionResult3D::get_collision_unsafe_fraction() const {
+	return collision_unsafe_fraction;
+}
+
+Vector3 PhysicsCastMotionResult3D::get_collision_point() const {
+	return rest_info.point;
+}
+
+Vector3 PhysicsCastMotionResult3D::get_collision_normal() const {
+	return rest_info.normal;
+}
+
+RID PhysicsCastMotionResult3D::get_collider_rid() const {
+	return rest_info.rid;
+}
+
+ObjectID PhysicsCastMotionResult3D::get_collider_id() const {
+	return rest_info.collider_id;
+}
+
+int PhysicsCastMotionResult3D::get_collider_shape() const {
+	return rest_info.shape;
+}
+
+Vector3 PhysicsCastMotionResult3D::get_collider_velocity() const {
+	return rest_info.linear_velocity;
+}
+
+void PhysicsCastMotionResult3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_collision_safe_fraction"), &PhysicsCastMotionResult3D::get_collision_safe_fraction);
+	ClassDB::bind_method(D_METHOD("get_collision_unsafe_fraction"), &PhysicsCastMotionResult3D::get_collision_unsafe_fraction);
+	ClassDB::bind_method(D_METHOD("get_collision_point"), &PhysicsCastMotionResult3D::get_collision_point);
+	ClassDB::bind_method(D_METHOD("get_collision_normal"), &PhysicsCastMotionResult3D::get_collision_normal);
+	ClassDB::bind_method(D_METHOD("get_collider_rid"), &PhysicsCastMotionResult3D::get_collider_rid);
+	ClassDB::bind_method(D_METHOD("get_collider_id"), &PhysicsCastMotionResult3D::get_collider_id);
+	ClassDB::bind_method(D_METHOD("get_collider_shape"), &PhysicsCastMotionResult3D::get_collider_shape);
+	ClassDB::bind_method(D_METHOD("get_collider_velocity"), &PhysicsCastMotionResult3D::get_collider_velocity);
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_safe_fraction", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_collision_safe_fraction");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_unsafe_fraction", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_collision_unsafe_fraction");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "collision_point", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_collision_point");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "collision_normal", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_collision_normal");
+	ADD_PROPERTY(PropertyInfo(Variant::RID, "collider_rid", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_collider_rid");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collider_id", PROPERTY_HINT_OBJECT_ID, "", PROPERTY_USAGE_NONE), "", "get_collider_id");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "collider_shape", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_collider_shape");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "collider_velocity", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_collider_velocity");
+}

--- a/servers/physics_3d/queries/physics_cast_motion_result_3d.h
+++ b/servers/physics_3d/queries/physics_cast_motion_result_3d.h
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  physics_direct_space_state_3d.h                                       */
+/*  physics_cast_motion_result_3d.h                                       */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -30,38 +30,34 @@
 
 #pragma once
 
-#include "core/variant/type_info.h"
+#include "core/object/ref_counted.h"
 #include "servers/physics_3d/physics_server_3d_types.h"
-#include "servers/physics_3d/queries/physics_cast_motion_result_3d.h"
-#include "servers/physics_3d/queries/physics_point_query_parameters_3d.h"
-#include "servers/physics_3d/queries/physics_ray_query_parameters_3d.h"
-#include "servers/physics_3d/queries/physics_shape_query_parameters_3d.h"
 
-class PhysicsDirectSpaceState3D : public Object {
-	GDCLASS(PhysicsDirectSpaceState3D, Object);
+class PhysicsDirectSpaceState3D;
 
-private:
-	Dictionary _intersect_ray(RequiredParam<PhysicsRayQueryParameters3D> p_ray_query);
-	TypedArray<Dictionary> _intersect_point(RequiredParam<PhysicsPointQueryParameters3D> p_point_query, int p_max_results = 32);
-	TypedArray<Dictionary> _intersect_shape(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query, int p_max_results = 32);
-	bool _cast_motion(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query, const Ref<PhysicsCastMotionResult3D> &p_result = Ref<PhysicsCastMotionResult3D>());
-	TypedArray<Vector3> _collide_shape(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query, int p_max_results = 32);
-	Dictionary _get_rest_info(RequiredParam<PhysicsShapeQueryParameters3D> p_shape_query);
+class PhysicsCastMotionResult3D : public RefCounted {
+	GDCLASS(PhysicsCastMotionResult3D, RefCounted);
+
+	friend class PhysicsDirectSpaceState3D;
+
+	real_t collision_safe_fraction = 1.0;
+	real_t collision_unsafe_fraction = 1.0;
+	PS3DT::ShapeRestInfo rest_info;
+
+	void _reset();
+	void _set_fractions(real_t p_safe_fraction, real_t p_unsafe_fraction);
+	PS3DT::ShapeRestInfo *_get_rest_info_ptr() { return &rest_info; }
 
 protected:
 	static void _bind_methods();
 
 public:
-	virtual bool intersect_ray(const PS3DT::RayParameters &p_parameters, PS3DT::RayResult &r_result) = 0;
-
-	virtual int intersect_point(const PS3DT::PointParameters &p_parameters, PS3DT::ShapeResult *r_results, int p_result_max) = 0;
-
-	virtual int intersect_shape(const PS3DT::ShapeParameters &p_parameters, PS3DT::ShapeResult *r_results, int p_result_max) = 0;
-	virtual bool cast_motion(const PS3DT::ShapeParameters &p_parameters, real_t &p_closest_safe, real_t &p_closest_unsafe, PS3DT::ShapeRestInfo *r_info = nullptr) = 0;
-	virtual bool collide_shape(const PS3DT::ShapeParameters &p_parameters, Vector3 *r_results, int p_result_max, int &r_result_count) = 0;
-	virtual bool rest_info(const PS3DT::ShapeParameters &p_parameters, PS3DT::ShapeRestInfo *r_info) = 0;
-
-	virtual Vector3 get_closest_point_to_object_volume(RID p_object, const Vector3 p_point) const = 0;
-
-	PhysicsDirectSpaceState3D();
+	real_t get_collision_safe_fraction() const;
+	real_t get_collision_unsafe_fraction() const;
+	Vector3 get_collision_point() const;
+	Vector3 get_collision_normal() const;
+	RID get_collider_rid() const;
+	ObjectID get_collider_id() const;
+	int get_collider_shape() const;
+	Vector3 get_collider_velocity() const;
 };

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -109,6 +109,7 @@
 #include "servers/physics_3d/physics_server_3d_dummy.h"
 #include "servers/physics_3d/physics_server_3d_extension.h"
 #include "servers/physics_3d/physics_server_3d_manager.h"
+#include "servers/physics_3d/queries/physics_cast_motion_result_3d.h"
 #endif // PHYSICS_3D_DISABLED
 
 // XR
@@ -349,6 +350,7 @@ void register_server_types() {
 	GDREGISTER_CLASS(PhysicsRayQueryParameters3D);
 	GDREGISTER_CLASS(PhysicsPointQueryParameters3D);
 	GDREGISTER_CLASS(PhysicsShapeQueryParameters3D);
+	GDREGISTER_CLASS(PhysicsCastMotionResult3D);
 	GDREGISTER_CLASS(PhysicsTestMotionParameters3D);
 	GDREGISTER_CLASS(PhysicsTestMotionResult3D);
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

PhysicsDirectSpaceState3D.cast_motion() currently returns a PackedFloat32Array, in C#, this creates a managed array for every call, causing avoidable allocations when the method is repeatedly used during physics processing.

Also callers that need additional information, such as the collision point and normal, collider RID and instance ID, shape index, or velocity at the contact point, must perform an additional get_rest_info() physics query, this requires another physics query and returns a result in dictionary causing more managed allocations, the native cast_motion() interface already supports an optional ShapeRestInfo, but this information is not exposed by the scripting API, Jolt implementation also does not currently support returning this information.

## Additional information

This PR changes the return type of `cast_motion()` to `bool`, indicating whether a collision did occur, and optional newly added reusable PhysicsCastMotionResult3D object can be passed to receive the safe and unsafe motion fractions, collision point and normal, collider RID and instance ID, collider shape index, and velocity at the collision point.

The result object is reset before each valid query and can be reused across calls, this avoids allocating a new managed result for every call, Jolt physics implementation has also been extended to return the collision that limits the motion.

- Related proposal: godotengine/godot-proposals#15430

### Benchmarks

Observed result for a hit requiring full contact data

Jolt:
- Legacy cast_motion() followed by get_rest_info(): 0.010727 ms/call, allocations 973 B/call
- Reusable result: 0.004950 ms/call, 0 B/call
- Time reduction: 53.9% (2.17x faster)

GodotPhysics3D:
- Legacy cast_motion() followed by get_rest_info(): 0.011327 ms/call, allocations  973 B/call
- Reusable result: 0.005915 ms/call, 0 B/call
- Time reduction: 47.8% (1.92x faster)

This is a compatibility-breaking API change, existing code that reads the returned array must migrate to the boolean return value and optionally pass a PhysicsCastMotionResult3D.