### PR TITLE
Initialize area light fallback values to vec3 since that is what they are in the user shader

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -1624,8 +1624,8 @@ void light_compute(vec3 N, vec3 L, vec3 V, float A, vec3 light_color, bool is_di
 	vec3 light = L;
 	vec3 view = V;
 	bool is_area = false;
-	float area_diffuse = 1.0;
-	float area_specular = 1.0;
+	vec3 area_diffuse = 1.0;
+	vec3 area_specular = 1.0;
 	vec3 area_diffuse_tex_color = vec3(1.0);
 	vec3 area_specular_tex_color = vec3(1.0);
 

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -163,8 +163,8 @@ void light_compute(hvec3 N, hvec3 L, hvec3 V, half A, hvec3 light_color, bool is
 	vec3 diffuse_light_highp = vec3(diffuse_light);
 	vec3 specular_light_highp = vec3(specular_light);
 	bool is_area = false;
-	float area_diffuse = 1.0;
-	float area_specular = 1.0;
+	vec3 area_diffuse = 1.0;
+	vec3 area_specular = 1.0;
 	vec3 area_diffuse_tex_color = vec3(1.0);
 	vec3 area_specular_tex_color = vec3(1.0);
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/122862

These defines only exist for compatibility reasons since the same user-light shader code runs for area lights and normal lights. At some point `area_diffuse` and `area_specular` were switched to `vec3`s in the area light function, but not here. They need to be `vec3`s everywhere or else the shader won't compile