### PR TITLE
Adjust the middle spacing between the dot columns on DragHandle.svg icon

### DIFF
--- a/editor/icons/DragHandle.svg
+++ b/editor/icons/DragHandle.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><g fill="#def"><circle cx="4" cy="3" r="2"/><circle cx="4" cy="8" r="2"/><circle cx="4" cy="13" r="2"/><circle cx="12" cy="3" r="2"/><circle cx="12" cy="8" r="2"/><circle cx="12" cy="13" r="2"/></g></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><g fill="#def"><circle cx="5.5" cy="3" r="2"/><circle cx="5.5" cy="8" r="2"/><circle cx="5.5" cy="13" r="2"/><circle cx="10.5" cy="3" r="2"/><circle cx="10.5" cy="8" r="2"/><circle cx="10.5" cy="13" r="2"/></g></svg>


### PR DESCRIPTION
## What problem(s) does this PR solve?

The current drag handle icon have too much spacing between the dots, making it look more like a "two dots columns" icon than a "drag handle" icon.

This was proposed by me here: https://github.com/godotengine/godot/pull/121675#issuecomment-5334720529

Includes: https://github.com/godotengine/godot/pull/121691

## Additional information

Tested on the Android builds of the game:
| 4.7.2-stable  | This PR |
| ------------- | ------------- |
| <img width="2340" height="1080" alt="Screenshot_20260826_084247 jpg" src="https://github.com/user-attachments/assets/e23cc0ee-5adc-4759-aa88-c32b3e14ac7d" /> | ![Screenshot_20260916_221205.jpg](https://github.com/user-attachments/assets/f9f0102c-7572-4d39-80cf-f103413b24d7) |

I just adjusted the dots on inkscape and edited the .svg file manually for optimization.

No AI was used for editing or authoring this PR.