### PR TITLE
List monitor resolutions and refresh rates in editor Copy System Info

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6207,6 +6207,17 @@ String EditorNode::_get_system_info() const {
 		display_driver_window_mode += ", " + itos(DisplayServer::get_singleton()->get_screen_count()) + " monitors";
 	}
 
+	// List resolution and refresh rate for each monitor.
+	display_driver_window_mode += " (";
+	for (int i = 0; i < DisplayServer::get_singleton()->get_screen_count(); i++) {
+		const Size2i screen_size = DisplayServer::get_singleton()->screen_get_size(i);
+		display_driver_window_mode += vformat("%dx%d @ %.2f Hz", screen_size.x, screen_size.y, DisplayServer::get_singleton()->screen_get_refresh_rate(i));
+		if (i < DisplayServer::get_singleton()->get_screen_count() - 1) {
+			display_driver_window_mode += ", ";
+		}
+	}
+	display_driver_window_mode += ")";
+
 	info.push_back(display_driver_window_mode);
 
 	info.push_back(vformat("%s (%s)", driver_name, rendering_method));


### PR DESCRIPTION
This is useful for troubleshooting issues specific to multi-monitor setups with different resolutions or refresh rates, as well as issues specific to unusual resolution/refresh rate combinations.

Refresh rate includes two fractional digits by design, as some jittering issues can be caused by these (e.g. 59.94 Hz NTSC vs "true" 60.00 Hz).

## Preview

> Godot v4.8.dev (8bc207870) - Windows 11 (build 26100) - Multi-window, 1 monitor (3840x2160 @ 240.02 Hz) - Direct3D 12 (Forward+) - dedicated NVIDIA GeForce RTX 5090 (NVIDIA; 32.0.15.9649) - AMD Ryzen 9 9950X3D 16-Core Processor (32 threads) - 63.55 GiB memory - WASAPI (48000 Hz, Stereo/mono)

