### PR TITLE
Add `ValuePtr` (like `std::indirect`). Halve `SignalData` size from ~176 -> ~80 bytes (12mb off editor)

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1188,9 +1188,8 @@ void Object::add_user_signal(const MethodInfo &p_signal) {
 	ObjectSignalLock signal_lock(this);
 
 	ERR_FAIL_COND_MSG(signal_map.has(p_signal.name), vformat("Trying to add already existing signal '%s'.", p_signal.name));
-	SignalData s;
-	s.user = p_signal;
-	signal_map[p_signal.name] = s;
+	SignalData &signal_data = signal_map[p_signal.name];
+	signal_data.user_signal_info = ValuePtr<MethodInfo>::make(p_signal);
 }
 
 bool Object::_has_user_signal(const StringName &p_name) const {
@@ -1199,7 +1198,7 @@ bool Object::_has_user_signal(const StringName &p_name) const {
 	if (!signal_map.has(p_name)) {
 		return false;
 	}
-	return signal_map[p_name].user.name.length() > 0;
+	return signal_map[p_name].user_signal_info;
 }
 
 void Object::_remove_user_signal(const StringName &p_name) {
@@ -1513,9 +1512,9 @@ void Object::get_signal_list(List<MethodInfo> *p_signals) const {
 	//find maybe usersignals?
 
 	for (const KeyValue<StringName, SignalData> &E : signal_map) {
-		if (!E.value.user.name.is_empty()) {
+		if (E.value.user_signal_info) {
 			//user signal
-			p_signals->push_back(E.value.user);
+			p_signals->push_back(*E.value.user_signal_info);
 		}
 	}
 }

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -41,6 +41,7 @@
 #include "core/templates/hash_set.h"
 #include "core/templates/list.h"
 #include "core/templates/safe_refcount.h"
+#include "core/templates/value_ptr.h"
 #include "core/variant/variant.h"
 
 #define ADD_SIGNAL(m_signal) get_gdtype_static_mutable().add_signal(m_signal)
@@ -418,7 +419,7 @@ private:
 			List<Connection>::Element *cE = nullptr;
 		};
 
-		MethodInfo user;
+		ValuePtr<MethodInfo> user_signal_info;
 		HashMap<Callable, Slot> slot_map;
 		bool removable = false;
 	};

--- a/core/templates/value_ptr.h
+++ b/core/templates/value_ptr.h
@@ -1,0 +1,165 @@
+/**************************************************************************/
+/*  value_ptr.h                                                           */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/os/memory.h"
+
+#include <cstddef>
+#include <utility>
+
+/**
+ * A smart pointer with unique ownership, similar to std::indirect.
+ * As opposed to unique_ptr, it supports copy assignment.
+ */
+template <typename T>
+class ValuePtr {
+	T *_ptr = nullptr;
+
+	explicit ValuePtr(T *p_data) :
+			_ptr(p_data) {}
+
+public:
+	// Allows access to the pointee type statically.
+	// Matches the same declaration from std smart pointers (std::shared_ptr etc.).
+	using element_type = T;
+
+	_FORCE_INLINE_ T &operator*() { return *_ptr; }
+	_FORCE_INLINE_ const T &operator*() const { return *_ptr; }
+
+	_FORCE_INLINE_ T *operator->() { return _ptr; }
+	_FORCE_INLINE_ const T *operator->() const { return _ptr; }
+
+	_FORCE_INLINE_ operator bool() const { return _ptr; }
+
+	_FORCE_INLINE_ T *ptr() { return _ptr; }
+	_FORCE_INLINE_ const T *ptr() const { return _ptr; }
+
+	_FORCE_INLINE_ void reset() {
+		if (_ptr) {
+			memdelete(_ptr);
+			_ptr = nullptr;
+		}
+	}
+
+	_FORCE_INLINE_ ValuePtr &operator=(const ValuePtr &p_ptr) {
+		if (this == &p_ptr) {
+			return *this;
+		}
+		reset();
+		if (p_ptr._ptr) {
+			_ptr = memnew(T(*p_ptr._ptr));
+		} else {
+			_ptr = nullptr;
+		}
+		return *this;
+	}
+	_FORCE_INLINE_ ValuePtr &operator=(ValuePtr &&p_ptr) {
+		if (_ptr == p_ptr._ptr) {
+			return *this;
+		}
+		reset();
+		_ptr = p_ptr._ptr;
+		p_ptr._ptr = nullptr;
+		return *this;
+	}
+
+	template <typename... Args>
+	static ValuePtr make(Args &&...p_args) {
+		return ValuePtr(memnew(T(std::forward<Args>(p_args)...)));
+	}
+
+	ValuePtr() = default;
+	ValuePtr(std::nullptr_t) :
+			_ptr(nullptr) {}
+	ValuePtr(const ValuePtr &p_ptr) {
+		if (!p_ptr._ptr) {
+			return;
+		}
+		_ptr = memnew(T(*p_ptr._ptr));
+	}
+	ValuePtr(ValuePtr &&p_ptr) {
+		_ptr = p_ptr._ptr;
+		p_ptr._ptr = nullptr;
+	}
+	~ValuePtr() {
+		reset();
+	}
+};
+
+template <typename TL, typename TR>
+bool operator==(const ValuePtr<TL> &p_lhs, const ValuePtr<TR> &p_rhs) {
+	return p_lhs.ptr() == p_rhs.ptr() || (p_lhs.ptr() && p_rhs.ptr() && *p_lhs == *p_rhs);
+}
+
+template <typename TL, typename TR>
+bool operator!=(const ValuePtr<TL> &p_lhs, const ValuePtr<TR> &p_rhs) {
+	return !(p_lhs == p_rhs);
+}
+
+template <typename TL, typename TR>
+bool operator==(const TL &p_lhs, const ValuePtr<TR> &p_rhs) {
+	return p_rhs.ptr() && p_lhs == *p_rhs;
+}
+
+template <typename TL, typename TR>
+bool operator!=(const TL &p_lhs, const ValuePtr<TR> &p_rhs) {
+	return !(p_lhs == p_rhs);
+}
+
+template <typename TL, typename TR>
+bool operator==(const ValuePtr<TL> &p_lhs, const TR &p_rhs) {
+	return p_lhs.ptr() && *p_lhs == p_rhs;
+}
+
+template <typename TL, typename TR>
+bool operator!=(const ValuePtr<TL> &p_lhs, const TR &p_rhs) {
+	return !(p_lhs == p_rhs);
+}
+
+template <typename TL>
+bool operator==(const ValuePtr<TL> &p_lhs, std::nullptr_t p_rhs) {
+	return p_lhs.ptr() == nullptr;
+}
+
+template <typename TL>
+bool operator!=(const ValuePtr<TL> &p_lhs, std::nullptr_t p_rhs) {
+	return p_lhs.ptr() != nullptr;
+}
+
+template <typename TR>
+bool operator==(std::nullptr_t p_lhs, const ValuePtr<TR> &p_rhs) {
+	return nullptr == p_rhs.ptr();
+}
+
+template <typename TR>
+bool operator!=(std::nullptr_t p_lhs, const ValuePtr<TR> &p_rhs) {
+	return nullptr != p_rhs.ptr();
+}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Related to `SharedPtr` (https://github.com/godotengine/godot/pull/106600/)

Halves `SignalData` size from ~176 -> ~80 bytes.

Expected savings:
- Medium size project with 5k connected-signal entries: 0.5mb
- Large project with 50k connected-signal entries: 5mb
- Editor measured at ~12mb savings (~2% of tracked static allocations)
     - 157,721 connections across 109,725 entries across 24,472 objects on an empty project

## Additional information

I added `ValuePtr` (analogous to `std::indirect`, which is in itself `std::unique_ptr` but with copy semantics) to make this easier. Without it, `SignalData` has to manage the lifetime by itself, which adds ~30 LOC that makes it unnecessarily complicated.

`ValuePtr` should be useful with the expectation that this won't be the last time we need to stash away rare values behind an allocation.
