### PR TITLE
harden: sanitize subprocess call in editor_builders.py...

### DIFF
--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -85,9 +85,9 @@ def make_translations(target, source, env):
             # msgfmt erases non-translated messages, so avoid using it if exporting the POT.
             if msgfmt and name != category:
                 mo_path = os.path.join(tempfile.gettempdir(), uuid.uuid4().hex + ".mo")
-                cmd = f'{msgfmt} "{path}" --no-hash -o "{mo_path}"'
+                cmd = [msgfmt, path, "--no-hash", "-o", mo_path]
                 try:
-                    subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE).communicate()
+                    subprocess.Popen(cmd, shell=False, stderr=subprocess.PIPE).communicate()
                     buffer = methods.get_buffer(mo_path)
                 except OSError as e:
                     methods.print_warning(


### PR DESCRIPTION
## Summary
Harden input handling in `editor/editor_builders.py` (flagged by semgrep).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | gitlab.bandit.B602 |
| **Severity** | HIGH |
| **Scanner** | semgrep |
| **Rule** | `gitlab.bandit.B602` |
| **File** | `editor/editor_builders.py:90` |
| **Assessment** | Defensive hardening |

**Description**: Found `subprocess` function `Popen` with `shell=True`. This is dangerous because this call will
spawn the command using a shell process. Doing so propagates current shell settings and
variables,
which makes it much easier for a malicious actor to execute commands. Use `shell=False`
instead.


## Threat Model Context

This is a CLI tool - exploitation requires the attacker to control arguments or input files passed to the tool.

## Changes
- `editor/editor_builders.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
