### PR TITLE
Add new `debug/shapes/collision/shape_color_3d_modulate_alpha` project setting

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -835,6 +835,11 @@
 		<member name="debug/shapes/collision/shape_color" type="Color" setter="" getter="" default="Color(0, 0.6, 0.7, 0.42)">
 			Color of the collision shapes, visible when "Visible Collision Shapes" is enabled in the Debug menu.
 		</member>
+		<member name="debug/shapes/collision/shape_color_3d_modulate_alpha" type="float" setter="" getter="" default="0.0625">
+			[member debug/shapes/collision/shape_color] is known not to be transparent enough for 3D views.
+			For collision shapes rendered in 3D, [member debug/shapes/collision/shape_color] is modulated by [code]Color(1.0, 1.0, 1.0, modulate_alpha)[/code] where [code]modulate_alpha[/code] is this value.
+			If you find the collision shape colors to be too faint even if you make their debug color fully opaque, you should bring this value closer to [code]1.0[/code].
+		</member>
 		<member name="debug/shapes/navigation/2d/agent_path_color" type="Color" setter="" getter="" default="Color(1, 0, 0, 1)">
 			Color to display enabled navigation agent paths when an agent has debug enabled.
 		</member>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -580,6 +580,7 @@ void EditorNode::_update_from_settings() {
 
 	SceneTree *tree = get_tree();
 	tree->set_debug_collisions_color(GLOBAL_GET("debug/shapes/collision/shape_color"));
+	tree->set_debug_collisions_color_3d_modulate_alpha(GLOBAL_GET("debug/shapes/collision/shape_color_3d_modulate_alpha"));
 	tree->set_debug_collision_contact_color(GLOBAL_GET("debug/shapes/collision/contact_color"));
 
 	if (ProjectSettings::get_singleton()->check_changed_settings_in_group("display/window/hdr/request_hdr_output") || ProjectSettings::get_singleton()->check_changed_settings_in_group("rendering/viewport/hdr_2d")) {

--- a/editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/collision_shape_3d_gizmo_plugin.cpp
@@ -38,6 +38,7 @@
 #include "editor/scene/3d/node_3d_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "scene/3d/physics/collision_shape_3d.h"
+#include "scene/main/scene_tree.h"
 #include "scene/resources/3d/box_shape_3d.h"
 #include "scene/resources/3d/capsule_shape_3d.h"
 #include "scene/resources/3d/concave_polygon_shape_3d.h"
@@ -45,6 +46,7 @@
 #include "scene/resources/3d/cylinder_shape_3d.h"
 #include "scene/resources/3d/height_map_shape_3d.h"
 #include "scene/resources/3d/separation_ray_shape_3d.h"
+#include "scene/resources/3d/shape_3d.h"
 #include "scene/resources/3d/sphere_shape_3d.h"
 #include "scene/resources/3d/world_boundary_shape_3d.h"
 
@@ -53,11 +55,11 @@ CollisionShape3DGizmoPlugin::CollisionShape3DGizmoPlugin() {
 
 	show_only_when_selected = EDITOR_GET("editors/3d_gizmos/gizmo_settings/show_collision_shapes_only_when_selected");
 
-	create_collision_material("shape_material", 2.0);
-	create_collision_material("shape_material_arraymesh", 0.0625);
+	create_collision_material("shape_material", Shape3D::DEBUG_ALPHA_FACTOR);
+	create_collision_material("shape_material_arraymesh", 1.0);
 
-	create_collision_material("shape_material_disabled", 0.0625);
-	create_collision_material("shape_material_arraymesh_disabled", 0.015625);
+	create_collision_material("shape_material_disabled", 1.0 / Shape3D::DEBUG_ALPHA_FACTOR);
+	create_collision_material("shape_material_arraymesh_disabled", 1.0 / (Shape3D::DEBUG_ALPHA_FACTOR * 2.0));
 
 	create_handle_material("handles");
 }
@@ -323,7 +325,11 @@ void CollisionShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			get_material(!cs->is_disabled() ? "shape_material_arraymesh" : "shape_material_arraymesh_disabled", p_gizmo);
 	const Ref<Material> handles_material = get_material("handles");
 
-	const Color collision_color = cs->is_disabled() ? Color(1.0, 1.0, 1.0, 0.75) : cs->get_debug_color();
+	real_t modulate_alpha = SceneTree::get_singleton()->get_debug_collisions_color_3d_modulate_alpha();
+	const Color collision_color =
+			cs->is_disabled()
+			? Color(1.0, 1.0, 1.0, modulate_alpha)
+			: cs->get_debug_color() * Color(1.0, 1.0, 1.0, modulate_alpha);
 
 	if (cs->get_debug_fill_enabled()) {
 		Ref<ArrayMesh> array_mesh = s->get_debug_arraymesh_faces(collision_color);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1004,6 +1004,14 @@ Color SceneTree::get_debug_collisions_color() const {
 	return debug_collisions_color;
 }
 
+void SceneTree::set_debug_collisions_color_3d_modulate_alpha(real_t p_modulate_alpha) {
+	debug_collisions_color_3d_modulate_alpha = p_modulate_alpha;
+}
+
+real_t SceneTree::get_debug_collisions_color_3d_modulate_alpha() const {
+	return debug_collisions_color_3d_modulate_alpha;
+}
+
 void SceneTree::set_debug_collision_contact_color(const Color &p_color) {
 	debug_collision_contact_color = p_color;
 }
@@ -2054,6 +2062,13 @@ SceneTree::SceneTree() {
 		singleton = this;
 	}
 	debug_collisions_color = GLOBAL_DEF("debug/shapes/collision/shape_color", Color(0.0, 0.6, 0.7, 0.42));
+	debug_collisions_color_3d_modulate_alpha = GLOBAL_DEF(
+			PropertyInfo(
+					Variant::FLOAT,
+					"debug/shapes/collision/shape_color_3d_modulate_alpha",
+					PROPERTY_HINT_RANGE,
+					"0.0,1.0,0.001,prefer_slider"),
+			0.0625);
 	debug_collision_contact_color = GLOBAL_DEF("debug/shapes/collision/contact_color", Color(1.0, 0.2, 0.1, 0.8));
 	debug_paths_color = GLOBAL_DEF("debug/shapes/paths/geometry_color", Color(0.1, 1.0, 0.7, 0.4));
 	debug_paths_width = GLOBAL_DEF(PropertyInfo(Variant::FLOAT, "debug/shapes/paths/geometry_width", PROPERTY_HINT_RANGE, "0.01,10,0.001,or_greater"), 2.0);

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -205,6 +205,7 @@ private:
 	ObjectID pending_new_scene_id;
 
 	Color debug_collisions_color;
+	real_t debug_collisions_color_3d_modulate_alpha;
 	Color debug_collision_contact_color;
 	Color debug_paths_color;
 	float debug_paths_width = 1.0f;
@@ -389,6 +390,9 @@ public:
 
 	void set_debug_collisions_color(const Color &p_color);
 	Color get_debug_collisions_color() const;
+
+	void set_debug_collisions_color_3d_modulate_alpha(real_t p_modulate_alpha);
+	real_t get_debug_collisions_color_3d_modulate_alpha() const;
 
 	void set_debug_collision_contact_color(const Color &p_color);
 	Color get_debug_collision_contact_color() const;

--- a/scene/resources/3d/shape_3d.cpp
+++ b/scene/resources/3d/shape_3d.cpp
@@ -112,7 +112,7 @@ Ref<ArrayMesh> Shape3D::get_debug_mesh() {
 	if (!lines.is_empty()) {
 		Vector<Color> colors;
 		colors.resize(lines.size());
-		colors.fill(debug_color);
+		colors.fill(debug_color * Color(1.0, 1.0, 1.0, DEBUG_ALPHA_FACTOR));
 
 		Array lines_array;
 		lines_array.resize(Mesh::ARRAY_MAX);
@@ -127,7 +127,7 @@ Ref<ArrayMesh> Shape3D::get_debug_mesh() {
 		}
 
 		if (debug_fill) {
-			Ref<ArrayMesh> array_mesh = get_debug_arraymesh_faces(debug_color * Color(1.0, 1.0, 1.0, 0.0625));
+			Ref<ArrayMesh> array_mesh = get_debug_arraymesh_faces(debug_color);
 			if (array_mesh.is_valid() && array_mesh->get_surface_count() > 0) {
 				Array solid_array = array_mesh->surface_get_arrays(0);
 				debug_mesh_cache->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, solid_array);

--- a/scene/resources/3d/shape_3d.h
+++ b/scene/resources/3d/shape_3d.h
@@ -52,6 +52,9 @@ class Shape3D : public Resource {
 	bool debug_properties_edited = false;
 #endif // DEBUG_ENABLED
 
+public:
+	inline static const real_t DEBUG_ALPHA_FACTOR = 32.0;
+
 protected:
 	static void _bind_methods();
 	void _validate_property(PropertyInfo &p_property) const;


### PR DESCRIPTION
This PR replaces hard-coded transparency for 3D collision shapes by that project setting value.

Users shouldn't even notice the difference.

Fixes #86774
Fixes #122842

<details markdown=1>

<summary><strong>Previous and outdated description</strong></summary>

>[!WARNING]
>This has an unfortunate (and understandable) side effect to make all the collision shapes 16× less transparent.
>It's because it's now actually respecting the alpha value set in `debug_color`.

| Version | 3D editor | Running the game with visible collision |
| :---: | :---: | :---: |
| 4.8.dev3 with default `debug_color` | <img width="2754" height="2290" alt="Capture d’écran, le 2026-08-26 à 10 30 25" src="https://github.com/user-attachments/assets/c3ad283b-120b-4182-ba15-7a77e8f24320" /> | <img width="2658" height="2290" alt="Capture d’écran, le 2026-08-26 à 10 30 36" src="https://github.com/user-attachments/assets/6d75ebe7-60f0-470c-91b9-8fa307372167" /> |
| This PR with default `debug_color` | <img width="2724" height="2226" alt="Capture d’écran, le 2026-08-26 à 10 27 40" src="https://github.com/user-attachments/assets/08d51814-d2db-4dff-869d-a3533c0ac45a" /> | <img width="2658" height="2226" alt="Capture d’écran, le 2026-08-26 à 10 27 48" src="https://github.com/user-attachments/assets/b0c34622-0bc2-47b7-9932-1fecba0945aa" /> |
| 4.8.dev3 with fully opaque `debug_color` | <img width="2754" height="2290" alt="Capture d’écran, le 2026-08-26 à 10 30 53" src="https://github.com/user-attachments/assets/866df440-87a0-4585-8ba7-a6a6a03413a5" /> | <img width="2658" height="2290" alt="Capture d’écran, le 2026-08-26 à 10 30 59" src="https://github.com/user-attachments/assets/5b7f3678-d802-429f-9f0b-9ba873b0bfd3" /> |
 | This PR with fully opaque `debug_color` | <img width="2724" height="2162" alt="Capture d’écran, le 2026-08-26 à 10 23 30" src="https://github.com/user-attachments/assets/f119f10d-1038-49d8-93c7-baa72feee095" /> |  <img width="2658" height="2162" alt="Capture d’écran, le 2026-08-26 à 10 23 46" src="https://github.com/user-attachments/assets/12bf5d4b-24e2-4251-b78b-db678736deb8" /> | 

</details>

### MRP
[collision-shape-debug_2026-08-26_10-24-01.zip](https://github.com/user-attachments/files/31475806/collision-shape-debug_2026-08-26_10-24-01.zip)
