### PR TITLE
Add `long_press` property to InputEventScreenTouch

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1384,6 +1384,14 @@ bool InputEventScreenTouch::is_double_tap() const {
 	return double_tap;
 }
 
+void InputEventScreenTouch::set_long_press(bool p_long_press) {
+	long_press = p_long_press;
+}
+
+bool InputEventScreenTouch::is_long_press() const {
+	return long_press;
+}
+
 RequiredResult<InputEvent> InputEventScreenTouch::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
 	Ref<InputEventScreenTouch> st;
 	st.instantiate();
@@ -1394,6 +1402,7 @@ RequiredResult<InputEvent> InputEventScreenTouch::xformed_by(const Transform2D &
 	st->set_pressed(pressed);
 	st->set_canceled(canceled);
 	st->set_double_tap(double_tap);
+	st->set_long_press(long_press);
 
 	st->merge_meta_from(this);
 
@@ -1410,7 +1419,8 @@ String InputEventScreenTouch::_to_string() {
 	String p = pressed ? "true" : "false";
 	String canceled_state = canceled ? "true" : "false";
 	String double_tap_string = double_tap ? "true" : "false";
-	return vformat("InputEventScreenTouch: index=%d, pressed=%s, canceled=%s, position=(%s), double_tap=%s", index, p, canceled_state, String(get_position()), double_tap_string);
+	String long_press_string = long_press ? "true" : "false";
+	return vformat("InputEventScreenTouch: index=%d, pressed=%s, canceled=%s, position=(%s), double_tap=%s long_press=%s", index, p, canceled_state, String(get_position()), double_tap_string, long_press_string);
 }
 
 void InputEventScreenTouch::_bind_methods() {
@@ -1426,11 +1436,15 @@ void InputEventScreenTouch::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_double_tap", "double_tap"), &InputEventScreenTouch::set_double_tap);
 	ClassDB::bind_method(D_METHOD("is_double_tap"), &InputEventScreenTouch::is_double_tap);
 
+	ClassDB::bind_method(D_METHOD("set_long_press", "long_press"), &InputEventScreenTouch::set_long_press);
+	ClassDB::bind_method(D_METHOD("is_long_press"), &InputEventScreenTouch::is_long_press);
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "index"), "set_index", "get_index");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position", PROPERTY_HINT_NONE, "suffix:px"), "set_position", "get_position");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "canceled"), "set_canceled", "is_canceled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "double_tap"), "set_double_tap", "is_double_tap");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "long_press"), "set_long_press", "is_long_press");
 }
 
 ///////////////////////////////////

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -374,6 +374,7 @@ class InputEventScreenTouch : public InputEventFromWindow {
 	int index = 0;
 	Vector2 pos;
 	bool double_tap = false;
+	bool long_press = false;
 
 protected:
 	static void _bind_methods();
@@ -390,6 +391,9 @@ public:
 
 	void set_double_tap(bool p_double_tap);
 	bool is_double_tap() const;
+
+	void set_long_press(bool p_double_tap);
+	bool is_long_press() const;
 
 	virtual RequiredResult<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 	virtual String as_text() const override;

--- a/doc/classes/InputEventScreenTouch.xml
+++ b/doc/classes/InputEventScreenTouch.xml
@@ -19,6 +19,10 @@
 		<member name="index" type="int" setter="set_index" getter="get_index" default="0">
 			The touch index in the case of a multi-touch event. One index = one finger.
 		</member>
+		<member name="long_press" type="bool" setter="set_long_press" getter="is_long_press" default="false">
+			If [code]true[/code], the touch's state is a long press.
+			[b]Note:[/b] This is only supported on Android.
+		</member>
 		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
 			The touch position in the viewport the node is in, using the coordinate system of this viewport.
 		</member>

--- a/doc/classes/InputEventScreenTouch.xml
+++ b/doc/classes/InputEventScreenTouch.xml
@@ -21,7 +21,7 @@
 		</member>
 		<member name="long_press" type="bool" setter="set_long_press" getter="is_long_press" default="false">
 			If [code]true[/code], the touch's state is a long press.
-			[b]Note:[/b] This is only supported on Android.
+			[b]Note:[/b] This is only supported on Android and iOS.
 		</member>
 		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
 			The touch position in the viewport the node is in, using the coordinate system of this viewport.

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1698,8 +1698,9 @@
 		<member name="input_devices/pointing/android/disable_scroll_deadzone" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], disables the scroll deadzone on Android, allowing even very small scroll movements to be registered. This may increase scroll sensitivity but can also lead to unintended scrolling from slight finger movements.
 		</member>
-		<member name="input_devices/pointing/android/enable_long_press_as_right_click" type="bool" setter="" getter="" default="false">
+		<member name="input_devices/pointing/android/enable_long_press_as_right_click" type="bool" setter="" getter="" default="false" deprecated="Use [member InputEventScreenTouch.long_press] instead.">
 			If [code]true[/code], long press events on an Android touchscreen are transformed into right click events.
+			[b]Note:[/b] Some control nodes might ignore this event, use [member InputEventScreenTouch.long_press] instead.
 		</member>
 		<member name="input_devices/pointing/android/enable_pan_and_scale_gestures" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], multi-touch pan and scale gestures are enabled on Android devices.

--- a/drivers/apple_embedded/display_server_apple_embedded.h
+++ b/drivers/apple_embedded/display_server_apple_embedded.h
@@ -131,7 +131,7 @@ public:
 
 	// MARK: Touches and Apple Pencil
 
