### PR TITLE
Remove includes causing `clangd(unused-includes)` and change to minimal includes

### DIFF
--- a/editor/debugger/debugger_editor_plugin.cpp
+++ b/editor/debugger/debugger_editor_plugin.cpp
@@ -35,7 +35,6 @@
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/editor_debugger_server.h"
 #include "editor/debugger/editor_file_server.h"
-#include "editor/debugger/script_editor_debugger.h"
 #include "editor/docks/editor_dock_manager.h"
 #include "editor/editor_node.h"
 #include "editor/run/run_instances_dialog.h"

--- a/editor/export/android_sdk_manager.cpp
+++ b/editor/export/android_sdk_manager.cpp
@@ -32,7 +32,6 @@
 
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
-#include "core/io/zip_io.h"
 #include "core/object/callable_mp.h"
 #include "core/os/os.h"
 #include "editor/editor_node.h"

--- a/editor/scene/2d/scene_paint_2d_editor_plugin.cpp
+++ b/editor/scene/2d/scene_paint_2d_editor_plugin.cpp
@@ -36,7 +36,6 @@
 #include "editor/docks/filesystem_dock.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/docks/scene_tree_dock.h"
-#include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/scene/canvas_item_editor_plugin.h"

--- a/editor/scene/3d/gizmos/mesh_instance_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/mesh_instance_3d_gizmo_plugin.cpp
@@ -30,7 +30,6 @@
 
 #include "mesh_instance_3d_gizmo_plugin.h"
 
-#include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/3d/physics/soft_body_3d.h"
 #include "scene/resources/3d/primitive_meshes.h"

--- a/editor/shader/shader_editor_plugin.cpp
+++ b/editor/shader/shader_editor_plugin.cpp
@@ -39,7 +39,6 @@
 #include "editor/settings/editor_settings.h"
 #include "editor/shader/editor_shader_language_plugin.h"
 #include "editor/shader/text_shader_language_plugin.h"
-#include "editor/themes/editor_scale.h"
 #include "scene/resources/shader.h"
 
 void ShaderEditorPlugin::shortcut_input(const Ref<InputEvent> &p_event) {

--- a/modules/mono/utils/path_utils.cpp
+++ b/modules/mono/utils/path_utils.cpp
@@ -34,8 +34,6 @@
 #include "core/io/file_access.h"
 #include "core/os/os.h"
 
-#include <cstdlib>
-
 #ifdef WINDOWS_ENABLED
 #include <windows.h>
 

--- a/modules/mono/utils/string_utils.cpp
+++ b/modules/mono/utils/string_utils.cpp
@@ -32,8 +32,6 @@
 
 #include "core/io/file_access.h"
 
-#include <cstdio>
-
 namespace {
 
 int sfind(const String &p_text, int p_from) {

--- a/modules/openxr/extensions/platform/openxr_d3d12_extension.cpp
+++ b/modules/openxr/extensions/platform/openxr_d3d12_extension.cpp
@@ -32,11 +32,11 @@
 
 #ifdef D3D12_ENABLED
 
+#include "../../openxr_api.h"
 #include "../../openxr_util.h"
 
 #include "servers/rendering/rendering_device.h"
 #include "servers/rendering/rendering_server.h"
-#include "servers/rendering/rendering_server_globals.h"
 
 HashMap<String, bool *> OpenXRD3D12Extension::get_requested_extensions(XrVersion p_version) {
 	HashMap<String, bool *> request_extensions;

--- a/modules/openxr/extensions/platform/openxr_d3d12_extension.h
+++ b/modules/openxr/extensions/platform/openxr_d3d12_extension.h
@@ -32,7 +32,6 @@
 
 #ifdef D3D12_ENABLED
 
-#include "../../openxr_api.h"
 #include "../../util.h"
 #include "../openxr_extension_wrapper.h"
 

--- a/platform/macos/editor/embedded_process_macos.h
+++ b/platform/macos/editor/embedded_process_macos.h
@@ -30,7 +30,6 @@
 
 #pragma once
 
-#include "core/object/class_db.h"
 #include "core/os/process_id.h"
 #include "editor/run/embedded_process.h"
 #include "scene/gui/control.h"

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -41,7 +41,6 @@
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
-#include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/io/marshalls.h"
 #include "core/io/xml_parser.h"

--- a/platform/windows/tts_driver_onecore.cpp
+++ b/platform/windows/tts_driver_onecore.cpp
@@ -30,6 +30,8 @@
 
 #include "tts_driver_onecore.h"
 
+#include "winrt_utils.h"
+
 #include "core/object/callable_mp.h"
 #include "servers/display/display_server.h"
 

--- a/platform/windows/tts_driver_onecore.h
+++ b/platform/windows/tts_driver_onecore.h
@@ -31,7 +31,7 @@
 #pragma once
 
 #include "tts_driver.h"
-#include "winrt_utils.h"
+#include "winrt_defines.h"
 
 struct TTSUtterance;
 

--- a/platform/windows/tts_driver_sapi.cpp
+++ b/platform/windows/tts_driver_sapi.cpp
@@ -30,7 +30,6 @@
 
 #include "tts_driver_sapi.h"
 
-#include "core/object/callable_mp.h"
 #include "servers/display/display_server.h"
 
 TTSDriverSAPI *TTSDriverSAPI::singleton = nullptr;

--- a/platform/windows/tts_driver_sapi.h
+++ b/platform/windows/tts_driver_sapi.h
@@ -38,8 +38,6 @@
 #include <sapi.h>
 #include <winnls.h>
 
-#include <cwchar>
-
 struct TTSUtterance;
 
 class TTSDriverSAPI : public TTSDriver {

--- a/platform/windows/winrt_utils.cpp
+++ b/platform/windows/winrt_utils.cpp
@@ -30,6 +30,8 @@
 
 #include "winrt_utils.h"
 
+#include "winrt_defines.h"
+
 #include "core/crypto/crypto_core.h"
 #include "core/io/dir_access.h"
 #include "core/os/mutex.h"

--- a/platform/windows/winrt_utils.h
+++ b/platform/windows/winrt_utils.h
@@ -30,8 +30,6 @@
 
 #pragma once
 
-#include "winrt_defines.h"
-
 #include "core/typedefs.h"
 #include "core/variant/callable.h"
 #include "core/variant/variant.h"


### PR DESCRIPTION
## What problem(s) does this PR solve?

Removes includes marked as unused by clangd and adds new ones in cases where the removed includes indirectly added necessary includes.

~PR is a draft for now to see if any CI checks fail~