### PR TITLE
Add EditorDock property for switching main screen

### DIFF
--- a/doc/classes/EditorDock.xml
+++ b/doc/classes/EditorDock.xml
@@ -95,6 +95,9 @@
 	</methods>
 	<members>
 		<member name="accessibility_region" type="bool" setter="set_accessibility_region" getter="is_accessibility_region" overrides="Container" default="true" />
+		<member name="allow_switch_screen" type="bool" setter="set_allow_switch_screen" getter="is_allow_switch_screen" default="false">
+			If [code]true[/code] and this dock is docked in the main screen, selecting a node in the scene tree can switch away from this dock. The selected node needs to be handled by another main screen dock (2D, 3D) for the switch to happen.
+		</member>
 		<member name="available_layouts" type="int" setter="set_available_layouts" getter="get_available_layouts" enum="EditorDock.DockLayout" is_bitfield="true" default="5">
 			The available layouts for this dock, as a bitmask. By default, the dock allows vertical and floating layouts.
 		</member>

--- a/editor/docks/editor_dock.cpp
+++ b/editor/docks/editor_dock.cpp
@@ -92,6 +92,10 @@ void EditorDock::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_closable"), &EditorDock::is_closable);
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "closable"), "set_closable", "is_closable");
 
+	ClassDB::bind_method(D_METHOD("set_allow_switch_screen", "allow"), &EditorDock::set_allow_switch_screen);
+	ClassDB::bind_method(D_METHOD("is_allow_switch_screen"), &EditorDock::is_allow_switch_screen);
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_switch_screen"), "set_allow_switch_screen", "is_allow_switch_screen");
+
 	ClassDB::bind_method(D_METHOD("set_icon_name", "icon_name"), &EditorDock::set_icon_name);
 	ClassDB::bind_method(D_METHOD("get_icon_name"), &EditorDock::get_icon_name);
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "icon_name"), "set_icon_name", "get_icon_name");

--- a/editor/docks/editor_dock.h
+++ b/editor/docks/editor_dock.h
@@ -80,9 +80,11 @@ private:
 	Color title_color = Color(0, 0, 0, 0);
 	Ref<Shortcut> shortcut;
 	DockSlot default_slot = DOCK_SLOT_NONE;
+
 	bool global = true;
 	bool transient = false;
 	bool closable = false;
+	bool allow_switch_screen = false;
 
 	DockLayout current_layout;
 	BitField<DockLayout> available_layouts = DOCK_LAYOUT_VERTICAL | DOCK_LAYOUT_FLOATING;
@@ -133,6 +135,9 @@ public:
 
 	void set_closable(bool p_closable) { closable = p_closable; }
 	bool is_closable() const { return closable; }
+
+	void set_allow_switch_screen(bool p_allow) { allow_switch_screen = p_allow; }
+	bool is_allow_switch_screen() const { return allow_switch_screen; }
 
 	void set_icon_name(const StringName &p_name);
 	StringName get_icon_name() const { return icon_name; }

--- a/editor/editor_main_screen.cpp
+++ b/editor/editor_main_screen.cpp
@@ -172,21 +172,11 @@ EditorPlugin *EditorMainScreen::get_selected_plugin() const {
 }
 
 bool EditorMainScreen::can_auto_switch_screens() const {
-	if (selected_plugin == nullptr) {
+	if (get_current_tab() == -1) {
 		return true;
 	}
-	// Only allow auto-switching if the selected tab is to the left of the Script tab, or is not in the TabBar.
-	bool was_script_tab = false;
-	for (int i = 0; i < get_tab_count(); i++) {
-		EditorDock *dock = get_dock(i);
-		if (dock == ScriptEditor::get_singleton()) {
-			was_script_tab = true;
-		}
-		if (dock->get_display_title() == selected_plugin->get_plugin_name()) {
-			return !was_script_tab;
-		}
-	}
-	return true;
+	EditorDock *dock = get_dock(get_current_tab());
+	return dock->is_allow_switch_screen();
 }
 
 #ifndef DISABLE_DEPRECATED

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3185,7 +3185,6 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 
 	bool is_resource = current_obj->is_class("Resource");
 	bool is_node = current_obj->is_class("Node");
-	bool stay_in_script_editor_on_node_selected = bool(EDITOR_GET("text_editor/behavior/navigation/stay_in_script_editor_on_node_selected"));
 	bool skip_main_plugin = false;
 
 	String editable_info; // None by default.
@@ -3241,11 +3240,7 @@ void EditorNode::_edit_current(bool p_skip_foreign, bool p_skip_inspector_update
 			SceneTreeDock::get_singleton()->set_selection({ current_node });
 			InspectorDock::get_singleton()->update(current_node);
 			if (!inspector_only && !skip_main_plugin) {
-				if ((ScriptEditor::get_singleton()->get_current_layout() != EditorDock::DOCK_LAYOUT_FLOATING) && ScriptEditor::get_singleton()->is_visible_in_tree()) {
-					skip_main_plugin = stay_in_script_editor_on_node_selected;
-				} else {
-					skip_main_plugin = !editor_main_screen->can_auto_switch_screens();
-				}
+				skip_main_plugin = !editor_main_screen->can_auto_switch_screens();
 			}
 		} else {
 			SignalsDock::get_singleton()->set_object(nullptr);

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -3233,6 +3233,7 @@ Node3DEditor::Node3DEditor() {
 	set_available_layouts(EditorDock::DOCK_LAYOUT_MAIN_SCREEN | EditorDock::DOCK_LAYOUT_FLOATING);
 	set_default_slot(EditorDock::DOCK_SLOT_MAIN_SCREEN);
 	set_dock_shortcut(ED_GET_SHORTCUT("editor/editor_3d"));
+	set_allow_switch_screen(true);
 
 	gizmo.visible = true;
 	gizmo.scale = 1.0;

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -5752,6 +5752,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	set_available_layouts(EditorDock::DOCK_LAYOUT_MAIN_SCREEN | EditorDock::DOCK_LAYOUT_FLOATING);
 	set_default_slot(EditorDock::DOCK_SLOT_MAIN_SCREEN);
 	set_dock_shortcut(ED_GET_SHORTCUT("editor/editor_2d"));
+	set_allow_switch_screen(true);
 
 	snap_target[0] = SNAP_TARGET_NONE;
 	snap_target[1] = SNAP_TARGET_NONE;

--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -3117,6 +3117,8 @@ void ScriptEditor::_apply_editor_settings() {
 		_connect_to_scene();
 	}
 
+	set_allow_switch_screen(!bool(EDITOR_GET("text_editor/behavior/navigation/stay_in_script_editor_on_node_selected")));
+
 	document_list->update_editor_settings();
 
 	ScriptServer::set_reload_scripts_on_save(EDITOR_GET("text_editor/behavior/files/auto_reload_and_parse_scripts_on_save"));


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Addresses https://github.com/godotengine/godot/pull/113051#discussion_r3833744276

Replaces a long-standing hack, where main screens won't be switched when to the right of the Script tab, with a property `allow_switch_screen` (name up to discussion) in EditorDock. If `false`, selecting nodes in scene tree won't switch away from this dock (when it's a main screen). 2D and 3D editor enable switching by default,  for Script it's controlled by `stay_in_script_editor_on_node_selected` editor setting like before.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
