### PR TITLE
Hide Shape3D properties when they have no effect on the current physics engine

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -186,6 +186,7 @@
 #include "servers/display/display_server_enums.h"
 #include "servers/navigation_2d/navigation_server_2d.h"
 #include "servers/navigation_3d/navigation_server_3d.h"
+#include "servers/physics_3d/physics_server_3d_manager.h"
 #include "servers/rendering/rendering_device.h"
 #include "servers/rendering/rendering_server.h"
 
@@ -8431,7 +8432,7 @@ HashMap<String, Variant> EditorNode::get_initial_settings() {
 	settings["display/window/stretch/mode"] = "canvas_items";
 	settings["gui/common/auto_focus_strategy"] = Control::AutoFocusStrategy::STRATEGY_BALLOON;
 	settings["input_devices/joypads/ignore_joypad_on_unfocused_application"] = true;
-	settings["physics/3d/physics_engine"] = "Jolt Physics";
+	settings["physics/3d/physics_engine"] = PhysicsServer3DManager::JOLT_PHYSICS_NAME;
 	settings["rendering/rendering_device/driver.windows"] = "d3d12";
 	settings["rendering/lights_and_shadows/multi_bounce_occlusion/enabled"] = true;
 	return settings;

--- a/editor/settings/editor_build_profile.cpp
+++ b/editor/settings/editor_build_profile.cpp
@@ -46,6 +46,7 @@
 #include "scene/gui/line_edit.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/separator.h"
+#include "servers/physics_3d/physics_server_3d_manager.h"
 
 #include "modules/modules_enabled.gen.h" // IWYU pragma: keep. For mono.
 
@@ -732,12 +733,12 @@ EditorBuildProfile::EditorBuildProfile() {
 	build_option_settings.insert(BUILD_OPTION_OPENGL, settings_opengl);
 
 	HashMap<String, LocalVector<Variant>> settings_phy_godot_3d = {
-		{ "physics/3d/physics_engine", { "DEFAULT", "GodotPhysics3D" } },
+		{ "physics/3d/physics_engine", { "DEFAULT", PhysicsServer3DManager::GODOT_PHYSICS_3D_NAME } },
 	};
 	build_option_settings.insert(BUILD_OPTION_PHYSICS_GODOT_3D, settings_phy_godot_3d);
 
 	HashMap<String, LocalVector<Variant>> settings_jolt = {
-		{ "physics/3d/physics_engine", { "Jolt Physics" } },
+		{ "physics/3d/physics_engine", { PhysicsServer3DManager::JOLT_PHYSICS_NAME } },
 	};
 	build_option_settings.insert(BUILD_OPTION_PHYSICS_JOLT, settings_jolt);
 

--- a/modules/godot_physics_3d/register_types.cpp
+++ b/modules/godot_physics_3d/register_types.cpp
@@ -54,8 +54,8 @@ void initialize_godot_physics_3d_module(ModuleInitializationLevel p_level) {
 	if (p_level != MODULE_INITIALIZATION_LEVEL_SERVERS) {
 		return;
 	}
-	PhysicsServer3DManager::get_singleton()->register_server("GodotPhysics3D", callable_mp_static(_createGodotPhysics3DCallback));
-	PhysicsServer3DManager::get_singleton()->set_default_server("GodotPhysics3D");
+	PhysicsServer3DManager::get_singleton()->register_server(PhysicsServer3DManager::GODOT_PHYSICS_3D_NAME, callable_mp_static(_createGodotPhysics3DCallback));
+	PhysicsServer3DManager::get_singleton()->set_default_server(PhysicsServer3DManager::GODOT_PHYSICS_3D_NAME);
 }
 
 void uninitialize_godot_physics_3d_module(ModuleInitializationLevel p_level) {

--- a/modules/jolt_physics/register_types.cpp
+++ b/modules/jolt_physics/register_types.cpp
@@ -57,7 +57,7 @@ void initialize_jolt_physics_module(ModuleInitializationLevel p_level) {
 	}
 
 	jolt_initialize();
-	PhysicsServer3DManager::get_singleton()->register_server("Jolt Physics", callable_mp_static(&create_jolt_physics_server));
+	PhysicsServer3DManager::get_singleton()->register_server(PhysicsServer3DManager::JOLT_PHYSICS_NAME, callable_mp_static(&create_jolt_physics_server));
 	JoltProjectSettings::register_settings();
 }
 

--- a/modules/jolt_physics/spaces/jolt_job_system.cpp
+++ b/modules/jolt_physics/spaces/jolt_job_system.cpp
@@ -34,6 +34,7 @@
 #include "core/object/worker_thread_pool.h"
 #include "core/os/os.h"
 #include "core/os/time.h"
+#include "servers/physics_3d/physics_server_3d_manager.h"
 
 #include <Jolt/Physics/PhysicsSettings.h>
 
@@ -100,7 +101,7 @@ void JoltJobSystem::Job::queue() {
 
 	// Ideally we would use Jolt's actual job name here, but I'd rather not incur the overhead of a memory allocation or
 	// thread-safe lookup every time we create/queue a task. So instead we use the same cached description for all of them.
-	static const String task_name("Jolt Physics");
+	static const String task_name(PhysicsServer3DManager::JOLT_PHYSICS_NAME);
 
 	task_id = WorkerThreadPool::get_singleton()->add_native_task(&_execute, this, true, task_name);
 }

--- a/scene/resources/3d/shape_3d.cpp
+++ b/scene/resources/3d/shape_3d.cpp
@@ -30,10 +30,12 @@
 
 #include "shape_3d.h"
 
+#include "core/config/project_settings.h"
 #include "core/object/class_db.h"
 #include "scene/main/scene_tree.h"
 #include "scene/resources/mesh.h"
 #include "servers/physics_3d/physics_server_3d.h"
+#include "servers/physics_3d/physics_server_3d_manager.h"
 
 void Shape3D::add_vertices_to_array(Vector<Vector3> &array, const Transform3D &p_xform) {
 	Vector<Vector3> toadd = get_debug_mesh_lines();
@@ -142,6 +144,20 @@ Ref<ArrayMesh> Shape3D::get_debug_mesh() {
 void Shape3D::_update_shape() {
 	emit_changed();
 	debug_mesh_cache.unref();
+}
+
+void Shape3D::_validate_property(PropertyInfo &p_property) const {
+	if (p_property.name == "custom_solver_bias" && GLOBAL_GET(PhysicsServer3DManager::setting_property_name) == PhysicsServer3DManager::JOLT_PHYSICS_NAME) {
+		// This property is not used by Jolt Physics. Hide it from the editor to avoid confusion.
+		// Third-party physics engines may make use of this property, so we leave it visible for those.
+		p_property.usage = PROPERTY_USAGE_STORAGE;
+	}
+
+	if (p_property.name == "margin" && GLOBAL_GET(PhysicsServer3DManager::setting_property_name) == PhysicsServer3DManager::GODOT_PHYSICS_3D_NAME) {
+		// This property is not used by GodotPhysics3D. Hide it from the editor to avoid confusion.
+		// Third-party physics engines may make use of this property, so we leave it visible for those.
+		p_property.usage = PROPERTY_USAGE_STORAGE;
+	}
 }
 
 void Shape3D::_bind_methods() {

--- a/scene/resources/3d/shape_3d.h
+++ b/scene/resources/3d/shape_3d.h
@@ -54,6 +54,7 @@ class Shape3D : public Resource {
 
 protected:
 	static void _bind_methods();
+	void _validate_property(PropertyInfo &p_property) const;
 
 	_FORCE_INLINE_ RID get_shape() const { return shape; }
 	Shape3D(RID p_shape);

--- a/servers/physics_3d/physics_server_3d_manager.h
+++ b/servers/physics_3d/physics_server_3d_manager.h
@@ -70,6 +70,8 @@ protected:
 
 public:
 	static const String setting_property_name;
+	static constexpr const char *GODOT_PHYSICS_3D_NAME = "GodotPhysics3D";
+	static constexpr const char *JOLT_PHYSICS_NAME = "Jolt Physics";
 
 	static PhysicsServer3DManager *get_singleton();
 


### PR DESCRIPTION
This helps reduce the space taken by Shape3D subresources in the inspector.

> [!NOTE]
>
> Since third-party physics engines may make use of these properties, the relevant properties are *hidden* when relevant. If you use a third-party physics engine, both properties remain visible as we can't know for certain whether it will make use of those properties.

- This closes https://github.com/godotengine/godot-proposals/issues/15318.

## Preview

`master` | This PR (Jolt Physics) | This PR (GodotPhysics3D)
-|-|-
<img width="302" height="333" alt="Image" src="https://github.com/user-attachments/assets/8192506c-998d-446e-a3cf-6450a5cd8548" /> | <img width="302" height="301" alt="Image" src="https://github.com/user-attachments/assets/103d81aa-f798-4857-8a2a-d1fa81790c65" /> | <img width="302" height="301" alt="Image" src="https://github.com/user-attachments/assets/d9d211e8-33c6-4cdf-ae4e-0c3acaa3b0ce" />
