### PR TITLE
Fix broken camera override panning with certain stretch modes

### DIFF
--- a/scene/debugger/runtime_node_select.cpp
+++ b/scene/debugger/runtime_node_select.cpp
@@ -332,7 +332,7 @@ void RuntimeNodeSelect::_root_window_input(const Ref<InputEvent> &p_event) {
 	bool is_dragging_camera = false;
 	if (camera_override && !list_shortcut_pressed) {
 		if (node_select_type == NODE_TYPE_2D) {
-			is_dragging_camera = panner->gui_input(p_event, Rect2(Vector2(), root->get_visible_rect().get_size()));
+			is_dragging_camera = panner->gui_input(p_event, root->get_visible_rect());
 #ifndef _3D_DISABLED
 		} else if (node_select_type == NODE_TYPE_3D && selection_drag_state == SELECTION_DRAG_NONE) {
 			if (_handle_3d_input(p_event)) {
@@ -1152,7 +1152,7 @@ void RuntimeNodeSelect::_find_canvas_items_at_rect(const Rect2 &p_rect, Node *p_
 }
 
 void RuntimeNodeSelect::_pan_callback(Vector2 p_scroll_vec, Ref<InputEvent> p_event) {
-	Vector2 scroll = SceneTree::get_singleton()->get_root()->get_screen_transform().affine_inverse().xform(p_scroll_vec);
+	Vector2 scroll = p_scroll_vec / SceneTree::get_singleton()->get_root()->get_screen_transform().get_scale();
 	view_2d_offset.x -= scroll.x / view_2d_zoom;
 	view_2d_offset.y -= scroll.y / view_2d_zoom;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #123358.

Depending on which stretch mode a project is using, the panning when camera override is enabled will not work correctly. This happened because the code applied a `xform` from the screen transform, instead of just multiplying by its scale.

This can be reproduced using the [Platform 2D demo from the official demo repo](https://github.com/godotengine/godot-demo-projects/tree/master/2d/platformer).