### PR TITLE
Avoid nullptr memcpy in ShaderRD

### DIFF
--- a/servers/rendering/renderer_rd/shader_rd.cpp
+++ b/servers/rendering/renderer_rd/shader_rd.cpp
@@ -1211,11 +1211,14 @@ PackedByteArray ShaderRD::save_shader_cache_bytes(const LocalVector<int> &p_vari
 
 	for (uint32_t i = 0; i < variant_count; i++) {
 		int variant_id = p_variants[i];
-		*(uint32_t *)(bytes_ptr) = uint32_t(p_variant_data[variant_id].size());
+		const int64_t variant_size = p_variant_data[variant_id].size();
+		*(uint32_t *)(bytes_ptr) = uint32_t(variant_size);
 		bytes_ptr += sizeof(uint32_t);
 
-		memcpy(bytes_ptr, p_variant_data[variant_id].ptr(), p_variant_data[variant_id].size());
-		bytes_ptr += p_variant_data[variant_id].size();
+		if (variant_size > 0) {
+			memcpy(bytes_ptr, p_variant_data[variant_id].ptr(), variant_size);
+			bytes_ptr += variant_size;
+		}
 	}
 
 	DEV_ASSERT((bytes.ptrw() + bytes.size()) == bytes_ptr);


### PR DESCRIPTION

## What problem(s) does this PR solve?

This code exists in `ShaderRD::save_shader_cache_bytes`:

```cpp
memcpy(bytes_ptr, p_variant_data[variant_id].ptr(), p_variant_data[variant_id].size());
```

The problem: `p_variant_data[variant_id]` is a PackedByteArray. If `.size()` is 0, then `.ptr()` is null, and this error occurs:

```
servers/rendering/renderer_rd/shader_rd.cpp:1217:9: runtime error: null pointer passed as argument 2, which is declared to never be null
```

This PR adds a new `if (variant_size > 0) {` check, which prevents reaching the `.ptr()` that returns null, and prevents the invalid memcpy call. In order to do this check, I added a variable to store `variant_size`, since otherwise we would need to write `p_variant_data[variant_id].size()` 4 times.

## Additional information

I used AI to search for fixes to runtime errors on the godot-dimensions CI, and I am verifying each one as I submit upstream. I rewrote this myself, but ultimately came to the same code as what was generated.