### PR TITLE
Unify BVH versions between 3.x and 4.x

### DIFF
--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -51,8 +51,13 @@
 // and pairable_mask is either 0 if static, or set to all if non static
 
 #include "core/math/bvh_tree.h"
-#include "core/math/geometry_3d.h"
 #include "core/os/mutex.h"
+
+#if GODOT_VERSION_MAJOR >= 4
+#include "core/math/geometry_3d.h"
+#else
+#include "core/math/geometry.h"
+#endif
 
 #include <climits> // INT_MAX
 
@@ -408,11 +413,17 @@ public:
 		if (!p_convex.size()) {
 			return 0;
 		}
-
+#if GODOT_VERSION_MAJOR >= 4
 		Vector<Vector3> convex_points = Geometry3D::compute_convex_mesh_points(&p_convex[0], p_convex.size());
 		if (convex_points.is_empty()) {
 			return 0;
 		}
+#else
+		Vector<Vector3> convex_points = Geometry::compute_convex_mesh_points(p_convex);
+		if (convex_points.size() == 0) {
+			return 0;
+		}
+#endif
 
 		typename BVHTREE_CLASS::CullParams params;
 		params.result_count_overall = 0;
@@ -439,7 +450,6 @@ private:
 			// noop
 			return;
 		}
-
 		typename BVHTREE_CLASS::CullParams params;
 
 		params.result_count_overall = 0;
@@ -447,7 +457,12 @@ private:
 		params.result_array = nullptr;
 		params.subindex_array = nullptr;
 
