### PR TITLE
Fix C# Ease documentation

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -774,14 +774,41 @@ namespace Godot
         }
 
         /// <summary>
-        /// Easing function, based on exponent. The <paramref name="curve"/> values are:
-        /// <c>0</c> is constant, <c>1</c> is linear, <c>0</c> to <c>1</c> is ease-in, <c>1</c> or more is ease-out.
-        /// Negative values are in-out/out-in.
+        /// Returns an eased value of <paramref name="s"/> based on an exponential easing function defined with <paramref name="curve"/>.
+        /// The <paramref name="curve"/> can be any floating-point number, with specific values leading to the following behaviors:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <term>Lower than <c>-1.0</c> (exclusive)</term>
+        ///         <description>Ease in-out.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Exactly <c>-1.0</c></term>
+        ///         <description>Linear.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Between <c>-1.0</c> and <c>0.0</c> (exclusive)</term>
+        ///         <description>Ease out-in.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Exactly <c>0.0</c></term>
+        ///         <description>Constant.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Between <c>0.0</c> and <c>1.0</c> (exclusive)</term>
+        ///         <description>Ease out.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Exactly <c>1.0</c></term>
+        ///         <description>Linear.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Greater than <c>1.0</c> (exclusive)</term>
+        ///         <description>Ease in.</description>
+        ///     </item>
+        /// </list>
         /// </summary>
         /// <param name="s">The value to ease.</param>
-        /// <param name="curve">
-        /// <c>0</c> is constant, <c>1</c> is linear, <c>0</c> to <c>1</c> is ease-in, <c>1</c> or more is ease-out.
-        /// </param>
+        /// <param name="curve">The exponent defining the easing curve.</param>
         /// <returns>The eased value.</returns>
         public static float Ease(float s, float curve)
         {
@@ -818,14 +845,41 @@ namespace Godot
         }
 
         /// <summary>
-        /// Easing function, based on exponent. The <paramref name="curve"/> values are:
-        /// <c>0</c> is constant, <c>1</c> is linear, <c>0</c> to <c>1</c> is ease-in, <c>1</c> or more is ease-out.
-        /// Negative values are in-out/out-in.
+        /// Returns an eased value of <paramref name="s"/> based on an exponential easing function defined with <paramref name="curve"/>.
+        /// The <paramref name="curve"/> can be any floating-point number, with specific values leading to the following behaviors:
+        /// <list type="bullet">
+        ///     <item>
+        ///         <term>Lower than <c>-1.0</c> (exclusive)</term>
+        ///         <description>Ease in-out.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Exactly <c>-1.0</c></term>
+        ///         <description>Linear.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Between <c>-1.0</c> and <c>0.0</c> (exclusive)</term>
+        ///         <description>Ease out-in.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Exactly <c>0.0</c></term>
+        ///         <description>Constant.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Between <c>0.0</c> and <c>1.0</c> (exclusive)</term>
+        ///         <description>Ease out.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Exactly <c>1.0</c></term>
+        ///         <description>Linear.</description>
+        ///     </item>
+        ///     <item>
+        ///         <term>Greater than <c>1.0</c> (exclusive)</term>
+        ///         <description>Ease in.</description>
+        ///     </item>
+        /// </list>
         /// </summary>
         /// <param name="s">The value to ease.</param>
-        /// <param name="curve">
-        /// <c>0</c> is constant, <c>1</c> is linear, <c>0</c> to <c>1</c> is ease-in, <c>1</c> or more is ease-out.
-        /// </param>
+        /// <param name="curve">The exponent defining the easing curve.</param>
         /// <returns>The eased value.</returns>
         public static double Ease(double s, double curve)
         {


### PR DESCRIPTION
## What problem(s) does this PR solve?

Correct the documented behavior for curve values between 0 and 1 and greater than 1.
For curve values strictly between 0 and 1, the easing behavior is ease-out. For values greater than 1, it is ease-in. The original description reversed these behaviors and did not mark the intermediate range as exclusive.
