### PR TITLE
Rename `GDType::Property` to `Member`, and `SETGET` to `PROPERTY`.

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -404,8 +404,8 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 		LocalVector<StringName> signals;
 		LocalVector<StringName> setgets;
 
-		for (const KeyValue<StringName, GDType::Property> &kv : t->gdtype->get_property_map(true)) {
-			if (kv.value.type == GDType::Property::Type::METHOD) {
+		for (const KeyValue<StringName, GDType::Member> &kv : t->gdtype->members(true)) {
+			if (kv.value.type == GDType::Member::Type::METHOD) {
 				String name = kv.key.string();
 
 				ERR_CONTINUE(name.is_empty());
@@ -415,11 +415,11 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 				}
 
 				methods.push_back(kv.key);
-			} else if (kv.value.type == GDType::Property::Type::INTEGER_CONSTANT) {
+			} else if (kv.value.type == GDType::Member::Type::INTEGER_CONSTANT) {
 				constants.push_back(kv.key);
-			} else if (kv.value.type == GDType::Property::Type::SIGNAL) {
+			} else if (kv.value.type == GDType::Member::Type::SIGNAL) {
 				signals.push_back(kv.key);
-			} else if (kv.value.type == GDType::Property::Type::SETGET) {
+			} else if (kv.value.type == GDType::Member::Type::PROPERTY) {
 				setgets.push_back(kv.key);
 			}
 		}
@@ -428,7 +428,7 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 			methods.sort_custom<StringName::AlphCompare>();
 
 			for (const StringName &F : methods) {
-				const MethodBind *mb = t->gdtype->get_property_map(true)[F].payload.method;
+				const MethodBind *mb = t->gdtype->members(true)[F].payload.method;
 				hash = hash_murmur3_one_64(mb->get_name().hash(), hash);
 				hash = hash_murmur3_one_64(mb->get_argument_count(), hash);
 				hash = hash_murmur3_one_64(mb->get_argument_type(-1), hash); //return
@@ -459,7 +459,7 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 
 			for (const StringName &F : constants) {
 				hash = hash_murmur3_one_64(F.hash(), hash);
-				hash = hash_murmur3_one_64(uint64_t(t->gdtype->get_property_map(true)[F].payload.integer_constant.value), hash);
+				hash = hash_murmur3_one_64(uint64_t(t->gdtype->members(true)[F].payload.integer_constant.value), hash);
 			}
 		}
 
@@ -467,7 +467,7 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 			signals.sort_custom<StringName::AlphCompare>();
 
 			for (const StringName &F : signals) {
-				const MethodInfo &mi = *t->gdtype->get_property_map(true)[F].payload.signal;
+				const MethodInfo &mi = *t->gdtype->members(true)[F].payload.signal;
 				hash = hash_murmur3_one_64(F.hash(), hash);
 				for (const PropertyInfo &pi : mi.arguments) {
 					hash = hash_murmur3_one_64(pi.type, hash);
@@ -479,8 +479,8 @@ uint32_t ClassDB::get_api_hash(APIType p_api) {
 			setgets.sort_custom<StringName::AlphCompare>();
 
 			for (const StringName &F : setgets) {
-				const GDType::Property &property = t->gdtype->get_property_map(true)[F];
-				const GDType::Property::SetGet &psg = property.payload.setget;
+				const GDType::Member &member = t->gdtype->members(true)[F];
+				const GDType::Member::Property &psg = member.payload.property;
 
 				hash = hash_murmur3_one_64(F.hash(), hash);
 				hash = hash_murmur3_one_64((psg.setter ? psg.setter->get_name() : StringName()).hash(), hash);
@@ -974,8 +974,8 @@ void ClassDB::get_method_list(const StringName &p_class, List<MethodInfo> *p_met
 			continue;
 		}
 
-		for (const KeyValue<StringName, GDType::Property> &kv : type->gdtype->get_property_map(true)) {
-			if (kv.value.type == GDType::Property::Type::METHOD) {
+		for (const KeyValue<StringName, GDType::Member> &kv : type->gdtype->members(true)) {
+			if (kv.value.type == GDType::Member::Type::METHOD) {
 				p_methods->push_back(info_from_bind(kv.value.payload.method));
 			}
 		}
@@ -1002,8 +1002,8 @@ void ClassDB::get_method_list_with_compatibility(const StringName &p_class, List
 			type = type->inherits_ptr;
 			continue;
 		}
-		for (const KeyValue<StringName, GDType::Property> &kv : type->gdtype->get_property_map(true)) {
-			if (kv.value.type == GDType::Property::Type::METHOD) {
+		for (const KeyValue<StringName, GDType::Member> &kv : type->gdtype->members(true)) {
+			if (kv.value.type == GDType::Member::Type::METHOD) {
 				p_methods->push_back(Pair(info_from_bind(kv.value.payload.method), kv.value.payload.method->get_hash()));
 			}
 		}
@@ -1046,10 +1046,10 @@ bool ClassDB::get_method_info(const StringName &p_class, const StringName &p_met
 		}
 
 #ifdef DEBUG_ENABLED
-		const GDType::Property *property = type->gdtype->get_property_map(true).getptr(p_method);
-		if (property && property->type == GDType::Property::Type::METHOD) {
+		const GDType::Member *member = type->gdtype->members(true).getptr(p_method);
+		if (member && member->type == GDType::Member::Type::METHOD) {
 			if (r_info != nullptr) {
-				*r_info = info_from_bind(property->payload.method);
+				*r_info = info_from_bind(member->payload.method);
 			}
 			return true;
 		} else if (type->virtual_methods_map.has(p_method)) {
@@ -1059,10 +1059,10 @@ bool ClassDB::get_method_info(const StringName &p_class, const StringName &p_met
 			return true;
 		}
 #else
-		const GDType::Property *property = type->gdtype->get_property_map(true).getptr(p_method);
-		if (property && property->type == GDType::Property::Type::METHOD) {
+		const GDType::Member *member = type->gdtype->members(true).getptr(p_method);
+		if (member && member->type == GDType::Member::Type::METHOD) {
 			if (r_info) {
-				*r_info = info_from_bind(property->payload.method);
+				*r_info = info_from_bind(member->payload.method);
 			}
 			return true;
 		}
@@ -1086,8 +1086,8 @@ const MethodBind *ClassDB::get_method(const StringName &p_class, const StringNam
 		return nullptr;
 	}
 
-	const GDType::Property *property = type->gdtype->get_property_map().getptr(p_name);
-	return property && property->type == GDType::Property::Type::METHOD ? property->payload.method : nullptr;
+	const GDType::Member *member = type->gdtype->members().getptr(p_name);
+	return member && member->type == GDType::Member::Type::METHOD ? member->payload.method : nullptr;
 }
 
 Vector<uint32_t> ClassDB::get_method_compatibility_hashes(const StringName &p_class, const StringName &p_name) {
@@ -1115,13 +1115,13 @@ const MethodBind *ClassDB::get_method_with_compatibility(const StringName &p_cla
 	ClassInfo *type = classes.getptr(p_class);
 
 	while (type) {
-		const GDType::Property *property = type->gdtype->get_property_map(true).getptr(p_name);
-		if (property && property->type == GDType::Property::Type::METHOD) {
+		const GDType::Member *member = type->gdtype->members(true).getptr(p_name);
+		if (member && member->type == GDType::Member::Type::METHOD) {
 			if (r_method_exists) {
 				*r_method_exists = true;
 			}
-			if (property->payload.method->get_hash() == p_hash) {
-				return property->payload.method;
+			if (member->payload.method->get_hash() == p_hash) {
+				return member->payload.method;
 			}
 		}
 
@@ -1159,8 +1159,8 @@ void ClassDB::get_integer_constant_list(const StringName &p_class, List<String> 
 	ClassInfo *type = classes.getptr(p_class);
 	ERR_FAIL_NO_CLASS(type, p_class);
 
-	for (const KeyValue<StringName, GDType::Property> &kv : type->gdtype->get_property_map(p_no_inheritance)) {
-		if (kv.value.type == GDType::Property::Type::INTEGER_CONSTANT) {
+	for (const KeyValue<StringName, GDType::Member> &kv : type->gdtype->members(p_no_inheritance)) {
+		if (kv.value.type == GDType::Member::Type::INTEGER_CONSTANT) {
 			p_constants->push_back(kv.key);
 		}
 	}
@@ -1171,12 +1171,12 @@ int64_t ClassDB::get_integer_constant(const StringName &p_class, const StringNam
 
 	ClassInfo *type = classes.getptr(p_class);
 	if (type) {
-		const GDType::Property *property = type->gdtype->get_property_map().getptr(p_name);
-		if (property && property->type == GDType::Property::Type::INTEGER_CONSTANT) {
+		const GDType::Member *member = type->gdtype->members().getptr(p_name);
+		if (member && member->type == GDType::Member::Type::INTEGER_CONSTANT) {
 			if (p_success) {
 				*p_success = true;
 			}
-			return property->payload.integer_constant.value;
+			return member->payload.integer_constant.value;
 		}
 	}
 
@@ -1192,8 +1192,8 @@ bool ClassDB::has_integer_constant(const StringName &p_class, const StringName &
 	ClassInfo *type = classes.getptr(p_class);
 	ERR_FAIL_NULL_V(type, false);
 
-	const GDType::Property *property = type->gdtype->get_property_map(p_no_inheritance).getptr(p_name);
-	return property && property->type == GDType::Property::Type::INTEGER_CONSTANT;
+	const GDType::Member *member = type->gdtype->members(p_no_inheritance).getptr(p_name);
+	return member && member->type == GDType::Member::Type::INTEGER_CONSTANT;
 }
 
 StringName ClassDB::get_integer_constant_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance) {
@@ -1216,8 +1216,8 @@ void ClassDB::get_enum_list(const StringName &p_class, List<StringName> *p_enums
 		return;
 	}
 
-	for (const KeyValue<StringName, GDType::Property> &kv : type->gdtype->get_property_map(p_no_inheritance)) {
-		if (kv.value.type == GDType::Property::Type::ENUM) {
+	for (const KeyValue<StringName, GDType::Member> &kv : type->gdtype->members(p_no_inheritance)) {
+		if (kv.value.type == GDType::Member::Type::ENUM) {
 			p_enums->push_back(kv.key);
 		}
 	}
@@ -1229,11 +1229,11 @@ void ClassDB::get_enum_constants(const StringName &p_class, const StringName &p_
 	ClassInfo *type = classes.getptr(p_class);
 	ERR_FAIL_NO_CLASS(type, p_class);
 
-	const GDType::Property *property = type->gdtype->get_property_map(p_no_inheritance).getptr(p_enum);
-	ERR_FAIL_NULL(property);
-	ERR_FAIL_COND(property->type != GDType::Property::Type::ENUM);
+	const GDType::Member *member = type->gdtype->members(p_no_inheritance).getptr(p_enum);
+	ERR_FAIL_NULL(member);
+	ERR_FAIL_COND(member->type != GDType::Member::Type::ENUM);
 
-	for (const KeyValue<StringName, int64_t> &kv : property->payload.enum_info->values) {
+	for (const KeyValue<StringName, int64_t> &kv : member->payload.enum_info->values) {
 		p_constants->push_back(kv.key);
 	}
 }
@@ -1271,8 +1271,8 @@ bool ClassDB::has_enum(const StringName &p_class, const StringName &p_name, bool
 	ClassInfo *type = classes.getptr(p_class);
 	ERR_FAIL_NULL_V(type, false);
 
-	const GDType::Property *property = type->gdtype->get_property_map(p_no_inheritance).getptr(p_name);
-	return property && property->type == GDType::Property::Type::ENUM;
+	const GDType::Member *member = type->gdtype->members(p_no_inheritance).getptr(p_name);
+	return member && member->type == GDType::Member::Type::ENUM;
 }
 
 bool ClassDB::is_enum_bitfield(const StringName &p_class, const StringName &p_name, bool p_no_inheritance) {
@@ -1281,13 +1281,13 @@ bool ClassDB::is_enum_bitfield(const StringName &p_class, const StringName &p_na
 	ClassInfo *type = classes.getptr(p_class);
 	ERR_FAIL_NULL_V(type, false);
 
-	const GDType::Property *property = type->gdtype->get_property_map(p_no_inheritance).getptr(p_name);
+	const GDType::Member *member = type->gdtype->members(p_no_inheritance).getptr(p_name);
 	// FIXME This fails unexpectedly often. Keeping legacy behavior to silently fail for now.
-	if (!property || property->type != GDType::Property::Type::ENUM) {
+	if (!member || member->type != GDType::Member::Type::ENUM) {
 		return false;
 	}
 
-	return property->payload.enum_info->is_bitfield;
+	return member->payload.enum_info->is_bitfield;
 }
 
 void ClassDB::add_signal(const StringName &p_class, const MethodInfo &p_signal) {
@@ -1305,8 +1305,8 @@ void ClassDB::get_signal_list(const StringName &p_class, List<MethodInfo> *p_sig
 	ClassInfo *type = classes.getptr(p_class);
 	ERR_FAIL_NO_CLASS(type, p_class);
 
-	for (const KeyValue<StringName, GDType::Property> &kv : type->gdtype->get_property_map(p_no_inheritance)) {
-		if (kv.value.type == GDType::Property::Type::SIGNAL) {
+	for (const KeyValue<StringName, GDType::Member> &kv : type->gdtype->members(p_no_inheritance)) {
+		if (kv.value.type == GDType::Member::Type::SIGNAL) {
 			p_signals->push_back(*kv.value.payload.signal);
 		}
 	}
@@ -1318,8 +1318,8 @@ bool ClassDB::has_signal(const StringName &p_class, const StringName &p_signal, 
 	if (!type) {
 		return false;
 	}
-	const GDType::Property *property = type->gdtype->get_property_map(p_no_inheritance).getptr(p_signal);
-	return property && property->type == GDType::Property::Type::SIGNAL;
+	const GDType::Member *member = type->gdtype->members(p_no_inheritance).getptr(p_signal);
+	return member && member->type == GDType::Member::Type::SIGNAL;
 }
 
 bool ClassDB::get_signal(const StringName &p_class, const StringName &p_signal, MethodInfo *r_signal) {
@@ -1328,11 +1328,11 @@ bool ClassDB::get_signal(const StringName &p_class, const StringName &p_signal, 
 	if (!type) {
 		return false;
 	}
-	const GDType::Property *property = type->gdtype->get_property_map().getptr(p_signal);
-	if (!property || property->type != GDType::Property::Type::SIGNAL) {
+	const GDType::Member *member = type->gdtype->members().getptr(p_signal);
+	if (!member || member->type != GDType::Member::Type::SIGNAL) {
 		return false;
 	}
-	*r_signal = *property->payload.signal;
+	*r_signal = *member->payload.signal;
 	return true;
 }
 
@@ -1396,13 +1396,13 @@ void ClassDB::add_linked_property(const StringName &p_class, const String &p_pro
 	ClassInfo *type = classes.getptr(p_class);
 	ERR_FAIL_NO_CLASS(type, p_class);
 
-	const GDType::Property *property = type->gdtype->get_property_map(true).getptr(p_property);
-	ERR_FAIL_NULL(property);
-	ERR_FAIL_COND(property->type != GDType::Property::Type::SETGET);
+	const GDType::Member *member = type->gdtype->members(true).getptr(p_property);
+	ERR_FAIL_NULL(member);
+	ERR_FAIL_COND(member->type != GDType::Member::Type::PROPERTY);
 
-	const GDType::Property *linked_property = type->gdtype->get_property_map(true).getptr(p_linked_property);
+	const GDType::Member *linked_property = type->gdtype->members(true).getptr(p_linked_property);
 	ERR_FAIL_NULL(linked_property);
-	ERR_FAIL_COND(linked_property->type != GDType::Property::Type::SETGET);
+	ERR_FAIL_COND(linked_property->type != GDType::Member::Type::PROPERTY);
 
 	if (!type->linked_properties.has(p_property)) {
 		type->linked_properties.insert(p_property, List<StringName>());
@@ -1456,10 +1456,10 @@ bool ClassDB::get_property_info(const StringName &p_class, const StringName &p_p
 
 	ClassInfo *class_info = classes.getptr(p_class);
 	if (class_info) {
-		const GDType::Property *property = class_info->gdtype->get_property_map(p_no_inheritance).getptr(p_property);
-		if (property && property->type == GDType::Property::Type::SETGET) {
+		const GDType::Member *member = class_info->gdtype->members(p_no_inheritance).getptr(p_property);
+		if (member && member->type == GDType::Member::Type::PROPERTY) {
 			if (r_info) {
-				*r_info = *property->payload.setget.property_info;
+				*r_info = *member->payload.property.property_info;
 			}
 			if (p_validator) {
 				p_validator->validate_property(*r_info);
@@ -1486,9 +1486,9 @@ bool ClassDB::get_property(Object *p_object, const StringName &p_property, Varia
 int ClassDB::get_property_index(const StringName &p_class, const StringName &p_property, bool *r_is_valid) {
 	ClassInfo *class_info = classes.getptr(p_class);
 	if (class_info) {
-		const GDType::Property *property = class_info->gdtype->get_property_map().getptr(p_property);
-		if (property && property->type == GDType::Property::Type::SETGET) {
-			const GDType::Property::SetGet &psg = property->payload.setget;
+		const GDType::Member *member = class_info->gdtype->members().getptr(p_property);
+		if (member && member->type == GDType::Member::Type::PROPERTY) {
+			const GDType::Member::Property &psg = member->payload.property;
 			if (r_is_valid) {
 				*r_is_valid = true;
 			}
@@ -1507,9 +1507,9 @@ int ClassDB::get_property_index(const StringName &p_class, const StringName &p_p
 Variant::Type ClassDB::get_property_type(const StringName &p_class, const StringName &p_property, bool *r_is_valid) {
 	ClassInfo *class_info = classes.getptr(p_class);
 	if (class_info) {
-		const GDType::Property *property = class_info->gdtype->get_property_map().getptr(p_property);
-		if (property && property->type == GDType::Property::Type::SETGET) {
-			const GDType::Property::SetGet &psg = property->payload.setget;
+		const GDType::Member *member = class_info->gdtype->members().getptr(p_property);
+		if (member && member->type == GDType::Member::Type::PROPERTY) {
+			const GDType::Member::Property &psg = member->payload.property;
 			if (r_is_valid) {
 				*r_is_valid = true;
 			}
@@ -1528,9 +1528,9 @@ Variant::Type ClassDB::get_property_type(const StringName &p_class, const String
 StringName ClassDB::get_property_setter(const StringName &p_class, const StringName &p_property) {
 	ClassInfo *class_info = classes.getptr(p_class);
 	if (class_info) {
-		const GDType::Property *property = class_info->gdtype->get_property_map().getptr(p_property);
-		if (property && property->type == GDType::Property::Type::SETGET) {
-			return property->payload.setget.setter ? property->payload.setget.setter->get_name() : StringName();
+		const GDType::Member *member = class_info->gdtype->members().getptr(p_property);
+		if (member && member->type == GDType::Member::Type::PROPERTY) {
+			return member->payload.property.setter ? member->payload.property.setter->get_name() : StringName();
 		}
 	}
 
@@ -1540,9 +1540,9 @@ StringName ClassDB::get_property_setter(const StringName &p_class, const StringN
 StringName ClassDB::get_property_getter(const StringName &p_class, const StringName &p_property) {
 	ClassInfo *class_info = classes.getptr(p_class);
 	if (class_info) {
-		const GDType::Property *property = class_info->gdtype->get_property_map().getptr(p_property);
-		if (property && property->type == GDType::Property::Type::SETGET) {
-			return property->payload.setget.getter ? property->payload.setget.getter->get_name() : StringName();
+		const GDType::Member *member = class_info->gdtype->members().getptr(p_property);
+		if (member && member->type == GDType::Member::Type::PROPERTY) {
+			return member->payload.property.getter ? member->payload.property.getter->get_name() : StringName();
 		}
 	}
 
@@ -1552,8 +1552,8 @@ StringName ClassDB::get_property_getter(const StringName &p_class, const StringN
 bool ClassDB::has_property(const StringName &p_class, const StringName &p_property, bool p_no_inheritance) {
 	ClassInfo *class_info = classes.getptr(p_class);
 	if (class_info) {
-		const GDType::Property *property = class_info->gdtype->get_property_map(p_no_inheritance).getptr(p_property);
-		return property ? property->type == GDType::Property::Type::SETGET : false;
+		const GDType::Member *member = class_info->gdtype->members(p_no_inheritance).getptr(p_property);
+		return member ? member->type == GDType::Member::Type::PROPERTY : false;
 	}
 
 	return false;
@@ -1571,8 +1571,8 @@ bool ClassDB::has_method(const StringName &p_class, const StringName &p_method, 
 	if (!type) {
 		return false;
 	}
-	const GDType::Property *property = type->gdtype->get_property_map(p_no_inheritance).getptr(p_method);
-	return property && property->type == GDType::Property::Type::METHOD;
+	const GDType::Member *member = type->gdtype->members(p_no_inheritance).getptr(p_method);
+	return member && member->type == GDType::Member::Type::METHOD;
 }
 
 int ClassDB::get_method_argument_count(const StringName &p_class, const StringName &p_method, bool *r_is_valid, bool p_no_inheritance) {
@@ -1580,12 +1580,12 @@ int ClassDB::get_method_argument_count(const StringName &p_class, const StringNa
 
 	ClassInfo *type = classes.getptr(p_class);
 	if (type) {
-		const GDType::Property *property = type->gdtype->get_property_map(p_no_inheritance).getptr(p_method);
-		if (property && property->type == GDType::Property::Type::METHOD) {
+		const GDType::Member *member = type->gdtype->members(p_no_inheritance).getptr(p_method);
+		if (member && member->type == GDType::Member::Type::METHOD) {
 			if (r_is_valid) {
 				*r_is_valid = true;
 			}
-			return property->payload.method->get_argument_count();
+			return member->payload.method->get_argument_count();
 		}
 	}
 

--- a/core/object/gdtype.cpp
+++ b/core/object/gdtype.cpp
@@ -46,10 +46,10 @@ GDType::GDType(const GDType *p_super_type, StringName p_name) :
 }
 
 GDType::~GDType() {
-	for (const KeyValue<StringName, Property> &kv : self_property_map) {
-		if (kv.value.type == Property::Type::ENUM) {
+	for (const KeyValue<StringName, Member> &kv : _self_members) {
+		if (kv.value.type == Member::Type::ENUM) {
 			memdelete(const_cast<EnumInfo *>(kv.value.payload.enum_info));
-		} else if (kv.value.type == Property::Type::SIGNAL) {
+		} else if (kv.value.type == Member::Type::SIGNAL) {
 			memdelete(const_cast<MethodInfo *>(kv.value.payload.signal));
 		}
 	}
@@ -76,7 +76,7 @@ void GDType::initialize() {
 		// parts in _bind_methods, which is called on registration.
 		super_type->init_state = InitState::FINALIZED;
 
-		property_map = super_type->property_map;
+		_members = super_type->_members;
 	}
 
 	init_state = InitState::MUTABLE;
@@ -85,7 +85,7 @@ void GDType::initialize() {
 void GDType::bind_integer_constant(const StringName &p_enum, const StringName &p_name, int64_t p_constant, bool p_is_bitfield) {
 	ERR_FAIL_COND(!Thread::is_main_thread());
 	ERR_FAIL_COND(init_state != InitState::MUTABLE);
-	ERR_FAIL_COND_MSG(property_map.has(p_name), vformat("Object '%s' already has property '%s'.", get_name(), p_name));
+	ERR_FAIL_COND_MSG(_members.has(p_name), vformat("Object '%s' already has member '%s'.", get_name(), p_name));
 
 	EnumInfo *enum_info = nullptr;
 
@@ -95,12 +95,12 @@ void GDType::bind_integer_constant(const StringName &p_enum, const StringName &p
 			enum_name = enum_name.get_slicec('.', 1);
 		}
 
-		const Property *enum_property = self_property_map.getptr(enum_name);
-		ERR_FAIL_COND_MSG(!enum_property && property_map.has(enum_name), vformat("Cannot bind integer constant '%s' to enum '%s' from class '%s' because the enum belongs to a parent class.", p_name, enum_name, get_name()));
-		ERR_FAIL_COND_MSG(enum_property && enum_property->type != Property::Type::ENUM, vformat("Object '%s' already has property '%s'.", get_name(), enum_name));
+		const Member *enum_member = _self_members.getptr(enum_name);
+		ERR_FAIL_COND_MSG(!enum_member && _members.has(enum_name), vformat("Cannot bind integer constant '%s' to enum '%s' from class '%s' because the enum belongs to a parent class.", p_name, enum_name, get_name()));
+		ERR_FAIL_COND_MSG(enum_member && enum_member->type != Member::Type::ENUM, vformat("Object '%s' already has member '%s'.", get_name(), enum_name));
 
-		if (enum_property) {
-			enum_info = const_cast<EnumInfo *>(enum_property->payload.enum_info);
+		if (enum_member) {
+			enum_info = const_cast<EnumInfo *>(enum_member->payload.enum_info);
 			enum_info->values.insert(p_name, p_constant);
 			enum_info->is_bitfield = p_is_bitfield;
 		} else {
@@ -108,22 +108,22 @@ void GDType::bind_integer_constant(const StringName &p_enum, const StringName &p
 			enum_info->name = enum_name;
 			enum_info->is_bitfield = p_is_bitfield;
 			enum_info->values.insert(p_name, p_constant);
-			self_property_map.insert(enum_name, Property::create_enum(enum_info));
-			property_map.insert(enum_name, Property::create_enum(enum_info));
+			_self_members.insert(enum_name, Member::create_enum(enum_info));
+			_members.insert(enum_name, Member::create_enum(enum_info));
 		}
 	}
 
-	Property::IntegerConstant entry{ p_constant, enum_info };
-	property_map.insert(p_name, Property::create_integer_constant(entry));
-	self_property_map.insert(p_name, Property::create_integer_constant(entry));
+	Member::IntegerConstant entry{ p_constant, enum_info };
+	_members.insert(p_name, Member::create_integer_constant(entry));
+	_self_members.insert(p_name, Member::create_integer_constant(entry));
 }
 
 const GDType::EnumInfo *GDType::get_integer_constant_enum(const StringName &p_name, bool p_no_inheritance) const {
-	const Property *property = get_property_map(p_no_inheritance).getptr(p_name);
-	if (!property || property->type != Property::Type::INTEGER_CONSTANT) {
+	const Member *member = members(p_no_inheritance).getptr(p_name);
+	if (!member || member->type != Member::Type::INTEGER_CONSTANT) {
 		return nullptr;
 	}
-	return property->payload.integer_constant.enum_info;
+	return member->payload.integer_constant.enum_info;
 }
 
 void GDType::add_signal(MethodInfo p_signal) {
@@ -131,30 +131,30 @@ void GDType::add_signal(MethodInfo p_signal) {
 	ERR_FAIL_COND(init_state != InitState::MUTABLE);
 
 	const StringName signal_name(p_signal.name);
-	ERR_FAIL_COND_MSG(property_map.has(signal_name), vformat("Object '%s' already has property '%s'.", get_name(), signal_name));
+	ERR_FAIL_COND_MSG(_members.has(signal_name), vformat("Object '%s' already has member '%s'.", get_name(), signal_name));
 
 	const MethodInfo *ptr = memnew(MethodInfo(std::move(p_signal)));
 
-	property_map.insert(ptr->name, Property::create_signal(ptr));
-	self_property_map.insert(ptr->name, Property::create_signal(ptr));
+	_members.insert(ptr->name, Member::create_signal(ptr));
+	_self_members.insert(ptr->name, Member::create_signal(ptr));
 }
 
 bool GDType::bind_method(MethodBind *p_method, bool p_take_ownership) {
 	ERR_FAIL_COND_V(!Thread::is_main_thread(), false);
 	ERR_FAIL_COND_V(init_state != InitState::MUTABLE, false);
 
-	if (property_map.has(p_method->get_name())) {
+	if (_members.has(p_method->get_name())) {
 		if (p_take_ownership) {
 			memdelete(p_method);
 		}
-		ERR_FAIL_V_MSG(false, vformat("Object '%s' already has property '%s'.", get_name(), p_method->get_name()));
+		ERR_FAIL_V_MSG(false, vformat("Object '%s' already has member '%s'.", get_name(), p_method->get_name()));
 	}
 
 	if (p_take_ownership) {
 		owned_method_map.push_back(p_method);
 	}
-	property_map.insert(p_method->get_name(), Property::create_method(p_method));
-	self_property_map.insert(p_method->get_name(), Property::create_method(p_method));
+	_members.insert(p_method->get_name(), Member::create_method(p_method));
+	_self_members.insert(p_method->get_name(), Member::create_method(p_method));
 
 	return true;
 }
@@ -163,11 +163,11 @@ void GDType::set_method_flags(const StringName &p_method, int p_flags) {
 	ERR_FAIL_COND(!Thread::is_main_thread());
 	ERR_FAIL_COND(init_state != InitState::MUTABLE);
 
-	const Property *property = self_property_map.getptr(p_method);
-	ERR_FAIL_NULL(property);
-	ERR_FAIL_COND(property->type != Property::Type::METHOD);
+	const Member *member = _self_members.getptr(p_method);
+	ERR_FAIL_NULL(member);
+	ERR_FAIL_COND(member->type != Member::Type::METHOD);
 
-	const_cast<MethodBind *>(property->payload.method)->set_hint_flags(p_flags);
+	const_cast<MethodBind *>(member->payload.method)->set_hint_flags(p_flags);
 }
 
 bool GDType::bind_compatibility_method(MethodBind *p_method) {
@@ -186,15 +186,15 @@ void GDType::add_property(const PropertyInfo &p_pinfo, const StringName &p_sette
 	ERR_FAIL_COND(!Thread::is_main_thread());
 	ERR_FAIL_COND(init_state != InitState::MUTABLE);
 
-	ERR_FAIL_COND_MSG(property_map.has(p_pinfo.name), vformat("Object '%s' already has property '%s'.", get_name(), p_pinfo.name));
+	ERR_FAIL_COND_MSG(_members.has(p_pinfo.name), vformat("Object '%s' already has member '%s'.", get_name(), p_pinfo.name));
 
 	const MethodBind *mb_set = nullptr;
 	if (p_setter) {
-		const Property *set_prop = property_map.getptr(p_setter);
+		const Member *set_member = _members.getptr(p_setter);
 
-		ERR_FAIL_COND_MSG(!set_prop || set_prop->type != Property::Type::METHOD, vformat("Invalid setter '%s::%s' for property '%s'.", get_name(), p_setter, p_pinfo.name));
+		ERR_FAIL_COND_MSG(!set_member || set_member->type != Member::Type::METHOD, vformat("Invalid setter '%s::%s' for property '%s'.", get_name(), p_setter, p_pinfo.name));
 
-		mb_set = set_prop->payload.method;
+		mb_set = set_member->payload.method;
 
 		int exp_args = 1 + (p_index >= 0 ? 1 : 0);
 		ERR_FAIL_COND_MSG(mb_set->get_argument_count() != exp_args, vformat("Invalid function for setter '%s::%s' for property '%s'.", get_name(), p_setter, p_pinfo.name));
@@ -202,11 +202,11 @@ void GDType::add_property(const PropertyInfo &p_pinfo, const StringName &p_sette
 
 	const MethodBind *mb_get = nullptr;
 	if (p_getter) {
-		const Property *get_prop = property_map.getptr(p_getter);
+		const Member *get_member = _members.getptr(p_getter);
 
-		ERR_FAIL_COND_MSG(!get_prop || get_prop->type != Property::Type::METHOD, vformat("Invalid getter '%s::%s' for property '%s'.", get_name(), p_getter, p_pinfo.name));
+		ERR_FAIL_COND_MSG(!get_member || get_member->type != Member::Type::METHOD, vformat("Invalid getter '%s::%s' for property '%s'.", get_name(), p_getter, p_pinfo.name));
 
-		mb_get = get_prop->payload.method;
+		mb_get = get_member->payload.method;
 
 		int exp_args = 0 + (p_index >= 0 ? 1 : 0);
 		ERR_FAIL_COND_MSG(mb_get->get_argument_count() != exp_args, vformat("Invalid function for getter '%s::%s' for property '%s'.", get_name(), p_getter, p_pinfo.name));
@@ -214,14 +214,14 @@ void GDType::add_property(const PropertyInfo &p_pinfo, const StringName &p_sette
 
 	PropertyInfo *info = memnew(PropertyInfo(p_pinfo));
 
-	Property::SetGet psg;
+	Member::Property psg;
 	psg.property_info = info;
 	psg.setter = mb_set;
 	psg.getter = mb_get;
 	psg.index = p_index;
 
-	property_map.insert(p_pinfo.name, Property::create_setget(psg));
-	self_property_map.insert(p_pinfo.name, Property::create_setget(psg));
+	_members.insert(p_pinfo.name, Member::create_property(psg));
+	_self_members.insert(p_pinfo.name, Member::create_property(psg));
 	ordered_self_properties.push_back(info);
 }
 

--- a/core/object/gdtype.h
+++ b/core/object/gdtype.h
@@ -51,16 +51,16 @@ public:
 		bool is_bitfield = false;
 	};
 
-	struct Property {
+	struct Member {
 		enum class Type {
-			SETGET,
+			PROPERTY,
 			INTEGER_CONSTANT,
 			ENUM,
 			METHOD,
 			SIGNAL
 		};
 
-		struct SetGet {
+		struct Property {
 			const PropertyInfo *property_info;
 			const MethodBind *setter;
 			const MethodBind *getter;
@@ -73,7 +73,7 @@ public:
 		};
 
 		union Payload {
-			SetGet setget;
+			Property property;
 			IntegerConstant integer_constant;
 			const EnumInfo *enum_info;
 			const MethodBind *method;
@@ -83,40 +83,40 @@ public:
 		Type type;
 		Payload payload;
 
-		Property &operator=(const Property &) = default;
+		Member &operator=(const Member &) = default;
 
-		static Property create_setget(const SetGet &p_setget) {
+		static Member create_property(const Property &p_property) {
 			Payload payload;
-			payload.setget = p_setget;
-			return Property(Type::SETGET, payload);
+			payload.property = p_property;
+			return Member(Type::PROPERTY, payload);
 		}
 
-		static Property create_integer_constant(IntegerConstant p_constant) {
+		static Member create_integer_constant(IntegerConstant p_constant) {
 			Payload payload;
 			payload.integer_constant = p_constant;
-			return Property(Type::INTEGER_CONSTANT, payload);
+			return Member(Type::INTEGER_CONSTANT, payload);
 		}
 
-		static Property create_enum(const EnumInfo *p_enum_info) {
+		static Member create_enum(const EnumInfo *p_enum_info) {
 			Payload payload;
 			payload.enum_info = p_enum_info;
-			return Property(Type::ENUM, payload);
+			return Member(Type::ENUM, payload);
 		}
 
-		static Property create_method(const MethodBind *p_method) {
+		static Member create_method(const MethodBind *p_method) {
 			Payload payload;
 			payload.method = p_method;
-			return Property(Type::METHOD, payload);
+			return Member(Type::METHOD, payload);
 		}
 
-		static Property create_signal(const MethodInfo *p_method) {
+		static Member create_signal(const MethodInfo *p_method) {
 			Payload payload;
 			payload.signal = p_method;
-			return Property(Type::SIGNAL, payload);
+			return Member(Type::SIGNAL, payload);
 		}
 
-		Property(const Property &) = default;
-		Property(Type p_type, const Payload &p_payload) : type(p_type), payload(p_payload) {}
+		Member(const Member &) = default;
+		Member(Type p_type, const Payload &p_payload) : type(p_type), payload(p_payload) {}
 	};
 
 protected:
@@ -134,9 +134,9 @@ protected:
 
 	AHashMap<StringName, LocalVector<MethodBind *>> self_compatibility_method_map;
 
-	/// Contains all properties that can be obtained or set with `object.property`.
-	AHashMap<StringName, Property> property_map;
-	AHashMap<StringName, Property> self_property_map;
+	/// Contains all members that can be obtained or set with dot notation (`object.member`).
+	AHashMap<StringName, Member> _members;
+	AHashMap<StringName, Member> _self_members;
 	LocalVector<const PropertyInfo *> ordered_self_properties;
 
 public:
@@ -171,6 +171,6 @@ public:
 	const LocalVector<const PropertyInfo *> &get_ordered_self_properties() const { return ordered_self_properties; }
 
 	// Access
-	const AHashMap<StringName, Property> &get_property_map(bool p_no_inheritance = false) const { return p_no_inheritance ? self_property_map : property_map; }
+	const AHashMap<StringName, Member> &members(bool p_no_inheritance = false) const { return p_no_inheritance ? _self_members : _members; }
 	const EnumInfo *get_integer_constant_enum(const StringName &p_name, bool p_no_inheritance = false) const;
 };

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -347,11 +347,11 @@ Variant Object::get(const StringName &p_name, bool *r_valid) const {
 }
 
 bool Object::set_native(const StringName &p_name, const Variant &p_value, bool *r_valid) {
-	const GDType::Property *property = get_gdtype().get_property_map().getptr(p_name);
-	if (property) {
-		switch (property->type) {
-			case GDType::Property::Type::SETGET: {
-				const GDType::Property::SetGet &psg = property->payload.setget;
+	const GDType::Member *member = get_gdtype().members().getptr(p_name);
+	if (member) {
+		switch (member->type) {
+			case GDType::Member::Type::PROPERTY: {
+				const GDType::Member::Property &psg = member->payload.property;
 				if (!psg.setter) {
 					if (r_valid) {
 						*r_valid = false;
@@ -376,10 +376,10 @@ bool Object::set_native(const StringName &p_name, const Variant &p_value, bool *
 				}
 				return true;
 			}
-			case GDType::Property::Type::INTEGER_CONSTANT:
-			case GDType::Property::Type::METHOD:
-			case GDType::Property::Type::ENUM:
-			case GDType::Property::Type::SIGNAL: {
+			case GDType::Member::Type::INTEGER_CONSTANT:
+			case GDType::Member::Type::METHOD:
+			case GDType::Member::Type::ENUM:
+			case GDType::Member::Type::SIGNAL: {
 				// All other properties are unsettable.
 				if (r_valid) {
 					*r_valid = false;
@@ -393,11 +393,11 @@ bool Object::set_native(const StringName &p_name, const Variant &p_value, bool *
 }
 
 bool Object::get_native(const StringName &p_name, Variant &r_value, bool *r_valid) const {
-	const GDType::Property *property = get_gdtype().get_property_map().getptr(p_name);
-	if (property) {
-		switch (property->type) {
-			case GDType::Property::Type::SETGET: {
-				const GDType::Property::SetGet &psg = property->payload.setget;
+	const GDType::Member *member = get_gdtype().members().getptr(p_name);
+	if (member) {
+		switch (member->type) {
+			case GDType::Member::Type::PROPERTY: {
+				const GDType::Member::Property &psg = member->payload.property;
 				if (!psg.getter) {
 					if (r_valid) {
 						*r_valid = true; // Set to true for compat reasons.
@@ -425,28 +425,28 @@ bool Object::get_native(const StringName &p_name, Variant &r_value, bool *r_vali
 				}
 				return true;
 			}
-			case GDType::Property::Type::INTEGER_CONSTANT: {
+			case GDType::Member::Type::INTEGER_CONSTANT: {
 				if (r_valid) {
 					*r_valid = true;
 				}
-				r_value = property->payload.integer_constant.value;
+				r_value = member->payload.integer_constant.value;
 				return true;
 			}
-			case GDType::Property::Type::METHOD: {
+			case GDType::Member::Type::METHOD: {
 				if (r_valid) {
 					*r_valid = true;
 				}
 				r_value = Callable(this, p_name);
 				return true;
 			}
-			case GDType::Property::Type::SIGNAL: {
+			case GDType::Member::Type::SIGNAL: {
 				if (r_valid) {
 					*r_valid = true;
 				}
 				r_value = Signal(this, p_name);
 				return true;
 			}
-			case GDType::Property::Type::ENUM: {
+			case GDType::Member::Type::ENUM: {
 				if (r_valid) {
 					*r_valid = false;
 				}
@@ -744,8 +744,8 @@ bool Object::has_method(const StringName &p_method) const {
 		return true;
 	}
 
-	const GDType::Property *property = get_gdtype().get_property_map().getptr(p_method);
-	if (property != nullptr && property->type == GDType::Property::Type::METHOD) {
+	const GDType::Member *member = get_gdtype().members().getptr(p_method);
+	if (member != nullptr && member->type == GDType::Member::Type::METHOD) {
 		return true;
 	}
 
@@ -899,13 +899,13 @@ Variant Object::callp(const StringName &p_method, const Variant **p_args, int p_
 
 	//extension does not need this, because all methods are registered in MethodBind
 
-	const GDType::Property *property = get_gdtype().get_property_map().getptr(p_method);
-	if (!property || property->type != GDType::Property::Type::METHOD) {
+	const GDType::Member *member = get_gdtype().members().getptr(p_method);
+	if (!member || member->type != GDType::Member::Type::METHOD) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
 		return Variant();
 	}
 
-	const MethodBind *method = property->payload.method;
+	const MethodBind *method = member->payload.method;
 	return method->call(this, p_args, p_argcount, r_error);
 }
 
@@ -941,13 +941,13 @@ Variant Object::call_const(const StringName &p_method, const Variant **p_args, i
 
 	//extension does not need this, because all methods are registered in MethodBind
 
-	const GDType::Property *property = get_gdtype().get_property_map().getptr(p_method);
-	if (!property || property->type != GDType::Property::Type::METHOD) {
+	const GDType::Member *member = get_gdtype().members().getptr(p_method);
+	if (!member || member->type != GDType::Member::Type::METHOD) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
 		return Variant();
 	}
 
-	const MethodBind *method = property->payload.method;
+	const MethodBind *method = member->payload.method;
 
 	if (!method->is_const()) {
 		r_error.error = Callable::CallError::CALL_ERROR_METHOD_NOT_CONST;
@@ -1183,7 +1183,7 @@ void Object::get_meta_list(List<StringName> *p_list) const {
 
 void Object::add_user_signal(const MethodInfo &p_signal) {
 	ERR_FAIL_COND_MSG(p_signal.name.is_empty(), "Signal name cannot be empty.");
-	ERR_FAIL_COND_MSG(get_gdtype().get_property_map().has(p_signal.name), vformat("User signal's name conflicts with a built-in property of '%s'.", get_class_name()));
+	ERR_FAIL_COND_MSG(get_gdtype().members().has(p_signal.name), vformat("User signal's name conflicts with a built-in member of '%s'.", get_class_name()));
 
 	ObjectSignalLock signal_lock(this);
 
@@ -1273,8 +1273,8 @@ Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int
 		SignalData *s = signal_map.getptr(p_name);
 		if (!s) {
 #ifdef DEBUG_ENABLED
-			const GDType::Property *property = get_gdtype().get_property_map().getptr(p_name);
-			bool signal_is_valid = property && property->type == GDType::Property::Type::SIGNAL;
+			const GDType::Member *member = get_gdtype().members().getptr(p_name);
+			bool signal_is_valid = member && member->type == GDType::Member::Type::SIGNAL;
 			//check in script
 			ERR_FAIL_COND_V_MSG(!signal_is_valid && script_instance && !script_instance->get_script()->has_script_signal(p_name), ERR_UNAVAILABLE, vformat("Can't emit non-existing signal \"%s\".", p_name));
 #endif
@@ -1490,8 +1490,8 @@ bool Object::has_signal(const StringName &p_name) const {
 		return true;
 	}
 
-	const GDType::Property *property = get_gdtype().get_property_map().getptr(p_name);
-	if (property && property->type == GDType::Property::Type::SIGNAL) {
+	const GDType::Member *member = get_gdtype().members().getptr(p_name);
+	if (member && member->type == GDType::Member::Type::SIGNAL) {
 		return true;
 	}
 
@@ -1598,8 +1598,8 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, ui
 
 	SignalData *s = signal_map.getptr(p_signal);
 	if (!s) {
-		const GDType::Property *property = get_gdtype().get_property_map().getptr(p_signal);
-		bool signal_is_valid = property && property->type == GDType::Property::Type::SIGNAL;
+		const GDType::Member *member = get_gdtype().members().getptr(p_signal);
+		bool signal_is_valid = member && member->type == GDType::Member::Type::SIGNAL;
 		//check in script
 		if (!signal_is_valid && script_instance) {
 			if (script_instance->get_script()->has_script_signal(p_signal)) {
@@ -1657,8 +1657,8 @@ bool Object::is_connected(const StringName &p_signal, const Callable &p_callable
 
 	const SignalData *s = signal_map.getptr(p_signal);
 	if (!s) {
-		const GDType::Property *property = get_gdtype().get_property_map().getptr(p_signal);
-		if (property && property->type == GDType::Property::Type::SIGNAL) {
+		const GDType::Member *member = get_gdtype().members().getptr(p_signal);
+		if (member && member->type == GDType::Member::Type::SIGNAL) {
 			return false;
 		}
 
@@ -1677,8 +1677,8 @@ bool Object::has_connections(const StringName &p_signal) const {
 
 	const SignalData *s = signal_map.getptr(p_signal);
 	if (!s) {
-		const GDType::Property *property = get_gdtype().get_property_map().getptr(p_signal);
-		if (property && property->type == GDType::Property::Type::SIGNAL) {
+		const GDType::Member *member = get_gdtype().members().getptr(p_signal);
+		if (member && member->type == GDType::Member::Type::SIGNAL) {
 			return false;
 		}
 
@@ -1703,8 +1703,8 @@ bool Object::_disconnect(const StringName &p_signal, const Callable &p_callable,
 
 	SignalData *s = signal_map.getptr(p_signal);
 	if (!s) {
-		const GDType::Property *property = get_gdtype().get_property_map().getptr(p_signal);
-		bool signal_is_valid = (property && property->type == GDType::Property::Type::SIGNAL) ||
+		const GDType::Member *member = get_gdtype().members().getptr(p_signal);
+		bool signal_is_valid = (member && member->type == GDType::Member::Type::SIGNAL) ||
 				(script_instance && script_instance->get_script()->has_script_signal(p_signal));
 		ERR_FAIL_COND_V_MSG(signal_is_valid, false, vformat("Attempt to disconnect a nonexistent connection from '%s'. Signal: '%s', callable: '%s'.", to_string(), p_signal, p_callable));
 	}
@@ -1727,8 +1727,8 @@ bool Object::_disconnect(const StringName &p_signal, const Callable &p_callable,
 
 	s->slot_map.erase(*p_callable.get_base_comparator());
 
-	const GDType::Property *property = get_gdtype().get_property_map().getptr(p_signal);
-	if (s->slot_map.is_empty() && property && property->type == GDType::Property::Type::SIGNAL) {
+	const GDType::Member *member = get_gdtype().members().getptr(p_signal);
+	if (s->slot_map.is_empty() && member && member->type == GDType::Member::Type::SIGNAL) {
 		//not user signal, delete
 		signal_map.erase(p_signal);
 	}

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1222,7 +1222,7 @@ struct _VariantCall {
 	static void add_variant_constant(int p_type, const StringName &p_constant_name, const Variant &p_constant_value) {
 #ifdef DEBUG_ENABLED
 		ERR_FAIL_COND(variant_constants[p_type].has(p_constant_name));
-		ERR_FAIL_COND(Variant::_get_gdtype_for_type(static_cast<Variant::Type>(p_type)).get_property_map(true).has(p_constant_name));
+		ERR_FAIL_COND(Variant::_get_gdtype_for_type(static_cast<Variant::Type>(p_type)).members(true).has(p_constant_name));
 #endif // DEBUG_ENABLED
 		variant_constants[p_type][p_constant_name] = p_constant_value;
 	}
@@ -1654,8 +1654,8 @@ void Variant::get_method_list(List<MethodInfo> *p_list) const {
 void Variant::get_constants_for_type(Variant::Type p_type, List<StringName> *p_constants) {
 	ERR_FAIL_INDEX(p_type, Variant::VARIANT_MAX);
 
-	for (const KeyValue<StringName, GDType::Property> &E : _get_gdtype_for_type(p_type).get_property_map()) {
-		if (E.value.type != GDType::Property::Type::INTEGER_CONSTANT) {
+	for (const KeyValue<StringName, GDType::Member> &E : _get_gdtype_for_type(p_type).members()) {
+		if (E.value.type != GDType::Member::Type::INTEGER_CONSTANT) {
 			continue;
 		}
 		if (!E.value.payload.integer_constant.enum_info) {
@@ -1678,9 +1678,9 @@ int Variant::get_constants_count_for_type(Variant::Type p_type) {
 
 bool Variant::has_constant(Variant::Type p_type, const StringName &p_value) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, false);
-	const GDType::Property *property = _get_gdtype_for_type(p_type).get_property_map().getptr(p_value);
+	const GDType::Member *member = _get_gdtype_for_type(p_type).members().getptr(p_value);
 	const bool is_non_enum_integer_constant =
-			property && property->type == GDType::Property::Type::INTEGER_CONSTANT && !property->payload.integer_constant.enum_info;
+			member && member->type == GDType::Member::Type::INTEGER_CONSTANT && !member->payload.integer_constant.enum_info;
 	return is_non_enum_integer_constant || _VariantCall::variant_constants[p_type].has(p_value);
 }
 
@@ -1691,12 +1691,12 @@ Variant Variant::get_constant_value(Variant::Type p_type, const StringName &p_va
 
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, 0);
 
-	const GDType::Property *property = _get_gdtype_for_type(p_type).get_property_map().getptr(p_value);
-	if (property && property->type == GDType::Property::Type::INTEGER_CONSTANT && !property->payload.integer_constant.enum_info) {
+	const GDType::Member *member = _get_gdtype_for_type(p_type).members().getptr(p_value);
+	if (member && member->type == GDType::Member::Type::INTEGER_CONSTANT && !member->payload.integer_constant.enum_info) {
 		if (r_valid) {
 			*r_valid = true;
 		}
-		return property->payload.integer_constant.value;
+		return member->payload.integer_constant.value;
 	}
 
 	HashMap<StringName, Variant>::Iterator F = _VariantCall::variant_constants[p_type].find(p_value);
@@ -1712,8 +1712,8 @@ Variant Variant::get_constant_value(Variant::Type p_type, const StringName &p_va
 
 void Variant::get_enums_for_type(Variant::Type p_type, List<StringName> *p_enums) {
 	ERR_FAIL_INDEX(p_type, Variant::VARIANT_MAX);
-	for (const KeyValue<StringName, GDType::Property> &E : _get_gdtype_for_type(p_type).get_property_map()) {
-		if (E.value.type == GDType::Property::Type::ENUM) {
+	for (const KeyValue<StringName, GDType::Member> &E : _get_gdtype_for_type(p_type).members()) {
+		if (E.value.type == GDType::Member::Type::ENUM) {
 			p_enums->push_back(E.key);
 		}
 	}
@@ -1721,12 +1721,12 @@ void Variant::get_enums_for_type(Variant::Type p_type, List<StringName> *p_enums
 
 void Variant::get_enumerations_for_enum(Variant::Type p_type, const StringName &p_enum_name, List<StringName> *p_enumerations) {
 	ERR_FAIL_INDEX(p_type, Variant::VARIANT_MAX);
-	const GDType::Property *property = _get_gdtype_for_type(p_type).get_property_map().getptr(p_enum_name);
-	if (!property || property->type != GDType::Property::Type::ENUM) {
+	const GDType::Member *member = _get_gdtype_for_type(p_type).members().getptr(p_enum_name);
+	if (!member || member->type != GDType::Member::Type::ENUM) {
 		return;
 	}
 
-	for (const KeyValue<StringName, int64_t> &V : property->payload.enum_info->values) {
+	for (const KeyValue<StringName, int64_t> &V : member->payload.enum_info->values) {
 		p_enumerations->push_back(V.key);
 	}
 }
@@ -1737,12 +1737,12 @@ int Variant::get_enum_value(Variant::Type p_type, const StringName &p_enum_name,
 	}
 
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, -1);
-	const GDType::Property *property = _get_gdtype_for_type(p_type).get_property_map().getptr(p_enum_name);
-	if (!property || property->type != GDType::Property::Type::ENUM) {
+	const GDType::Member *member = _get_gdtype_for_type(p_type).members().getptr(p_enum_name);
+	if (!member || member->type != GDType::Member::Type::ENUM) {
 		return -1;
 	}
 
-	const int64_t *enum_value = property->payload.enum_info->values.getptr(p_enumeration);
+	const int64_t *enum_value = member->payload.enum_info->values.getptr(p_enumeration);
 	if (!enum_value) {
 		return -1;
 	}
@@ -1756,8 +1756,8 @@ int Variant::get_enum_value(Variant::Type p_type, const StringName &p_enum_name,
 
 bool Variant::has_enum(Variant::Type p_type, const StringName &p_enum_name) {
 	ERR_FAIL_INDEX_V(p_type, Variant::VARIANT_MAX, false);
-	const GDType::Property *property = _get_gdtype_for_type(p_type).get_property_map().getptr(p_enum_name);
-	return property && property->type == GDType::Property::Type::ENUM;
+	const GDType::Member *member = _get_gdtype_for_type(p_type).members().getptr(p_enum_name);
+	return member && member->type == GDType::Member::Type::ENUM;
 }
 
 StringName Variant::get_enum_for_enumeration(Variant::Type p_type, const StringName &p_enumeration) {

--- a/editor/inspector/property_selector.cpp
+++ b/editor/inspector/property_selector.cpp
@@ -190,11 +190,11 @@ void PropertySelector::_update_search() {
 
 			// Skip getters and setters of properties because users will usually use the property instead.
 			HashSet<StringName> methods_to_skip;
-			for (const KeyValue<StringName, GDType::Property> &kv : ClassDB::get_gdtype(base_type)->get_property_map()) {
-				if (kv.value.type != GDType::Property::Type::SETGET) {
+			for (const KeyValue<StringName, GDType::Member> &kv : ClassDB::get_gdtype(base_type)->members()) {
+				if (kv.value.type != GDType::Member::Type::PROPERTY) {
 					continue; // Not relevant.
 				}
-				const GDType::Property::SetGet &psg = kv.value.payload.setget;
+				const GDType::Member::Property &psg = kv.value.payload.property;
 				if (psg.index != -1 || (psg.property_info->usage & PROPERTY_USAGE_INTERNAL)) {
 					continue; // Not exposed.
 				}

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1482,11 +1482,11 @@ static void _find_identifiers_in_base(const GDScriptCompletionIdentifier &p_base
 
 				// Skip getters and setters of properties because users will usually use the property instead.
 				HashSet<StringName> methods_to_skip;
-				for (const KeyValue<StringName, GDType::Property> &kv : ClassDB::get_gdtype(type)->get_property_map()) {
-					if (kv.value.type != GDType::Property::Type::SETGET) {
+				for (const KeyValue<StringName, GDType::Member> &kv : ClassDB::get_gdtype(type)->members()) {
+					if (kv.value.type != GDType::Member::Type::PROPERTY) {
 						continue; // Not relevant.
 					}
-					const GDType::Property::SetGet &psg = kv.value.payload.setget;
+					const GDType::Member::Property &psg = kv.value.payload.property;
 					if (psg.index != -1 || (psg.property_info->usage & PROPERTY_USAGE_INTERNAL)) {
 						continue; // Not exposed.
 					}

--- a/modules/mono/class_db_api_json.cpp
+++ b/modules/mono/class_db_api_json.cpp
@@ -58,8 +58,8 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 			List<StringName> snames;
 
-			for (const KeyValue<StringName, GDType::Property> &F : t->gdtype->get_property_map(true)) {
-				if (F.value.type != GDType::Property::Type::METHOD) {
+			for (const KeyValue<StringName, GDType::Member> &F : t->gdtype->members(true)) {
+				if (F.value.type != GDType::Member::Type::METHOD) {
 					continue;
 				}
 				String name = F.key.string();
@@ -81,7 +81,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 				Dictionary method_dict;
 				methods.push_back(method_dict);
 
-				const MethodBind *mb = t->gdtype->get_property_map(true)[F].payload.method;
+				const MethodBind *mb = t->gdtype->members(true)[F].payload.method;
 				method_dict["name"] = mb->get_name();
 				method_dict["argument_count"] = mb->get_argument_count();
 				method_dict["return_type"] = mb->get_argument_type(-1);
@@ -124,8 +124,8 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 			List<StringName> snames;
 
-			for (const KeyValue<StringName, GDType::Property> &F : t->gdtype->get_property_map(true)) {
-				if (F.value.type != GDType::Property::Type::INTEGER_CONSTANT) {
+			for (const KeyValue<StringName, GDType::Member> &F : t->gdtype->members(true)) {
+				if (F.value.type != GDType::Member::Type::INTEGER_CONSTANT) {
 					continue;
 				}
 				snames.push_back(F.key);
@@ -140,7 +140,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 				constants.push_back(constant_dict);
 
 				constant_dict["name"] = F;
-				constant_dict["value"] = t->gdtype->get_property_map(true)[F].payload.integer_constant.value;
+				constant_dict["value"] = t->gdtype->members(true)[F].payload.integer_constant.value;
 			}
 
 			if (!constants.is_empty()) {
@@ -152,8 +152,8 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 			List<StringName> snames;
 
-			for (const KeyValue<StringName, GDType::Property> &F : t->gdtype->get_property_map(true)) {
-				if (F.value.type != GDType::Property::Type::SIGNAL) {
+			for (const KeyValue<StringName, GDType::Member> &F : t->gdtype->members(true)) {
+				if (F.value.type != GDType::Member::Type::SIGNAL) {
 					continue;
 				}
 				snames.push_back(F.key);
@@ -167,7 +167,7 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 				Dictionary signal_dict;
 				signals.push_back(signal_dict);
 
-				const MethodInfo &mi = *t->gdtype->get_property_map(true)[F].payload.signal;
+				const MethodInfo &mi = *t->gdtype->members(true)[F].payload.signal;
 				signal_dict["name"] = F;
 
 				Array arguments;
@@ -188,8 +188,8 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 
 			List<StringName> snames;
 
-			for (const KeyValue<StringName, GDType::Property> &kv : t->gdtype->get_property_map(true)) {
-				if (kv.value.type == GDType::Property::Type::SETGET) {
+			for (const KeyValue<StringName, GDType::Member> &kv : t->gdtype->members(true)) {
+				if (kv.value.type == GDType::Member::Type::PROPERTY) {
 					snames.push_back(kv.key);
 				}
 			}
@@ -201,8 +201,8 @@ void class_db_api_to_json(const String &p_output_file, ClassDB::APIType p_api) {
 				Dictionary property_dict;
 				properties.push_back(property_dict);
 
-				const GDType::Property &property = t->gdtype->get_property_map(true)[F];
-				const GDType::Property::SetGet &psg = property.payload.setget;
+				const GDType::Member &property = t->gdtype->members(true)[F];
+				const GDType::Member::Property &psg = property.payload.property;
 
 				property_dict["name"] = F;
 				property_dict["setter"] = psg.setter;

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -4234,10 +4234,10 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 
 		// Populate signals
 
-		const AHashMap<StringName, GDType::Property> &property_map = class_info->gdtype->get_property_map(true);
+		const AHashMap<StringName, GDType::Member> &member_map = class_info->gdtype->members(true);
 
-		for (const KeyValue<StringName, GDType::Property> &E : property_map) {
-			if (E.value.type != GDType::Property::Type::SIGNAL) {
+		for (const KeyValue<StringName, GDType::Member> &E : member_map) {
+			if (E.value.type != GDType::Member::Type::SIGNAL) {
 				continue;
 			}
 			SignalInterface isignal;
@@ -4333,8 +4333,8 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 		List<String> constants;
 		ClassDB::get_integer_constant_list(type_cname, &constants, true);
 
-		for (const KeyValue<StringName, GDType::Property> &kv : property_map) {
-			if (kv.value.type != GDType::Property::Type::ENUM) {
+		for (const KeyValue<StringName, GDType::Member> &kv : member_map) {
+			if (kv.value.type != GDType::Member::Type::ENUM) {
 				continue;
 			}
 			StringName enum_proxy_cname = kv.key;
@@ -4392,9 +4392,9 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 		}
 
 		for (const String &constant_name : constants) {
-			const GDType::Property *property = class_info->gdtype->get_property_map(true).getptr(StringName(constant_name));
-			ERR_FAIL_NULL_V(property, false);
-			int64_t value = property->payload.integer_constant.value;
+			const GDType::Member *member = class_info->gdtype->members(true).getptr(StringName(constant_name));
+			ERR_FAIL_NULL_V(member, false);
+			int64_t value = member->payload.integer_constant.value;
 
 			String constant_proxy_name = snake_to_pascal_case(constant_name, true);
 

--- a/tests/core/object/test_class_db.cpp
+++ b/tests/core/object/test_class_db.cpp
@@ -711,10 +711,10 @@ void add_exposed_classes(Context &r_context) {
 
 		// Add signals
 
-		const AHashMap<StringName, GDType::Property> &property_map = class_info->gdtype->get_property_map(true);
+		const AHashMap<StringName, GDType::Member> &property_map = class_info->gdtype->members(true);
 
-		for (const KeyValue<StringName, GDType::Property> &K : property_map) {
-			if (K.value.type != GDType::Property::Type::SIGNAL) {
+		for (const KeyValue<StringName, GDType::Member> &K : property_map) {
+			if (K.value.type != GDType::Member::Type::SIGNAL) {
 				continue;
 			}
 			SignalData signal;
@@ -767,8 +767,8 @@ void add_exposed_classes(Context &r_context) {
 		List<String> constants;
 		ClassDB::get_integer_constant_list(class_name, &constants, true);
 
-		for (const KeyValue<StringName, GDType::Property> &kv_enum : property_map) {
-			if (kv_enum.value.type != GDType::Property::Type::ENUM) {
+		for (const KeyValue<StringName, GDType::Member> &kv_enum : property_map) {
+			if (kv_enum.value.type != GDType::Member::Type::ENUM) {
 				continue;
 			}
 			EnumData enum_;
@@ -779,14 +779,14 @@ void add_exposed_classes(Context &r_context) {
 				TEST_FAIL_COND(String(constant_name).contains("::"),
 						"Enum constant contains '::', check bindings to remove the scope: '",
 						String(class_name), ".", String(enum_.name), ".", String(constant_name), "'.");
-				const GDType::Property *constant_property = property_map.getptr(constant_name);
-				TEST_FAIL_COND(!constant_property, "Missing enum constant value: '",
+				const GDType::Member *constant_member = property_map.getptr(constant_name);
+				TEST_FAIL_COND(!constant_member, "Missing enum constant value: '",
 						String(class_name), ".", String(enum_.name), ".", String(constant_name), "'.");
 				constants.erase(constant_name);
 
 				ConstantData constant;
 				constant.name = constant_name;
-				constant.value = constant_property->payload.integer_constant.value;
+				constant.value = constant_member->payload.integer_constant.value;
 
 				enum_.constants.push_back(constant);
 			}
@@ -801,12 +801,12 @@ void add_exposed_classes(Context &r_context) {
 			TEST_FAIL_COND(constant_name.contains("::"),
 					"Constant contains '::', check bindings to remove the scope: '",
 					String(class_name), ".", constant_name, "'.");
-			const GDType::Property *constant_property = property_map.getptr(constant_name);
-			TEST_FAIL_COND(!constant_property, "Missing constant value: '", String(class_name), ".", String(constant_name), "'.");
+			const GDType::Member *constant_member = property_map.getptr(constant_name);
+			TEST_FAIL_COND(!constant_member, "Missing constant value: '", String(class_name), ".", String(constant_name), "'.");
 
 			ConstantData constant;
 			constant.name = constant_name;
-			constant.value = constant_property->payload.integer_constant.value;
+			constant.value = constant_member->payload.integer_constant.value;
 
 			exposed_class.constants.push_back(constant);
 		}

--- a/tests/core/object/test_method_bind.cpp
+++ b/tests/core/object/test_method_bind.cpp
@@ -221,7 +221,7 @@ TEST_CASE("[MethodBind] check all method binds") {
 }
 
 TEST_CASE("[MethodBind] check bound enums") {
-	const AHashMap<StringName, GDType::Property> &property_map = MethodBindTester::get_gdtype_static().get_property_map();
+	const AHashMap<StringName, GDType::Member> &property_map = MethodBindTester::get_gdtype_static().members();
 
 #define BOUND_ENUM_LOOP(m_info, m_value, m_name) \
 	CHECK(m_info->values.has(#m_name)); \
@@ -229,10 +229,10 @@ TEST_CASE("[MethodBind] check bound enums") {
 		CHECK(static_cast<int64_t>(m_value) == m_info->values[#m_name]); \
 	}
 
-	const GDType::Property *property = property_map.getptr("Test");
-	CHECK(property);
-	CHECK(property->type == GDType::Property::Type::ENUM);
-	const GDType::EnumInfo *enum_info_test = property->payload.enum_info;
+	const GDType::Member *member = property_map.getptr("Test");
+	CHECK(member);
+	CHECK(member->type == GDType::Member::Type::ENUM);
+	const GDType::EnumInfo *enum_info_test = member->payload.enum_info;
 	if (enum_info_test) {
 		BOUND_ENUM_LOOP(enum_info_test, MethodBindTester::TEST_METHOD, TEST_METHOD)
 		BOUND_ENUM_LOOP(enum_info_test, MethodBindTester::TEST_METHOD_ARGS, TEST_METHOD_ARGS)
@@ -247,9 +247,9 @@ TEST_CASE("[MethodBind] check bound enums") {
 		BOUND_ENUM_LOOP(enum_info_test, MethodBindTester::TEST_MAX, TEST_MAX)
 	}
 
-	const GDType::Property *property_scoped = property_map.getptr("TestScoped");
+	const GDType::Member *property_scoped = property_map.getptr("TestScoped");
 	CHECK(property_scoped);
-	CHECK(property_scoped->type == GDType::Property::Type::ENUM);
+	CHECK(property_scoped->type == GDType::Member::Type::ENUM);
 	const GDType::EnumInfo *enum_info_test_scoped = property_scoped->payload.enum_info;
 	if (enum_info_test_scoped) {
 		BOUND_ENUM_LOOP(enum_info_test_scoped, MethodBindTester::TestScoped::METHOD, TEST_SCOPED_METHOD)


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Follow-up of https://github.com/godotengine/godot/pull/122596
- Follow-up of https://github.com/godotengine/godot/pull/122751

`GDType` so far has been adopting the name "property" for all its members. This is terminologically incorrect: "property" is what we call a stored field, and "member" is anything that can be accessed with dot notation.

To remedy this, this PR renames `GDType::Property` to `GDType::Member`, and `GDType::Property::SetGet` to `GDType::Member::Property`, which matches the expected terminology better.

## Additional information

No behavior change expected.