+#if GODOT_VERSION_MAJOR >= 4
 		for (const BVHHandle &h : changed_items) {
+#else
+		for (unsigned int n = 0; n < changed_items.size(); n++) {
+			const BVHHandle &h = changed_items[n];
+#endif
 			// use the expanded aabb for pairing
 			const BOUNDS &expanded_aabb = tree._pairs[h.id()].expanded_aabb;
 			BVHABB_CLASS abb;
@@ -465,8 +480,12 @@ private:
 
 			params.result_count_overall = 0; // might not be needed
 			tree.cull_aabb(params, false);
-
+#if GODOT_VERSION_MAJOR >= 4
 			for (const uint32_t ref_id : tree._cull_hits) {
+#else
+			for (unsigned int i = 0; i < tree._cull_hits.size(); i++) {
+				uint32_t ref_id = tree._cull_hits[i];
+#endif
 				// don't collide against ourself
 				if (ref_id == changed_item_ref_id) {
 					continue;
@@ -753,8 +772,11 @@ private:
 		// remove from changed items (not very efficient yet)
 		for (int n = 0; n < (int)changed_items.size(); n++) {
 			if (changed_items[n] == p_handle) {
+#if GODOT_VERSION_MAJOR >= 4
 				changed_items.remove_at_unordered(n);
-
+#else
+				changed_items.remove_unordered(n);
+#endif
 				// because we are using an unordered remove,
 				// the last changed item will now be at spot 'n',
 				// and we need to redo it, so we prevent moving on to
@@ -778,7 +800,11 @@ private:
 
 	// for collision pairing,
 	// maintain a list of all items moved etc on each frame / tick
+#if GODOT_VERSION_MAJOR >= 4
 	LocalVector<BVHHandle> changed_items;
+#else
+	LocalVector<BVHHandle, uint32_t, true> changed_items;
+#endif
 	uint32_t _tick = 1; // Start from 1 so items with 0 indicate never updated.
 
 	class BVHLockedFunction {

--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -267,7 +267,7 @@ struct BVH_ABB {
 	// Actually surface area metric.
 	real_t get_area() const {
 		POINT d = calculate_size();
-		return 2.0f * (d.x * d.y + d.y * d.z + d.z * d.x);
+		return 2.0 * (d.x * d.y + d.y * d.z + d.z * d.x);
 	}
 
 	void set_to_max_opposite_extents() {

--- a/core/math/bvh_cull.inc
+++ b/core/math/bvh_cull.inc
@@ -185,7 +185,7 @@ bool _cull_hits_full(const CullParams &p_params) {
 	return (int)_cull_hits.size() >= p_params.result_max;
 }
 
-void _cull_hit(uint32_t p_ref_id, CullParams &r_params) {
+void _cull_hit(uint32_t p_ref_id, const CullParams &p_params) {
 	// take into account masks etc
 	// this would be more efficient to do before plane checks,
 	// but done here for ease to get started
@@ -193,7 +193,7 @@ void _cull_hit(uint32_t p_ref_id, CullParams &r_params) {
 		const ItemExtra &ex = _extra[p_ref_id];
 
 		// user supplied function (for e.g. pairable types and pairable masks in the render tree)
-		if (!USER_CULL_TEST_FUNCTION::user_cull_check(r_params.tester, ex.userdata)) {
+		if (!USER_CULL_TEST_FUNCTION::user_cull_check(p_params.tester, ex.userdata)) {
 			return;
 		}
 	}
@@ -201,7 +201,7 @@ void _cull_hit(uint32_t p_ref_id, CullParams &r_params) {
 	_cull_hits.push_back(p_ref_id);
 }
 
-bool _cull_segment_iterative(uint32_t p_node_id, CullParams &r_params) {
+bool _cull_segment_iterative(uint32_t p_node_id, const CullParams &p_params) {
 	// our function parameters to keep on a stack
 	struct CullSegParams {
 		uint32_t node_id;
@@ -225,7 +225,7 @@ bool _cull_segment_iterative(uint32_t p_node_id, CullParams &r_params) {
 
 		if (tnode.is_leaf()) {
 			// lazy check for hits full up condition
-			if (_cull_hits_full(r_params)) {
+			if (_cull_hits_full(p_params)) {
 				return false;
 			}
 
@@ -235,11 +235,11 @@ bool _cull_segment_iterative(uint32_t p_node_id, CullParams &r_params) {
 			for (int n = 0; n < leaf.num_items; n++) {
 				const BVHABB_CLASS &aabb = leaf.get_aabb(n);
 
-				if (aabb.intersects_segment(r_params.segment)) {
+				if (aabb.intersects_segment(p_params.segment)) {
 					uint32_t child_id = leaf.get_item_ref_id(n);
 
 					// register hit
-					_cull_hit(child_id, r_params);
+					_cull_hit(child_id, p_params);
 				}
 			}
 		} else {
@@ -248,7 +248,7 @@ bool _cull_segment_iterative(uint32_t p_node_id, CullParams &r_params) {
 				uint32_t child_id = tnode.children[n];
 				const BVHABB_CLASS &child_abb = _nodes[child_id].aabb;
 
-				if (child_abb.intersects_segment(r_params.segment)) {
+				if (child_abb.intersects_segment(p_params.segment)) {
 					// add to the stack
 					CullSegParams *child = ii.request();
 					child->node_id = child_id;
@@ -262,7 +262,7 @@ bool _cull_segment_iterative(uint32_t p_node_id, CullParams &r_params) {
 	return true;
 }
 
-bool _cull_point_iterative(uint32_t p_node_id, CullParams &r_params) {
+bool _cull_point_iterative(uint32_t p_node_id, const CullParams &p_params) {
 	// our function parameters to keep on a stack
 	struct CullPointParams {
 		uint32_t node_id;
@@ -284,13 +284,13 @@ bool _cull_point_iterative(uint32_t p_node_id, CullParams &r_params) {
 	while (ii.pop(cpp)) {
 		TNode &tnode = _nodes[cpp.node_id];
 		// no hit with this node?
-		if (!tnode.aabb.intersects_point(r_params.point)) {
+		if (!tnode.aabb.intersects_point(p_params.point)) {
 			continue;
 		}
 
 		if (tnode.is_leaf()) {
 			// lazy check for hits full up condition
-			if (_cull_hits_full(r_params)) {
+			if (_cull_hits_full(p_params)) {
 				return false;
 			}
 
@@ -298,11 +298,11 @@ bool _cull_point_iterative(uint32_t p_node_id, CullParams &r_params) {
 
 			// test children individually
 			for (int n = 0; n < leaf.num_items; n++) {
-				if (leaf.get_aabb(n).intersects_point(r_params.point)) {
+				if (leaf.get_aabb(n).intersects_point(p_params.point)) {
 					uint32_t child_id = leaf.get_item_ref_id(n);
 
 					// register hit
-					_cull_hit(child_id, r_params);
+					_cull_hit(child_id, p_params);
 				}
 			}
 		} else {
@@ -323,7 +323,7 @@ bool _cull_point_iterative(uint32_t p_node_id, CullParams &r_params) {
 }
 
 // Note: This is a very hot loop profiling wise. Take care when changing this and profile.
-bool _cull_aabb_iterative(uint32_t p_node_id, CullParams &r_params, bool p_fully_within = false) {
+bool _cull_aabb_iterative(uint32_t p_node_id, const CullParams &p_params, bool p_fully_within = false) {
 	// our function parameters to keep on a stack
 	struct CullAABBParams {
 		uint32_t node_id;
@@ -349,7 +349,7 @@ bool _cull_aabb_iterative(uint32_t p_node_id, CullParams &r_params, bool p_fully
 
 		if (tnode.is_leaf()) {
 			// lazy check for hits full up condition
-			if (_cull_hits_full(r_params)) {
+			if (_cull_hits_full(p_params)) {
 				return false;
 			}
 
@@ -362,7 +362,7 @@ bool _cull_aabb_iterative(uint32_t p_node_id, CullParams &r_params, bool p_fully
 					uint32_t child_id = leaf.get_item_ref_id(n);
 
 					// register hit
-					_cull_hit(child_id, r_params);
+					_cull_hit(child_id, p_params);
 				}
 			} else {
 				// This section is the hottest area in profiling, so
@@ -371,8 +371,8 @@ bool _cull_aabb_iterative(uint32_t p_node_id, CullParams &r_params, bool p_fully
 				int leaf_num_items = leaf.num_items;
 
 				BVHABB_CLASS swizzled_tester;
-				swizzled_tester.min = -r_params.abb.neg_max;
-				swizzled_tester.neg_max = -r_params.abb.min;
+				swizzled_tester.min = -p_params.abb.neg_max;
+				swizzled_tester.neg_max = -p_params.abb.min;
 
 				for (int n = 0; n < leaf_num_items; n++) {
 					const BVHABB_CLASS &aabb = leaf.get_aabb(n);
@@ -381,7 +381,7 @@ bool _cull_aabb_iterative(uint32_t p_node_id, CullParams &r_params, bool p_fully
 						uint32_t child_id = leaf.get_item_ref_id(n);
 
 						// register hit
-						_cull_hit(child_id, r_params);
+						_cull_hit(child_id, p_params);
 					}
 				}
 
@@ -393,9 +393,9 @@ bool _cull_aabb_iterative(uint32_t p_node_id, CullParams &r_params, bool p_fully
 					uint32_t child_id = tnode.children[n];
 					const BVHABB_CLASS &child_abb = _nodes[child_id].aabb;
 
-					if (child_abb.intersects(r_params.abb)) {
+					if (child_abb.intersects(p_params.abb)) {
 						// is the node totally within the aabb?
-						bool fully_within = r_params.abb.is_other_within(child_abb);
+						bool fully_within = p_params.abb.is_other_within(child_abb);
 
 						// add to the stack
 						CullAABBParams *child = ii.request();
@@ -426,7 +426,7 @@ bool _cull_aabb_iterative(uint32_t p_node_id, CullParams &r_params, bool p_fully
 }
 
 // returns full up with results
-bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_fully_within = false) {
+bool _cull_convex_iterative(uint32_t p_node_id, const CullParams &p_params, bool p_fully_within = false) {
 	// our function parameters to keep on a stack
 	struct CullConvexParams {
 		uint32_t node_id;
@@ -445,7 +445,7 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 	ii.get_first()->fully_within = p_fully_within;
 
 	// preallocate these as a once off to be reused
-	uint32_t max_planes = r_params.hull.num_planes;
+	uint32_t max_planes = p_params.hull.num_planes;
 	uint32_t *plane_ids = (uint32_t *)alloca(sizeof(uint32_t) * max_planes);
 
 	CullConvexParams ccp;
@@ -455,7 +455,7 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 		const TNode &tnode = _nodes[ccp.node_id];
 
 		if (!ccp.fully_within) {
-			typename BVHABB_CLASS::IntersectResult res = tnode.aabb.intersects_convex(r_params.hull);
+			typename BVHABB_CLASS::IntersectResult res = tnode.aabb.intersects_convex(p_params.hull);
 
 			switch (res) {
 				default: {
@@ -472,7 +472,7 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 
 		if (tnode.is_leaf()) {
 			// lazy check for hits full up condition
-			if (_cull_hits_full(r_params)) {
+			if (_cull_hits_full(p_params)) {
 				return false;
 			}
 
@@ -485,7 +485,7 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 					uint32_t child_id = leaf.get_item_ref_id(n);
 
 					// register hit
-					_cull_hit(child_id, r_params);
+					_cull_hit(child_id, p_params);
 				}
 
 			} else {
@@ -495,7 +495,7 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 #define BVH_CONVEX_CULL_OPTIMIZED
 #ifdef BVH_CONVEX_CULL_OPTIMIZED
 				// first find which planes cut the aabb
-				uint32_t num_planes = tnode.aabb.find_cutting_planes(r_params.hull, plane_ids);
+				uint32_t num_planes = tnode.aabb.find_cutting_planes(p_params.hull, plane_ids);
 				BVH_ASSERT(num_planes <= max_planes);
 
 //#define BVH_CONVEX_CULL_OPTIMIZED_RIGOR_CHECK
@@ -510,7 +510,7 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 					//const Item &item = leaf.get_item(n);
 					const BVHABB_CLASS &aabb = leaf.get_aabb(n);
 
-					if (aabb.intersects_convex_optimized(r_params.hull, plane_ids, num_planes)) {
+					if (aabb.intersects_convex_optimized(p_params.hull, plane_ids, num_planes)) {
 						uint32_t child_id = leaf.get_item_ref_id(n);
 
 #ifdef BVH_CONVEX_CULL_OPTIMIZED_RIGOR_CHECK
@@ -518,7 +518,7 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 #endif
 
 						// register hit
-						_cull_hit(child_id, r_params);
+						_cull_hit(child_id, p_params);
 					}
 				}
 
@@ -528,7 +528,7 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 				for (int n = 0; n < leaf.num_items; n++) {
 					const BVHABB_CLASS &aabb = leaf.get_aabb(n);
 
-					if (aabb.intersects_convex_partial(r_params.hull)) {
+					if (aabb.intersects_convex_partial(p_params.hull)) {
 						uint32_t child_id = leaf.get_item_ref_id(n);
 
 						CRASH_COND(child_id != results[test_count++]);
@@ -543,11 +543,11 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 				for (int n = 0; n < leaf.num_items; n++) {
 					const BVHABB_CLASS &aabb = leaf.get_aabb(n);
 
-					if (aabb.intersects_convex_partial(r_params.hull)) {
+					if (aabb.intersects_convex_partial(p_params.hull)) {
 						uint32_t child_id = leaf.get_item_ref_id(n);
 
 						// full up with results? exit early, no point in further testing
-						if (!_cull_hit(child_id, r_params)) {
+						if (!_cull_hit(child_id, p_params)) {
 							return false;
 						}
 					}

--- a/core/math/bvh_misc.inc
+++ b/core/math/bvh_misc.inc
@@ -31,15 +31,15 @@ void create_root_node(int p_tree) {
 	}
 }
 
-bool node_is_leaf_full(TNode &r_tnode) const {
-	const TLeaf &leaf = _node_get_leaf(r_tnode);
+bool node_is_leaf_full(const TNode &p_tnode) const {
+	const TLeaf &leaf = _node_get_leaf(p_tnode);
 	return leaf.is_full();
 }
 
 public:
-TLeaf &_node_get_leaf(TNode &r_tnode) {
-	BVH_ASSERT(r_tnode.is_leaf());
-	return _leaves[r_tnode.get_leaf_id()];
+TLeaf &_node_get_leaf(const TNode &p_tnode) {
+	BVH_ASSERT(p_tnode.is_leaf());
+	return _leaves[p_tnode.get_leaf_id()];
 }
 
 const TLeaf &_node_get_leaf(const TNode &p_tnode) const {

--- a/core/math/bvh_pair.inc
+++ b/core/math/bvh_pair.inc
@@ -51,7 +51,11 @@ struct ItemPairs {
 		for (int n = 0; n < num_pairs; n++) {
 			if (extended_pairs[n].handle == p_handle) {
 				userdata = extended_pairs[n].userdata;
+#if GODOT_VERSION_MAJOR >= 4
 				extended_pairs.remove_at_unordered(n);
+#else
+				extended_pairs.remove_unordered(n);
+#endif
 				num_pairs--;
 				break;
 			}

--- a/core/math/bvh_public.inc
+++ b/core/math/bvh_public.inc
@@ -202,8 +202,11 @@ void item_remove(BVHHandle p_handle) {
 
 	// swap back and decrement for fast unordered remove
 	_active_refs[active_ref_id] = ref_id_moved_back;
+#if GODOT_VERSION_MAJOR >= 4
 	_active_refs.resize_uninitialized(_active_refs.size() - 1);
-
+#else
+	_active_refs.resize(_active_refs.size() - 1);
+#endif
 	// keep the moved active reference up to date
 	_extra[ref_id_moved_back].active_ref_id = active_ref_id;
 	////////////////////////////////////////

--- a/core/math/bvh_split.inc
+++ b/core/math/bvh_split.inc
@@ -11,17 +11,17 @@ void _split_inform_references(uint32_t p_node_id) {
 	}
 }
 
-void _split_leaf_sort_groups_simple(int &p_num_a, int &p_num_b, uint16_t *r_group_a, uint16_t *r_group_b, const BVHABB_CLASS *r_temp_bounds, const BVHABB_CLASS p_full_bound) {
+void _split_leaf_sort_groups_simple(int &r_num_a, int &r_num_b, uint16_t *r_group_a, uint16_t *r_group_b, const BVHABB_CLASS *p_temp_bounds, const BVHABB_CLASS p_full_bound) {
 	// special case for low leaf sizes .. should static compile out
 	if constexpr (MAX_ITEMS < 4) {
 		uint32_t ind = r_group_a[0];
 
 		// add to b
-		r_group_b[p_num_b++] = ind;
+		r_group_b[r_num_b++] = ind;
 
 		// remove from a
-		p_num_a--;
-		r_group_a[0] = r_group_a[p_num_a];
+		r_num_a--;
+		r_group_a[0] = r_group_a[r_num_a];
 		return;
 	}
 
@@ -29,9 +29,13 @@ void _split_leaf_sort_groups_simple(int &p_num_a, int &p_num_b, uint16_t *r_grou
 	POINT size = p_full_bound.calculate_size();
 
 	int order[POINT::AXIS_COUNT];
-
+#if GODOT_VERSION_MAJOR >= 4
 	order[0] = size.max_axis_index(); // The longest axis.
 	order[POINT::AXIS_COUNT - 1] = size.min_axis_index(); // The shortest axis.
+#else
+	order[0] = size.max_axis();
+	order[POINT::AXIS_COUNT - 1] = size.min_axis();
+#endif
 
 	static_assert(POINT::AXIS_COUNT <= 3, "BVH POINT::AXIS_COUNT has unexpected size");
 	if constexpr (POINT::AXIS_COUNT == 3) {
@@ -40,16 +44,16 @@ void _split_leaf_sort_groups_simple(int &p_num_a, int &p_num_b, uint16_t *r_grou
 
 	// Simplest case, split on the longest axis.
 	int split_axis = order[0];
-	for (int a = 0; a < p_num_a; a++) {
+	for (int a = 0; a < r_num_a; a++) {
 		uint32_t ind = r_group_a[a];
 
-		if (r_temp_bounds[ind].min[split_axis] > center[split_axis]) {
+		if (p_temp_bounds[ind].min[split_axis] > center[split_axis]) {
 			// add to b
-			r_group_b[p_num_b++] = ind;
+			r_group_b[r_num_b++] = ind;
 
 			// remove from a
-			p_num_a--;
-			r_group_a[a] = r_group_a[p_num_a];
+			r_num_a--;
+			r_group_a[a] = r_group_a[r_num_a];
 
 			// do this one again, as it has been replaced
 			a--;
@@ -59,28 +63,28 @@ void _split_leaf_sort_groups_simple(int &p_num_a, int &p_num_b, uint16_t *r_grou
 	// detect when split on longest axis failed
 	int min_threshold = MAX_ITEMS / 4;
 	int min_group_size[POINT::AXIS_COUNT];
-	min_group_size[0] = MIN(p_num_a, p_num_b);
+	min_group_size[0] = MIN(r_num_a, r_num_b);
 	if (min_group_size[0] < min_threshold) {
 		// slow but sure .. first move everything back into a
-		for (int b = 0; b < p_num_b; b++) {
-			r_group_a[p_num_a++] = r_group_b[b];
+		for (int b = 0; b < r_num_b; b++) {
+			r_group_a[r_num_a++] = r_group_b[b];
 		}
-		p_num_b = 0;
+		r_num_b = 0;
 
 		// Now calculate the best split.
 		for (int axis = 1; axis < POINT::AXIS_COUNT; axis++) {
 			split_axis = order[axis];
 			int count = 0;
 
-			for (int a = 0; a < p_num_a; a++) {
+			for (int a = 0; a < r_num_a; a++) {
 				uint32_t ind = r_group_a[a];
 
-				if (r_temp_bounds[ind].min[split_axis] > center[split_axis]) {
+				if (p_temp_bounds[ind].min[split_axis] > center[split_axis]) {
 					count++;
 				}
 			}
 
-			min_group_size[axis] = MIN(count, p_num_a - count);
+			min_group_size[axis] = MIN(count, r_num_a - count);
 		} // for axis
 
 		// best axis
@@ -97,16 +101,16 @@ void _split_leaf_sort_groups_simple(int &p_num_a, int &p_num_b, uint16_t *r_grou
 		if (best_min > 0) {
 			split_axis = order[best_axis];
 
-			for (int a = 0; a < p_num_a; a++) {
+			for (int a = 0; a < r_num_a; a++) {
 				uint32_t ind = r_group_a[a];
 
-				if (r_temp_bounds[ind].min[split_axis] > center[split_axis]) {
+				if (p_temp_bounds[ind].min[split_axis] > center[split_axis]) {
 					// add to b
-					r_group_b[p_num_b++] = ind;
+					r_group_b[r_num_b++] = ind;
 
 					// remove from a
-					p_num_a--;
-					r_group_a[a] = r_group_a[p_num_a];
+					r_num_a--;
+					r_group_a[a] = r_group_a[r_num_a];
 
 					// do this one again, as it has been replaced
 					a--;
@@ -116,35 +120,35 @@ void _split_leaf_sort_groups_simple(int &p_num_a, int &p_num_b, uint16_t *r_grou
 	} // if the longest axis wasn't a good split
 
 	// special case, none crossed threshold
-	if (!p_num_b) {
+	if (!r_num_b) {
 		uint32_t ind = r_group_a[0];
 
 		// add to b
-		r_group_b[p_num_b++] = ind;
+		r_group_b[r_num_b++] = ind;
 
 		// remove from a
-		p_num_a--;
-		r_group_a[0] = r_group_a[p_num_a];
+		r_num_a--;
+		r_group_a[0] = r_group_a[r_num_a];
 	}
 	// opposite problem! :)
-	if (!p_num_a) {
+	if (!r_num_a) {
 		uint32_t ind = r_group_b[0];
 
 		// add to a
-		r_group_a[p_num_a++] = ind;
+		r_group_a[r_num_a++] = ind;
 
 		// remove from b
-		p_num_b--;
-		r_group_b[0] = r_group_b[p_num_b];
+		r_num_b--;
+		r_group_b[0] = r_group_b[r_num_b];
 	}
 }
 
-void _split_leaf_sort_groups(int &p_num_a, int &p_num_b, uint16_t *r_group_a, uint16_t *r_group_b, const BVHABB_CLASS *r_temp_bounds) {
+void _split_leaf_sort_groups(int &r_num_a, int &r_num_b, uint16_t *r_group_a, uint16_t *r_group_b, const BVHABB_CLASS *p_temp_bounds) {
 	BVHABB_CLASS groupb_aabb;
 	groupb_aabb.set_to_max_opposite_extents();
-	for (int n = 0; n < p_num_b; n++) {
+	for (int n = 0; n < r_num_b; n++) {
 		int which = r_group_b[n];
-		groupb_aabb.merge(r_temp_bounds[which]);
+		groupb_aabb.merge(p_temp_bounds[which]);
 	}
 	BVHABB_CLASS groupb_aabb_new;
 
@@ -154,21 +158,21 @@ void _split_leaf_sort_groups(int &p_num_a, int &p_num_b, uint16_t *r_group_a, ui
 	int best_candidate = -1;
 
 	// find most likely from a to move into b
-	for (int check = 0; check < p_num_a; check++) {
+	for (int check = 0; check < r_num_a; check++) {
 		rest_aabb.set_to_max_opposite_extents();
 		groupb_aabb_new = groupb_aabb;
 
 		// find aabb of all the rest
-		for (int rest = 0; rest < p_num_a; rest++) {
+		for (int rest = 0; rest < r_num_a; rest++) {
 			if (rest == check) {
 				continue;
 			}
 
 			int which = r_group_a[rest];
-			rest_aabb.merge(r_temp_bounds[which]);
+			rest_aabb.merge(p_temp_bounds[which]);
 		}
 
-		groupb_aabb_new.merge(r_temp_bounds[r_group_a[check]]);
+		groupb_aabb_new.merge(p_temp_bounds[r_group_a[check]]);
 
 		// now compare the sizes
 		real_t size = groupb_aabb_new.get_area() + rest_aabb.get_area();
@@ -179,11 +183,11 @@ void _split_leaf_sort_groups(int &p_num_a, int &p_num_b, uint16_t *r_group_a, ui
 	}
 
 	// we should now have the best, move it from group a to group b
-	r_group_b[p_num_b++] = r_group_a[best_candidate];
+	r_group_b[r_num_b++] = r_group_a[best_candidate];
 
 	// remove best candidate from group a
-	p_num_a--;
-	r_group_a[best_candidate] = r_group_a[p_num_a];
+	r_num_a--;
+	r_group_a[best_candidate] = r_group_a[r_num_a];
 }
 
 uint32_t split_leaf(uint32_t p_node_id, const BVHABB_CLASS &p_added_item_aabb) {

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -37,12 +37,17 @@
 // It also means that the splitting logic etc have to be completely different
 // to a simpler tree.
 // Note that MAX_CHILDREN should be fixed at 2 for now.
-
 #include "core/math/aabb.h"
 #include "core/math/bvh_abb.h"
 #include "core/math/vector3.h"
+#include "core/version_generated.gen.h"
+#if GODOT_VERSION_MAJOR >= 4
 #include "core/templates/local_vector.h"
 #include "core/templates/pooled_list.h"
+#else
+#include "core/local_vector.h"
+#include "core/pooled_list.h"
+#endif
 
 #define BVHABB_CLASS BVH_ABB<BOUNDS, POINT>
 
@@ -50,8 +55,17 @@
 #define BVH_EXPAND_LEAF_AABBS
 
 // never do these checks in release
-#ifdef DEV_ENABLED
+#if ((GODOT_VERSION_MAJOR >= 4) && defined(DEV_ENABLED)) || (defined(TOOLS_ENABLED) && defined(DEBUG_ENABLED))
 //#define BVH_VERBOSE
+
+#ifdef BVH_VERBOSE
+#if GODOT_VERSION_MAJOR >= 4
+#include "core/variant/variant.h"
+#else
+#include "core/print_string.h"
+#endif
+#endif
+
 //#define BVH_VERBOSE_TREE
 //#define BVH_VERBOSE_PAIRING
 //#define BVH_VERBOSE_MOVES
@@ -134,7 +148,11 @@ public:
 	// request new addition to stack
 	T *request() {
 		if (depth > threshold) {
+#if GODOT_VERSION_MAJOR >= 4
 			if (aux_stack.is_empty()) {
+#else
+			if (aux_stack.empty()) {
+#endif
 				aux_stack.resize(ALLOCA_STACK_SIZE * 2);
 				memcpy(aux_stack.ptr(), stack, get_alloca_stacksize());
 			} else {
@@ -150,7 +168,7 @@ public:
 template <typename T>
 class BVH_DummyPairTestFunction {
 public:
-	static bool user_collision_check(T *p_a, T *p_b) {
+	static bool user_pair_check(const T *p_a, const T *p_b) {
 		// return false if no collision, decided by masks etc
 		return true;
 	}
@@ -159,7 +177,7 @@ public:
 template <typename T>
 class BVH_DummyCullTestFunction {
 public:
-	static bool user_cull_check(T *p_a, T *p_b) {
+	static bool user_cull_check(const T *p_a, const T *p_b) {
 		// return false if no collision
 		return true;
 	}
@@ -229,7 +247,7 @@ private:
 
 		// no need to keep back references for children at the moment
 
-		uint32_t sibling_id = 0; // always a node id, as tnode is never a leaf
+		uint32_t sibling_id = BVHCommon::INVALID; // always a node id, as tnode is never a leaf
 		bool sibling_present = false;
 
 		// if there are more children, or this is the root node, don't try and delete


### PR DESCRIPTION

## What problem(s) does this PR solve?

Makes all the core/math/bvh_\*\.\* files the same between 4.x and 3.x. 

This will allow additional BVH work to benefit both 3.x and 4.x.

## Additional information

Uses GODOT_VERSION_MAJOR macros to handle discrepencies.

Code was cleaned up along the way, including a few r_param / p_param errors and adding const where possible.

Macros should be easy to mechanically remove in future if we want to revert to seperate BVH code.