### PR TITLE
SDL: Backport fix for infinite loop in joystick force recentering

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -1009,6 +1009,7 @@ Patches:
 - `0007-shield-duplicate-macos.patch` ([GH-115510](https://github.com/godotengine/godot/pull/115510))
 - `0008-fix-linux-joycon-serial-num.patch` ([GH-113873](https://github.com/godotengine/godot/pull/113873))
 - `0009-update-device-blocklist.patch` ([GH-119403](https://github.com/godotengine/godot/pull/119403))
+- `0010-fix-recentering-infinite-loop.patch` ([GH-122810](https://github.com/godotengine/godot/pull/122810))
 
 
 ## spirv-cross

--- a/thirdparty/sdl/joystick/SDL_joystick.c
+++ b/thirdparty/sdl/joystick/SDL_joystick.c
@@ -2200,7 +2200,7 @@ bool SDL_IsJoystickBeingAdded(void)
 
 void SDL_PrivateJoystickForceRecentering(SDL_Joystick *joystick)
 {
-    Uint8 i, j;
+    int i, j;
     Uint64 timestamp = SDL_GetTicksNS();
 
     SDL_AssertJoysticksLocked();

--- a/thirdparty/sdl/patches/0010-fix-recentering-infinite-loop.patch
+++ b/thirdparty/sdl/patches/0010-fix-recentering-infinite-loop.patch
@@ -1,0 +1,13 @@
+diff --git a/thirdparty/sdl/joystick/SDL_joystick.c b/thirdparty/sdl/joystick/SDL_joystick.c
+index 768f8f9025..8847fc1d1c 100644
+--- a/thirdparty/sdl/joystick/SDL_joystick.c
++++ b/thirdparty/sdl/joystick/SDL_joystick.c
+@@ -2200,7 +2200,7 @@ bool SDL_IsJoystickBeingAdded(void)
+ 
+ void SDL_PrivateJoystickForceRecentering(SDL_Joystick *joystick)
+ {
+-    Uint8 i, j;
++    int i, j;
+     Uint64 timestamp = SDL_GetTicksNS();
+ 
+     SDL_AssertJoysticksLocked();


### PR DESCRIPTION
## What problem(s) does this PR solve?

Discovered while using a third-party gamepad with Godot: after unplugging the controller, input processing could hang forever and the engine became unresponsive until killed. Tracing it down led to an infinite loop in `SDL_PrivateJoystickForceRecentering()` in Godot's vendored SDL copy.

In `thirdparty/sdl/joystick/SDL_joystick.c`, the loop counters of `SDL_PrivateJoystickForceRecentering()` are declared as `Uint8`:

```c
void SDL_PrivateJoystickForceRecentering(SDL_Joystick *joystick)
{
    Uint8 i, j;
    ...
    for (i = 0; i < joystick->naxes; i++) { ... }
    for (i = 0; i < joystick->nbuttons; i++) { ... }
    for (i = 0; i < joystick->nhats; i++) { ... }
    for (i = 0; i < joystick->ntouchpads; i++) {
        for (j = 0; j < touchpad->nfingers; ++j) { ... }
    }
}
```

The limits (`naxes`, `nbuttons`, `nhats`, `ntouchpads`, `nfingers`) are plain `int`s. Some devices, notably third-party controllers with unusual HID descriptors as well as virtual/exotic HID devices, can report more than 255 of these. Once a limit exceeds `SDL_MAX_UINT8`, the counter wraps around to 0 and never reaches it, so the loop never terminates.

This function is called from `SDL_PrivateJoystickRemoved()` when a device is disconnected, **while the joystick system lock is held** (`SDL_AssertJoysticksLocked()`). The infinite loop therefore permanently stalls the thread that processes joystick events and deadlocks every other joystick API waiting for that lock. In practice, the engine freezes when the controller is unplugged.

This is already fixed upstream in libsdl-org/SDL:

- mainline: https://github.com/libsdl-org/SDL/commit/b5ef75249f2f39bae77fcb009832ba6ec753a3cc
- cherry-picked to release branches: https://github.com/libsdl-org/SDL/commit/212f7539cb7f7b24a1e02398b99f430921485aab

There is no corresponding Godot issue to close; the problem was reproduced locally against the vendored copy.

## Additional information

Godot's vendored SDL is pinned to 3.2.28 (7f3ae3d57459e59943a4ecfefc8f6277ec6bf540, 2025), which predates the upstream fix, so this PR backports it as a thirdparty patch:

- one-line fix in `thirdparty/sdl/joystick/SDL_joystick.c` (`Uint8 i, j;` -> `int i, j;`)
- new patch file `thirdparty/sdl/patches/0010-fix-recentering-infinite-loop.patch`
- README entry under the `sdl` section

The patch can be dropped when the vendored SDL copy is updated to a version that includes the upstream fix.

AI disclosure: this pull request was prepared with the help of an AI coding assistant, which drafted the patch file layout, the commit message, and this description based on my own debugging and fix.
