### PR TITLE
ScriptCreateDialog: Make validation messages clearer

### DIFF
--- a/editor/script/script_create_dialog.cpp
+++ b/editor/script/script_create_dialog.cpp
@@ -609,22 +609,22 @@ void ScriptCreateDialog::_update_dialog() {
 	// "Add Script Dialog" GUI logic and script checks.
 	_update_template_menu();
 
-	// Is script path/name valid (order from top to bottom)?
+	// Is inherited parent valid?
 
-	if (!is_built_in && !is_path_valid) {
-		validation_panel->set_message(MSG_ID_SCRIPT, TTRC("Invalid path."), EditorValidationPanel::MSG_ERROR);
+	if (!is_parent_name_valid) {
+		validation_panel->set_message(MSG_ID_INHERITED_PARENT, TTRC("Invalid inherited parent name or path."), EditorValidationPanel::MSG_ERROR);
 	}
 
-	if (!is_parent_name_valid && is_new_script_created) {
-		validation_panel->set_message(MSG_ID_SCRIPT, TTRC("Invalid inherited parent name or path."), EditorValidationPanel::MSG_ERROR);
-	}
+	// Is script path valid?
 
-	if (validation_panel->is_valid() && !is_new_script_created) {
-		validation_panel->set_message(MSG_ID_SCRIPT, TTRC("File exists, it will be reused."), EditorValidationPanel::MSG_OK);
-	}
-
-	if (!is_built_in && !path_error.is_empty()) {
+	if (is_built_in) {
+		// Hide the message if built-in, as it will be displayed in MSG_ID_SCRIPT.
+		validation_panel->set_message(MSG_ID_PATH, "", EditorValidationPanel::MSG_OK);
+	} else if (!path_error.is_empty()) {
 		validation_panel->set_message(MSG_ID_PATH, path_error, EditorValidationPanel::MSG_ERROR);
+	} else if (!is_path_valid) {
+		// This should never happen, as when is_path_valid is false, path_error shouldn't be empty.
+		validation_panel->set_message(MSG_ID_PATH, TTRC("Script path is invalid."), EditorValidationPanel::MSG_ERROR);
 	}
 
 	// Is script Built-in?
@@ -669,18 +669,14 @@ void ScriptCreateDialog::_update_dialog() {
 	String button_text = is_new_file ? TTR("Create") : TTR("Load");
 	set_ok_button_text(button_text);
 
-	if (is_new_file) {
-		if (is_built_in) {
-			validation_panel->set_message(MSG_ID_PATH, TTRC("Built-in script (into scene file)."), EditorValidationPanel::MSG_OK);
-		}
-	} else {
-		template_inactive_message = TTRC("Using existing script file.");
+	if (is_built_in) {
+		validation_panel->set_message(MSG_ID_SCRIPT, TTRC("Built-in script (into scene file)."), EditorValidationPanel::MSG_OK);
+	} else if (!is_new_script_created) {
 		if (load_enabled) {
-			if (is_path_valid) {
-				validation_panel->set_message(MSG_ID_PATH, TTRC("Will load an existing script file."), EditorValidationPanel::MSG_OK);
-			}
+			template_inactive_message = TTRC("Using existing script file.");
+			validation_panel->set_message(MSG_ID_SCRIPT, TTRC("Will load an existing script file."), EditorValidationPanel::MSG_OK);
 		} else {
-			validation_panel->set_message(MSG_ID_PATH, TTRC("Script file already exists."), EditorValidationPanel::MSG_ERROR);
+			validation_panel->set_message(MSG_ID_SCRIPT, TTRC("Script file already exists."), EditorValidationPanel::MSG_ERROR);
 		}
 	}
 
@@ -691,7 +687,7 @@ void ScriptCreateDialog::_update_dialog() {
 			template_inactive_message = TTRC("No suitable template.");
 		}
 	} else {
-		template_inactive_message = TTRC("Empty");
+		template_inactive_message = TTRC("Disabled");
 	}
 
 	if (!template_inactive_message.is_empty()) {
@@ -853,8 +849,9 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	/* Information Messages Field */
 
 	validation_panel = memnew(EditorValidationPanel);
-	validation_panel->add_line(MSG_ID_SCRIPT, TTRC("Script path/name is valid."));
-	validation_panel->add_line(MSG_ID_PATH, TTRC("Will create a new script file."));
+	validation_panel->add_line(MSG_ID_INHERITED_PARENT, TTRC("Valid inherited parent name or path."));
+	validation_panel->add_line(MSG_ID_PATH, TTRC("Script path is valid."));
+	validation_panel->add_line(MSG_ID_SCRIPT, TTRC("Will create a new script file."));
 	validation_panel->add_line(MSG_ID_BUILT_IN);
 	validation_panel->add_line(MSG_ID_TEMPLATE);
 	validation_panel->set_update_callback(callable_mp(this, &ScriptCreateDialog::_update_dialog));

--- a/editor/script/script_create_dialog.h
+++ b/editor/script/script_create_dialog.h
@@ -44,8 +44,9 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	GDCLASS(ScriptCreateDialog, ConfirmationDialog);
 
 	enum {
-		MSG_ID_SCRIPT,
+		MSG_ID_INHERITED_PARENT,
 		MSG_ID_PATH,
+		MSG_ID_SCRIPT,
 		MSG_ID_BUILT_IN,
 		MSG_ID_TEMPLATE,
 	};


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Quite messy/complicated logic
- Weird error combinations
- Partially supersedes https://github.com/godotengine/godot/pull/110292

## Overview

Now each line has a clear goal (not combined, as it was before):

- (new) `MSG_ID_INHERITED_PARENT`: Check if the "Inherits:" is a valid Object.
- `MSG_ID_PATH`: Check if the path is valid.
- `MSG_ID_SCRIPT`: Check if the file already exists, is built-in, can load an existing script.

Also forced the button text to be "Create" instead of "Load" if `load_enabled = false`.

This also accidentally fixed the bug where you can't select templates when the script already exists but reusing one is not allowed.

## Sample screenshots

| BEFORE | AFTER |
|--------|--------|
| <img width="501" height="454" alt="image" src="https://github.com/user-attachments/assets/d31bc883-8461-4533-9344-f7d7ca87abca" /> | <img width="504" height="451" alt="image" src="https://github.com/user-attachments/assets/a1743085-35ae-452d-a9cf-db626c6df1e4" /> |
| <img width="502" height="455" alt="image" src="https://github.com/user-attachments/assets/b45d2109-2202-4d1e-a40e-a2f1b55c86e9" /> | <img width="500" height="428" alt="image" src="https://github.com/user-attachments/assets/0991b620-ad0c-4a4c-be00-ce40a719323a" /> | 

## Additional information

Tried to reuse messages where applicable (to avoid translation work). No AI was used.

Also changed the message when templates were disabled from "Empty" to "Disabled". Can remove this if deemed too far out-of-scope.