### PR TITLE
[macOS] Fix removal of last key down event before IME activation.

### DIFF
--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -78,6 +78,7 @@ public:
 		bool pressed = false;
 		bool echo = false;
 		bool raw = false;
+		bool ime = false;
 		Key keycode = Key::NONE;
 		Key physical_keycode = Key::NONE;
 		Key key_label = Key::NONE;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -511,7 +511,7 @@ void DisplayServerMacOS::_process_key_events() {
 	for (int i = 0; i < key_event_pos; i++) {
 		const KeyEvent &ke = key_event_buffer[i];
 		if (ke.raw) {
-			// Non IME input - no composite characters, pass events as is.
+			// No composite characters, pass events as is.
 			k.instantiate();
 
 			k->set_window_id(ke.window_id);
@@ -749,7 +749,7 @@ void DisplayServerMacOS::update_mouse_pos(DisplayServerMacOS::WindowData &p_wd, 
 
 void DisplayServerMacOS::pop_last_key_event() {
 	// Does not pop last key event when it is an IME key event.
-	if (key_event_pos > 0 && key_event_buffer[key_event_pos - 1].raw) {
+	if (key_event_pos > 0 && !key_event_buffer[key_event_pos - 1].ime) {
 		key_event_pos--;
 	}
 }

--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -323,7 +323,8 @@
 		ke.macos_state = 0;
 		ke.pressed = true;
 		ke.echo = false;
-		ke.raw = false; // IME input event.
+		ke.raw = false; // Can have composite characters.
+		ke.ime = true; // IME event, do not remove.
 		ke.keycode = Key::NONE;
 		ke.physical_keycode = Key::NONE;
 		ke.key_label = Key::NONE;
@@ -728,7 +729,7 @@
 			ke.key_label = KeyMappingMacOS::remap_key([event keyCode], [event modifierFlags], true);
 			ke.unicode = 0;
 			ke.location = KeyMappingMacOS::translate_location([event keyCode]);
-			ke.raw = false;
+			ke.raw = false; // Can have composite characters.
 
 			ds->push_to_key_event_buffer(ke);
 		}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/122795
