### PR TITLE
Fix billboard in GPU particles

### DIFF
--- a/drivers/gles3/shaders/particles_copy.glsl
+++ b/drivers/gles3/shaders/particles_copy.glsl
@@ -105,7 +105,6 @@ void main() {
 						oc * axis.z * axis.x - axis.y * s, oc * axis.y * axis.z + axis.x * s, oc * axis.z * axis.z + c);
 				vec3 new_up = rotated * align_up;
 				mat3 local = mat3(normalize(cross(new_up, sort_direction)), new_up, sort_direction);
-				local = local * mat3(txform);
 				txform[0].xyz = local[0];
 				txform[1].xyz = local[1];
 				txform[2].xyz = local[2];

--- a/servers/rendering/renderer_rd/shaders/particles_copy.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles_copy.glsl
@@ -199,7 +199,6 @@ void main() {
 						oc * axis.z * axis.x - axis.y * s, oc * axis.y * axis.z + axis.x * s, oc * axis.z * axis.z + c);
 				vec3 new_up = rotated * params.align_up;
 				mat3 local = mat3(normalize(cross(new_up, params.sort_direction)), new_up, params.sort_direction);
-				local = local * mat3(txform);
 				txform[0].xyz = local[0];
 				txform[1].xyz = local[1];
 				txform[2].xyz = local[2];


### PR DESCRIPTION
## What problem(s) does this PR solve?

If the GPUParticle node is rotated, billboarding form the node (copy shader) will preserve that rotation and THEN billboard.
This was something i did intentionally because i thought it'd be nice to allow it, but as it turns out, and as i should have known lol, it causes more problems for the sake of a feature nobody actually asked for.
Emitting particles from something that moves along a path follow, for example, doesn't work, and causes the particles to be half invisible because they are "billboarding wrong"

## Additional information

No ai