### PR TITLE
[Linux] Do not overwrite inverse scancode map entries.

### DIFF
--- a/platform/linuxbsd/wayland/key_mapping_xkb.cpp
+++ b/platform/linuxbsd/wayland/key_mapping_xkb.cpp
@@ -357,6 +357,9 @@ void KeyMappingXKB::initialize() {
 
 	// Godot to scancode map.
 	for (const KeyValue<unsigned int, Key> &E : scancode_map) {
+		if (scancode_map_inv.has(E.value)) {
+			continue;
+		}
 		scancode_map_inv[E.value] = E.key;
 	}
 

--- a/platform/linuxbsd/x11/key_mapping_x11.cpp
+++ b/platform/linuxbsd/x11/key_mapping_x11.cpp
@@ -351,6 +351,9 @@ void KeyMappingX11::initialize() {
 
 	// Godot to scancode map.
 	for (const KeyValue<unsigned int, Key> &E : scancode_map) {
+		if (scancode_map_inv.has(E.value)) {
+			continue;
+		}
 		scancode_map_inv[E.value] = E.key;
 	}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/122740

## Additional information
Scancode map include some rarely used duplicate values for key without equivalent in Godot `Key`, these values were overwriting more common keys when building inverse map.