### PR TITLE
Fix memory leak of a `ScannedDirectory` instance in `EditorFileSystem`

### DIFF
--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -534,7 +534,9 @@ void EditorFileSystem::_scan_filesystem() {
 		first_scan_root_dir = nullptr;
 		memdelete(processed_files);
 	} else {
-		//on the first scan this is done from the main thread after re-importing
+		// A local `sd` is created only on non-first scan, otherwise `sd` is not owned by this function.
+		memdelete(sd);
+		// On the first scan this is done from the main thread after re-importing.
 		_save_filesystem_cache();
 	}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

The function `EditorFileSystem::_scan_filesystem` has a `ScannedDirectory *sd;` object which is either set to a pre-existing object, or set to an object created inside of this function in the `else` branch here:

```cpp
	ScannedDirectory *sd;
	HashSet<String> *processed_files = nullptr;
	// On the first scan, the first_scan_root_dir is created in _first_scan_filesystem.
	if (first_scan) {
		sd = first_scan_root_dir;
		// Will be updated on scan.
		ResourceUID::get_singleton()->clear();
		ResourceUID::scan_for_uid_on_startup = nullptr;
		processed_files = memnew(HashSet<String>());
	} else {
		Ref<DirAccess> d = DirAccess::create(DirAccess::ACCESS_RESOURCES);
		sd = memnew(ScannedDirectory); // <- here
		sd->full_path = "res://";
		nb_files_total = _scan_new_dir(sd, d);
	}
```

But then, this instance is not cleaned up, it is simply leaked. This PR fixes the leak.

## Additional information

I used AI to find the problem by telling it to fix memory leaks in godot-dimensions. Once found, the changes are from me.
