### PR TITLE
Fix: Corrupted scene load caused by misplaced character in scene file

### DIFF
--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1829,6 +1829,9 @@ Error VariantParser::parse_tag_assign_eof(Stream *p_stream, int &r_line, String 
 				return err;
 			}
 		} else if (c == '\n') {
+			if (what.length()) {
+				return ERR_FILE_CORRUPT;
+			}
 			r_line++;
 		}
 	}


### PR DESCRIPTION

## What problem(s) does this PR solve?

- Closes #122824

## Additional information

```
[gd_scene format=3 uid="uid://y30mf816qt5b"]

[node name="Node" type="Node" unique_id=70928734]

[node name="Node" type="Node" parent="." unique_id=709208734]
m
[node name="Node1" type="Node" parent="." unique_id=1613559442]

[node name="Node2" type="Node" parent="." unique_id=134649808]
```


On newline there is no check for `what` not being empty, therefore it builds up to `m[node name` breaking the parser without throwing an error. This leads to the scene partially loading. A simple check fixes the issue.