### PR TITLE
Use memcpy for misaligned pointer write in RenderingShaderContainer

### DIFF
--- a/servers/rendering/rendering_shader_container.cpp
+++ b/servers/rendering/rendering_shader_container.cpp
@@ -799,7 +799,7 @@ RenderingDeviceCommons::ShaderReflection RenderingShaderContainer::get_shader_re
 }
 
 bool RenderingShaderContainer::from_bytes(const PackedByteArray &p_bytes) {
-	const uint64_t alignment = sizeof(uint32_t);
+	constexpr uint64_t alignment = sizeof(uint32_t);
 	const uint8_t *bytes_ptr = p_bytes.ptr();
 	uint64_t bytes_offset = 0;
 
@@ -819,7 +819,7 @@ bool RenderingShaderContainer::from_bytes(const PackedByteArray &p_bytes) {
 
 	// Read reflection data.
 	ERR_FAIL_COND_V_MSG(int64_t(bytes_offset + sizeof(ReflectionData)) > p_bytes.size(), false, "Not enough bytes for reflection data in shader container.");
-	reflection_data = *(const ReflectionData *)(&bytes_ptr[bytes_offset]);
+	memcpy(&reflection_data, &bytes_ptr[bytes_offset], sizeof(ReflectionData));
 	bytes_offset += sizeof(ReflectionData);
 	bytes_offset += _from_bytes_reflection_extra_data(&bytes_ptr[bytes_offset]);
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

This code exists in `RenderingShaderContainer::from_bytes`:

```cpp
reflection_data = *(const ReflectionData *)(&bytes_ptr[bytes_offset]);
```

This reads a pointer, which is only required to be aligned to 4 bytes in this code, leading to this error on CI:

```
servers/rendering/rendering_shader_container.cpp:822:21: runtime error: reference binding to misaligned address 0x5160002e0bc4 for type 'const struct ReflectionData', which requires 8 byte alignment
0x5160002e0bc4: note: pointer points here
  01 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 01 00 00 00  00 00 00 00 00 00 00 00
              ^ 
servers/rendering/rendering_shader_container.cpp:822:18: runtime error: load of misaligned address 0x5160002e0bc4 for type 'const struct ReflectionData', which requires 8 byte alignment
0x5160002e0bc4: note: pointer points here
  01 00 00 00 00 00 00 00  00 00 00 00 00 00 00 00  00 00 00 00 01 00 00 00  00 00 00 00 00 00 00 00
              ^ 
```

This PR changes this line to a `memcpy` call to fix it.

I considered whether the root of the problem is the misalignment itself, since maybe it would be better to force align the memory to 8 bytes. However, the function explicitly declares this at the top:

```cpp
const uint64_t alignment = sizeof(uint32_t);
```

So it looks like the code is very explicitly intended to have 4 byte alignment only.

Also... this should really be `constexpr`, so this PR changes that line as well.

## Additional information

I used AI to search for fixes to runtime errors on the godot-dimensions CI, and I am verifying each one as I submit upstream. This one should be checked by rendering folks to confirm the intended memory alignment.
