### PR TITLE
Change File system search to use actual glob search

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -41,6 +41,7 @@
 #include "core/object/class_db.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
+#include "core/string/regex.h"
 #include "core/templates/list.h"
 #include "editor/docks/editor_dock_manager.h"
 #include "editor/docks/import_dock.h"
@@ -874,7 +875,7 @@ bool FileSystemDock::_update_filtered_items(TreeItem *p_tree_item) {
 	} else {
 		// res:// and favorites are always visible.
 		keep_visible = item == resources_item || item == favorites_item;
-		keep_visible = keep_visible || _matches_all_search_tokens(item->get_text(0));
+		keep_visible = keep_visible || _matches_all_search_tokens(item->get_metadata(0));
 	}
 	item->set_visible(keep_visible);
 	return keep_visible;
@@ -991,7 +992,7 @@ void FileSystemDock::_search(EditorFileSystemDirectory *p_path, List<FileInfo> *
 	for (int i = 0; i < p_path->get_file_count(); i++) {
 		String file = p_path->get_file(i);
 
-		if (_matches_all_search_tokens(file)) {
+		if (_matches_all_search_tokens(p_path->get_file_path(i) + file)) {
 			FileInfo file_info;
 			file_info.name = file;
 			file_info.type = p_path->get_file_type(i);
@@ -2875,7 +2876,34 @@ void FileSystemDock::_search_changed(const String &p_text, const Control *p_from
 		uncollapsed_paths_before_search = get_uncollapsed_paths();
 	}
 
-	const String searched_string = p_text.to_lower();
+	// This is "cached" similar to `searched_tokens` below.
+	searched_string = p_text.to_lower();
+	searched_string_as_regex.clear();
+	if (searched_string.ends_with("/")) {
+		searched_string += "**";
+	}
+
+	// Without this check, having **/test at the start means the top level
+	// "test" directory would be skipped.
+	if (searched_string.begins_with("**/")) {
+		searched_string = "**/?" + searched_string.trim_prefix("**/");
+	}
+
+	int slash_asterisk_streak = 0;
+	while (searched_string.ends_with("/*")) {
+		searched_string = searched_string.trim_suffix("/*");
+		slash_asterisk_streak += 1;
+	}
+	if (slash_asterisk_streak > 0) {
+		searched_string = vformat("%s(/*){1,%d}", searched_string, slash_asterisk_streak);
+	}
+	searched_string_as_regex.compile(vformat("^%s$",
+			searched_string
+					.replace("\\", "\\\\")
+					.replace(".", "\\.")
+					.replace("**", ".+")
+					.replace("*", "[^/]*")));
+
 	if (searched_string.begins_with("uid://")) {
 		ResourceUID::ID id = ResourceUID::get_singleton()->text_to_id(searched_string);
 		if (id != ResourceUID::INVALID_ID && ResourceUID::get_singleton()->has_id(id)) {
@@ -2901,17 +2929,21 @@ void FileSystemDock::_search_changed(const String &p_text, const Control *p_from
 	}
 }
 
-bool FileSystemDock::_matches_all_search_tokens(const String &p_text) {
+bool FileSystemDock::_matches_all_search_tokens(const String &p_text_being_searched_in) {
 	if (searched_tokens.is_empty()) {
 		return false;
 	}
-	const String s = p_text.to_lower();
-	for (const String &t : searched_tokens) {
-		if (!s.contains(t) && !s.matchn(t)) {
-			return false;
-		}
+	String text_to_search_in_no_prefix = p_text_being_searched_in.trim_prefix("res://");
+	if (!searched_string.contains("*") && !searched_string.contains("/")) {
+		return searched_string.is_subsequence_ofn(text_to_search_in_no_prefix);
 	}
-	return true;
+	// These are basically glob search.
+	// If the user typed a "/", they do care about filtering directories.
+	if (searched_string.contains("/") || searched_string == "*") {
+		return searched_string_as_regex.search(text_to_search_in_no_prefix).is_valid();
+	}
+	// Otherwise, only the base file should be taken into consideration.
+	return searched_string_as_regex.search(text_to_search_in_no_prefix.get_file()).is_valid();
 }
 
 void FileSystemDock::_rescan() {
@@ -4585,7 +4617,8 @@ FileSystemDock::FileSystemDock() {
 
 	tree_search_box = memnew(LineEdit);
 	tree_search_box->set_h_size_flags(SIZE_EXPAND_FILL);
-	tree_search_box->set_placeholder(TTRC("Filter Files"));
+	tree_search_box->set_placeholder(TTRC("Include: e.g. src/**/*.gd"));
+	tree_search_box->set_tooltip_text(TTRC("Filter Files\nSupports glob search"));
 	tree_search_box->set_clear_button_enabled(true);
 	tree_search_box->connect(SceneStringName(text_changed), callable_mp(this, &FileSystemDock::_search_changed).bind(tree_search_box));
 	toolbar2_hbc->add_child(tree_search_box);
@@ -4644,7 +4677,7 @@ FileSystemDock::FileSystemDock() {
 
 	file_list_search_box = memnew(LineEdit);
 	file_list_search_box->set_h_size_flags(SIZE_EXPAND_FILL);
-	file_list_search_box->set_placeholder(TTRC("Filter Files"));
+	file_list_search_box->set_placeholder(TTRC("Include: e.g. src/**/*.gd"));
 	file_list_search_box->set_accessibility_name(TTRC("Filter Files"));
 	file_list_search_box->set_clear_button_enabled(true);
 	file_list_search_box->connect(SceneStringName(text_changed), callable_mp(this, &FileSystemDock::_search_changed).bind(file_list_search_box));

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/string/regex.h"
 #include "editor/docks/editor_dock.h"
 #include "editor/file_system/dependency_editor.h"
 #include "editor/file_system/editor_file_system.h"
@@ -183,6 +184,8 @@ private:
 	MenuButton *file_list_button_sort = nullptr;
 
 	PackedStringArray searched_tokens;
+	String searched_string;
+	RegEx searched_string_as_regex;
 	Vector<String> uncollapsed_paths_before_search;
 
 	HBoxContainer *path_hb = nullptr;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?
Partially addresses https://github.com/godotengine/godot-proposals/discussions/14883
Closes https://github.com/godotengine/godot-proposals/discussions/15431
Bugsquad edit: Addresses regression / problem from https://github.com/godotengine/godot/pull/119103

EDIT since the goal changed: Implements actual glob searching according to https://learn.microsoft.com/en-us/dotnet/core/extensions/file-globbing. If the user search does not include "/" or "*", the search defaults to using subsequence.

~Removes the glob searching in the FileSystem, instead using a subsequence search which looks in the file path as well as the file name.~

NEW video:

<table>
<tr>
 <td>
<img width="815" height="608" alt="image" src="https://github.com/user-attachments/assets/529231db-8ff5-4940-9776-160beb6b0aaa" />
 <td>

https://github.com/user-attachments/assets/92b9dca0-2788-4518-bc11-80f095448f56


</table>


OLD video:

https://github.com/user-attachments/assets/2c6450fb-6387-45eb-a01e-3e1a50a71271


## Additional information
EDIT: Something similar was implemented, see the edit at the top
Since glob search was recently merged in the 4.8 dev cycle, some people may be confused that it doesn't work, so maybe as a fix "*" could be replaced with "" in these subsequence searches
