### PR TITLE
GDScript: Suppress `-Wdangling-pointer` warning for Linux Arm64 release templates

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -493,7 +493,17 @@ public:
 		}
 
 		call_level->prev = _call_stack;
+
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 12
+		GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wdangling-pointer") // The VM ensures call_level is not freed while it is in use, so this warning is a false positive for GCC 12+.
+#endif
+
 		_call_stack = call_level;
+
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 12
+		GODOT_GCC_WARNING_POP
+#endif
+
 		call_level->stack = p_stack;
 		call_level->instance = p_instance;
 		call_level->function = p_function;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #118150

## Additional information

It changes the declaration of the `call_level` variable to be inside the enter_function method, using the **memnew** function (it is freed on the exit_function method, using **memdelete**). It also changes the enter_function's signature, as the call_level pointer is not passed as a parameter anymore.

<ins>No AI assistance was used on this PR.</ins>

This is also my first PR, so any considerations are very much welcome :)

## Tests

- Ran `scons target=template_release werror=yes` and it finished compiling
- Ran a simple recursion script to make sure no stack underflow/overflow bugs or memory leaks were introduced