### PR TITLE
Disable GCC's `-fsanitize=bounds-strict` for HarfBuzz

### DIFF
--- a/modules/text_server_adv/SCsub
+++ b/modules/text_server_adv/SCsub
@@ -164,6 +164,13 @@ if env["builtin_harfbuzz"]:
     if env["platform"] in ["android", "linuxbsd", "web"]:
         env_harfbuzz.Append(CPPDEFINES=["HAVE_PTHREAD"])
 
+    # GCC's `-fsanitize=bounds-strict` shows false positives for HarfBuzz's
+    # variable-length arrays as one-element trailing arrays (see `HB_VAR_ARRAY`).
+    # HarfBuzz has its own way of validating the bounds, so this is safe to disable.
+    # Disable this sanitizer for HarfBuzz to avoid a false positive showing in sanitizer output.
+    if env["platform"] == "linuxbsd" and env["use_ubsan"] and not env["use_llvm"]:
+        env_harfbuzz.Append(CCFLAGS=["-fno-sanitize=bounds-strict"])
+
     env_text_server_adv.Prepend(CPPPATH=["#thirdparty/harfbuzz/src"])
 
     lib = env_harfbuzz.add_library("harfbuzz_builtin", thirdparty_sources)


### PR DESCRIPTION
## What problem(s) does this PR solve?

GCC's `-fsanitize=bounds-strict` shows false positives for HarfBuzz's variable-length arrays as one-element trailing arrays (see `HB_VAR_ARRAY`). It's a strange mechanism, which causes these errors in GCC sanitizers:

```
thirdparty/harfbuzz/src/OT/Layout/Common/CoverageFormat2.hh:197:36: runtime error: index 1 out of bounds for type 'RangeRecord [1]'
thirdparty/harfbuzz/src/OT/Layout/Common/CoverageFormat2.hh:197:36: runtime error: index 1 out of bounds for type 'RangeRecord [1]'
thirdparty/harfbuzz/src/OT/Layout/Common/CoverageFormat2.hh:198:43: runtime error: index 1 out of bounds for type 'RangeRecord [1]'
thirdparty/harfbuzz/src/OT/Layout/Common/CoverageFormat2.hh:198:43: runtime error: index 1 out of bounds for type 'RangeRecord [1]'
```

HarfBuzz seems to do this on purpose, and has its own way of validating the bounds, so this is safe to disable.

This PR disables this sanitizer for HarfBuzz to avoid a false positive showing in sanitizer output.

## Additional information

I used AI to search for fixes to runtime errors on the godot-dimensions CI, and I am verifying each one as I submit upstream. This time, the fix ended up very different than what the AI first suggested: upon closer inspection of its suggested fix to HarfBuzz, it turns out that its fix was wrong, and the proper thing is to disable this check.

This is the only sanitizer error in `thirdparty/` code that isn't simply resolved by updating the dependencies. I am also seeing sanitizer runtime errors in SDL and ThorVG, but those are fixed upstream already, so they will be fixed in Godot the next time that Godot updates SDL and ThorVG.