### PR TITLE
[3.x] Unify BVH versions between 3.x and 4.x

### DIFF
--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef BVH_H
-#define BVH_H
+#pragma once
 
 // BVH
 // This class provides a wrapper around BVH tree, which contains most of the functionality
@@ -51,13 +50,21 @@
 // TYPE_BODY
 // and pairable_mask is either 0 if static, or set to all if non static
 
-#include "bvh_tree.h"
+#include "core/math/bvh_tree.h"
 #include "core/os/mutex.h"
+
+#if GODOT_VERSION_MAJOR >= 4
+#include "core/math/geometry_3d.h"
+#else
+#include "core/math/geometry.h"
+#endif
+
+#include <climits> // INT_MAX
 
 #define BVHTREE_CLASS BVH_Tree<T, NUM_TREES, 2, MAX_ITEMS, USER_PAIR_TEST_FUNCTION, USER_CULL_TEST_FUNCTION, USE_PAIRS, BOUNDS, POINT>
 #define BVH_LOCKED_FUNCTION BVHLockedFunction _lock_guard(&_mutex, BVH_THREAD_SAFE &&_thread_safe);
 
-template <class T, int NUM_TREES = 1, bool USE_PAIRS = false, int MAX_ITEMS = 32, class USER_PAIR_TEST_FUNCTION = BVH_DummyPairTestFunction<T>, class USER_CULL_TEST_FUNCTION = BVH_DummyCullTestFunction<T>, class BOUNDS = AABB, class POINT = Vector3, bool BVH_THREAD_SAFE = true>
+template <typename T, int NUM_TREES = 1, bool USE_PAIRS = false, int MAX_ITEMS = 32, typename USER_PAIR_TEST_FUNCTION = BVH_DummyPairTestFunction<T>, typename USER_CULL_TEST_FUNCTION = BVH_DummyCullTestFunction<T>, typename BOUNDS = AABB, typename POINT = Vector3, bool BVH_THREAD_SAFE = true>
 class BVH_Manager {
 public:
 	// note we are using uint32_t instead of BVHHandle, losing type safety, but this
@@ -75,7 +82,7 @@ public:
 	// see the variable declarations for more info.
 	void params_set_node_expansion(real_t p_value) {
 		BVH_LOCKED_FUNCTION
-		if (p_value >= 0) {
+		if (p_value >= 0.0) {
 			tree._node_expansion = p_value;
 			tree._auto_node_expansion = false;
 		} else {
@@ -177,28 +184,29 @@ public:
 	}
 
 	uint32_t get_tree_id(uint32_t p_handle) const {
-		BVH_LOCKED_FUNCTION
 		BVHHandle h;
 		h.set(p_handle);
+		BVH_LOCKED_FUNCTION
 		return item_get_tree_id(h);
 	}
 	int get_subindex(uint32_t p_handle) const {
-		BVH_LOCKED_FUNCTION
 		BVHHandle h;
 		h.set(p_handle);
+		BVH_LOCKED_FUNCTION
 		return item_get_subindex(h);
 	}
 
 	T *get(uint32_t p_handle) const {
-		BVH_LOCKED_FUNCTION
 		BVHHandle h;
 		h.set(p_handle);
+		BVH_LOCKED_FUNCTION
 		return item_get_userdata(h);
 	}
 
 	////////////////////////////////////////////////////
 
 	void move(BVHHandle p_handle, const BOUNDS &p_aabb) {
+		DEV_ASSERT(!p_handle.is_invalid());
 		BVH_LOCKED_FUNCTION
 		if (tree.item_move(p_handle, p_aabb)) {
 			if (USE_PAIRS) {
@@ -208,10 +216,12 @@ public:
 	}
 
 	void recheck_pairs(BVHHandle p_handle) {
+		DEV_ASSERT(!p_handle.is_invalid());
 		force_collision_check(p_handle);
 	}
 
 	void erase(BVHHandle p_handle) {
+		DEV_ASSERT(!p_handle.is_invalid());
 		BVH_LOCKED_FUNCTION
 		// call unpair and remove all references to the item
 		// before deleting from the tree
@@ -228,6 +238,7 @@ public:
 	// set pairable has never been called.
 	// (deferred collision checks are a workaround for visual server for historical reasons)
 	void force_collision_check(BVHHandle p_handle) {
+		DEV_ASSERT(!p_handle.is_invalid());
 		BVH_LOCKED_FUNCTION
 		if (USE_PAIRS) {
 			// the aabb should already be up to date in the BVH
@@ -246,6 +257,7 @@ public:
 	// but generically this makes items add or remove from the
 	// tree internally, to speed things up by ignoring inactive items
 	bool activate(BVHHandle p_handle, const BOUNDS &p_aabb, bool p_delay_collision_check = false) {
+		DEV_ASSERT(!p_handle.is_invalid());
 		BVH_LOCKED_FUNCTION
 		// sending the aabb here prevents the need for the BVH to maintain
 		// a redundant copy of the aabb.
@@ -270,6 +282,7 @@ public:
 	}
 
 	bool deactivate(BVHHandle p_handle) {
+		DEV_ASSERT(!p_handle.is_invalid());
 		BVH_LOCKED_FUNCTION
 		// returns success
 		if (tree.item_deactivate(p_handle)) {
@@ -288,6 +301,7 @@ public:
 	}
 
 	bool get_active(BVHHandle p_handle) {
+		DEV_ASSERT(!p_handle.is_invalid());
 		BVH_LOCKED_FUNCTION
 		return tree.item_get_active(p_handle);
 	}
@@ -310,6 +324,7 @@ public:
 
 	// prefer calling this directly as type safe
 	void set_tree(const BVHHandle &p_handle, uint32_t p_tree_id, uint32_t p_tree_collision_mask, bool p_force_collision_check = true) {
+		DEV_ASSERT(!p_handle.is_invalid());
 		BVH_LOCKED_FUNCTION
 		// Returns true if the pairing state has changed.
 		bool state_changed = tree.item_set_tree(p_handle, p_tree_id, p_tree_collision_mask);
@@ -398,11 +413,17 @@ public:
 		if (!p_convex.size()) {
 			return 0;
 		}
-
+#if GODOT_VERSION_MAJOR >= 4
+		Vector<Vector3> convex_points = Geometry3D::compute_convex_mesh_points(&p_convex[0], p_convex.size());
+		if (convex_points.is_empty()) {
+			return 0;
+		}
+#else
 		Vector<Vector3> convex_points = Geometry::compute_convex_mesh_points(p_convex);
 		if (convex_points.size() == 0) {
 			return 0;
 		}
+#endif
 
 		typename BVHTREE_CLASS::CullParams params;
 		params.result_count_overall = 0;
@@ -429,9 +450,6 @@ private:
 			// noop
 			return;
 		}
-
-		BOUNDS bb;
-
 		typename BVHTREE_CLASS::CullParams params;
 
 		params.result_count_overall = 0;
@@ -439,9 +457,12 @@ private:
 		params.result_array = nullptr;
 		params.subindex_array = nullptr;
 
+#if GODOT_VERSION_MAJOR >= 4
+		for (const BVHHandle &h : changed_items) {
+#else
 		for (unsigned int n = 0; n < changed_items.size(); n++) {
 			const BVHHandle &h = changed_items[n];
-
+#endif
 			// use the expanded aabb for pairing
 			const BOUNDS &expanded_aabb = tree._pairs[h.id()].expanded_aabb;
 			BVHABB_CLASS abb;
@@ -459,10 +480,12 @@ private:
 
 			params.result_count_overall = 0; // might not be needed
 			tree.cull_aabb(params, false);
-
+#if GODOT_VERSION_MAJOR >= 4
+			for (const uint32_t ref_id : tree._cull_hits) {
+#else
 			for (unsigned int i = 0; i < tree._cull_hits.size(); i++) {
 				uint32_t ref_id = tree._cull_hits[i];
-
+#endif
 				// don't collide against ourself
 				if (ref_id == changed_item_ref_id) {
 					continue;
@@ -481,8 +504,9 @@ private:
 
 public:
 	void item_get_AABB(BVHHandle p_handle, BOUNDS &r_aabb) {
-		BVH_LOCKED_FUNCTION
+		DEV_ASSERT(!p_handle.is_invalid());
 		BVHABB_CLASS abb;
+		BVH_LOCKED_FUNCTION
 		tree.item_get_ABB(p_handle, abb);
 		abb.to(r_aabb);
 	}
@@ -573,10 +597,10 @@ private:
 
 	// find all the existing paired aabbs that are no longer
 	// paired, and send callbacks
-	void _find_leavers(BVHHandle p_handle, const BVHABB_CLASS &expanded_abb_from, bool p_full_check) {
+	void _find_leavers(BVHHandle p_handle, const BVHABB_CLASS &p_expanded_abb_from, bool p_full_check) {
 		typename BVHTREE_CLASS::ItemPairs &p_from = tree._pairs[p_handle.id()];
 
-		BVHABB_CLASS abb_from = expanded_abb_from;
+		BVHABB_CLASS abb_from = p_expanded_abb_from;
 
 		// remove from pairing list for every partner
 		for (uint32_t n = 0; n < p_from.extended_pairs.size(); n++) {
@@ -695,7 +719,7 @@ private:
 		_tick++;
 	}
 
-	void _add_changed_item(BVHHandle p_handle, const BOUNDS &aabb, bool p_check_aabb = true) {
+	void _add_changed_item(BVHHandle p_handle, const BOUNDS &p_aabb, bool p_check_aabb = true) {
 		// Note that non pairable items can pair with pairable,
 		// so all types must be added to the list
 
@@ -712,13 +736,13 @@ private:
 		// passing p_check_aabb false disables the optimization which prevents collision checks if
 		// the aabb hasn't changed. This is needed where set_pairable has been called, but the position
 		// has not changed.
-		if (p_check_aabb && tree.expanded_aabb_encloses_not_shrink(expanded_aabb, aabb)) {
+		if (p_check_aabb && tree.expanded_aabb_encloses_not_shrink(expanded_aabb, p_aabb)) {
 			return;
 		}
 
 		// ALWAYS update the new expanded aabb, even if already changed once
 		// this tick, because it is vital that the AABB is kept up to date
-		expanded_aabb = aabb;
+		expanded_aabb = p_aabb;
 		expanded_aabb.grow_by(tree._pairing_expansion);
 #endif
 
@@ -748,8 +772,11 @@ private:
 		// remove from changed items (not very efficient yet)
 		for (int n = 0; n < (int)changed_items.size(); n++) {
 			if (changed_items[n] == p_handle) {
+#if GODOT_VERSION_MAJOR >= 4
+				changed_items.remove_at_unordered(n);
+#else
 				changed_items.remove_unordered(n);
-
+#endif
 				// because we are using an unordered remove,
 				// the last changed item will now be at spot 'n',
 				// and we need to redo it, so we prevent moving on to
@@ -762,19 +789,23 @@ private:
 		tree._extra[p_handle.id()].last_updated_tick = 0;
 	}
 
-	PairCallback pair_callback;
-	UnpairCallback unpair_callback;
-	CheckPairCallback check_pair_callback;
-	void *pair_callback_userdata;
-	void *unpair_callback_userdata;
-	void *check_pair_callback_userdata;
+	PairCallback pair_callback = nullptr;
+	UnpairCallback unpair_callback = nullptr;
+	CheckPairCallback check_pair_callback = nullptr;
+	void *pair_callback_userdata = nullptr;
+	void *unpair_callback_userdata = nullptr;
+	void *check_pair_callback_userdata = nullptr;
 
 	BVHTREE_CLASS tree;
 
 	// for collision pairing,
 	// maintain a list of all items moved etc on each frame / tick
+#if GODOT_VERSION_MAJOR >= 4
+	LocalVector<BVHHandle> changed_items;
+#else
 	LocalVector<BVHHandle, uint32_t, true> changed_items;
-	uint32_t _tick;
+#endif
+	uint32_t _tick = 1; // Start from 1 so items with 0 indicate never updated.
 
 	class BVHLockedFunction {
 	public:
@@ -782,11 +813,7 @@ private:
 			// will be compiled out if not set in template
 			if (p_thread_safe) {
 				_mutex = p_mutex;
-
-				if (_mutex->try_lock() != OK) {
-					WARN_PRINT_ONCE("Info : multithread BVH access detected (benign)");
-					_mutex->lock();
-				}
+				_mutex->lock();
 
 			} else {
 				_mutex = nullptr;
@@ -800,25 +827,13 @@ private:
 		}
 
 	private:
-		Mutex *_mutex;
+		Mutex *_mutex = nullptr;
 	};
 
 	mutable Mutex _mutex;
 
 	// local toggle for turning on and off thread safety in project settings
-	bool _thread_safe;
-
-public:
-	BVH_Manager() {
-		_tick = 1; // start from 1 so items with 0 indicate never updated
-		pair_callback = nullptr;
-		unpair_callback = nullptr;
-		pair_callback_userdata = nullptr;
-		unpair_callback_userdata = nullptr;
-		_thread_safe = BVH_THREAD_SAFE;
-	}
+	bool _thread_safe = BVH_THREAD_SAFE;
 };
 
 #undef BVHTREE_CLASS
-
-#endif // BVH_H

--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -28,14 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef BVH_ABB_H
-#define BVH_ABB_H
+#pragma once
 
-#include <float.h>
-#include <cmath>
+#include "core/math/aabb.h"
+
+#include <cfloat> // FLT_MAX
 
 // special optimized version of axis aligned bounding box
-template <class BOUNDS = AABB, class POINT = Vector3>
+template <typename BOUNDS = AABB, typename POINT = Vector3>
 struct BVH_ABB {
 	struct ConvexHull {
 		// convex hulls (optional)
@@ -60,12 +60,12 @@ struct BVH_ABB {
 	POINT min;
 	POINT neg_max;
 
-	bool operator==(const BVH_ABB &o) const { return (min == o.min) && (neg_max == o.neg_max); }
-	bool operator!=(const BVH_ABB &o) const { return (*this == o) == false; }
+	bool operator==(const BVH_ABB &p_other) const { return (min == p_other.min) && (neg_max == p_other.neg_max); }
+	bool operator!=(const BVH_ABB &p_other) const { return (*this == p_other) == false; }
 
-	void set(const POINT &_min, const POINT &_max) {
-		min = _min;
-		neg_max = -_max;
+	void set(const POINT &p_min, const POINT &p_max) {
+		min = p_min;
+		neg_max = -p_max;
 	}
 
 	// to and from standard AABB
@@ -90,13 +90,13 @@ struct BVH_ABB {
 		return -neg_max - min;
 	}
 
-	POINT calculate_centre() const {
-		return POINT((calculate_size() * 0.5f) + min);
+	POINT calculate_center() const {
+		return POINT((calculate_size() * 0.5) + min);
 	}
 
 	real_t get_proximity_to(const BVH_ABB &p_b) const {
 		const POINT d = (min - neg_max) - (p_b.min - p_b.neg_max);
-		real_t proximity = 0;
+		real_t proximity = 0.0;
 		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
 			proximity += Math::abs(d[axis]);
 		}
@@ -122,7 +122,7 @@ struct BVH_ABB {
 
 	bool intersects_plane(const Plane &p_p) const {
 		Vector3 size = calculate_size();
-		Vector3 half_extents = size * 0.5f;
+		Vector3 half_extents = size * 0.5;
 		Vector3 ofs = min + half_extents;
 
 		// forward side of plane?
@@ -146,7 +146,7 @@ struct BVH_ABB {
 
 	bool intersects_convex_optimized(const ConvexHull &p_hull, const uint32_t *p_plane_ids, uint32_t p_num_planes) const {
 		Vector3 size = calculate_size();
-		Vector3 half_extents = size * 0.5f;
+		Vector3 half_extents = size * 0.5;
 		Vector3 ofs = min + half_extents;
 
 		for (unsigned int i = 0; i < p_num_planes; i++) {
@@ -192,7 +192,7 @@ struct BVH_ABB {
 
 	bool is_point_within_hull(const ConvexHull &p_hull, const Vector3 &p_pt) const {
 		for (int n = 0; n < p_hull.num_planes; n++) {
-			if (p_hull.planes[n].distance_to(p_pt) > 0) {
+			if (p_hull.planes[n].distance_to(p_pt) > 0.0f) {
 				return false;
 			}
 		}
@@ -258,38 +258,22 @@ struct BVH_ABB {
 
 	void expand(real_t p_change) {
 		POINT change;
-		change.set_all(p_change);
+		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
+			change[axis] = p_change;
+		}
 		grow(change);
 	}
 
 	// Actually surface area metric.
 	real_t get_area() const {
 		POINT d = calculate_size();
-		return 2 * (d.x * d.y + d.y * d.z + d.z * d.x);
+		return 2.0 * (d.x * d.y + d.y * d.z + d.z * d.x);
 	}
 
 	void set_to_max_opposite_extents() {
-		neg_max.set_all(FLT_MAX);
+		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
+			neg_max[axis] = FLT_MAX;
+		}
 		min = neg_max;
 	}
-
-	bool _any_morethan(const POINT &p_a, const POINT &p_b) const {
-		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
-			if (p_a[axis] > p_b[axis]) {
-				return true;
-			}
-		}
-		return false;
-	}
-
-	bool _any_lessthan(const POINT &p_a, const POINT &p_b) const {
-		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
-			if (p_a[axis] < p_b[axis]) {
-				return true;
-			}
-		}
-		return false;
-	}
 };
-
-#endif // BVH_ABB_H

--- a/core/math/bvh_cull.inc
+++ b/core/math/bvh_cull.inc
@@ -28,31 +28,31 @@ struct CullParams {
 };
 
 private:
-void _cull_translate_hits(CullParams &p) {
+void _cull_translate_hits(CullParams &r_params) {
 	int num_hits = _cull_hits.size();
-	int left = p.result_max - p.result_count_overall;
+	int left = r_params.result_max - r_params.result_count_overall;
 
 	if (num_hits > left) {
 		num_hits = left;
 	}
 
-	int out_n = p.result_count_overall;
+	int out_n = r_params.result_count_overall;
 
 	for (int n = 0; n < num_hits; n++) {
 		uint32_t ref_id = _cull_hits[n];
 
 		const ItemExtra &ex = _extra[ref_id];
-		p.result_array[out_n] = ex.userdata;
+		r_params.result_array[out_n] = ex.userdata;
 
-		if (p.subindex_array) {
-			p.subindex_array[out_n] = ex.subindex;
+		if (r_params.subindex_array) {
+			r_params.subindex_array[out_n] = ex.subindex;
 		}
 
 		out_n++;
 	}
 
-	p.result_count = num_hits;
-	p.result_count_overall += num_hits;
+	r_params.result_count = num_hits;
+	r_params.result_count_overall += num_hits;
 }
 
 public:
@@ -177,15 +177,15 @@ int cull_aabb(CullParams &r_params, bool p_translate_hits = true) {
 	return r_params.result_count;
 }
 
-bool _cull_hits_full(const CullParams &p) {
+bool _cull_hits_full(const CullParams &p_params) {
 	// instead of checking every hit, we can do a lazy check for this condition.
 	// it isn't a problem if we write too much _cull_hits because they only the
 	// result_max amount will be translated and outputted. But we might as
 	// well stop our cull checks after the maximum has been reached.
-	return (int)_cull_hits.size() >= p.result_max;
+	return (int)_cull_hits.size() >= p_params.result_max;
 }
 
-void _cull_hit(uint32_t p_ref_id, CullParams &p) {
+void _cull_hit(uint32_t p_ref_id, const CullParams &p_params) {
 	// take into account masks etc
 	// this would be more efficient to do before plane checks,
 	// but done here for ease to get started
@@ -193,7 +193,7 @@ void _cull_hit(uint32_t p_ref_id, CullParams &p) {
 		const ItemExtra &ex = _extra[p_ref_id];
 
 		// user supplied function (for e.g. pairable types and pairable masks in the render tree)
-		if (!USER_CULL_TEST_FUNCTION::user_cull_check(p.tester, ex.userdata)) {
+		if (!USER_CULL_TEST_FUNCTION::user_cull_check(p_params.tester, ex.userdata)) {
 			return;
 		}
 	}
@@ -201,7 +201,7 @@ void _cull_hit(uint32_t p_ref_id, CullParams &p) {
 	_cull_hits.push_back(p_ref_id);
 }
 
-bool _cull_segment_iterative(uint32_t p_node_id, CullParams &r_params) {
+bool _cull_segment_iterative(uint32_t p_node_id, const CullParams &p_params) {
 	// our function parameters to keep on a stack
 	struct CullSegParams {
 		uint32_t node_id;
@@ -225,7 +225,7 @@ bool _cull_segment_iterative(uint32_t p_node_id, CullParams &r_params) {
 
 		if (tnode.is_leaf()) {
 			// lazy check for hits full up condition
-			if (_cull_hits_full(r_params)) {
+			if (_cull_hits_full(p_params)) {
 				return false;
 			}
 
@@ -235,11 +235,11 @@ bool _cull_segment_iterative(uint32_t p_node_id, CullParams &r_params) {
 			for (int n = 0; n < leaf.num_items; n++) {
 				const BVHABB_CLASS &aabb = leaf.get_aabb(n);
 
-				if (aabb.intersects_segment(r_params.segment)) {
+				if (aabb.intersects_segment(p_params.segment)) {
 					uint32_t child_id = leaf.get_item_ref_id(n);
 
 					// register hit
-					_cull_hit(child_id, r_params);
+					_cull_hit(child_id, p_params);
 				}
 			}
 		} else {
@@ -248,7 +248,7 @@ bool _cull_segment_iterative(uint32_t p_node_id, CullParams &r_params) {
 				uint32_t child_id = tnode.children[n];
 				const BVHABB_CLASS &child_abb = _nodes[child_id].aabb;
 
-				if (child_abb.intersects_segment(r_params.segment)) {
+				if (child_abb.intersects_segment(p_params.segment)) {
 					// add to the stack
 					CullSegParams *child = ii.request();
 					child->node_id = child_id;
@@ -262,7 +262,7 @@ bool _cull_segment_iterative(uint32_t p_node_id, CullParams &r_params) {
 	return true;
 }
 
-bool _cull_point_iterative(uint32_t p_node_id, CullParams &r_params) {
+bool _cull_point_iterative(uint32_t p_node_id, const CullParams &p_params) {
 	// our function parameters to keep on a stack
 	struct CullPointParams {
 		uint32_t node_id;
@@ -284,13 +284,13 @@ bool _cull_point_iterative(uint32_t p_node_id, CullParams &r_params) {
 	while (ii.pop(cpp)) {
 		TNode &tnode = _nodes[cpp.node_id];
 		// no hit with this node?
-		if (!tnode.aabb.intersects_point(r_params.point)) {
+		if (!tnode.aabb.intersects_point(p_params.point)) {
 			continue;
 		}
 
 		if (tnode.is_leaf()) {
 			// lazy check for hits full up condition
-			if (_cull_hits_full(r_params)) {
+			if (_cull_hits_full(p_params)) {
 				return false;
 			}
 
@@ -298,11 +298,11 @@ bool _cull_point_iterative(uint32_t p_node_id, CullParams &r_params) {
 
 			// test children individually
 			for (int n = 0; n < leaf.num_items; n++) {
-				if (leaf.get_aabb(n).intersects_point(r_params.point)) {
+				if (leaf.get_aabb(n).intersects_point(p_params.point)) {
 					uint32_t child_id = leaf.get_item_ref_id(n);
 
 					// register hit
-					_cull_hit(child_id, r_params);
+					_cull_hit(child_id, p_params);
 				}
 			}
 		} else {
@@ -323,7 +323,7 @@ bool _cull_point_iterative(uint32_t p_node_id, CullParams &r_params) {
 }
 
 // Note: This is a very hot loop profiling wise. Take care when changing this and profile.
-bool _cull_aabb_iterative(uint32_t p_node_id, CullParams &r_params, bool p_fully_within = false) {
+bool _cull_aabb_iterative(uint32_t p_node_id, const CullParams &p_params, bool p_fully_within = false) {
 	// our function parameters to keep on a stack
 	struct CullAABBParams {
 		uint32_t node_id;
@@ -349,7 +349,7 @@ bool _cull_aabb_iterative(uint32_t p_node_id, CullParams &r_params, bool p_fully
 
 		if (tnode.is_leaf()) {
 			// lazy check for hits full up condition
-			if (_cull_hits_full(r_params)) {
+			if (_cull_hits_full(p_params)) {
 				return false;
 			}
 
@@ -362,7 +362,7 @@ bool _cull_aabb_iterative(uint32_t p_node_id, CullParams &r_params, bool p_fully
 					uint32_t child_id = leaf.get_item_ref_id(n);
 
 					// register hit
-					_cull_hit(child_id, r_params);
+					_cull_hit(child_id, p_params);
 				}
 			} else {
 				// This section is the hottest area in profiling, so
@@ -371,8 +371,8 @@ bool _cull_aabb_iterative(uint32_t p_node_id, CullParams &r_params, bool p_fully
 				int leaf_num_items = leaf.num_items;
 
 				BVHABB_CLASS swizzled_tester;
-				swizzled_tester.min = -r_params.abb.neg_max;
-				swizzled_tester.neg_max = -r_params.abb.min;
+				swizzled_tester.min = -p_params.abb.neg_max;
+				swizzled_tester.neg_max = -p_params.abb.min;
 
 				for (int n = 0; n < leaf_num_items; n++) {
 					const BVHABB_CLASS &aabb = leaf.get_aabb(n);
@@ -381,7 +381,7 @@ bool _cull_aabb_iterative(uint32_t p_node_id, CullParams &r_params, bool p_fully
 						uint32_t child_id = leaf.get_item_ref_id(n);
 
 						// register hit
-						_cull_hit(child_id, r_params);
+						_cull_hit(child_id, p_params);
 					}
 				}
 
@@ -393,9 +393,9 @@ bool _cull_aabb_iterative(uint32_t p_node_id, CullParams &r_params, bool p_fully
 					uint32_t child_id = tnode.children[n];
 					const BVHABB_CLASS &child_abb = _nodes[child_id].aabb;
 
-					if (child_abb.intersects(r_params.abb)) {
+					if (child_abb.intersects(p_params.abb)) {
 						// is the node totally within the aabb?
-						bool fully_within = r_params.abb.is_other_within(child_abb);
+						bool fully_within = p_params.abb.is_other_within(child_abb);
 
 						// add to the stack
 						CullAABBParams *child = ii.request();
@@ -426,7 +426,7 @@ bool _cull_aabb_iterative(uint32_t p_node_id, CullParams &r_params, bool p_fully
 }
 
 // returns full up with results
-bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_fully_within = false) {
+bool _cull_convex_iterative(uint32_t p_node_id, const CullParams &p_params, bool p_fully_within = false) {
 	// our function parameters to keep on a stack
 	struct CullConvexParams {
 		uint32_t node_id;
@@ -445,7 +445,7 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 	ii.get_first()->fully_within = p_fully_within;
 
 	// preallocate these as a once off to be reused
-	uint32_t max_planes = r_params.hull.num_planes;
+	uint32_t max_planes = p_params.hull.num_planes;
 	uint32_t *plane_ids = (uint32_t *)alloca(sizeof(uint32_t) * max_planes);
 
 	CullConvexParams ccp;
@@ -455,7 +455,7 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 		const TNode &tnode = _nodes[ccp.node_id];
 
 		if (!ccp.fully_within) {
-			typename BVHABB_CLASS::IntersectResult res = tnode.aabb.intersects_convex(r_params.hull);
+			typename BVHABB_CLASS::IntersectResult res = tnode.aabb.intersects_convex(p_params.hull);
 
 			switch (res) {
 				default: {
@@ -472,7 +472,7 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 
 		if (tnode.is_leaf()) {
 			// lazy check for hits full up condition
-			if (_cull_hits_full(r_params)) {
+			if (_cull_hits_full(p_params)) {
 				return false;
 			}
 
@@ -485,7 +485,7 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 					uint32_t child_id = leaf.get_item_ref_id(n);
 
 					// register hit
-					_cull_hit(child_id, r_params);
+					_cull_hit(child_id, p_params);
 				}
 
 			} else {
@@ -495,7 +495,7 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 #define BVH_CONVEX_CULL_OPTIMIZED
 #ifdef BVH_CONVEX_CULL_OPTIMIZED
 				// first find which planes cut the aabb
-				uint32_t num_planes = tnode.aabb.find_cutting_planes(r_params.hull, plane_ids);
+				uint32_t num_planes = tnode.aabb.find_cutting_planes(p_params.hull, plane_ids);
 				BVH_ASSERT(num_planes <= max_planes);
 
 //#define BVH_CONVEX_CULL_OPTIMIZED_RIGOR_CHECK
@@ -510,7 +510,7 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 					//const Item &item = leaf.get_item(n);
 					const BVHABB_CLASS &aabb = leaf.get_aabb(n);
 
-					if (aabb.intersects_convex_optimized(r_params.hull, plane_ids, num_planes)) {
+					if (aabb.intersects_convex_optimized(p_params.hull, plane_ids, num_planes)) {
 						uint32_t child_id = leaf.get_item_ref_id(n);
 
 #ifdef BVH_CONVEX_CULL_OPTIMIZED_RIGOR_CHECK
@@ -518,7 +518,7 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 #endif
 
 						// register hit
-						_cull_hit(child_id, r_params);
+						_cull_hit(child_id, p_params);
 					}
 				}
 
@@ -528,7 +528,7 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 				for (int n = 0; n < leaf.num_items; n++) {
 					const BVHABB_CLASS &aabb = leaf.get_aabb(n);
 
-					if (aabb.intersects_convex_partial(r_params.hull)) {
+					if (aabb.intersects_convex_partial(p_params.hull)) {
 						uint32_t child_id = leaf.get_item_ref_id(n);
 
 						CRASH_COND(child_id != results[test_count++]);
@@ -543,12 +543,13 @@ bool _cull_convex_iterative(uint32_t p_node_id, CullParams &r_params, bool p_ful
 				for (int n = 0; n < leaf.num_items; n++) {
 					const BVHABB_CLASS &aabb = leaf.get_aabb(n);
 
-					if (aabb.intersects_convex_partial(r_params.hull)) {
+					if (aabb.intersects_convex_partial(p_params.hull)) {
 						uint32_t child_id = leaf.get_item_ref_id(n);
 
 						// full up with results? exit early, no point in further testing
-						if (!_cull_hit(child_id, r_params))
+						if (!_cull_hit(child_id, p_params)) {
 							return false;
+						}
 					}
 				}
 #endif // BVH_CONVEX_CULL_OPTIMIZED

--- a/core/math/bvh_debug.inc
+++ b/core/math/bvh_debug.inc
@@ -1,21 +1,22 @@
 public:
 #ifdef BVH_VERBOSE
 void _debug_recursive_print_tree(int p_tree_id) const {
-	if (_root_node_id[p_tree_id] != BVHCommon::INVALID)
+	if (_root_node_id[p_tree_id] != BVHCommon::INVALID) {
 		_debug_recursive_print_tree_node(_root_node_id[p_tree_id]);
+	}
 }
 
-String _debug_aabb_to_string(const BVHABB_CLASS &aabb) const {
-	POINT size = aabb.calculate_size();
+String _debug_aabb_to_string(const BVHABB_CLASS &p_aabb) const {
+	POINT size = p_aabb.calculate_size();
 
 	String sz;
-	float vol = 0.0;
+	real_t vol = 0.0;
 
 	for (int i = 0; i < POINT::AXIS_COUNT; ++i) {
 		sz += "(";
-		sz += itos(aabb.min[i]);
+		sz += itos(p_aabb.min[i]);
 		sz += " ~ ";
-		sz += itos(-aabb.neg_max[i]);
+		sz += itos(-p_aabb.neg_max[i]);
 		sz += ") ";
 
 		vol += size[i];
@@ -29,11 +30,7 @@ String _debug_aabb_to_string(const BVHABB_CLASS &aabb) const {
 void _debug_recursive_print_tree_node(uint32_t p_node_id, int depth = 0) const {
 	const TNode &tnode = _nodes[p_node_id];
 
-	String sz = "";
-	for (int n = 0; n < depth; n++) {
-		sz += "\t";
-	}
-	sz += itos(p_node_id);
+	String sz = String("\t").repeat(depth) + itos(p_node_id);
 
 	if (tnode.is_leaf()) {
 		sz += " L";
@@ -42,8 +39,9 @@ void _debug_recursive_print_tree_node(uint32_t p_node_id, int depth = 0) const {
 
 		sz += "[";
 		for (int n = 0; n < leaf.num_items; n++) {
-			if (n)
+			if (n) {
 				sz += ", ";
+			}
 			sz += "r";
 			sz += itos(leaf.get_item_ref_id(n));
 		}

--- a/core/math/bvh_logic.inc
+++ b/core/math/bvh_logic.inc
@@ -1,4 +1,3 @@
-
 // for slow incremental optimization, we will periodically remove each
 // item from the tree and reinsert, to give it a chance to find a better position
 void _logic_item_remove_and_reinsert(uint32_t p_ref_id) {
@@ -34,10 +33,10 @@ void _logic_item_remove_and_reinsert(uint32_t p_ref_id) {
 }
 
 // from randy gaul balance function
-BVHABB_CLASS _logic_abb_merge(const BVHABB_CLASS &a, const BVHABB_CLASS &b) {
-	BVHABB_CLASS c = a;
-	c.merge(b);
-	return c;
+BVHABB_CLASS _logic_abb_merge(const BVHABB_CLASS &p_left, const BVHABB_CLASS &p_right) {
+	BVHABB_CLASS tmp = p_left;
+	tmp.merge(p_right);
+	return tmp;
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -66,7 +65,7 @@ BVHABB_CLASS _logic_abb_merge(const BVHABB_CLASS &a, const BVHABB_CLASS &b) {
 // https://github.com/RandyGaul/qu3e
 // It is MODIFIED from qu3e version.
 // This is the only function used (and _logic_abb_merge helper function).
-int32_t _logic_balance(int32_t iA, uint32_t p_tree_id) {
+int32_t _logic_balance(int32_t iA, uint32_t p_tree_id) { // NOLINT(readability-identifier-naming)
 	//return iA; // uncomment this to bypass balance
 
 	TNode *A = &_nodes[iA];

--- a/core/math/bvh_misc.inc
+++ b/core/math/bvh_misc.inc
@@ -1,4 +1,3 @@
-
 int _handle_get_tree_id(BVHHandle p_handle) const {
 	if (USE_PAIRS) {
 		return _extra[p_handle.id()].tree_id;
@@ -32,20 +31,20 @@ void create_root_node(int p_tree) {
 	}
 }
 
-bool node_is_leaf_full(TNode &tnode) const {
-	const TLeaf &leaf = _node_get_leaf(tnode);
+bool node_is_leaf_full(const TNode &p_tnode) const {
+	const TLeaf &leaf = _node_get_leaf(p_tnode);
 	return leaf.is_full();
 }
 
 public:
-TLeaf &_node_get_leaf(TNode &tnode) {
-	BVH_ASSERT(tnode.is_leaf());
-	return _leaves[tnode.get_leaf_id()];
+TLeaf &_node_get_leaf(const TNode &p_tnode) {
+	BVH_ASSERT(p_tnode.is_leaf());
+	return _leaves[p_tnode.get_leaf_id()];
 }
 
-const TLeaf &_node_get_leaf(const TNode &tnode) const {
-	BVH_ASSERT(tnode.is_leaf());
-	return _leaves[tnode.get_leaf_id()];
+const TLeaf &_node_get_leaf(const TNode &p_tnode) const {
+	BVH_ASSERT(p_tnode.is_leaf());
+	return _leaves[p_tnode.get_leaf_id()];
 }
 
 private:

--- a/core/math/bvh_pair.inc
+++ b/core/math/bvh_pair.inc
@@ -3,9 +3,9 @@ public:
 // depends which works best for cache.
 struct ItemPairs {
 	struct Link {
-		void set(BVHHandle h, void *ud) {
-			handle = h;
-			userdata = ud;
+		void set(BVHHandle p_handle, void *p_userdata) {
+			handle = p_handle;
+			userdata = p_userdata;
 		}
 		BVHHandle handle;
 		void *userdata;
@@ -23,35 +23,39 @@ struct ItemPairs {
 	int32_t num_pairs;
 	LocalVector<Link> extended_pairs;
 
-	void add_pair_to(BVHHandle h, void *p_userdata) {
+	void add_pair_to(BVHHandle p_handle, void *p_userdata) {
 		Link temp;
-		temp.set(h, p_userdata);
+		temp.set(p_handle, p_userdata);
 
 		extended_pairs.push_back(temp);
 		num_pairs++;
 	}
 
-	uint32_t find_pair_to(BVHHandle h) const {
+	uint32_t find_pair_to(BVHHandle p_handle) const {
 		for (int n = 0; n < num_pairs; n++) {
-			if (extended_pairs[n].handle == h) {
+			if (extended_pairs[n].handle == p_handle) {
 				return n;
 			}
 		}
-		return -1;
+		return uint32_t(-1);
 	}
 
-	bool contains_pair_to(BVHHandle h) const {
-		return find_pair_to(h) != BVHCommon::INVALID;
+	bool contains_pair_to(BVHHandle p_handle) const {
+		return find_pair_to(p_handle) != BVHCommon::INVALID;
 	}
 
 	// return success
-	void *remove_pair_to(BVHHandle h) {
+	void *remove_pair_to(BVHHandle p_handle) {
 		void *userdata = nullptr;
 
 		for (int n = 0; n < num_pairs; n++) {
-			if (extended_pairs[n].handle == h) {
+			if (extended_pairs[n].handle == p_handle) {
 				userdata = extended_pairs[n].userdata;
+#if GODOT_VERSION_MAJOR >= 4
+				extended_pairs.remove_at_unordered(n);
+#else
 				extended_pairs.remove_unordered(n);
+#endif
 				num_pairs--;
 				break;
 			}
@@ -64,9 +68,9 @@ struct ItemPairs {
 	// when the number of pairs is high, the density is high and a lower collision margin is better.
 	// when there are few local pairs, a larger margin is more optimal.
 	real_t scale_expansion_margin(real_t p_margin) const {
-		real_t x = (real_t)num_pairs * (real_t)(1.0 / 9.0);
+		real_t x = real_t(num_pairs) * (1.0 / 9.0);
 		x = MIN(x, 1.0);
-		x = 1 - x;
+		x = 1.0 - x;
 		return p_margin * x;
 	}
 };

--- a/core/math/bvh_public.inc
+++ b/core/math/bvh_public.inc
@@ -202,8 +202,11 @@ void item_remove(BVHHandle p_handle) {
 
 	// swap back and decrement for fast unordered remove
 	_active_refs[active_ref_id] = ref_id_moved_back;
+#if GODOT_VERSION_MAJOR >= 4
+	_active_refs.resize_uninitialized(_active_refs.size() - 1);
+#else
 	_active_refs.resize(_active_refs.size() - 1);
-
+#endif
 	// keep the moved active reference up to date
 	_extra[ref_id_moved_back].active_ref_id = active_ref_id;
 	////////////////////////////////////////
@@ -452,7 +455,7 @@ void update() {
 }
 
 void params_set_pairing_expansion(real_t p_value) {
-	if (p_value < 0) {
+	if (p_value < 0.0) {
 #ifdef BVH_ALLOW_AUTO_EXPANSION
 		_auto_pairing_expansion = true;
 #endif
@@ -465,8 +468,8 @@ void params_set_pairing_expansion(real_t p_value) {
 	_pairing_expansion = p_value;
 
 	// calculate shrinking threshold
-	const real_t fudge_factor = 1.1f;
-	_aabb_shrinkage_threshold = _pairing_expansion * POINT::AXIS_COUNT * 2 * fudge_factor;
+	const real_t fudge_factor = 1.1;
+	_aabb_shrinkage_threshold = _pairing_expansion * POINT::AXIS_COUNT * 2.0 * fudge_factor;
 }
 
 // This routine is not just an enclose check, it also checks for special case of shrinkage
@@ -481,8 +484,8 @@ bool expanded_aabb_encloses_not_shrink(const BOUNDS &p_expanded_aabb, const BOUN
 	const POINT &exp_size = p_expanded_aabb.size;
 	const POINT &new_size = p_aabb.size;
 
-	real_t exp_l = 0;
-	real_t new_l = 0;
+	real_t exp_l = 0.0;
+	real_t new_l = 0.0;
 
 	for (int i = 0; i < POINT::AXIS_COUNT; ++i) {
 		exp_l += exp_size[i];

--- a/core/math/bvh_split.inc
+++ b/core/math/bvh_split.inc
@@ -11,45 +11,49 @@ void _split_inform_references(uint32_t p_node_id) {
 	}
 }
 
-void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, uint16_t *group_b, const BVHABB_CLASS *temp_bounds, const BVHABB_CLASS full_bound) {
+void _split_leaf_sort_groups_simple(int &r_num_a, int &r_num_b, uint16_t *r_group_a, uint16_t *r_group_b, const BVHABB_CLASS *p_temp_bounds, const BVHABB_CLASS p_full_bound) {
 	// special case for low leaf sizes .. should static compile out
-	if (MAX_ITEMS < 4) {
-		uint32_t ind = group_a[0];
+	if constexpr (MAX_ITEMS < 4) {
+		uint32_t ind = r_group_a[0];
 
 		// add to b
-		group_b[num_b++] = ind;
+		r_group_b[r_num_b++] = ind;
 
 		// remove from a
-		group_a[0] = group_a[num_a - 1];
-		num_a--;
+		r_num_a--;
+		r_group_a[0] = r_group_a[r_num_a];
 		return;
 	}
 
-	POINT centre = full_bound.calculate_centre();
-	POINT size = full_bound.calculate_size();
+	POINT center = p_full_bound.calculate_center();
+	POINT size = p_full_bound.calculate_size();
 
 	int order[POINT::AXIS_COUNT];
-
+#if GODOT_VERSION_MAJOR >= 4
+	order[0] = size.max_axis_index(); // The longest axis.
+	order[POINT::AXIS_COUNT - 1] = size.min_axis_index(); // The shortest axis.
+#else
 	order[0] = size.max_axis();
 	order[POINT::AXIS_COUNT - 1] = size.min_axis();
+#endif
 
 	static_assert(POINT::AXIS_COUNT <= 3, "BVH POINT::AXIS_COUNT has unexpected size");
-	if (POINT::AXIS_COUNT == 3) {
+	if constexpr (POINT::AXIS_COUNT == 3) {
 		order[1] = 3 - (order[0] + order[2]);
 	}
 
-	// simplest case, split on the longest axis
+	// Simplest case, split on the longest axis.
 	int split_axis = order[0];
-	for (int a = 0; a < num_a; a++) {
-		uint32_t ind = group_a[a];
+	for (int a = 0; a < r_num_a; a++) {
+		uint32_t ind = r_group_a[a];
 
-		if (temp_bounds[ind].min.coord[split_axis] > centre.coord[split_axis]) {
+		if (p_temp_bounds[ind].min[split_axis] > center[split_axis]) {
 			// add to b
-			group_b[num_b++] = ind;
+			r_group_b[r_num_b++] = ind;
 
 			// remove from a
-			group_a[a] = group_a[num_a - 1];
-			num_a--;
+			r_num_a--;
+			r_group_a[a] = r_group_a[r_num_a];
 
 			// do this one again, as it has been replaced
 			a--;
@@ -59,28 +63,28 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 	// detect when split on longest axis failed
 	int min_threshold = MAX_ITEMS / 4;
 	int min_group_size[POINT::AXIS_COUNT];
-	min_group_size[0] = MIN(num_a, num_b);
+	min_group_size[0] = MIN(r_num_a, r_num_b);
 	if (min_group_size[0] < min_threshold) {
 		// slow but sure .. first move everything back into a
-		for (int b = 0; b < num_b; b++) {
-			group_a[num_a++] = group_b[b];
+		for (int b = 0; b < r_num_b; b++) {
+			r_group_a[r_num_a++] = r_group_b[b];
 		}
-		num_b = 0;
+		r_num_b = 0;
 
-		// now calculate the best split
+		// Now calculate the best split.
 		for (int axis = 1; axis < POINT::AXIS_COUNT; axis++) {
 			split_axis = order[axis];
 			int count = 0;
 
-			for (int a = 0; a < num_a; a++) {
-				uint32_t ind = group_a[a];
+			for (int a = 0; a < r_num_a; a++) {
+				uint32_t ind = r_group_a[a];
 
-				if (temp_bounds[ind].min.coord[split_axis] > centre.coord[split_axis]) {
+				if (p_temp_bounds[ind].min[split_axis] > center[split_axis]) {
 					count++;
 				}
 			}
 
-			min_group_size[axis] = MIN(count, num_a - count);
+			min_group_size[axis] = MIN(count, r_num_a - count);
 		} // for axis
 
 		// best axis
@@ -97,16 +101,16 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 		if (best_min > 0) {
 			split_axis = order[best_axis];
 
-			for (int a = 0; a < num_a; a++) {
-				uint32_t ind = group_a[a];
+			for (int a = 0; a < r_num_a; a++) {
+				uint32_t ind = r_group_a[a];
 
-				if (temp_bounds[ind].min.coord[split_axis] > centre.coord[split_axis]) {
+				if (p_temp_bounds[ind].min[split_axis] > center[split_axis]) {
 					// add to b
-					group_b[num_b++] = ind;
+					r_group_b[r_num_b++] = ind;
 
 					// remove from a
-					group_a[a] = group_a[num_a - 1];
-					num_a--;
+					r_num_a--;
+					r_group_a[a] = r_group_a[r_num_a];
 
 					// do this one again, as it has been replaced
 					a--;
@@ -116,62 +120,62 @@ void _split_leaf_sort_groups_simple(int &num_a, int &num_b, uint16_t *group_a, u
 	} // if the longest axis wasn't a good split
 
 	// special case, none crossed threshold
-	if (!num_b) {
-		uint32_t ind = group_a[0];
+	if (!r_num_b) {
+		uint32_t ind = r_group_a[0];
 
 		// add to b
-		group_b[num_b++] = ind;
+		r_group_b[r_num_b++] = ind;
 
 		// remove from a
-		group_a[0] = group_a[num_a - 1];
-		num_a--;
+		r_num_a--;
+		r_group_a[0] = r_group_a[r_num_a];
 	}
 	// opposite problem! :)
-	if (!num_a) {
-		uint32_t ind = group_b[0];
+	if (!r_num_a) {
+		uint32_t ind = r_group_b[0];
 
 		// add to a
-		group_a[num_a++] = ind;
+		r_group_a[r_num_a++] = ind;
 
 		// remove from b
-		group_b[0] = group_b[num_b - 1];
-		num_b--;
+		r_num_b--;
+		r_group_b[0] = r_group_b[r_num_b];
 	}
 }
 
-void _split_leaf_sort_groups(int &num_a, int &num_b, uint16_t *group_a, uint16_t *group_b, const BVHABB_CLASS *temp_bounds) {
+void _split_leaf_sort_groups(int &r_num_a, int &r_num_b, uint16_t *r_group_a, uint16_t *r_group_b, const BVHABB_CLASS *p_temp_bounds) {
 	BVHABB_CLASS groupb_aabb;
 	groupb_aabb.set_to_max_opposite_extents();
-	for (int n = 0; n < num_b; n++) {
-		int which = group_b[n];
-		groupb_aabb.merge(temp_bounds[which]);
+	for (int n = 0; n < r_num_b; n++) {
+		int which = r_group_b[n];
+		groupb_aabb.merge(p_temp_bounds[which]);
 	}
 	BVHABB_CLASS groupb_aabb_new;
 
 	BVHABB_CLASS rest_aabb;
 
-	float best_size = FLT_MAX;
+	real_t best_size = FLT_MAX;
 	int best_candidate = -1;
 
 	// find most likely from a to move into b
-	for (int check = 0; check < num_a; check++) {
+	for (int check = 0; check < r_num_a; check++) {
 		rest_aabb.set_to_max_opposite_extents();
 		groupb_aabb_new = groupb_aabb;
 
 		// find aabb of all the rest
-		for (int rest = 0; rest < num_a; rest++) {
+		for (int rest = 0; rest < r_num_a; rest++) {
 			if (rest == check) {
 				continue;
 			}
 
-			int which = group_a[rest];
-			rest_aabb.merge(temp_bounds[which]);
+			int which = r_group_a[rest];
+			rest_aabb.merge(p_temp_bounds[which]);
 		}
 
-		groupb_aabb_new.merge(temp_bounds[group_a[check]]);
+		groupb_aabb_new.merge(p_temp_bounds[r_group_a[check]]);
 
 		// now compare the sizes
-		float size = groupb_aabb_new.get_area() + rest_aabb.get_area();
+		real_t size = groupb_aabb_new.get_area() + rest_aabb.get_area();
 		if (size < best_size) {
 			best_size = size;
 			best_candidate = check;
@@ -179,11 +183,11 @@ void _split_leaf_sort_groups(int &num_a, int &num_b, uint16_t *group_a, uint16_t
 	}
 
 	// we should now have the best, move it from group a to group b
-	group_b[num_b++] = group_a[best_candidate];
+	r_group_b[r_num_b++] = r_group_a[best_candidate];
 
 	// remove best candidate from group a
-	num_a--;
-	group_a[best_candidate] = group_a[num_a];
+	r_num_a--;
+	r_group_a[best_candidate] = r_group_a[r_num_a];
 }
 
 uint32_t split_leaf(uint32_t p_node_id, const BVHABB_CLASS &p_added_item_aabb) {

--- a/core/math/bvh_structs.inc
+++ b/core/math/bvh_structs.inc
@@ -1,4 +1,3 @@
-
 public:
 struct ItemRef {
 	uint32_t tnode_id; // -1 is invalid
@@ -60,14 +59,26 @@ private:
 
 public:
 	// accessors
-	BVHABB_CLASS &get_aabb(uint32_t p_id) { return aabbs[p_id]; }
-	const BVHABB_CLASS &get_aabb(uint32_t p_id) const { return aabbs[p_id]; }
+	BVHABB_CLASS &get_aabb(uint32_t p_id) {
+		BVH_ASSERT(p_id < MAX_ITEMS);
+		return aabbs[p_id];
+	}
+	const BVHABB_CLASS &get_aabb(uint32_t p_id) const {
+		BVH_ASSERT(p_id < MAX_ITEMS);
+		return aabbs[p_id];
+	}
 
-	uint32_t &get_item_ref_id(uint32_t p_id) { return item_ref_ids[p_id]; }
-	const uint32_t &get_item_ref_id(uint32_t p_id) const { return item_ref_ids[p_id]; }
+	uint32_t &get_item_ref_id(uint32_t p_id) {
+		BVH_ASSERT(p_id < MAX_ITEMS);
+		return item_ref_ids[p_id];
+	}
+	const uint32_t &get_item_ref_id(uint32_t p_id) const {
+		BVH_ASSERT(p_id < MAX_ITEMS);
+		return item_ref_ids[p_id];
+	}
 
 	bool is_dirty() const { return dirty; }
-	void set_dirty(bool p) { dirty = p; }
+	void set_dirty(bool p_dirty) { dirty = p_dirty; }
 
 	void clear() {
 		num_items = 0;
@@ -129,8 +140,8 @@ struct TNode {
 
 	bool is_full_of_children() const { return num_children >= MAX_CHILDREN; }
 
-	void remove_child_internal(uint32_t child_num) {
-		children[child_num] = children[num_children - 1];
+	void remove_child_internal(uint32_t p_child_num) {
+		children[p_child_num] = children[num_children - 1];
 		num_children--;
 	}
 
@@ -161,13 +172,13 @@ PooledList<TLeaf, uint32_t, true> _leaves;
 // we can maintain an un-ordered list of which references are active,
 // in order to do a slow incremental optimize of the tree over each frame.
 // This will work best if dynamic objects and static objects are in a different tree.
-LocalVector<uint32_t, uint32_t, true> _active_refs;
+LocalVector<uint32_t> _active_refs;
 uint32_t _current_active_ref = 0;
 
 // instead of translating directly to the userdata output,
 // we keep an intermediate list of hits as reference IDs, which can be used
 // for pairing collision detection
-LocalVector<uint32_t, uint32_t, true> _cull_hits;
+LocalVector<uint32_t> _cull_hits;
 
 // We can now have a user definable number of trees.
 // This allows using e.g. a non-pairable and pairable tree,

--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -28,8 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#ifndef BVH_TREE_H
-#define BVH_TREE_H
+#pragma once
 
 // BVH Tree
 // This is an implementation of a dynamic BVH with templated leaf size.
@@ -38,15 +37,17 @@
 // It also means that the splitting logic etc have to be completely different
 // to a simpler tree.
 // Note that MAX_CHILDREN should be fixed at 2 for now.
-
-#include "core/local_vector.h"
 #include "core/math/aabb.h"
 #include "core/math/bvh_abb.h"
-#include "core/math/geometry.h"
 #include "core/math/vector3.h"
+#include "core/version_generated.gen.h"
+#if GODOT_VERSION_MAJOR >= 4
+#include "core/templates/local_vector.h"
+#include "core/templates/pooled_list.h"
+#else
+#include "core/local_vector.h"
 #include "core/pooled_list.h"
-#include "core/print_string.h"
-#include <limits.h>
+#endif
 
 #define BVHABB_CLASS BVH_ABB<BOUNDS, POINT>
 
@@ -54,8 +55,17 @@
 #define BVH_EXPAND_LEAF_AABBS
 
 // never do these checks in release
-#if defined(TOOLS_ENABLED) && defined(DEBUG_ENABLED)
+#if ((GODOT_VERSION_MAJOR >= 4) && defined(DEV_ENABLED)) || (defined(TOOLS_ENABLED) && defined(DEBUG_ENABLED))
 //#define BVH_VERBOSE
+
+#ifdef BVH_VERBOSE
+#if GODOT_VERSION_MAJOR >= 4
+#include "core/variant/variant.h"
+#else
+#include "core/print_string.h"
+#endif
+#endif
+
 //#define BVH_VERBOSE_TREE
 //#define BVH_VERBOSE_PAIRING
 //#define BVH_VERBOSE_MOVES
@@ -107,12 +117,10 @@ struct BVHHandle {
 };
 
 // helper class to make iterative versions of recursive functions
-template <class T>
+template <typename T>
 class BVH_IterativeInfo {
 public:
-	enum {
-		ALLOCA_STACK_SIZE = 128
-	};
+	constexpr static const size_t ALLOCA_STACK_SIZE = 128;
 
 	int32_t depth = 1;
 	int32_t threshold = ALLOCA_STACK_SIZE - 2;
@@ -140,7 +148,11 @@ public:
 	// request new addition to stack
 	T *request() {
 		if (depth > threshold) {
+#if GODOT_VERSION_MAJOR >= 4
+			if (aux_stack.is_empty()) {
+#else
 			if (aux_stack.empty()) {
+#endif
 				aux_stack.resize(ALLOCA_STACK_SIZE * 2);
 				memcpy(aux_stack.ptr(), stack, get_alloca_stacksize());
 			} else {
@@ -153,7 +165,7 @@ public:
 	}
 };
 
-template <class T>
+template <typename T>
 class BVH_DummyPairTestFunction {
 public:
 	static bool user_pair_check(const T *p_a, const T *p_b) {
@@ -162,7 +174,7 @@ public:
 	}
 };
 
-template <class T>
+template <typename T>
 class BVH_DummyCullTestFunction {
 public:
 	static bool user_cull_check(const T *p_a, const T *p_b) {
@@ -171,12 +183,12 @@ public:
 	}
 };
 
-template <class T, int NUM_TREES, int MAX_CHILDREN, int MAX_ITEMS, class USER_PAIR_TEST_FUNCTION = BVH_DummyPairTestFunction<T>, class USER_CULL_TEST_FUNCTION = BVH_DummyCullTestFunction<T>, bool USE_PAIRS = false, class BOUNDS = AABB, class POINT = Vector3>
+template <typename T, int NUM_TREES, int MAX_CHILDREN, int MAX_ITEMS, typename USER_PAIR_TEST_FUNCTION = BVH_DummyPairTestFunction<T>, typename USER_CULL_TEST_FUNCTION = BVH_DummyCullTestFunction<T>, bool USE_PAIRS = false, typename BOUNDS = AABB, typename POINT = Vector3>
 class BVH_Tree {
 	friend class BVH;
 
-#include "bvh_pair.inc"
-#include "bvh_structs.inc"
+#include "core/math/bvh_pair.inc"
+#include "core/math/bvh_structs.inc"
 
 public:
 	BVH_Tree() {
@@ -217,7 +229,7 @@ private:
 		BVH_ASSERT(!parent.is_leaf());
 
 		int child_num = parent.find_child(p_old_child_id);
-		BVH_ASSERT(child_num != BVHCommon::INVALID);
+		BVH_ASSERT(child_num != -1);
 		parent.children[child_num] = p_new_child_id;
 
 		TNode &new_child = _nodes[p_new_child_id];
@@ -229,14 +241,13 @@ private:
 		BVH_ASSERT(!parent.is_leaf());
 
 		int child_num = parent.find_child(p_child_id);
-		BVH_ASSERT(child_num != BVHCommon::INVALID);
+		BVH_ASSERT(child_num != -1);
 
 		parent.remove_child_internal(child_num);
 
 		// no need to keep back references for children at the moment
 
-		// Always a node id, as tnode is never a leaf.
-		uint32_t sibling_id = BVHCommon::INVALID;
+		uint32_t sibling_id = BVHCommon::INVALID; // always a node id, as tnode is never a leaf
 		bool sibling_present = false;
 
 		// if there are more children, or this is the root node, don't try and delete
@@ -447,16 +458,14 @@ private:
 		return child_node_id;
 	}
 
-#include "bvh_cull.inc"
-#include "bvh_debug.inc"
-#include "bvh_integrity.inc"
-#include "bvh_logic.inc"
-#include "bvh_misc.inc"
-#include "bvh_public.inc"
-#include "bvh_refit.inc"
-#include "bvh_split.inc"
+#include "core/math/bvh_cull.inc"
+#include "core/math/bvh_debug.inc"
+#include "core/math/bvh_integrity.inc"
+#include "core/math/bvh_logic.inc"
+#include "core/math/bvh_misc.inc"
+#include "core/math/bvh_public.inc"
+#include "core/math/bvh_refit.inc"
+#include "core/math/bvh_split.inc"
 };
 
 #undef VERBOSE_PRINT
-
-#endif // BVH_TREE_H


### PR DESCRIPTION
This is the 3.x version, see #122867 for the equivalent 4.x PR

## What problem(s) does this PR solve?

Makes all the core/math/bvh_\*\.\* files the same between 4.x and 3.x. 

This will allow additional BVH work to benefit both 3.x and 4.x.

## Additional information

Uses GODOT_VERSION_MAJOR macros to handle discrepencies.

Code was cleaned up along the way, including a few r_param / p_param errors and adding const where possible.

Macros should be easy to mechanically remove in future if we want to revert to seperate BVH code.
