### PR TITLE
Fix initial axis state for raw SDL joysticks

### DIFF
--- a/drivers/sdl/joypad_sdl.cpp
+++ b/drivers/sdl/joypad_sdl.cpp
@@ -49,6 +49,11 @@
 		continue; \
 	}
 
+// SDL axes go from SDL_JOYSTICK_AXIS_MIN to SDL_JOYSTICK_AXIS_MAX, Godot axes go from -1 to 1.
+static float _sdl_axis_to_godot(Sint16 p_value) {
+	return ((p_value - SDL_JOYSTICK_AXIS_MIN) / (float)(SDL_JOYSTICK_AXIS_MAX - SDL_JOYSTICK_AXIS_MIN) - 0.5f) * 2.0f;
+}
+
 JoypadSDL::~JoypadSDL() {
 	// Process any remaining input events
 	process_events();
@@ -163,6 +168,11 @@ void JoypadSDL::process_events() {
 
 				joypads[joy_id].attached = true;
 				joypads[joy_id].sdl_instance_idx = sdl_event.jdevice.which;
+				// SDL gamepads are left alone: they are reported through SDL's mapped gamepad
+				// events, which have their own trigger semantics.
+				joypads[joy_id].axes_pending_initial_sync = SDL_IsGamepad(sdl_event.jdevice.which)
+						? 0
+						: (((uint32_t)1 << MIN(SDL_GetNumJoystickAxes(joy), (int)JoyAxis::MAX)) - 1);
 				joypads[joy_id].supports_force_feedback = SDL_GetBooleanProperty(propertiesID, SDL_PROP_JOYSTICK_CAP_RUMBLE_BOOLEAN, false);
 				joypads[joy_id].guid = StringName(String(guid));
 				joypads[joy_id].supports_motion_sensors = SDL_GamepadHasSensor(gamepad, SDL_SENSOR_ACCEL) || SDL_GamepadHasSensor(gamepad, SDL_SENSOR_GYRO);
@@ -226,7 +236,7 @@ void JoypadSDL::process_events() {
 					Input::get_singleton()->joy_axis(
 							joy_id,
 							static_cast<JoyAxis>(sdl_event.jaxis.axis), // Godot joy axis constants are already intentionally the same as SDL's
-							((sdl_event.jaxis.value - SDL_JOYSTICK_AXIS_MIN) / (float)(SDL_JOYSTICK_AXIS_MAX - SDL_JOYSTICK_AXIS_MIN) - 0.5f) * 2.0f);
+							_sdl_axis_to_godot(sdl_event.jaxis.value));
 					break;
 
 				case SDL_EVENT_JOYSTICK_BUTTON_UP:
@@ -262,8 +272,7 @@ void JoypadSDL::process_events() {
 						axis_value = sdl_event.gaxis.value / (float)SDL_JOYSTICK_AXIS_MAX;
 					} else {
 						// Other axis go from SDL_JOYSTICK_AXIS_MIN to SDL_JOYSTICK_AXIS_MAX
-						axis_value =
-								((sdl_event.gaxis.value - SDL_JOYSTICK_AXIS_MIN) / (float)(SDL_JOYSTICK_AXIS_MAX - SDL_JOYSTICK_AXIS_MIN) - 0.5f) * 2.0f;
+						axis_value = _sdl_axis_to_godot(sdl_event.gaxis.value);
 					}
 
 					Input::get_singleton()->joy_axis(
@@ -296,6 +305,49 @@ void JoypadSDL::process_events() {
 		}
 	}
 
+	/*
+		SDL does not emit an axis motion event for the position an axis was already in when
+		the device was opened, it waits until the axis moves away from that position first.
+		Axes that do not spring back to a resting position (HOTAS throttles, RC transmitter
+		controls, pedals, sliders) can therefore start anywhere, while Godot keeps reporting
+		the default 0 until the user moves them.
+
+		Seed those axes from SDL's own state as soon as SDL has an initial value for them.
+	*/
+	for (int i = 0; i < Input::JOYPADS_MAX; i++) {
+		Joypad &joy = joypads[i];
+		if (!joy.attached || joy.axes_pending_initial_sync == 0) {
+			continue;
+		}
+
+		SDL_Joystick *sdl_joy = joy.get_sdl_joystick();
+		if (!sdl_joy) {
+			continue;
+		}
+
+		for (int axis = 0; axis < (int)JoyAxis::MAX; axis++) {
+			const uint32_t axis_bit = (uint32_t)1 << axis;
+			if (!(joy.axes_pending_initial_sync & axis_bit)) {
+				continue;
+			}
+
+			Sint16 initial_value;
+			if (!SDL_GetJoystickAxisInitialState(sdl_joy, axis, &initial_value)) {
+				// SDL has nothing for this axis yet, try again on the next frame.
+				continue;
+			}
+
+			// Send the current value rather than the initial one, so that movement that
+			// happened while SDL was waiting for a first report is not overwritten.
+			Input::get_singleton()->joy_axis(
+					i,
+					static_cast<JoyAxis>(axis), // Godot joy axis constants are already intentionally the same as SDL's
+					_sdl_axis_to_godot(SDL_GetJoystickAxis(sdl_joy, axis)));
+
+			joy.axes_pending_initial_sync &= ~axis_bit;
+		}
+	}
+
 	for (int i = 0; i < Input::JOYPADS_MAX; i++) {
 		Joypad &joy = joypads[i];
 		if (!joy.attached || !joy.supports_motion_sensors) {
@@ -320,6 +372,7 @@ void JoypadSDL::close_joypad(int p_pad_idx) {
 	int sdl_instance_idx = joypads[p_pad_idx].sdl_instance_idx;
 
 	joypads[p_pad_idx].attached = false;
+	joypads[p_pad_idx].axes_pending_initial_sync = 0;
 	sdl_instance_id_to_joypad_id.erase(sdl_instance_idx);
 
 	if (SDL_IsGamepad(sdl_instance_idx)) {

--- a/drivers/sdl/joypad_sdl.h
+++ b/drivers/sdl/joypad_sdl.h
@@ -51,6 +51,9 @@ private:
 
 		SDL_JoystickID sdl_instance_idx;
 
+		// Bitmask of the axes that still need their initial state queried from SDL.
+		uint32_t axes_pending_initial_sync = 0;
+
 		bool supports_force_feedback = false;
 		bool supports_motion_sensors = false;
 		uint64_t ff_effect_timestamp = 0;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #105676

Raw SDL joysticks can have axes that do not spring back to a resting position:
HOTAS throttles, RC transmitter controls, pedals and sliders.

SDL does not emit an `SDL_EVENT_JOYSTICK_AXIS_MOTION` event for the position an
axis was already in when the device was opened — it treats the first value it
receives as that axis' baseline and stays quiet until the axis moves roughly 2.5%
away from it (`MAX_ALLOWED_JITTER` in `SDL_SendJoystickAxis()`). Since
`drivers/sdl/joypad_sdl.cpp` only updates raw joystick axes from those motion
events, `Input.get_joy_axis()` returns the default `0.0` until the user moves the
control, even when it physically starts somewhere else.

## Additional information

Once SDL has an initial value for an axis, the driver seeds Godot's input state
from that axis' current value via the normal `Input::joy_axis()` path, so
mappings, actions and input events all behave as they would for a real motion
event.

A few details worth flagging for reviewers:

- **Current value, not initial value.** `SDL_GetJoystickAxisInitialState()` is used
  only to tell whether SDL has anything to report; the value actually sent comes
  from `SDL_GetJoystickAxis()`. This avoids clobbering movement that happened
  while SDL was still waiting for a first report.
- **Per-axis, not per-device.** Each axis is tracked in a bitmask and retried
  independently, so one axis that never reports cannot block the rest of the
  device.
- **Axis count is clamped to `JoyAxis::MAX`**, because `Input::joy_axis()` has an
  `ERR_FAIL_INDEX` on it. Note that the existing `SDL_EVENT_JOYSTICK_AXIS_MOTION`
  handler does *not* clamp, so a device with more than `JoyAxis::MAX` axes can
  already trip that assert on `master`. I've left that alone to keep this PR
  focused, but I'm happy to fix it here or separately.
- **SDL gamepads are excluded.** They're reported through SDL's mapped gamepad
  event path, which has its own trigger semantics, and the common at-rest case
  (triggers at minimum) already yields the correct `0.0`. A mapped clutch or
  handbrake would still be wrong; I can extend this if reviewers prefer.
- **Known limitation.** With `input_devices/joypads/ignore_joypad_on_unfocused_application`
  enabled (off by default), `Input::joy_axis()` drops events while the app is
  unfocused, and `Input::release_pressed_events()` clears `_joy_axis` on focus
  loss. A one-shot seed is therefore lost if the app starts unfocused, and a
  non-centering axis reverts to `0.0` after an alt-tab — the latter already
  happens on `master`. Re-seeding on focus regain would need a way to observe that
  state from the driver; I'd appreciate direction on whether that belongs here.

The normalization expression was factored into a small `_sdl_axis_to_godot()`
helper rather than copied a third time. It is token-for-token identical to the
existing inline expressions, so no behaviour changes.

### Testing

Tested on macOS 15 (arm64) with an OpenTX RadioMaster Pocket in USB joystick mode
(`0300bf1e09120000544f000012020000`, 8 axes), against `master` at b56a918 built
with and without this patch. This device goes through SDL's IOKit backend, and
reports its switches as axes rather than buttons.

Without the patch, every axis reads `0.000` indefinitely and only starts
reporting once the control is moved:

```
[frame 1] device 0 axes [0:+0.000 1:+0.000 2:+0.000 3:+0.000 4:+0.000 ...]
```

With the patch, on frame 1 and without touching the transmitter:

```
[frame 1] device 0 axes [0:+0.006 1:+0.005 2:-1.000 3:+0.002 4:-1.000 5:+1.000 6:-1.000 7:-1.000 8:+0.000 9:+0.000]
```

Axis 2 is the throttle at minimum; axes 4-7 are switches; axes 0/1/3 show the
gimbals' true resting offsets. Axes 8-9 stay untouched because the device only
has 8 axes.

- **Reads the current position, not a stale one.** Moving the throttle to roughly
  a quarter travel and reconnecting the device made frame 1 report `2:-0.242`
  instead of `2:-1.000`, and a flicked switch changed from `5:+1.000` to
  `5:+0.000`. Values come from the device's actual state at the time of the sync,
  and reconnecting re-seeds correctly.
- **No discontinuity after seeding.** Over a 3600-frame session sweeping the
  throttle across its full range several times: 2252 logged samples, the value
  continued smoothly from the seeded position, covered the full `-1.000 .. +1.000`
  range, and never once reported exactly `0.000` after the seed. The largest
  single-frame change was a monotonic 5-frame full-range sweep by hand, with no
  spikes or dropouts.
- **No device attached:** the new loop is inert, engine starts normally.

Not covered by my testing, and where review or a second tester would help:

- **SDL-mapped gamepads.** I don't have one to hand, so I have only verified that
  the gamepad path is untouched by inspection, not by running it.
- **Linux.** I could not test the device from #105676. The mechanism is the same
  there (`PollAllValues()` reads every axis with `EVIOCGABS` and feeds
  `SDL_SendJoystickAxis()`), so I would expect this to fix the reported case, but
  confirmation would be appreciated.
  
> AI disclosure: I used Claude Code to draft this PR description.
> I built and hardware tested the submitted implementation myself.