### PR TITLE
ScriptCreateDialog: Don't disable `parent_*` controls if reusing script is forbidden

### DIFF
--- a/editor/script/script_create_dialog.cpp
+++ b/editor/script/script_create_dialog.cpp
@@ -662,9 +662,9 @@ void ScriptCreateDialog::_update_dialog() {
 
 	bool is_new_file = is_built_in || is_new_script_created;
 
-	parent_name->set_editable(is_new_file);
-	parent_search_button->set_disabled(!is_new_file);
-	parent_browse_button->set_disabled(!is_new_file || !can_inherit_from_file);
+	parent_name->set_editable(!load_enabled || is_new_file);
+	parent_search_button->set_disabled(load_enabled && !is_new_file);
+	parent_browse_button->set_disabled((load_enabled && !is_new_file) || !can_inherit_from_file);
 	template_inactive_message = "";
 	String button_text = is_new_file ? TTR("Create") : TTR("Load");
 	set_ok_button_text(button_text);


### PR DESCRIPTION
## What problem(s) does this PR solve?

The code that disabled the Inherited Parent controls when the file already exists didn't account for the case that reusing scripts is disabled (for example when creating one from the FileSystem dock), in which case you can't create the script if the file already exists, so there isn't a reason to disable the controls.

## Additional information

No AI was used.

Note that I'm talking about the selected line of controls:
<img width="505" height="422" alt="image" src="https://github.com/user-attachments/assets/9e137ea7-ac31-4fe2-9832-5f46f56ae47c" />

