### PR TITLE
Don't register creator for internal classes

### DIFF
--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -260,9 +260,7 @@ public:
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_NULL(t);
-		t->creation_func = &creator<T>;
 		t->exposed = false;
-		t->is_virtual = false;
 		t->class_ptr = T::get_class_ptr_static();
 		t->api = current_api;
 		T::register_custom_data_to_otdb();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Motivated by https://github.com/godotengine/godot/pull/111947. Internal classes should not be forced to have an empty constructor. They are not constructed through `ClassDB` anyway.

## Additional information

- GDExtension `REGISTER_INTERNAL_CLASS` goes through other registration code and can still add a constructor. They need it for some editor plugin usecase according to https://github.com/godotengine/godot/issues/104905
- In theory this might have side effects on some other ClassDB methods but we currently only have two usages of registering an internal class. So the blast radius should be rather low. Also `ClassDB::is_abstract` which would be the prime contender for regressions is not exposed and only used by GDScript. I checked that and see no possibility of passing in an internal class.