### PR TITLE
Fix xkb dead key labels

### DIFF
--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -11,6 +11,7 @@ common_linuxbsd = [
     "freedesktop_portal_desktop.cpp",
     "freedesktop_screensaver.cpp",
     "freedesktop_at_spi_monitor.cpp",
+    "xkb_convert_dead_keys.cpp",
 ]
 
 if env["library_type"] == "executable":

--- a/platform/linuxbsd/wayland/key_mapping_xkb.cpp
+++ b/platform/linuxbsd/wayland/key_mapping_xkb.cpp
@@ -357,6 +357,9 @@ void KeyMappingXKB::initialize() {
 
 	// Godot to scancode map.
 	for (const KeyValue<unsigned int, Key> &E : scancode_map) {
+		if (scancode_map_inv.has(E.value)) {
+			continue;
+		}
 		scancode_map_inv[E.value] = E.key;
 	}
 

--- a/platform/linuxbsd/wayland/wayland_thread.cpp
+++ b/platform/linuxbsd/wayland/wayland_thread.cpp
@@ -32,6 +32,8 @@
 
 #ifdef WAYLAND_ENABLED
 
+#include "xkb_convert_dead_keys.h"
+
 #include "core/config/engine.h"
 #include "core/io/image.h"
 #include "core/os/os.h"
@@ -5865,6 +5867,7 @@ Key WaylandThread::keyboard_get_label_from_physical(Key p_key) const {
 
 		xkb_keycode_t xkb_keycode = KeyMappingXKB::get_xkb_keycode(keycode_no_mod);
 		xkb_keycode_t xkb_keysym = xkb_state_key_get_one_sym(ss->xkb_state, xkb_keycode);
+		xkb_keysym = xkb_convert_if_dead_key(xkb_keysym);
 		char32_t chr = xkb_keysym_to_utf32(xkb_keysym_to_upper(xkb_keysym));
 		if (chr != 0) {
 			String keysym = String::chr(chr);

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -33,6 +33,7 @@
 #ifdef X11_ENABLED
 
 #include "x11/key_mapping_x11.h"
+#include "xkb_convert_dead_keys.h"
 
 #include "core/config/project_settings.h"
 #include "core/input/input.h"
@@ -3873,6 +3874,7 @@ Key DisplayServerX11::keyboard_get_label_from_physical(Key p_keycode) const {
 	Key keycode_no_mod = p_keycode & KeyModifierMask::CODE_MASK;
 	unsigned int xkeycode = KeyMappingX11::get_xlibcode(keycode_no_mod);
 	KeySym xkeysym = XkbKeycodeToKeysym(x11_display, xkeycode, keyboard_get_current_layout(), 0);
+	xkeysym = xkb_convert_if_dead_key(xkeysym);
 	if (is_ascii_lower_case(xkeysym)) {
 		xkeysym -= ('a' - 'A');
 	}

--- a/platform/linuxbsd/x11/key_mapping_x11.cpp
+++ b/platform/linuxbsd/x11/key_mapping_x11.cpp
@@ -351,6 +351,9 @@ void KeyMappingX11::initialize() {
 
 	// Godot to scancode map.
 	for (const KeyValue<unsigned int, Key> &E : scancode_map) {
+		if (scancode_map_inv.has(E.value)) {
+			continue;
+		}
 		scancode_map_inv[E.value] = E.key;
 	}
 

--- a/platform/linuxbsd/xkb_convert_dead_keys.cpp
+++ b/platform/linuxbsd/xkb_convert_dead_keys.cpp
@@ -1,0 +1,195 @@
+/**************************************************************************/
+/*  xkb_convert_dead_keys.cpp                                             */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "xkb_convert_dead_keys.h"
+
+#include "xkbcommon/xkbcommon-keysyms.h"
+#include "xkbcommon/xkbcommon.h"
+
+xkb_keysym_t xkb_convert_if_dead_key(xkb_keysym_t p_keysym) {
+	switch (p_keysym) {
+		case XKB_KEY_dead_grave: // not tested
+			p_keysym = XKB_KEY_grave;
+			break;
+		case XKB_KEY_dead_acute:
+			p_keysym = XKB_KEY_acute;
+			break;
+		case XKB_KEY_dead_circumflex:
+			p_keysym = XKB_KEY_asciicircum;
+			break;
+
+		// from here not yet tested
+		case XKB_KEY_dead_tilde: /*XKB_KEY_dead_perispomeni*/
+			p_keysym = XKB_KEY_asciitilde;
+			break;
+		case XKB_KEY_dead_macron:
+			p_keysym = XKB_KEY_macron;
+			break;
+		case XKB_KEY_dead_breve:
+			p_keysym = XKB_KEY_breve;
+			break;
+		case XKB_KEY_dead_abovedot:
+			p_keysym = XKB_KEY_abovedot;
+			break;
+		case XKB_KEY_dead_diaeresis:
+			p_keysym = XKB_KEY_diaeresis;
+			break;
+		case XKB_KEY_dead_abovering:
+			// haven't found non dead equivalent
+			break;
+		case XKB_KEY_dead_doubleacute:
+			p_keysym = XKB_KEY_doubleacute;
+			break;
+		case XKB_KEY_dead_caron:
+			p_keysym = XKB_KEY_caron;
+			break;
+		case XKB_KEY_dead_cedilla:
+			p_keysym = XKB_KEY_cedilla;
+			break;
+		case XKB_KEY_dead_ogonek:
+			p_keysym = XKB_KEY_ogonek;
+			break;
+		case XKB_KEY_dead_iota:
+			p_keysym = XKB_KEY_Greek_iota;
+			break;
+		case XKB_KEY_dead_voiced_sound:
+			p_keysym = XKB_KEY_voicedsound;
+			break;
+		case XKB_KEY_dead_semivoiced_sound:
+			p_keysym = XKB_KEY_semivoicedsound;
+			break;
+		case XKB_KEY_dead_belowdot:
+			//
+			break;
+		case XKB_KEY_dead_hook:
+			//
+			break;
+		case XKB_KEY_dead_horn:
+			//
+			break;
+		case XKB_KEY_dead_stroke:
+			//
+			break;
+		case XKB_KEY_dead_abovecomma: /*XKB_KEY_dead_psili*/
+			//
+			break;
+		case XKB_KEY_dead_abovereversedcomma: /*XKB_KEY_dead_dasia*/
+			//
+			break;
+		case XKB_KEY_dead_doublegrave:
+			//
+			break;
+		case XKB_KEY_dead_belowring:
+			//
+			break;
+		case XKB_KEY_dead_belowmacron:
+			//
+			break;
+		case XKB_KEY_dead_belowcircumflex:
+			//
+			break;
+		case XKB_KEY_dead_belowtilde:
+			//
+			break;
+		case XKB_KEY_dead_belowbreve:
+			//
+			break;
+		case XKB_KEY_dead_belowdiaeresis:
+			//
+			break;
+		case XKB_KEY_dead_invertedbreve:
+			//
+			break;
+		case XKB_KEY_dead_belowcomma:
+			//
+			break;
+		case XKB_KEY_dead_currency:
+			p_keysym = XKB_KEY_currency;
+			break;
+
+		/* extra dead elements for German T3 layout */
+		case XKB_KEY_dead_lowline:
+			//xkb_keysym = XKB_KEY_underscore;
+			//xkb_keysym = XKB_KEY_underbar;
+			break;
+		case XKB_KEY_dead_aboveverticalline:
+			//
+			break;
+		case XKB_KEY_dead_belowverticalline:
+			//
+			break;
+		case XKB_KEY_dead_longsolidusoverlay:
+			//
+			break;
+
+		/* dead vowels for universal syllable entry */
+		case XKB_KEY_dead_a:
+			p_keysym = XKB_KEY_a;
+			break;
+		case XKB_KEY_dead_A:
+			p_keysym = XKB_KEY_A;
+			break;
+		case XKB_KEY_dead_e:
+			p_keysym = XKB_KEY_e;
+			break;
+		case XKB_KEY_dead_E:
+			p_keysym = XKB_KEY_E;
+			break;
+		case XKB_KEY_dead_i:
+			p_keysym = XKB_KEY_i;
+			break;
+		case XKB_KEY_dead_I:
+			p_keysym = XKB_KEY_I;
+			break;
+		case XKB_KEY_dead_o:
+			p_keysym = XKB_KEY_o;
+			break;
+		case XKB_KEY_dead_O:
+			p_keysym = XKB_KEY_O;
+			break;
+		case XKB_KEY_dead_u:
+			p_keysym = XKB_KEY_u;
+			break;
+		case XKB_KEY_dead_U:
+			p_keysym = XKB_KEY_U;
+			break;
+		case XKB_KEY_dead_small_schwa:
+			//
+			break;
+		case XKB_KEY_dead_capital_schwa:
+			//
+			break;
+		case XKB_KEY_dead_greek:
+			//
+			break;
+	}
+
+	return p_keysym;
+}

--- a/platform/linuxbsd/xkb_convert_dead_keys.h
+++ b/platform/linuxbsd/xkb_convert_dead_keys.h
@@ -1,0 +1,35 @@
+/**************************************************************************/
+/*  xkb_convert_dead_keys.h                                               */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "xkbcommon/xkbcommon.h"
+
+xkb_keysym_t xkb_convert_if_dead_key(xkb_keysym_t p_keysym);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #122740


## Use of AI and other PRs
AI was used to help with linker issues (SCsub), Git-related questions, and finding the function responsible for printing logs to the editor (as this was my first time in the source code)(needed for debugging not part of this PR anymore). 

I merged PR #122801 into my branch because it fixes the issue where the inverse scanmap is overwritten. Without that fix, my changes would only work partially.


## Additional information
`xkb_keysym_to_utf32(xkb_keysym_to_upper(...))` was returning 0, when the keysym was a Dead-Key. I created a function that converts Dead-Key keysyms to their non dead equivalents, so that `keyboard_get_label_from_physical()` returns the correct label.

However I have not found non dead equivalents for every dead-key, and only a few dead keys where tested.

### From #122801
Scancode map include some rarely used duplicate values for key without equivalent in Godot Key, these values were overwriting more common keys when building inverse map.