-	void touch_press(int p_idx, int p_x, int p_y, bool p_pressed, bool p_double_click);
+	void touch_press(int p_idx, int p_x, int p_y, bool p_pressed, bool p_double_click, bool p_long_press);
 	void touch_drag(int p_idx, int p_prev_x, int p_prev_y, int p_x, int p_y, float p_pressure, Vector2 p_tilt);
 	void touches_canceled(int p_idx);
 

--- a/drivers/apple_embedded/display_server_apple_embedded.mm
+++ b/drivers/apple_embedded/display_server_apple_embedded.mm
@@ -269,7 +269,7 @@ void DisplayServerAppleEmbedded::_window_callback(const Callable &p_callable, co
 
 // MARK: Touches
 
-void DisplayServerAppleEmbedded::touch_press(int p_idx, int p_x, int p_y, bool p_pressed, bool p_double_click) {
+void DisplayServerAppleEmbedded::touch_press(int p_idx, int p_x, int p_y, bool p_pressed, bool p_double_click, bool p_long_press) {
 	Ref<InputEventScreenTouch> ev;
 	ev.instantiate();
 
@@ -277,6 +277,7 @@ void DisplayServerAppleEmbedded::touch_press(int p_idx, int p_x, int p_y, bool p
 	ev->set_pressed(p_pressed);
 	ev->set_position(Vector2(p_x, p_y));
 	ev->set_double_tap(p_double_click);
+	ev->set_long_press(p_long_press);
 	perform_event(ev);
 }
 
@@ -302,7 +303,7 @@ void DisplayServerAppleEmbedded::perform_event(const Ref<InputEvent> &p_event) {
 }
 
 void DisplayServerAppleEmbedded::touches_canceled(int p_idx) {
-	touch_press(p_idx, -1, -1, false, false);
+	touch_press(p_idx, -1, -1, false, false, false);
 }
 
 // MARK: Keyboard

--- a/drivers/apple_embedded/godot_view_apple_embedded.mm
+++ b/drivers/apple_embedded/godot_view_apple_embedded.mm
@@ -45,6 +45,8 @@ static const float earth_gravity = 9.80665;
 @interface GDTView () {
 	UITouch *godot_touches[max_touches];
 	CGFloat last_edr_headroom;
+	NSTimeInterval begin_timestamp[max_touches];
+	CGPoint begin_delta[max_touches];
 }
 
 @property(assign, nonatomic) BOOL isActive;
@@ -358,7 +360,9 @@ static const float earth_gravity = 9.80665;
 		int tid = [self getTouchIDForTouch:touch];
 		ERR_FAIL_COND(tid == -1);
 		CGPoint touchPoint = [touch locationInView:self];
-		DisplayServerAppleEmbedded::get_singleton()->touch_press(tid, touchPoint.x * self.contentScaleFactor, touchPoint.y * self.contentScaleFactor, true, touch.tapCount > 1);
+		begin_timestamp[tid] = [touch timestamp];
+		begin_delta[tid] = CGPointMake(0, 0);
+		DisplayServerAppleEmbedded::get_singleton()->touch_press(tid, touchPoint.x * self.contentScaleFactor, touchPoint.y * self.contentScaleFactor, true, touch.tapCount > 1, false);
 	}
 }
 
@@ -368,6 +372,17 @@ static const float earth_gravity = 9.80665;
 		ERR_FAIL_COND(tid == -1);
 		CGPoint touchPoint = [touch locationInView:self];
 		CGPoint prev_point = [touch previousLocationInView:self];
+		if (begin_timestamp[tid] != 0.0) {
+			begin_delta[tid].x = fmax(begin_delta[tid].x, Math::abs(touchPoint.x - prev_point.x));
+			begin_delta[tid].y = fmax(begin_delta[tid].y, Math::abs(touchPoint.y - prev_point.y));
+			if ([touch timestamp] - begin_timestamp[tid] >= 0.5) {
+				begin_timestamp[tid] = 0.0;
+				if (begin_delta[tid].x <= 10.0 && begin_delta[tid].y <= 10.0) {
+					DisplayServerAppleEmbedded::get_singleton()->touch_press(tid, touchPoint.x * self.contentScaleFactor, touchPoint.y * self.contentScaleFactor, true, touch.tapCount > 1, true);
+					return;
+				}
+			}
+		}
 		CGFloat alt = [touch altitudeAngle];
 		CGVector azim = [touch azimuthUnitVectorInView:self];
 		DisplayServerAppleEmbedded::get_singleton()->touch_drag(tid, prev_point.x * self.contentScaleFactor, prev_point.y * self.contentScaleFactor, touchPoint.x * self.contentScaleFactor, touchPoint.y * self.contentScaleFactor, [touch force] / [touch maximumPossibleForce], Vector2(azim.dx, azim.dy) * Math::cos(alt));
@@ -380,7 +395,7 @@ static const float earth_gravity = 9.80665;
 		ERR_FAIL_COND(tid == -1);
 		[self removeTouch:touch];
 		CGPoint touchPoint = [touch locationInView:self];
-		DisplayServerAppleEmbedded::get_singleton()->touch_press(tid, touchPoint.x * self.contentScaleFactor, touchPoint.y * self.contentScaleFactor, false, false);
+		DisplayServerAppleEmbedded::get_singleton()->touch_press(tid, touchPoint.x * self.contentScaleFactor, touchPoint.y * self.contentScaleFactor, false, false, false);
 	}
 }
 

--- a/platform/android/android_input_handler.cpp
+++ b/platform/android/android_input_handler.cpp
@@ -264,13 +264,13 @@ void AndroidInputHandler::process_touch_event(int p_event, int p_pointer, const 
 	}
 }
 
