### PR TITLE
Fix documentation tooltips closing on false mouse exit

### DIFF
--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -4996,7 +4996,16 @@ Control *EditorHelpBitTooltip::_make_invisible_control() {
 	return control;
 }
 
+bool EditorHelpBitTooltip::_is_mouse_inside_target() const {
+	Control *target = Object::cast_to<Control>(get_parent());
+	return target && target->is_inside_tree() && target->get_screen_rect().has_point(DisplayServer::get_singleton()->mouse_get_position());
+}
+
 void EditorHelpBitTooltip::_start_timer() {
+	// Showing the tooltip window can make the target emit `mouse_exited` even though the mouse is still over it.
+	if (!_is_shortcut_pressed && _is_mouse_inside_target()) {
+		return;
+	}
 	if (timer->is_inside_tree() && timer->is_stopped()) {
 		timer->start();
 	}

--- a/editor/doc/editor_help.h
+++ b/editor/doc/editor_help.h
@@ -388,6 +388,7 @@ class EditorHelpBitTooltip : public PopupPanel {
 
 	static Control *_make_invisible_control();
 
+	bool _is_mouse_inside_target() const;
 	void _start_timer();
 	void _target_gui_input(const Ref<InputEvent> &p_event);
 	void _shortcut_pressed(Control *p_target);

--- a/tests/editor/test_editor_help.cpp
+++ b/tests/editor/test_editor_help.cpp
@@ -1,0 +1,75 @@
+/**************************************************************************/
+/*  test_editor_help.cpp                                                  */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_editor_help)
+
+#include "editor/doc/editor_help.h"
+#include "scene/gui/control.h"
+#include "scene/main/scene_tree.h"
+#include "scene/main/timer.h"
+#include "tests/display_server_mock.h"
+
+namespace TestEditorHelp {
+
+TEST_CASE("[Editor][EditorHelpBitTooltip] Ignore false target mouse exit") {
+	Control *target = memnew(Control);
+	target->set_position(Point2(100, 100));
+	target->set_size(Size2(100, 100));
+	SceneTree::get_singleton()->get_root()->add_child(target);
+
+	EditorHelpBitTooltip *tooltip = memnew(EditorHelpBitTooltip(target));
+	Timer *timer = nullptr;
+	for (int i = 0; i < tooltip->get_child_count(); i++) {
+		timer = Object::cast_to<Timer>(tooltip->get_child(i));
+		if (timer) {
+			break;
+		}
+	}
+	if (!timer) {
+		memdelete(tooltip);
+		memdelete(target);
+		FAIL_CHECK("The tooltip dismissal timer was not found.");
+		return;
+	}
+	target->add_child(tooltip);
+
+	SEND_GUI_MOUSE_MOTION_EVENT(Point2(150, 150), MouseButtonMask::NONE, Key::NONE);
+	target->emit_signal(SceneStringName(mouse_exited));
+	CHECK_UNARY(timer->is_stopped());
+
+	SEND_GUI_MOUSE_MOTION_EVENT(Point2(250, 250), MouseButtonMask::NONE, Key::NONE);
+	CHECK_UNARY_FALSE(timer->is_stopped());
+
+	memdelete(target);
+}
+
+} // namespace TestEditorHelp


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes #122770.

Documentation tooltips can receive `mouse_exited` from their target as the tooltip window is shown even while the cursor is still over that target. The resulting 250 ms dismissal timer makes the tooltip disappear before it can be read or entered.

## Additional information

Before starting the dismissal timer, the tooltip now checks the current cursor position against the target screen rectangle. Shortcut-triggered tooltips retain their existing behavior. The patch adds no persistent state.

A regression test uses the mock display server to verify both sides of the behavior: a false exit while the cursor remains over the target does not start the timer, while moving outside the target does.

Validation performed:

- Built the Windows editor with tests enabled.
- Ran the focused `EditorHelpBitTooltip` test: 1 test case and 2 assertions passed.
- Verified tooltip persistence and dismissal interactively in both the Inspector and Editor Settings.
- Tested rapid target/tooltip crossings, adjacent properties/settings, entering the tooltip itself, and five repeated trigger/dismiss cycles in each location.
- Confirmed the regression test fails with the old dismissal behavior and passes with this fix.