### PR TITLE
Fix divide by zero in scale check in RenderGeometryInstanceBase

### DIFF
--- a/servers/rendering/renderer_geometry_instance.cpp
+++ b/servers/rendering/renderer_geometry_instance.cpp
@@ -75,7 +75,7 @@ void RenderGeometryInstanceBase::set_transform(const Transform3D &p_transform, c
 
 	float max_scale = MAX(model_scale_vec.x, MAX(model_scale_vec.y, model_scale_vec.z));
 	float min_scale = MIN(model_scale_vec.x, MIN(model_scale_vec.y, model_scale_vec.z));
-	non_uniform_scale = max_scale >= 0.0 && (min_scale / max_scale) < 0.999;
+	non_uniform_scale = max_scale > 0.0 && (min_scale / max_scale) < 0.999;
 
 	lod_model_scale = max_scale;
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

This code exists in `RenderGeometryInstanceBase::set_transform`:

```cpp
non_uniform_scale = max_scale >= 0.0 && (min_scale / max_scale) < 0.999;
```

This code is wrong for 2 reasons:

1) If `max_scale` equals zero, then `/ max_scale` will fail, as shown by this sanitizer error:

```cpp
servers/rendering/renderer_geometry_instance.cpp:78:53: runtime error: division by zero
```

2) The check `max_scale >= 0.0` does not make any sense due to how the value originates. The value gets distilled from `.get_scale_abs()`. The comparison `abs(x) >= 0.0` will always be true (except for NaN).

For both of these reasons, surely `>` was intended. This PR fixes it by changing `>=` to `>`.

## Additional information

I used AI to search for fixes to runtime errors on the godot-dimensions CI, and I am verifying each one as I submit upstream. This one is... very trivial, but I still checked anyway.