-void AndroidInputHandler::_cancel_mouse_event_info(bool p_source_mouse_relative) {
+void AndroidInputHandler::_cancel_mouse_event_info(bool p_source_mouse_relative, bool p_emulated) {
 	buttons_state = BitField<MouseButtonMask>();
-	_parse_mouse_event_info(BitField<MouseButtonMask>(), false, true, false, p_source_mouse_relative);
+	_parse_mouse_event_info(BitField<MouseButtonMask>(), false, true, false, p_source_mouse_relative, p_emulated);
 	mouse_event_info.valid = false;
 }
 
-void AndroidInputHandler::_parse_mouse_event_info(BitField<MouseButtonMask> event_buttons_mask, bool p_pressed, bool p_canceled, bool p_double_click, bool p_source_mouse_relative) {
+void AndroidInputHandler::_parse_mouse_event_info(BitField<MouseButtonMask> event_buttons_mask, bool p_pressed, bool p_canceled, bool p_double_click, bool p_source_mouse_relative, bool p_emulated) {
 	if (!mouse_event_info.valid) {
 		return;
 	}
@@ -295,15 +295,18 @@ void AndroidInputHandler::_parse_mouse_event_info(BitField<MouseButtonMask> even
 	ev->set_button_index(_button_index_from_mask(changed_button_mask));
 	ev->set_button_mask(event_buttons_mask);
 	ev->set_double_click(p_double_click);
+	if (p_emulated) {
+		ev->set_device(InputEvent::DEVICE_ID_EMULATION);
+	}
 	Input::get_singleton()->parse_input_event(ev);
 }
 
-void AndroidInputHandler::_release_mouse_event_info(bool p_source_mouse_relative) {
-	_parse_mouse_event_info(BitField<MouseButtonMask>(), false, false, false, p_source_mouse_relative);
+void AndroidInputHandler::_release_mouse_event_info(bool p_source_mouse_relative, bool p_emulated) {
+	_parse_mouse_event_info(BitField<MouseButtonMask>(), false, false, false, p_source_mouse_relative, p_emulated);
 	mouse_event_info.valid = false;
 }
 
-void AndroidInputHandler::process_mouse_event(int p_event_action, int p_event_android_buttons_mask, Point2 p_event_pos, Vector2 p_delta, bool p_double_click, bool p_source_mouse_relative, float p_pressure, Vector2 p_tilt) {
+void AndroidInputHandler::process_mouse_event(int p_event_action, int p_event_android_buttons_mask, Point2 p_event_pos, Vector2 p_delta, bool p_double_click, bool p_source_mouse_relative, float p_pressure, Vector2 p_tilt, bool p_emulated) {
 	BitField<MouseButtonMask> event_buttons_mask = _android_button_mask_to_godot_button_mask(p_event_android_buttons_mask);
 	switch (p_event_action) {
 		case AMOTION_EVENT_ACTION_HOVER_MOVE: // hover move
@@ -317,6 +320,9 @@ void AndroidInputHandler::process_mouse_event(int p_event_action, int p_event_an
 			ev->set_global_position(p_event_pos);
 			ev->set_relative(p_event_pos - hover_prev_pos);
 			ev->set_relative_screen_position(ev->get_relative());
+			if (p_emulated) {
+				ev->set_device(InputEvent::DEVICE_ID_EMULATION);
+			}
 			Input::get_singleton()->parse_input_event(ev);
 			hover_prev_pos = p_event_pos;
 		} break;
@@ -325,20 +331,24 @@ void AndroidInputHandler::process_mouse_event(int p_event_action, int p_event_an
 		case AMOTION_EVENT_ACTION_BUTTON_PRESS: {
 			// Release any remaining touches or mouse event
 			_release_mouse_event_info();
-			_release_all_touch();
+			if (!p_emulated) {
+				// In case of emulation, preserve touch state so one can ignore the emulated mouse event and continue interacting via touch.
+				// p_emulated = true, is set only for emulated right clicks.
+				_release_all_touch();
+			}
 
 			mouse_event_info.valid = true;
 			mouse_event_info.pos = p_event_pos;
-			_parse_mouse_event_info(event_buttons_mask, true, false, p_double_click, p_source_mouse_relative);
+			_parse_mouse_event_info(event_buttons_mask, true, false, p_double_click, p_source_mouse_relative, p_emulated);
 		} break;
 
 		case AMOTION_EVENT_ACTION_CANCEL: {
-			_cancel_mouse_event_info(p_source_mouse_relative);
+			_cancel_mouse_event_info(p_source_mouse_relative, p_emulated);
 		} break;
 
 		case AMOTION_EVENT_ACTION_UP:
 		case AMOTION_EVENT_ACTION_BUTTON_RELEASE: {
-			_release_mouse_event_info(p_source_mouse_relative);
+			_release_mouse_event_info(p_source_mouse_relative, p_emulated);
 		} break;
 
 		case AMOTION_EVENT_ACTION_MOVE: {
@@ -365,6 +375,9 @@ void AndroidInputHandler::process_mouse_event(int p_event_action, int p_event_an
 			ev->set_button_mask(event_buttons_mask);
 			ev->set_pressure(p_pressure);
 			ev->set_tilt(p_tilt);
+			if (p_emulated) {
+				ev->set_device(InputEvent::DEVICE_ID_EMULATION);
+			}
 			Input::get_singleton()->parse_input_event(ev);
 		} break;
 
@@ -380,6 +393,9 @@ void AndroidInputHandler::process_mouse_event(int p_event_action, int p_event_an
 				ev->set_global_position(p_event_pos);
 			}
 			ev->set_pressed(true);
+			if (p_emulated) {
+				ev->set_device(InputEvent::DEVICE_ID_EMULATION);
+			}
 			buttons_state = event_buttons_mask;
 			if (p_delta.y > 0) {
 				_wheel_button_click(event_buttons_mask, ev, MouseButton::WHEEL_UP, p_delta.y);

--- a/platform/android/android_input_handler.cpp
+++ b/platform/android/android_input_handler.cpp
@@ -157,6 +157,7 @@ void AndroidInputHandler::_parse_all_touch(bool p_pressed, bool p_canceled) {
 			ev->set_canceled(p_canceled);
 			ev->set_position(touch[i].pos);
 			ev->set_double_tap(touch[i].double_tap);
+			ev->set_long_press(touch[i].long_press);
 			Input::get_singleton()->parse_input_event(ev);
 		}
 	}
@@ -181,6 +182,7 @@ void AndroidInputHandler::process_touch_event(int p_event, int p_pointer, const 
 				touch.write[i].pressure = p_points[i].pressure;
 				touch.write[i].tilt = p_points[i].tilt;
 				touch.write[i].double_tap = p_points[i].double_tap;
+				touch.write[i].long_press = p_points[i].long_press;
 			}
 
 			//send touch

--- a/platform/android/android_input_handler.h
+++ b/platform/android/android_input_handler.h
@@ -44,6 +44,7 @@ public:
 		float pressure = 0;
 		Vector2 tilt;
 		bool double_tap = false;
+		bool long_press = false;
 	};
 
 	struct MouseEventInfo {

--- a/platform/android/android_input_handler.h
+++ b/platform/android/android_input_handler.h
@@ -86,11 +86,11 @@ private:
 
 	void _wheel_button_click(BitField<MouseButtonMask> event_buttons_mask, const Ref<InputEventMouseButton> &ev, MouseButton wheel_button, float factor);
 
-	void _parse_mouse_event_info(BitField<MouseButtonMask> event_buttons_mask, bool p_pressed, bool p_canceled, bool p_double_click, bool p_source_mouse_relative);
+	void _parse_mouse_event_info(BitField<MouseButtonMask> event_buttons_mask, bool p_pressed, bool p_canceled, bool p_double_click, bool p_source_mouse_relative, bool p_emulated);
 
-	void _release_mouse_event_info(bool p_source_mouse_relative = false);
+	void _release_mouse_event_info(bool p_source_mouse_relative = false, bool emulated = false);
 
-	void _cancel_mouse_event_info(bool p_source_mouse_relative = false);
+	void _cancel_mouse_event_info(bool p_source_mouse_relative = false, bool emulated = false);
 
 	void _parse_all_touch(bool p_pressed, bool p_canceled = false);
 
@@ -99,7 +99,7 @@ private:
 	void _cancel_all_touch();
 
 public:
-	void process_mouse_event(int p_event_action, int p_event_android_buttons_mask, Point2 p_event_pos, Vector2 p_delta, bool p_double_click, bool p_source_mouse_relative, float p_pressure, Vector2 p_tilt);
+	void process_mouse_event(int p_event_action, int p_event_android_buttons_mask, Point2 p_event_pos, Vector2 p_delta, bool p_double_click, bool p_source_mouse_relative, float p_pressure, Vector2 p_tilt, bool p_emulated);
 	void process_touch_event(int p_event, int p_pointer, const Vector<TouchPos> &p_points);
 	void process_magnify(Point2 p_pos, float p_factor);
 	void process_pan(Point2 p_pos, Vector2 p_delta);

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -468,7 +468,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 
 	override fun onGodotSetupCompleted() {
 		super.onGodotSetupCompleted()
-		val longPressEnabled = enableLongPressGestures()
+		val rightClickEmulationEnabled = enableRightClickEmulation()
 		val panScaleEnabled = enablePanAndScaleGestures()
 		val overrideVolumeButtonsEnabled = overrideVolumeButtons()
 		val hapticEnabled = enableHapticOnLongPress()
@@ -476,7 +476,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 		runOnUiThread {
 			// Enable long press, panning and scaling gestures
 			godotFragment?.godot?.renderView?.inputHandler?.apply {
-				enableLongPress(longPressEnabled)
+				enableRightClickEmulation(rightClickEmulationEnabled)
 				enablePanningAndScalingGestures(panScaleEnabled)
 				setOverrideVolumeButtons(overrideVolumeButtonsEnabled)
 				enableHapticFeedback(hapticEnabled)
@@ -755,7 +755,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 	/**
 	 * Enable long press gestures for the Godot Android editor.
 	 */
-	protected open fun enableLongPressGestures() =
+	protected open fun enableRightClickEmulation() =
 		java.lang.Boolean.parseBoolean(GodotLib.getEditorSetting("interface/touchscreen/enable_long_press_as_right_click"))
 
 	/**

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotGame.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotGame.kt
@@ -50,7 +50,7 @@ abstract class BaseGodotGame: GodotEditor() {
 
 	override fun overrideVolumeButtons() = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/override_volume_buttons"))
 
-	override fun enableLongPressGestures() = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_long_press_as_right_click"))
+	override fun enableRightClickEmulation() = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_long_press_as_right_click"))
 
 	override fun enablePanAndScaleGestures() = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_pan_and_scale_gestures"))
 

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
@@ -830,7 +830,7 @@ class Godot private constructor(val context: Context) {
 		Log.v(TAG, "OnGodotSetupCompleted")
 
 		// These properties are defined after Godot setup completion, so we retrieve them here.
-		val longPressEnabled = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_long_press_as_right_click"))
+		val rightClickEmulataionEnabled = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_long_press_as_right_click"))
 		val panScaleEnabled = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_pan_and_scale_gestures"))
 		val rotaryInputAxisValue = GodotLib.getGlobal("input_devices/pointing/android/rotary_input_scroll_axis")
 		val overrideVolumeButtons = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/override_volume_buttons"))
@@ -838,7 +838,7 @@ class Godot private constructor(val context: Context) {
 
 		runOnHostThread {
 			godotInputHandler.apply {
-				enableLongPress(longPressEnabled)
+				enableRightClickEmulation(rightClickEmulataionEnabled)
 				enablePanningAndScalingGestures(panScaleEnabled)
 				setOverrideVolumeButtons(overrideVolumeButtons)
 				disableScrollDeadzone(scrollDeadzoneDisabled)

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotLib.java
@@ -116,7 +116,7 @@ public class GodotLib {
 	/**
 	 * Dispatch mouse events
 	 */
-	public static native void dispatchMouseEvent(int event, int buttonMask, float x, float y, float deltaX, float deltaY, boolean doubleClick, boolean sourceMouseRelative, float pressure, float tiltX, float tiltY);
+	public static native void dispatchMouseEvent(int event, int buttonMask, float x, float y, float deltaX, float deltaY, boolean doubleClick, boolean sourceMouseRelative, float pressure, float tiltX, float tiltY, boolean emulated);
 
 	public static native void magnify(float x, float y, float factor);
 

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotLib.java
@@ -111,7 +111,7 @@ public class GodotLib {
 	/**
 	 * Forward touch events.
 	 */
-	public static native void dispatchTouchEvent(int event, int pointer, int pointerCount, float[] positions, boolean doubleTap);
+	public static native void dispatchTouchEvent(int event, int pointer, int pointerCount, float[] positions, boolean doubleTap, boolean longPress);
 
 	/**
 	 * Dispatch mouse events

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotGestureHandler.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotGestureHandler.kt
@@ -59,7 +59,7 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 
 	var scrollDeadzoneDisabled = false
 
-	var longPressEnabled = false
+	var rightClickEmulation = false
 
 	/**
 	 * Enable haptic feedback on long-press right-click
@@ -69,7 +69,8 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 	private var nextDownIsDoubleTap = false
 	private var dragInProgress = false
 	private var scaleInProgress = false
-	private var contextClickInProgress = false
+	private var longPressInProgress = false
+	private var emulatedRightClickInProgress = false
 	private var pointerCaptureInProgress = false
 
 	private var lastDragX: Float = 0.0f
@@ -92,11 +93,11 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 			if (hapticFeedbackEnabled) {
 				inputHandler.performHapticFeedback()
 			}
-			contextClickRouter(event)
+			handleLongPress(event)
 		}
 	}
 
-	private fun contextClickRouter(event: MotionEvent) {
+	private fun handleLongPress(event: MotionEvent) {
 		if (scaleInProgress || nextDownIsDoubleTap) {
 			return
 		}
@@ -104,14 +105,19 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 		// Cancel the previous down event
 		inputHandler.handleMotionEvent(event, MotionEvent.ACTION_CANCEL)
 
-		// Turn a context click into a single tap right mouse button click.
-		inputHandler.handleMouseEvent(
-			event,
-			MotionEvent.ACTION_DOWN,
-			MotionEvent.BUTTON_SECONDARY,
-			false
-		)
-		contextClickInProgress = true
+		inputHandler.handleTouchEvent(event, event.action, false, true)
+		longPressInProgress = true
+
+		if (rightClickEmulation) {
+			// Turn a long press into a single tap right mouse button click.
+			inputHandler.handleMouseEvent(
+				event,
+				MotionEvent.ACTION_DOWN,
+				MotionEvent.BUTTON_SECONDARY,
+				false
+			)
+			emulatedRightClickInProgress = true
+		}
 	}
 
 	fun onPointerCaptureChange(hasCapture: Boolean) {
@@ -144,17 +150,22 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 			return true
 		}
 
-		if (pointerCaptureInProgress || dragInProgress || contextClickInProgress) {
-			if (contextClickInProgress || GodotInputHandler.isMouseEvent(event)) {
+		if (pointerCaptureInProgress || dragInProgress || emulatedRightClickInProgress) {
+			if (GodotInputHandler.isMouseEvent(event)) {
 				// This may be an ACTION_BUTTON_RELEASE event which we don't handle,
 				// so we convert it to an ACTION_UP event.
 				inputHandler.handleMouseEvent(event, MotionEvent.ACTION_UP)
+			} else if (emulatedRightClickInProgress) {
+				inputHandler.handleMouseEvent(event, MotionEvent.ACTION_UP)
+				// Handling both touch and emulated mouse, so one can ignore the emulated mouse event and continue interacting via touch.
+				inputHandler.handleTouchEvent(event)
 			} else {
 				inputHandler.handleTouchEvent(event)
 			}
 			pointerCaptureInProgress = false
 			dragInProgress = false
-			contextClickInProgress = false
+			longPressInProgress = false
+			emulatedRightClickInProgress = false
 			lastDragX = 0.0f
 			lastDragY = 0.0f
 			return true
@@ -164,14 +175,20 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 	}
 
 	private fun onActionMove(event: MotionEvent): Boolean {
-		if (contextClickInProgress) {
+		var emulatedClickHandled = false
+		if (emulatedRightClickInProgress) {
 			inputHandler.handleMouseEvent(event, event.actionMasked, MotionEvent.BUTTON_SECONDARY, false)
-			return true
-		} else if (scrollDeadzoneDisabled && !scaleInProgress) {
+			emulatedClickHandled = true
+		}
+
+		if ((scrollDeadzoneDisabled || longPressInProgress) && !scaleInProgress) {
 			// The 'onScroll' event is triggered with a long delay.
 			// Force the 'InputEventScreenDrag' event earlier here.
 			// We don't toggle 'dragInProgress' here so that the scaling logic can override the drag operation if needed.
 			// Once the 'onScroll' event kicks-in, 'dragInProgress' will be properly set.
+
+			// Long press drag doesn't invoke `onScroll` event, handling it here.
+
 			if (lastDragX != event.getX(0) || lastDragY != event.getY(0)) {
 				lastDragX = event.getX(0)
 				lastDragY = event.getY(0)
@@ -179,15 +196,15 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 				return true
 			}
 		}
-		return false
+		return emulatedClickHandled
 	}
 
 	override fun onDoubleTapEvent(event: MotionEvent): Boolean {
 		if (event.actionMasked == MotionEvent.ACTION_UP) {
 			nextDownIsDoubleTap = false
 
-			// Long press is restored to its previous value.
-			inputHandler.gestureDetector.setIsLongpressEnabled(longPressEnabled)
+			// Re-enable Long press.
+			inputHandler.gestureDetector.setIsLongpressEnabled(true)
 
 			inputHandler.handleMotionEvent(event, event.actionMasked, true)
 		} else if (event.actionMasked == MotionEvent.ACTION_MOVE && !(scalingEnabled && inputHandler.scaleGestureDetector.isQuickScaleEnabled)) {

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotGestureHandler.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotGestureHandler.kt
@@ -114,7 +114,8 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 				event,
 				MotionEvent.ACTION_DOWN,
 				MotionEvent.BUTTON_SECONDARY,
-				false
+				false,
+				true
 			)
 			emulatedRightClickInProgress = true
 		}
@@ -156,7 +157,7 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 				// so we convert it to an ACTION_UP event.
 				inputHandler.handleMouseEvent(event, MotionEvent.ACTION_UP)
 			} else if (emulatedRightClickInProgress) {
-				inputHandler.handleMouseEvent(event, MotionEvent.ACTION_UP)
+				inputHandler.handleMouseEvent(event, MotionEvent.ACTION_UP, event.buttonState, false, true)
 				// Handling both touch and emulated mouse, so one can ignore the emulated mouse event and continue interacting via touch.
 				inputHandler.handleTouchEvent(event)
 			} else {
@@ -177,7 +178,7 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 	private fun onActionMove(event: MotionEvent): Boolean {
 		var emulatedClickHandled = false
 		if (emulatedRightClickInProgress) {
-			inputHandler.handleMouseEvent(event, event.actionMasked, MotionEvent.BUTTON_SECONDARY, false)
+			inputHandler.handleMouseEvent(event, event.actionMasked, MotionEvent.BUTTON_SECONDARY, false, true)
 			emulatedClickHandled = true
 		}
 

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotInputHandler.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotInputHandler.java
@@ -56,6 +56,7 @@ import android.view.Surface;
 import android.view.WindowManager;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.RestrictTo;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -112,7 +113,7 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 
 		this.godotGestureHandler = new GodotGestureHandler(this);
 		this.gestureDetector = new GestureDetector(context, godotGestureHandler);
-		enableLongPress(false);
+		this.gestureDetector.setIsLongpressEnabled(true);
 
 		this.scaleGestureDetector = new ScaleGestureDetector(context, godotGestureHandler);
 		this.scaleGestureDetector.setStylusScaleEnabled(true);
@@ -125,10 +126,20 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 
 	/**
 	 * Enable long press events. This is false by default.
+	 * @deprecated Long-press is now always enabled. Calling this method has no effect.
 	 */
+	@Deprecated
 	public void enableLongPress(boolean enable) {
-		this.gestureDetector.setIsLongpressEnabled(enable);
-		this.godotGestureHandler.setLongPressEnabled(enable);
+		Log.d(TAG, "This method is no-op. Long-Press is now always enabled.");
+	}
+
+	/**
+	 * Enables or disables right-click emulation.
+	 * <p><b>Internal Use Only:</b> This method is intended solely for internal use and should not be used by external callers.
+	 */
+	@RestrictTo(RestrictTo.Scope.LIBRARY_GROUP)
+	public void enableRightClickEmulation(boolean enable) {
+		this.godotGestureHandler.setRightClickEmulation(enable);
 	}
 
 	/**
@@ -693,10 +704,14 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 	}
 
 	boolean handleTouchEvent(final MotionEvent event, int eventActionOverride) {
-		return handleTouchEvent(event, eventActionOverride, false);
+		return handleTouchEvent(event, eventActionOverride, false, false);
 	}
 
 	boolean handleTouchEvent(final MotionEvent event, int eventActionOverride, boolean doubleTap) {
+		return handleTouchEvent(event, eventActionOverride, doubleTap, false);
+	}
+
+	boolean handleTouchEvent(final MotionEvent event, int eventActionOverride, boolean doubleTap, boolean longPress) {
 		if (event.getPointerCount() == 0) {
 			return true;
 		}
@@ -713,7 +728,7 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 			case MotionEvent.ACTION_MOVE:
 			case MotionEvent.ACTION_POINTER_UP:
 			case MotionEvent.ACTION_POINTER_DOWN: {
-				runnable.setTouchEvent(event, eventActionOverride, doubleTap);
+				runnable.setTouchEvent(event, eventActionOverride, doubleTap, longPress);
 				dispatchInputEventRunnable(runnable);
 				return true;
 			}

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotInputHandler.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotInputHandler.java
@@ -622,10 +622,10 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 	}
 
 	boolean handleMouseEvent(final MotionEvent event, int eventActionOverride, boolean doubleTap) {
-		return handleMouseEvent(event, eventActionOverride, event.getButtonState(), doubleTap);
+		return handleMouseEvent(event, eventActionOverride, event.getButtonState(), doubleTap, false);
 	}
 
-	boolean handleMouseEvent(final MotionEvent event, int eventActionOverride, int buttonMaskOverride, boolean doubleTap) {
+	boolean handleMouseEvent(final MotionEvent event, int eventActionOverride, int buttonMaskOverride, boolean doubleTap, boolean emulated) {
 		final float x = event.getX();
 		final float y = event.getY();
 
@@ -651,14 +651,14 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 		if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
 			sourceMouseRelative = event.isFromSource(InputDevice.SOURCE_MOUSE_RELATIVE);
 		}
-		return handleMouseEvent(eventActionOverride, buttonMaskOverride, x, y, horizontalFactor, verticalFactor, doubleTap, sourceMouseRelative, pressure, getEventTiltX(event), getEventTiltY(event));
+		return handleMouseEvent(eventActionOverride, buttonMaskOverride, x, y, horizontalFactor, verticalFactor, doubleTap, sourceMouseRelative, pressure, getEventTiltX(event), getEventTiltY(event), emulated);
 	}
 
 	boolean handleMouseEvent(int eventAction, boolean sourceMouseRelative) {
-		return handleMouseEvent(eventAction, 0, 0f, 0f, 0f, 0f, false, sourceMouseRelative, 1f, 0f, 0f);
+		return handleMouseEvent(eventAction, 0, 0f, 0f, 0f, 0f, false, sourceMouseRelative, 1f, 0f, 0f, false);
 	}
 
-	boolean handleMouseEvent(int eventAction, int buttonsMask, float x, float y, float deltaX, float deltaY, boolean doubleClick, boolean sourceMouseRelative, float pressure, float tiltX, float tiltY) {
+	boolean handleMouseEvent(int eventAction, int buttonsMask, float x, float y, float deltaX, float deltaY, boolean doubleClick, boolean sourceMouseRelative, float pressure, float tiltX, float tiltY, boolean emulated) {
 		InputEventRunnable runnable = InputEventRunnable.obtain();
 		if (runnable == null) {
 			return false;
@@ -691,7 +691,7 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 			case MotionEvent.ACTION_HOVER_MOVE:
 			case MotionEvent.ACTION_MOVE:
 			case MotionEvent.ACTION_SCROLL: {
-				runnable.setMouseEvent(eventAction, buttonsMask, x, y, deltaX, deltaY, doubleClick, sourceMouseRelative, pressure, tiltX, tiltY);
+				runnable.setMouseEvent(eventAction, buttonsMask, x, y, deltaX, deltaY, doubleClick, sourceMouseRelative, pressure, tiltX, tiltY, emulated);
 				dispatchInputEventRunnable(runnable);
 				return true;
 			}

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/InputEventRunnable.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/InputEventRunnable.java
@@ -128,6 +128,7 @@ final class InputEventRunnable implements Runnable {
 	// common touch / mouse fields
 	private int eventAction;
 	private boolean doubleTap;
+	private boolean longPress;
 
 	// Mouse event fields and setter
 	private int buttonsMask;
@@ -154,10 +155,11 @@ final class InputEventRunnable implements Runnable {
 	private int actionPointerId;
 	private int pointerCount;
 	private final float[] positions = new float[MAX_TOUCH_POINTER_COUNT * 6]; // pointerId1, x1, y1, pressure1, tiltX1, tiltY1, pointerId2, etc...
-	void setTouchEvent(MotionEvent event, int eventAction, boolean doubleTap) {
+	void setTouchEvent(MotionEvent event, int eventAction, boolean doubleTap, boolean longPress) {
 		this.currentEventType = EventType.TOUCH;
 		this.eventAction = eventAction;
 		this.doubleTap = doubleTap;
+		this.longPress = longPress;
 		this.actionPointerId = event.getPointerId(event.getActionIndex());
 		this.pointerCount = Math.min(event.getPointerCount(), MAX_TOUCH_POINTER_COUNT);
 		for (int i = 0; i < pointerCount; i++) {
@@ -287,7 +289,8 @@ final class InputEventRunnable implements Runnable {
 							actionPointerId,
 							pointerCount,
 							positions,
-							doubleTap);
+							doubleTap,
+							longPress);
 					break;
 
 				case MAGNIFY:

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/InputEventRunnable.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/InputEventRunnable.java
@@ -136,7 +136,8 @@ final class InputEventRunnable implements Runnable {
 	private float pressure;
 	private float tiltX;
 	private float tiltY;
-	void setMouseEvent(int eventAction, int buttonsMask, float x, float y, float deltaX, float deltaY, boolean doubleClick, boolean sourceMouseRelative, float pressure, float tiltX, float tiltY) {
+	private boolean emulated;
+	void setMouseEvent(int eventAction, int buttonsMask, float x, float y, float deltaX, float deltaY, boolean doubleClick, boolean sourceMouseRelative, float pressure, float tiltX, float tiltY, boolean emulated) {
 		this.currentEventType = EventType.MOUSE;
 		this.eventAction = eventAction;
 		this.buttonsMask = buttonsMask;
@@ -149,6 +150,7 @@ final class InputEventRunnable implements Runnable {
 		this.pressure = pressure;
 		this.tiltX = tiltX;
 		this.tiltY = tiltY;
+		this.emulated = emulated;
 	}
 
 	// Touch event fields and setter
@@ -280,7 +282,8 @@ final class InputEventRunnable implements Runnable {
 							sourceMouseRelative,
 							pressure,
 							tiltX,
-							tiltY);
+							tiltY,
+							emulated);
 					break;
 
 				case TOUCH:

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -357,12 +357,12 @@ JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env,
 }
 
 // Called on the UI thread
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchMouseEvent(JNIEnv *env, jclass clazz, jint p_event_type, jint p_button_mask, jfloat p_x, jfloat p_y, jfloat p_delta_x, jfloat p_delta_y, jboolean p_double_click, jboolean p_source_mouse_relative, jfloat p_pressure, jfloat p_tilt_x, jfloat p_tilt_y) {
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchMouseEvent(JNIEnv *env, jclass clazz, jint p_event_type, jint p_button_mask, jfloat p_x, jfloat p_y, jfloat p_delta_x, jfloat p_delta_y, jboolean p_double_click, jboolean p_source_mouse_relative, jfloat p_pressure, jfloat p_tilt_x, jfloat p_tilt_y, jboolean p_emulated) {
 	if (step.get() <= STEP_SETUP) {
 		return;
 	}
 
-	input_handler->process_mouse_event(p_event_type, p_button_mask, Point2(p_x, p_y), Vector2(p_delta_x, p_delta_y), p_double_click, p_source_mouse_relative, p_pressure, Vector2(p_tilt_x, p_tilt_y));
+	input_handler->process_mouse_event(p_event_type, p_button_mask, Point2(p_x, p_y), Vector2(p_delta_x, p_delta_y), p_double_click, p_source_mouse_relative, p_pressure, Vector2(p_tilt_x, p_tilt_y), p_emulated);
 }
 
 // Called on the UI thread

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -366,7 +366,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchMouseEvent(JN
 }
 
 // Called on the UI thread
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchTouchEvent(JNIEnv *env, jclass clazz, jint ev, jint pointer, jint pointer_count, jfloatArray position, jboolean p_double_tap) {
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchTouchEvent(JNIEnv *env, jclass clazz, jint ev, jint pointer, jint pointer_count, jfloatArray position, jboolean p_double_tap, jboolean p_long_press) {
 	if (step.get() <= STEP_SETUP) {
 		return;
 	}
@@ -381,6 +381,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchTouchEvent(JN
 		tp.pressure = p[3];
 		tp.tilt = Vector2(p[4], p[5]);
 		tp.double_tap = p_double_tap;
+		tp.long_press = p_long_press;
 		points.push_back(tp);
 	}
 

--- a/platform/android/java_godot_lib_jni.h
+++ b/platform/android/java_godot_lib_jni.h
@@ -44,7 +44,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_newcontext(JNIEnv *en
 JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, jclass clazz);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_ttsCallback(JNIEnv *env, jclass clazz, jint event, jlong id, jint pos);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_back(JNIEnv *env, jclass clazz);
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchMouseEvent(JNIEnv *env, jclass clazz, jint p_event_type, jint p_button_mask, jfloat p_x, jfloat p_y, jfloat p_delta_x, jfloat p_delta_y, jboolean p_double_click, jboolean p_source_mouse_relative, jfloat p_pressure, jfloat p_tilt_x, jfloat p_tilt_y);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchMouseEvent(JNIEnv *env, jclass clazz, jint p_event_type, jint p_button_mask, jfloat p_x, jfloat p_y, jfloat p_delta_x, jfloat p_delta_y, jboolean p_double_click, jboolean p_source_mouse_relative, jfloat p_pressure, jfloat p_tilt_x, jfloat p_tilt_y, jboolean p_emulated);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchTouchEvent(JNIEnv *env, jclass clazz, jint ev, jint pointer, jint pointer_count, jfloatArray positions, jboolean p_double_tap, jboolean p_long_press);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_magnify(JNIEnv *env, jclass clazz, jfloat p_x, jfloat p_y, jfloat p_factor);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_pan(JNIEnv *env, jclass clazz, jfloat p_x, jfloat p_y, jfloat p_delta_x, jfloat p_delta_y);

--- a/platform/android/java_godot_lib_jni.h
+++ b/platform/android/java_godot_lib_jni.h
@@ -45,7 +45,7 @@ JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env,
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_ttsCallback(JNIEnv *env, jclass clazz, jint event, jlong id, jint pos);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_back(JNIEnv *env, jclass clazz);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchMouseEvent(JNIEnv *env, jclass clazz, jint p_event_type, jint p_button_mask, jfloat p_x, jfloat p_y, jfloat p_delta_x, jfloat p_delta_y, jboolean p_double_click, jboolean p_source_mouse_relative, jfloat p_pressure, jfloat p_tilt_x, jfloat p_tilt_y);
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchTouchEvent(JNIEnv *env, jclass clazz, jint ev, jint pointer, jint pointer_count, jfloatArray positions, jboolean p_double_tap);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchTouchEvent(JNIEnv *env, jclass clazz, jint ev, jint pointer, jint pointer_count, jfloatArray positions, jboolean p_double_tap, jboolean p_long_press);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_magnify(JNIEnv *env, jclass clazz, jfloat p_x, jfloat p_y, jfloat p_factor);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_pan(JNIEnv *env, jclass clazz, jfloat p_x, jfloat p_y, jfloat p_delta_x, jfloat p_delta_y);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_key(JNIEnv *env, jclass clazz, jint p_physical_keycode, jint p_unicode, jint p_key_label, jboolean p_pressed, jboolean p_echo);


### PR DESCRIPTION
This PR:
- Adds `long_press` property to InputEventScreenTouch and implements it on iOS and Android.
- Deprecates  project setting `input_devices/pointing/android/enable_long_press_as_right_click` and mark these right clicks as emulated.