### PR TITLE
`Tree`: Change scroll bars to be unaffected by content margins per default

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -663,16 +663,16 @@
 		<theme_item name="scrollbar_h_separation" data_type="constant" type="int" default="4">
 			The horizontal separation of tree content and scrollbar.
 		</theme_item>
-		<theme_item name="scrollbar_margin_bottom" data_type="constant" type="int" default="-1">
+		<theme_item name="scrollbar_margin_bottom" data_type="constant" type="int" default="0">
 			The bottom margin of the scrollbars. When negative, uses [theme_item panel] bottom margin.
 		</theme_item>
-		<theme_item name="scrollbar_margin_left" data_type="constant" type="int" default="-1">
+		<theme_item name="scrollbar_margin_left" data_type="constant" type="int" default="0">
 			The left margin of the horizontal scrollbar. When negative, uses [theme_item panel] left margin.
 		</theme_item>
-		<theme_item name="scrollbar_margin_right" data_type="constant" type="int" default="-1">
+		<theme_item name="scrollbar_margin_right" data_type="constant" type="int" default="0">
 			The right margin of the scrollbars. When negative, uses [theme_item panel] right margin.
 		</theme_item>
-		<theme_item name="scrollbar_margin_top" data_type="constant" type="int" default="-1">
+		<theme_item name="scrollbar_margin_top" data_type="constant" type="int" default="0">
 			The top margin of the vertical scrollbar. When negative, uses [theme_item panel] top margin.
 		</theme_item>
 		<theme_item name="scrollbar_v_separation" data_type="constant" type="int" default="4">

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -710,10 +710,10 @@ private:
 		int scroll_speed = 0;
 		int scroll_max_sticky_items = 5;
 
-		int scrollbar_margin_top = -1;
-		int scrollbar_margin_right = -1;
-		int scrollbar_margin_bottom = -1;
-		int scrollbar_margin_left = -1;
+		int scrollbar_margin_top = 0;
+		int scrollbar_margin_right = 0;
+		int scrollbar_margin_bottom = 0;
+		int scrollbar_margin_left = 0;
 		int scrollbar_h_separation = 0;
 		int scrollbar_v_separation = 0;
 	} theme_cache;

--- a/scene/theme/default_theme.cpp
+++ b/scene/theme/default_theme.cpp
@@ -955,10 +955,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("scroll_speed", "Tree", 12);
 	theme->set_constant("outline_size", "Tree", 0);
 	theme->set_constant("icon_max_width", "Tree", 0);
-	theme->set_constant("scrollbar_margin_left", "Tree", -1);
-	theme->set_constant("scrollbar_margin_top", "Tree", -1);
-	theme->set_constant("scrollbar_margin_right", "Tree", -1);
-	theme->set_constant("scrollbar_margin_bottom", "Tree", -1);
+	theme->set_constant("scrollbar_margin_left", "Tree", 0);
+	theme->set_constant("scrollbar_margin_top", "Tree", 0);
+	theme->set_constant("scrollbar_margin_right", "Tree", 0);
+	theme->set_constant("scrollbar_margin_bottom", "Tree", 0);
 	theme->set_constant("scrollbar_h_separation", "Tree", Math::round(4 * scale));
 	theme->set_constant("scrollbar_v_separation", "Tree", Math::round(4 * scale));
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/122844

## Additional information

Changes the default behavior of `Tree` scroll bars to be unaffected by `panel/content_margin`, same as it is in both editor themes. Here an extreme example of the change with `panel/content_margin_(top/bottom) = 70` and a maximum size:

## Old default
<img width="133" height="178" alt="image" src="https://github.com/user-attachments/assets/24218e8f-b065-42ee-b434-1d98bc6de484" />

## PR default
<img width="131" height="170" alt="image" src="https://github.com/user-attachments/assets/f4abb381-ed31-49d5-8c86-684b388812c7" />