### PR TITLE
Add missing `<memory>` includes in SVG module

### DIFF
--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -34,6 +34,8 @@
 
 #include <thorvg.h>
 
+#include <memory>
+
 HashMap<Color, Color> ImageLoaderSVG::forced_color_map = HashMap<Color, Color>();
 
 void ImageLoaderSVG::set_forced_color_map(const HashMap<Color, Color> &p_color_map) {

--- a/modules/text_server_adv/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_adv/thorvg_svg_in_ot.cpp
@@ -39,6 +39,8 @@
 
 #include "modules/modules_enabled.gen.h" // For svg, freetype.
 
+#include <memory>
+
 #ifdef MODULE_SVG_ENABLED
 #ifdef MODULE_FREETYPE_ENABLED
 

--- a/modules/text_server_fb/thorvg_svg_in_ot.cpp
+++ b/modules/text_server_fb/thorvg_svg_in_ot.cpp
@@ -39,6 +39,8 @@
 
 #include "modules/modules_enabled.gen.h" // For svg, freetype.
 
+#include <memory>
+
 #ifdef MODULE_SVG_ENABLED
 #ifdef MODULE_FREETYPE_ENABLED
 


### PR DESCRIPTION
- Fixes #121790.

---

I was able to reproduce the issue on my end:

```cmd
modules/text_server_fb/thorvg_svg_in_ot.cpp: In function 'FT_Error tvg_svg_in_ot_render(FT_GlyphSlot, void**)':
modules/text_server_fb/thorvg_svg_in_ot.cpp:330:14: error: 'unique_ptr' is not a member of 'std'
  330 |         std::unique_ptr<tvg::SwCanvas> sw_canvas(tvg::SwCanvas::gen());
      |              ^~~~~~~~~~
modules/text_server_fb/thorvg_svg_in_ot.cpp:35:1: note: 'std::unique_ptr' is defined in header '<memory>'; this is probably fixable by adding '#include <memory>'
   34 | #include "core/io/xml_parser.h"
  +++ |+#include <memory>
   35 | #include "core/os/memory.h"
modules/text_server_fb/thorvg_svg_in_ot.cpp:330:38: error: expected primary-expression before '>' token
  330 |         std::unique_ptr<tvg::SwCanvas> sw_canvas(tvg::SwCanvas::gen());
      |                                      ^
modules/text_server_fb/thorvg_svg_in_ot.cpp:330:40: error: 'sw_canvas' was not declared in this scope; did you mean 'swscanf_s'?
  330 |         std::unique_ptr<tvg::SwCanvas> sw_canvas(tvg::SwCanvas::gen());
      |                                        ^~~~~~~~~
      |                                        swscanf_s
```

I think the solution proposed by @AThousandShips is the right one; including `<memory>` in affected files solves the issue.
