### PR TITLE
[macOS/iOS] Use `application/run/use_game_mode` to enable/disable game mode on export.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -434,9 +434,10 @@
 			If [code]true[/code], the engine header is printed in the console on startup. This header describes the current version of the engine, as well as the renderer being used. This behavior can also be disabled on the command line with the [code]--no-header[/code] option.
 		</member>
 		<member name="application/run/use_game_mode" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], the engine will request [url=https://github.com/FeralInteractive/gamemode]GameMode[/url] to be activated. This allows optimizing system performance during gameplay, e.g. by using a specific CPU governor or forcing a high GPU power state. The GameMode daemon needs to be installed and running on the system to work (typically available as [code]gamemode[/code] in Linux distribution repositories).
-			[b]Note:[/b] This setting does not affect the editor itself, although it affects projects being run from the editor.
-			[b]Note:[/b] This setting is available only on Linux.
+			If [code]true[/code], the engine will request Game Mode to be activated. This allows optimizing system performance during gameplay, e.g. by using a specific CPU governor or forcing a high GPU power state. On Linux the [url=https://github.com/FeralInteractive/gamemode]GameMode[/url] daemon needs to be installed and running on the system to work (typically available as [code]gamemode[/code] in Linux distribution repositories).
+			[b]Note:[/b] This setting does not affect the editor itself.
+			[b]Note:[/b] On Linux, this setting affect projects being run from the editor.
+			[b]Note:[/b] This setting is available on Linux, macOS, and iOS.
 		</member>
 		<member name="audio/buses/channel_disable_threshold_db" type="float" setter="" getter="" default="-60.0">
 			Audio buses will disable automatically when sound goes below a given dB threshold for a given time. This saves CPU as effects assigned to that bus will no longer do any processing.

--- a/editor/export/editor_export_platform_apple_embedded.cpp
+++ b/editor/export/editor_export_platform_apple_embedded.cpp
@@ -752,7 +752,8 @@ String EditorExportPlatformAppleEmbedded::_process_config_file_line(const Ref<Ed
 		strnew += "\t</array>\n";
 	} else if (p_line.contains("$sdkroot")) {
 		strnew += p_line.replace("$sdkroot", get_sdk_name()) + "\n";
-
+	} else if (p_line.contains("$gamemode")) {
+		strnew += "\n";
 	} else {
 		strnew += p_line + "\n";
 	}

--- a/misc/dist/apple_embedded_xcode/godot_apple_embedded/godot_apple_embedded-Info.plist
+++ b/misc/dist/apple_embedded_xcode/godot_apple_embedded/godot_apple_embedded-Info.plist
@@ -32,6 +32,7 @@
 	<true/>
 	<key>LSSupportsOpeningDocumentsInPlace</key>
 	$docs_in_place
+	$gamemode
 	<key>UIFileSharingEnabled</key>
 	$docs_sharing
 	<key>UIRequiredDeviceCapabilities</key>

--- a/misc/dist/macos_template.app/Contents/Info.plist
+++ b/misc/dist/macos_template.app/Contents/Info.plist
@@ -50,6 +50,7 @@ $usage_descriptions
 	<string>NSApplication</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.$app_category</string>
+$gamemode
 	<key>LSArchitecturePriority</key>
 	<array>
 		<string>arm64</string>

--- a/platform/ios/export/export_plugin.cpp
+++ b/platform/ios/export/export_plugin.cpp
@@ -342,6 +342,11 @@ String EditorExportPlatformIOS::_process_config_file_line(const Ref<EditorExport
 	} else if (p_line.contains("$accessory_tracking_usage_description")) {
 		strnew += p_line.replace("$accessory_tracking_usage_description", "") + "\n";
 
+		// Info.plist LSSupportsGameMode
+	} else if (p_line.contains("$gamemode")) {
+		bool use_gamemode = get_project_setting(p_preset, "application/run/use_game_mode");
+		strnew += p_line.replace("$gamemode", String("<key>LSSupportsGameMode</key>\n\t") + (use_gamemode ? "<true/>" : "<false/>")) + "\n";
+
 		// Apple Embedded common
 	} else {
 		strnew += EditorExportPlatformAppleEmbedded::_process_config_file_line(p_preset, p_line, p_config, p_debug, p_code_signing);

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -941,6 +941,9 @@ void EditorExportPlatformMacOS::_fix_plist(const Ref<EditorExportPreset> &p_pres
 			if (!descriptions.is_empty()) {
 				strnew += lines[i].replace("$usage_descriptions", descriptions);
 			}
+		} else if (lines[i].contains("$gamemode")) {
+			bool use_gamemode = get_project_setting(p_preset, "application/run/use_game_mode");
+			strnew += lines[i].replace("$gamemode", String("\t<key>LSSupportsGameMode</key>\n\t") + (use_gamemode ? "<true/>" : "<false/>")) + "\n";
 		} else {
 			strnew += lines[i] + "\n";
 		}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Follow up to https://github.com/godotengine/godot/pull/117938, reuses the same setting to enable/disable game mode on export.
