### PR TITLE
[4.7] SCons: Pass `-mcmodel=medium` on Linux x86_64 GCC sanitizers

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -162,6 +162,10 @@ def configure(env: "SConsEnvironment"):
     if env["use_ubsan"] or env["use_asan"] or env["use_lsan"] or env["use_tsan"] or env["use_msan"]:
         env.extra_suffix += ".san"
 
+        if not env["use_llvm"] and env["arch"] == "x86_64":
+            env.Append(CCFLAGS=["-mcmodel=medium"])
+            env.Append(LINKFLAGS=["-mcmodel=medium"])
+
         if env["use_ubsan"]:
             env.Append(CPPDEFINES=["UBSAN_ENABLED"])
             env.Append(


### PR DESCRIPTION
This is a manual cherry-pick of PR #121647 and its follow-up PR #121719 to ensure that the commit is atomically correct.

## What problem(s) does this PR solve?

When additional C++ modules are added to the Godot 4.7 branch (current stable), the same problem described in https://github.com/godotengine/godot/issues/109158 occurs. It's simply a matter of repo size. @WhalesState encountered this problem earlier in 4.5, and I am seeing this problem in godot-dimensions as well. I believe we should cherry-pick this change to all supported branches in order to fix all of them and enable users to extend Godot arbitrarily without running into this limitation.

## Additional information

I've had this problem for a long time in godot-dimensions, but haven't bothered investigating too deeply. When I saw that the problem was fixed in master, I used AI to search for the commits responsible for fixing it, in order to find these PRs so we can cherry-pick this. The lines of code themselves are entirely authored by @Repiteo.
