### PR TITLE
Fix uninitialized `DockLayout` in `EditorDock`

### DIFF
--- a/editor/docks/editor_dock.h
+++ b/editor/docks/editor_dock.h
@@ -42,6 +42,7 @@ class EditorDock : public MarginContainer {
 
 public:
 	enum DockLayout {
+		DOCK_LAYOUT_NONE = 0,
 		DOCK_LAYOUT_VERTICAL = 1,
 		DOCK_LAYOUT_HORIZONTAL = 2,
 		DOCK_LAYOUT_FLOATING = 4,
@@ -84,7 +85,7 @@ private:
 	bool transient = false;
 	bool closable = false;
 
-	DockLayout current_layout;
+	DockLayout current_layout = DOCK_LAYOUT_NONE;
 	BitField<DockLayout> available_layouts = DOCK_LAYOUT_VERTICAL | DOCK_LAYOUT_FLOATING;
 
 	bool is_open = false;


### PR DESCRIPTION
## What problem(s) does this PR solve?

This fixes a runtime error reported by CI:

```
editor/docks/editor_dock_manager.cpp:380:101: runtime error: load of value 3200171710, which is not a valid value for type 'DockLayout'
```

This PR fixes the problem by initializing the field.

I initialized it to `DOCK_LAYOUT_VERTICAL` because:

1. This is the default value used by `DockTabContainer`.
2. This is one of the two values in the neighboring `available_layouts`.

EDIT: Changed to `DOCK_LAYOUT_NONE` per @KoBeWi's suggestion.

## Additional information

I used AI to search for fixes to runtime errors on the godot-dimensions CI, and I am verifying each one as I submit upstream. This one is... quite trivial, but I still checked anyway.