### PR TITLE
[macOS] Support exporting with debug symbols.

### DIFF
--- a/editor/export/editor_export_platform_pc.cpp
+++ b/editor/export/editor_export_platform_pc.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
+#include "core/io/zip_io.h"
 #include "core/os/os.h"
 #include "core/os/shared_object.h"
 #include "scene/resources/image_texture.h" // IWYU pragma: keep. Misdetection of `logo`.
@@ -61,6 +62,7 @@ void EditorExportPlatformPC::get_export_options(List<ExportOption> *r_options) c
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/release", PROPERTY_HINT_GLOBAL_FILE, ext_filter), ""));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "debug/export_console_wrapper", PROPERTY_HINT_ENUM, "No,Debug Only,Debug and Release"), 1));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "debug/export_debug_symbols", PROPERTY_HINT_ENUM, "No,Debug Only,Debug and Release"), 1));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "binary_format/embed_pck"), false));
 
@@ -152,6 +154,91 @@ Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_pr
 	return err;
 }
 
+Error EditorExportPlatformPC::_unzip_debugsymbols(Ref<DirAccess> &p_da, const String &p_path, const String &p_symbols_path, const String &p_zip_path) {
+	PackedByteArray extracted_data;
+	{
+		Ref<FileAccess> zip_access;
+		zlib_filefunc_def io = zipio_create_io(&zip_access);
+		unzFile uzf = unzOpen2(p_zip_path.utf8().get_data(), &io);
+		if (!uzf) {
+			return ERR_FILE_CANT_OPEN;
+		}
+
+		int err = UNZ_OK;
+
+		// Locate and open the file.
+		err = godot_unzip_locate_file(uzf, p_symbols_path, true);
+		if (err != UNZ_OK) {
+			unzClose(uzf);
+			return ERR_FILE_NOT_FOUND;
+		}
+
+		err = unzOpenCurrentFile(uzf);
+		if (err != UNZ_OK) {
+			unzClose(uzf);
+			return ERR_FILE_CANT_OPEN;
+		}
+
+		// Read the file info.
+		unz_file_info info;
+		err = unzGetCurrentFileInfo(uzf, &info, nullptr, 0, nullptr, 0, nullptr, 0);
+		if (err != UNZ_OK) {
+			unzCloseCurrentFile(uzf);
+			unzClose(uzf);
+			return ERR_FILE_CANT_OPEN;
+		}
+
+		// Read the file data.
+		extracted_data.resize(info.uncompressed_size);
+		uint8_t *buffer = extracted_data.ptrw();
+		int to_read = extracted_data.size();
+		while (to_read > 0) {
+			int bytes_read_current = unzReadCurrentFile(uzf, buffer, to_read);
+			if (bytes_read_current < 0 || (bytes_read_current == UNZ_EOF && to_read != 0)) {
+				unzCloseCurrentFile(uzf);
+				unzClose(uzf);
+				return ERR_FILE_CANT_READ;
+			}
+			buffer += bytes_read_current;
+			to_read -= bytes_read_current;
+		}
+
+		// Verify the data and return.
+		err = unzCloseCurrentFile(uzf);
+		if (err != UNZ_OK) {
+			unzClose(uzf);
+			return ERR_FILE_CANT_READ;
+		}
+		unzClose(uzf);
+	}
+
+	// Prepare target file.
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::WRITE);
+	if (f.is_null()) {
+		return ERR_CANT_CREATE;
+	}
+	f->store_buffer(extracted_data);
+
+	return OK;
+}
+
+bool EditorExportPlatformPC::_copy_debugsymbols(Ref<DirAccess> &p_da, const String &p_path, const String &p_symbols_path, Error &r_err) {
+	r_err = OK;
+
+	if (FileAccess::exists(p_symbols_path)) {
+		r_err = p_da->copy(p_symbols_path, p_path + ".debugsymbols");
+	} else if (FileAccess::exists(p_symbols_path + ".zip")) {
+		r_err = _unzip_debugsymbols(p_da, p_path + ".debugsymbols", p_symbols_path.get_file(), p_symbols_path + ".zip");
+	} else {
+		return false;
+	}
+	if (r_err == OK) {
+		r_err = fixup_debug_symbol_link(p_path, p_path.get_file() + ".debugsymbols");
+	}
+
+	return r_err == OK;
+}
+
 Error EditorExportPlatformPC::prepare_template(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags) {
 	if (!DirAccess::exists(p_path.get_base_dir())) {
 		add_message(EXPORT_MESSAGE_ERROR, TTR("Prepare Template"), TTR("The given export path doesn't exist."));
@@ -182,8 +269,12 @@ Error EditorExportPlatformPC::prepare_template(const Ref<EditorExportPreset> &p_
 		"console.exe",
 		nullptr,
 	};
+
 	int con_wrapper_mode = p_preset->get("debug/export_console_wrapper");
 	bool copy_wrapper = (con_wrapper_mode == 1 && p_debug) || (con_wrapper_mode == 2);
+
+	int debug_symbols_mode = p_preset->get("debug/export_debug_symbols");
+	bool copy_debug_symbols = (debug_symbols_mode == 1 && p_debug) || (debug_symbols_mode == 2);
 
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	da->make_dir_recursive(p_path.get_base_dir());
@@ -194,6 +285,16 @@ Error EditorExportPlatformPC::prepare_template(const Ref<EditorExportPreset> &p_
 			if (FileAccess::exists(wrapper_path)) {
 				err = da->copy(wrapper_path, p_path.get_basename() + ".console.exe", get_chmod_flags());
 				break;
+			}
+		}
+	}
+	if (err == OK && copy_debug_symbols) {
+		_copy_debugsymbols(da, p_path, template_path + ".debugsymbols", err);
+		if (err == OK && copy_wrapper) {
+			for (int i = 0; wrapper_extensions[i]; ++i) {
+				if (_copy_debugsymbols(da, p_path.get_basename() + ".console.exe", template_path.get_basename() + wrapper_extensions[i] + ".debugsymbols", err)) {
+					break;
+				}
 			}
 		}
 	}

--- a/editor/export/editor_export_platform_pc.h
+++ b/editor/export/editor_export_platform_pc.h
@@ -44,6 +44,9 @@ private:
 
 	int chmod_flags = -1;
 
+	Error _unzip_debugsymbols(Ref<DirAccess> &p_da, const String &p_path, const String &p_symbols_path, const String &p_zip_path);
+	bool _copy_debugsymbols(Ref<DirAccess> &p_da, const String &p_path, const String &p_symbols_path, Error &r_err);
+
 public:
 	virtual void get_preset_features(const Ref<EditorExportPreset> &p_preset, List<String> *r_features) const override;
 	virtual void get_export_options(List<ExportOption> *r_options) const override;
@@ -76,6 +79,9 @@ public:
 	void set_chmod_flags(int p_flags);
 
 	virtual Error fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size) {
+		return Error::OK;
+	}
+	virtual Error fixup_debug_symbol_link(const String &p_path, const String &p_symbol_path) {
 		return Error::OK;
 	}
 };

--- a/platform/linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml
+++ b/platform/linuxbsd/doc_classes/EditorExportPlatformLinuxBSD.xml
@@ -26,6 +26,11 @@
 		<member name="debug/export_console_wrapper" type="int" setter="" getter="">
 			If [code]true[/code], a console wrapper is exported alongside the main executable, which allows running the project with enabled console output.
 		</member>
+		<member name="debug/export_debug_symbols" type="int" setter="" getter="">
+			If [code]true[/code], a debug symbol file ([code].debugsymbols[/code]) is exported alongside the main executable. This also applies to the console wrapper if enabled.
+			[b]Note:[/b] This requires a separate debug symbols file. This file must have the same name as the export template binary and an additional [code].debugsymbols[/code] extension, and must be present in the same directory as the export template binary, or in a ZIP archive with a [code].debugsymbols.zip[/code] extension.
+			[b]Note:[/b] If debug symbols are embedded in the export template binary, they will remain embedded in the exported project binary regardless of this option, so it should be disabled in that case.
+		</member>
 		<member name="shader_baker/enabled" type="bool" setter="" getter="">
 			If [code]true[/code], shaders will be compiled and embedded in the application. This option is only supported when using the Forward+ or Mobile renderers.
 			[b]Note:[/b] When exporting as a dedicated server, the shader baker is always disabled since no rendering is performed.

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -302,6 +302,177 @@ String EditorExportPlatformLinuxBSD::_get_exe_arch(const String &p_path) const {
 	}
 }
 
+static inline size_t _padding(size_t p_s, size_t p_a) {
+	return (p_s % p_a == 0) ? 0 : (p_a - p_s % p_a);
+}
+
+Error EditorExportPlatformLinuxBSD::fixup_debug_symbol_link(const String &p_path, const String &p_symbol_file) {
+	// Patch the ".gnu_debuglink" section in the ELF file so that it corresponds to external debug symbols file.
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ_WRITE);
+	if (f.is_null()) {
+		add_message(EXPORT_MESSAGE_ERROR, TTR("Debug Symbols Link"), vformat(TTR("Failed to open executable file \"%s\"."), p_path));
+		return ERR_CANT_OPEN;
+	}
+
+	// New debug symbols link data.
+	CharString cs_link = p_symbol_file.utf8();
+	uint32_t new_link_size = cs_link.size() + _padding(cs_link.size(), 4) + 4;
+
+	// Read and check ELF magic number.
+	{
+		uint32_t magic = f->get_32();
+		if (magic != 0x464c457f) { // 0x7F + "ELF"
+			add_message(EXPORT_MESSAGE_ERROR, TTR("Debug Symbols Link"), TTR("Executable file header corrupted."));
+			return ERR_FILE_CORRUPT;
+		}
+	}
+
+	// Read program architecture bits from class field.
+
+	int bits = f->get_8() * 32;
+
+	// Get info about the section header table.
+
+	int64_t section_table_pos;
+	int64_t section_header_size;
+	if (bits == 32) {
+		section_header_size = 40;
+		f->seek(0x20);
+		section_table_pos = f->get_32();
+		f->seek(0x30);
+	} else { // 64
+		section_header_size = 64;
+		f->seek(0x28);
+		section_table_pos = f->get_64();
+		f->seek(0x3c);
+	}
+	int num_sections = f->get_16();
+	int string_section_idx = f->get_16();
+
+	// Load the strings table.
+	uint8_t *strings;
+	{
+		// Jump to the strings section header.
+		f->seek(section_table_pos + string_section_idx * section_header_size);
+
+		// Read strings data size and offset.
+		int64_t string_data_pos;
+		int64_t string_data_size;
+		if (bits == 32) {
+			f->seek(f->get_position() + 0x10);
+			string_data_pos = f->get_32();
+			string_data_size = f->get_32();
+		} else { // 64
+			f->seek(f->get_position() + 0x18);
+			string_data_pos = f->get_64();
+			string_data_size = f->get_64();
+		}
+
+		// Read strings data.
+		f->seek(string_data_pos);
+		strings = (uint8_t *)memalloc(string_data_size);
+		if (!strings) {
+			return ERR_OUT_OF_MEMORY;
+		}
+		f->get_buffer(strings, string_data_size);
+	}
+
+	// Search for the ".gnu_debuglink" section.
+
+	uint32_t link_crc32 = 0;
+	bool found = false;
+	for (int i = 0; i < num_sections; ++i) {
+		int64_t section_header_pos = section_table_pos + i * section_header_size;
+		f->seek(section_header_pos);
+
+		uint32_t name_offset = f->get_32();
+		if (strcmp((char *)strings + name_offset, ".gnu_debuglink") == 0) {
+			// ".gnu_debuglink" section found.
+
+			int64_t link_start = 0;
+			int64_t link_size = 0;
+			if (bits == 32) {
+				f->seek(section_header_pos + 0x10);
+				link_start = f->get_32();
+				link_size = f->get_32();
+			} else { // 64
+				f->seek(section_header_pos + 0x18);
+				link_start = f->get_64();
+				link_size = f->get_64();
+			}
+
+			f->seek(link_start);
+
+			// Read CRC.
+			uint32_t link_off = 0;
+			while (link_off < link_size) {
+				uint8_t c = f->get_8();
+				link_off++;
+				if (c == 0x00) {
+					uint32_t pad = _padding(link_off, 4);
+					f->seek(f->get_position() + pad);
+					link_crc32 = f->get_32();
+					break;
+				}
+			}
+
+			if (link_size >= new_link_size) {
+				// Update existing section in place.
+				f->seek(link_start);
+				f->store_buffer((const uint8_t *)cs_link.get_data(), cs_link.size());
+				for (uint32_t j = 0; j < _padding(cs_link.size(), 4); j++) {
+					f->store_8(0x00);
+				}
+				f->store_32(link_crc32);
+
+				// Update section data.
+				if (bits == 32) {
+					f->seek(section_header_pos + 0x14);
+					f->store_32(new_link_size);
+				} else { // 64
+					f->seek(section_header_pos + 0x20);
+					f->store_64(new_link_size);
+				}
+			} else {
+				// Zero old section data.
+				f->seek(link_start);
+				for (uint32_t j = 0; j < link_size; j++) {
+					f->store_8(0x00);
+				}
+				// Append new data.
+				f->seek_end();
+				uint64_t link_pos = f->get_position();
+				f->store_buffer((const uint8_t *)cs_link.get_data(), cs_link.size());
+				for (uint32_t j = 0; j < _padding(cs_link.size(), 4); j++) {
+					f->store_8(0x00);
+				}
+				f->store_32(link_crc32);
+				// Update section data.
+				if (bits == 32) {
+					f->seek(section_header_pos + 0x10);
+					f->store_32(link_pos);
+					f->store_32(new_link_size);
+				} else { // 64
+					f->seek(section_header_pos + 0x18);
+					f->store_64(link_pos);
+					f->store_64(new_link_size);
+				}
+			}
+
+			found = true;
+			break;
+		}
+	}
+
+	memfree(strings);
+
+	if (!found) {
+		add_message(EXPORT_MESSAGE_WARNING, TTR("Debug Symbols Link"), TTR("Executable \".gnu_debuglink\" section not found."));
+		return ERR_FILE_CORRUPT;
+	}
+	return OK;
+}
+
 Error EditorExportPlatformLinuxBSD::fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size) {
 	// Patch the header of the "pck" section in the ELF file so that it corresponds to the embedded data.
 

--- a/platform/linuxbsd/export/export_plugin.h
+++ b/platform/linuxbsd/export/export_plugin.h
@@ -76,6 +76,7 @@ public:
 	virtual bool has_valid_export_configuration(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates, bool p_debug = false) const override;
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags = 0, bool p_notify = true) override;
 	virtual String get_template_file_name(const String &p_target, const String &p_arch) const override;
+	virtual Error fixup_debug_symbol_link(const String &p_path, const String &p_symbol_file) override;
 	virtual Error fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size) override;
 	virtual bool is_executable(const String &p_path) const override;
 

--- a/platform/macos/crash_handler_macos.mm
+++ b/platform/macos/crash_handler_macos.mm
@@ -30,10 +30,12 @@
 
 #import "crash_handler_macos.h"
 
+#include "os_macos.h"
+
 #include "core/config/project_settings.h"
+#include "core/io/dir_access.h"
 #include "core/object/script_language.h"
 #include "core/os/main_loop.h"
-#include "core/os/os.h"
 #include "core/string/print_string.h"
 #include "core/version.h"
 #include "main/main.h"
@@ -52,6 +54,20 @@
 #include <cxxabi.h>
 #include <execinfo.h>
 
+static String find_debugsymbols(const String &p_exec_path) {
+	const String base_dir = p_exec_path.get_base_dir() + "/";
+	const String exec_bundle = p_exec_path.get_file() + ".dSYM";
+
+	// First try the current executable name plus `.dSYM`, possibly in a `.debug` folder.
+	if (DirAccess::exists(p_exec_path + ".dSYM")) {
+		return p_exec_path + ".dSYM";
+	} else if (DirAccess::exists(base_dir + ".debug/" + exec_bundle)) {
+		return base_dir + ".debug/" + exec_bundle;
+	}
+
+	return p_exec_path;
+}
+
 static void handle_crash(int sig) {
 	signal(SIGSEGV, SIG_DFL);
 	signal(SIGFPE, SIG_DFL);
@@ -68,7 +84,7 @@ static void handle_crash(int sig) {
 
 	void *bt_buffer[256];
 	size_t size = backtrace(bt_buffer, 256);
-	String exec_path = OS::get_singleton()->get_executable_path();
+	String exec_path = find_debugsymbols(static_cast<OS_MacOS *>(OS::get_singleton())->get_bundle_or_executable_path());
 
 	String msg;
 	if (ProjectSettings::get_singleton()) {

--- a/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
+++ b/platform/macos/doc_classes/EditorExportPlatformMacOS.xml
@@ -181,6 +181,11 @@
 		<member name="debug/export_console_wrapper" type="int" setter="" getter="">
 			If enabled, a wrapper that can be used to run the application with console output is created alongside the exported application.
 		</member>
+		<member name="debug/export_debug_symbols" type="int" setter="" getter="">
+			If [code]true[/code], a debug symbol bundle ([code].dSYM[/code]) is exported alongside the main executable.
+			[b]Note:[/b] This requires a separate debug symbols bundle. This bundle must have the same name as the export template archive and an additional [code].dSYM[/code] extension, and must be present in the same directory as the export template binary, or in a ZIP archive with a [code].dSYM.zip[/code] extension.
+			[b]Note:[/b] If debug symbols are embedded in the export template binary, they will remain embedded in the exported project binary regardless of this option, so it should be disabled in that case.
+		</member>
 		<member name="display/high_res" type="bool" setter="" getter="">
 			If [code]true[/code], the application is rendered at native display resolution, otherwise it is always rendered at loDPI resolution and upscaled by OS when required.
 		</member>

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -480,6 +480,7 @@ void EditorExportPlatformMacOS::get_export_options(List<ExportOption> *r_options
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/release", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "debug/export_console_wrapper", PROPERTY_HINT_ENUM, "No,Debug Only,Debug and Release"), 1));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "debug/export_debug_symbols", PROPERTY_HINT_ENUM, "No,Debug Only,Debug and Release"), 1));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/liquid_glass_icon", PROPERTY_HINT_FILE, "*.icon"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/icon", PROPERTY_HINT_FILE, "*.icns,*.png,*.webp,*.svg"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "application/icon_interpolation", PROPERTY_HINT_ENUM, "Nearest neighbor,Bilinear,Cubic,Trilinear,Lanczos"), 4));
@@ -1623,6 +1624,143 @@ Error EditorExportPlatformMacOS::_export_debug_script(const Ref<EditorExportPres
 	return OK;
 }
 
+Error EditorExportPlatformMacOS::_unzip_debugsymbols(Ref<DirAccess> &p_da, const String &p_path, const String &p_zip_path, const String &p_app_name, bool p_debug) {
+	Ref<FileAccess> io_fa;
+	zlib_filefunc_def io = zipio_create_io(&io_fa);
+
+	unzFile src_pkg_zip = unzOpen2(p_zip_path.utf8().get_data(), &io);
+	if (!src_pkg_zip) {
+		add_message(EXPORT_MESSAGE_WARNING, TTR("Prepare Templates"), vformat(TTR("Could not find debug symbols to export: \"%s\"."), p_zip_path));
+		return ERR_FILE_NOT_FOUND;
+	}
+
+	String template_name = p_debug ? "template_debug" : "template_release";
+	int ret = unzGoToFirstFile(src_pkg_zip);
+	while (ret == UNZ_OK) {
+		// Get filename.
+		unz_file_info info;
+		char fname[16384];
+		ret = unzGetCurrentFileInfo(src_pkg_zip, &info, fname, 16384, nullptr, 0, nullptr, 0);
+		if (ret != UNZ_OK) {
+			break;
+		}
+		String file = String::utf8(fname);
+		file = file.trim_prefix("out/macos/templates/");
+		if (file.begins_with(vformat("godot.macos.%s.universal.dSYM/", template_name))) {
+			file = file.trim_prefix(vformat("godot.macos.%s.universal.dSYM/", template_name));
+			file = file.replace(vformat("godot.macos.%s.universal", template_name), p_app_name);
+
+			Vector<uint8_t> data;
+			data.resize(info.uncompressed_size);
+
+			// Read.
+			unzOpenCurrentFile(src_pkg_zip);
+			unzReadCurrentFile(src_pkg_zip, data.ptrw(), data.size());
+			unzCloseCurrentFile(src_pkg_zip);
+
+			if (data.size() > 0) {
+				print_verbose("ADDING: " + file + " size: " + itos(data.size()));
+
+				file = p_path.path_join(file);
+				Error err = p_da->make_dir_recursive(file.get_base_dir());
+				if (err != OK) {
+					add_message(EXPORT_MESSAGE_WARNING, TTR("Export"), vformat(TTR("Could not create directory \"%s\"."), file.get_base_dir()));
+				}
+				if (err == OK) {
+					Ref<FileAccess> f = FileAccess::open(file, FileAccess::WRITE);
+					if (f.is_valid()) {
+						f->store_buffer(data.ptr(), data.size());
+						f.unref();
+					} else {
+						add_message(EXPORT_MESSAGE_WARNING, TTR("Export"), vformat(TTR("Could not open \"%s\"."), file));
+						err = ERR_CANT_CREATE;
+					}
+				}
+			}
+		}
+
+		ret = unzGoToNextFile(src_pkg_zip);
+	}
+
+	// We're done with our source zip.
+	unzClose(src_pkg_zip);
+
+	return OK;
+}
+
+Error EditorExportPlatformMacOS::_copy_debugsymbols_recursively(Ref<DirAccess> &p_da, const String &p_path, const String &p_src_path, const String &p_app_name, bool p_debug) {
+	List<String> dirs;
+
+	Ref<DirAccess> src_da = DirAccess::create_for_path(p_src_path);
+	if (!p_da->dir_exists(p_path)) {
+		Error err = p_da->make_dir(p_path);
+		if (err != OK) {
+			add_message(EXPORT_MESSAGE_WARNING, TTR("Export"), vformat(TTR("Cannot create directory \"%s\"."), p_path));
+			return err;
+		}
+	}
+
+	Error err = src_da->change_dir(p_src_path);
+	if (err != OK) {
+		add_message(EXPORT_MESSAGE_WARNING, TTR("Export"), vformat(TTR("Cannot change current directory to \"%s\"."), p_src_path));
+		return err;
+	}
+
+	String template_name = p_debug ? "template_debug" : "template_release";
+	src_da->list_dir_begin();
+	String n = src_da->get_next();
+	while (!n.is_empty()) {
+		if (n != "." && n != "..") {
+			if (src_da->current_is_dir()) {
+				dirs.push_back(n);
+			} else {
+				const String &rel_path = n.replace(vformat("godot.macos.%s.universal", template_name), p_app_name);
+				if (!n.is_relative_path()) {
+					src_da->list_dir_end();
+					if (err != OK) {
+						add_message(EXPORT_MESSAGE_WARNING, TTR("Export"), vformat(TTR("\"%s\" is not a relative path."), n));
+						return err;
+					}
+				}
+				print_verbose("ADDING: " + rel_path);
+
+				err = p_da->copy(src_da->get_current_dir().path_join(n), p_path.path_join(rel_path));
+				if (err) {
+					src_da->list_dir_end();
+					if (err != OK) {
+						add_message(EXPORT_MESSAGE_WARNING, TTR("Export"), vformat(TTR("Failed to copy file \"%s\"."), n));
+						return err;
+					}
+				}
+			}
+		}
+
+		n = src_da->get_next();
+	}
+
+	src_da->list_dir_end();
+
+	for (const String &rel_path : dirs) {
+		err = _copy_debugsymbols_recursively(p_da, p_path.path_join(rel_path), p_src_path.path_join(rel_path), p_app_name, p_debug);
+		if (err != OK) {
+			return err;
+		}
+	}
+
+	return OK;
+}
+
+bool EditorExportPlatformMacOS::_copy_debugsymbols(Ref<DirAccess> &p_da, const String &p_path, const String &p_symbols_path, const String &p_app_name, bool p_debug, Error &r_err) {
+	if (DirAccess::exists(p_symbols_path.get_basename() + ".dSYM")) {
+		r_err = _copy_debugsymbols_recursively(p_da, p_path.simplify_path(), p_symbols_path.simplify_path().get_basename() + ".dSYM", p_app_name, p_debug);
+	} else if (FileAccess::exists(p_symbols_path.get_basename() + ".dSYM.zip")) {
+		r_err = _unzip_debugsymbols(p_da, p_path.simplify_path(), p_symbols_path.simplify_path().get_basename() + ".dSYM.zip", p_app_name, p_debug);
+	} else {
+		return false;
+	}
+	return r_err == OK;
+}
+
 Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, BitField<EditorExportPlatform::DebugFlags> p_flags, bool p_notify) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags, p_notify);
 
@@ -1698,14 +1836,17 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 	String tmp_base_path_name;
 	String tmp_app_path_name;
 	String scr_path;
+	String dbg_name;
 	if (export_format == "app") {
 		tmp_base_path_name = p_path.get_base_dir();
 		tmp_app_path_name = p_path;
 		scr_path = p_path.get_basename() + ".command";
+		dbg_name = p_path.get_file().get_basename();
 	} else {
 		tmp_base_path_name = EditorPaths::get_singleton()->get_temp_dir().path_join(pkg_name);
 		tmp_app_path_name = tmp_base_path_name.path_join(tmp_app_dir_name);
 		scr_path = tmp_base_path_name.path_join(pkg_name + ".command");
+		dbg_name = pkg_name;
 	}
 
 	print_verbose("Exporting to " + tmp_app_path_name);
@@ -1727,6 +1868,14 @@ Error EditorExportPlatformMacOS::export_project(const Ref<EditorExportPreset> &p
 			tmp_app_dir->erase_contents_recursive();
 			tmp_app_dir->change_dir(old_dir);
 		}
+	}
+
+	int debug_symbols_mode = p_preset->get("debug/export_debug_symbols");
+	bool copy_debug_symbols = (debug_symbols_mode == 1 && p_debug) || (debug_symbols_mode == 2);
+
+	if (copy_debug_symbols) {
+		print_verbose("Exporting debug symbols to " + tmp_app_path_name + ".dSYM");
+		_copy_debugsymbols(tmp_app_dir, tmp_app_path_name + ".dSYM", src_pkg_name, dbg_name, p_debug, err);
 	}
 
 	Array helpers = p_preset->get("codesign/entitlements/app_sandbox/helper_executables");

--- a/platform/macos/export/export_plugin.h
+++ b/platform/macos/export/export_plugin.h
@@ -84,6 +84,10 @@ class EditorExportPlatformMacOS : public EditorExportPlatform {
 	void _fix_plist(const Ref<EditorExportPreset> &p_preset, Vector<uint8_t> &plist, const String &p_binary, bool p_lg_icon_exported, const String &p_lg_icon);
 	void _make_icon(const Ref<EditorExportPreset> &p_preset, const Ref<Image> &p_icon, Vector<uint8_t> &p_data);
 
+	Error _unzip_debugsymbols(Ref<DirAccess> &p_da, const String &p_path, const String &p_zip_path, const String &p_app_name, bool p_debug);
+	Error _copy_debugsymbols_recursively(Ref<DirAccess> &p_da, const String &p_path, const String &p_src_path, const String &p_app_name, bool p_debug);
+	bool _copy_debugsymbols(Ref<DirAccess> &p_da, const String &p_path, const String &p_symbols_path, const String &p_app_name, bool p_debug, Error &r_err);
+
 	Error _export_liquid_glass_icon(const Ref<EditorExportPreset> &p_preset, const String &p_app_path, const String &p_icon_path);
 	Error _notarize(const Ref<EditorExportPreset> &p_preset, const String &p_path);
 	void _code_sign(const Ref<EditorExportPreset> &p_preset, const String &p_path, const String &p_ent_path, bool p_warn = true, bool p_set_id = false);

--- a/platform/macos/os_macos.h
+++ b/platform/macos/os_macos.h
@@ -123,6 +123,7 @@ public:
 	virtual String get_bundle_icon_path() const override;
 	virtual String get_bundle_icon_name() const override;
 	virtual String get_godot_dir_name() const override;
+	String get_bundle_or_executable_path() const;
 
 	virtual String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const override;
 	virtual Error get_entropy(uint8_t *r_buffer, int p_bytes) override;

--- a/platform/macos/os_macos.mm
+++ b/platform/macos/os_macos.mm
@@ -461,6 +461,20 @@ String OS_MacOS::get_bundle_resource_dir() const {
 	return ret;
 }
 
+String OS_MacOS::get_bundle_or_executable_path() const {
+	String ret;
+
+	NSBundle *main = [NSBundle mainBundle];
+	if (main) {
+		NSString *resource_path = [main bundlePath];
+		ret.append_utf8([resource_path UTF8String]);
+	}
+	if (ret.is_empty()) {
+		ret = get_executable_path();
+	}
+	return ret;
+}
+
 String OS_MacOS::get_bundle_icon_path() const {
 	String ret;
 

--- a/platform/windows/doc_classes/EditorExportPlatformWindows.xml
+++ b/platform/windows/doc_classes/EditorExportPlatformWindows.xml
@@ -98,6 +98,11 @@
 		<member name="debug/export_console_wrapper" type="int" setter="" getter="">
 			If [code]true[/code], a console wrapper executable is exported alongside the main executable, which allows running the project with enabled console output.
 		</member>
+		<member name="debug/export_debug_symbols" type="int" setter="" getter="">
+			If [code]true[/code], a debug symbol file ([code].debugsymbols[/code]) is exported alongside the main executable. This also applies to the console wrapper if enabled.
+			[b]Note:[/b] This requires a separate debug symbols file. This file must have the same name as the export template binary and an additional [code].debugsymbols[/code] extension, and must be present in the same directory as the export template binary, or in a ZIP archive with a [code].debugsymbols.zip[/code] extension. A separate file is required for the console wrapper.
+			[b]Note:[/b] If debug symbols are embedded in the export template binary, they will remain embedded in the exported project binary regardless of this option, so it should be disabled in that case.
+		</member>
 		<member name="shader_baker/enabled" type="bool" setter="" getter="">
 			If [code]true[/code], shaders will be compiled and embedded in the application. This option is only supported when using the Forward+ and Mobile renderers.
 			[b]Note:[/b] When exporting as a dedicated server, the shader baker is always disabled since no rendering is performed.

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -808,6 +808,203 @@ String EditorExportPlatformWindows::_get_exe_arch(const String &p_path) const {
 	}
 }
 
+static inline size_t _padding(size_t p_s, size_t p_a) {
+	return (p_s % p_a == 0) ? 0 : (p_a - p_s % p_a);
+}
+
+Error EditorExportPlatformWindows::fixup_debug_symbol_link(const String &p_path, const String &p_symbol_file) {
+	// Patch the ".gnu_debuglink" section in the PE file so that it corresponds to external debug symbols file.
+	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ_WRITE);
+	if (f.is_null()) {
+		add_message(EXPORT_MESSAGE_ERROR, TTR("Debug Symbols Link"), vformat(TTR("Failed to open executable file \"%s\"."), p_path));
+		return ERR_CANT_OPEN;
+	}
+
+	// New debug symbols link data.
+	CharString cs_link = p_symbol_file.utf8();
+	uint32_t new_link_size = cs_link.size() + _padding(cs_link.size(), 4) + 4;
+
+	// Jump to the PE header and check the magic number.
+	{
+		f->seek(0x3c);
+		uint32_t pe_pos = f->get_32();
+
+		f->seek(pe_pos);
+		uint32_t magic = f->get_32();
+		if (magic != 0x00004550) {
+			add_message(EXPORT_MESSAGE_ERROR, TTR("Debug Symbols Link"), TTR("Executable file header corrupted."));
+			return ERR_FILE_CORRUPT;
+		}
+	}
+
+	// Process header.
+	uint32_t sect_alignment = 0x1000;
+	uint32_t image_size = 0;
+	int num_sections;
+	uint64_t string_table_pos = 0;
+
+	int64_t opt_header_pos = 0;
+	int64_t section_table_pos = 0;
+	{
+		int64_t header_pos = f->get_position();
+
+		f->seek(header_pos + 2);
+		num_sections = f->get_16();
+		f->seek(header_pos + 8);
+		string_table_pos += f->get_32();
+		f->seek(header_pos + 12);
+		string_table_pos += f->get_32() * 18;
+		f->seek(header_pos + 16);
+		uint16_t opt_header_size = f->get_16();
+		opt_header_pos = f->get_position() + 2;
+
+		f->seek(opt_header_pos + 32);
+		sect_alignment = f->get_32();
+
+		f->seek(opt_header_pos + 56);
+		image_size = f->get_32();
+
+		// Skip rest of header + optional header to go to the section headers.
+		f->seek(opt_header_pos + opt_header_size);
+		section_table_pos = f->get_position();
+	}
+
+	if (string_table_pos == 0) {
+		add_message(EXPORT_MESSAGE_ERROR, TTR("Debug Symbols Link"), TTR("String table missing."));
+		return ERR_FILE_CORRUPT;
+	}
+
+	// Load the strings table.
+	uint8_t *strings = nullptr;
+	{
+		f->seek(string_table_pos);
+		uint32_t string_data_size = f->get_32();
+
+		// Read strings data.
+		f->seek(string_table_pos);
+		strings = (uint8_t *)memalloc(string_data_size);
+		if (!strings) {
+			return ERR_OUT_OF_MEMORY;
+		}
+		f->get_buffer(strings, string_data_size);
+	}
+
+	// Search for the ".gnu_debuglink" section.
+	bool found = false;
+	uint32_t link_crc32 = 0;
+	int link_old_pos = -1;
+	uint8_t link_section_name[9];
+
+	for (int i = 0; i < num_sections; i++) {
+		int64_t section_header_pos = section_table_pos + i * 40;
+		f->seek(section_header_pos);
+
+		uint8_t section_name[9];
+		f->get_buffer(section_name, 8);
+		section_name[8] = 0x00;
+
+		if (section_name[0] == '/') {
+			uint32_t string_table_off = String::utf8((const char *)&section_name[1], 7).to_int();
+			if (strcmp((char *)strings + string_table_off, ".gnu_debuglink") == 0) {
+				// ".gnu_debuglink" section found.
+
+				f->seek(section_table_pos + i * 40 + 16);
+				uint32_t raw_size = f->get_32();
+				f->seek(section_table_pos + i * 40 + 20);
+				uint32_t raw_pos = f->get_32();
+				f->seek(raw_pos);
+
+				// Read CRC.
+				uint32_t link_off = 0;
+				while (link_off < raw_size) {
+					uint8_t c = f->get_8();
+					link_off++;
+					if (c == 0x00) {
+						uint32_t pad = _padding(link_off, 4);
+						f->seek(f->get_position() + pad);
+						link_crc32 = f->get_32();
+						break;
+					}
+				}
+
+				if (raw_size >= new_link_size && new_link_size < sect_alignment) {
+					// Update existing section in place.
+					f->seek(section_table_pos + i * 40 + 8);
+					f->store_32(new_link_size);
+					f->seek(raw_pos);
+					f->store_buffer((const uint8_t *)cs_link.get_data(), cs_link.size());
+					for (uint32_t j = 0; j < _padding(cs_link.size(), 4); j++) {
+						f->store_8(0x00);
+					}
+					f->store_32(link_crc32);
+				} else {
+					// Zero old section data.
+					f->seek(raw_pos);
+					for (uint32_t j = 0; j < raw_size; j++) {
+						f->store_8(0x00);
+					}
+					// Update virtual size of previous section to avoid gaps in the virtual addresses.
+					f->seek(section_table_pos + (i - 1) * 40 + 8);
+					uint32_t virt_size = f->get_32();
+					f->seek(section_table_pos + (i - 1) * 40 + 8);
+					f->store_32(virt_size + sect_alignment);
+
+					link_old_pos = i;
+					memcpy(&link_section_name[0], &section_name[0], 8);
+				}
+				found = true;
+				break;
+			}
+		}
+	}
+	if (link_old_pos >= 0) {
+		// Move section data.
+		uint8_t section_data[40];
+		for (int i = link_old_pos; i < num_sections - 1; i++) {
+			f->seek(section_table_pos + (i + 1) * 40);
+			f->get_buffer(section_data, 40);
+			f->seek(section_table_pos + i * 40);
+			f->store_buffer(section_data, 40);
+		}
+
+		// Append new data.
+		f->seek_end();
+		uint64_t link_pos = f->get_position();
+		f->store_buffer((const uint8_t *)cs_link.get_data(), cs_link.size());
+		for (uint32_t j = 0; j < _padding(cs_link.size(), 4); j++) {
+			f->store_8(0x00);
+		}
+		f->store_32(link_crc32);
+
+		// Add ".gnu_debuglink" at the end.
+		f->seek(section_table_pos + (num_sections - 1) * 40);
+		f->store_buffer(link_section_name, 8); // Name (reference to string table).
+		f->store_32(new_link_size); // VirtualSize.
+		f->store_32(image_size); // VirtualAddress.
+		f->store_32(new_link_size); // SizeOfRawData.
+		f->store_32(link_pos); // PointerToRawData.
+		f->store_32(0); // PointerToRelocations, not used.
+		f->store_32(0); // PointerToLinenumbers, not used.
+		f->store_16(0); // NumberOfRelocations.
+		f->store_16(0); // NumberOfLinenumbers.
+		f->store_32(0x42000040); // Characteristics: Read, can discard, initialized data.
+
+		// Update image virtual size.
+		f->seek(opt_header_pos + 56);
+		f->store_32(image_size + sect_alignment);
+	}
+
+	f->close();
+
+	memfree(strings);
+
+	if (!found) {
+		add_message(EXPORT_MESSAGE_WARNING, TTR("Debug Symbols Link"), TTR("Executable \".gnu_debuglink\" section not found."));
+		return ERR_FILE_CORRUPT;
+	}
+	return OK;
+}
+
 Error EditorExportPlatformWindows::fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size) {
 	// Patch the header of the "pck" section in the PE file so that it corresponds to the embedded data.
 

--- a/platform/windows/export/export_plugin.h
+++ b/platform/windows/export/export_plugin.h
@@ -84,6 +84,7 @@ public:
 	virtual String get_export_option_warning(const EditorExportPreset *p_preset, const StringName &p_name) const override;
 
 	virtual String get_template_file_name(const String &p_target, const String &p_arch) const override;
+	virtual Error fixup_debug_symbol_link(const String &p_path, const String &p_symbol_file) override;
 	virtual Error fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size) override;
 
 	virtual void get_platform_features(List<String> *r_features) const override;


### PR DESCRIPTION
## What problem(s) does this PR solve?

macOS implementation for https://github.com/godotengine/godot/pull/114924 and https://github.com/godotengine/godot/pull/122764

## Additional information

- Depends on https://github.com/godotengine/godot/pull/114924
- Might require adjustment depending on the way symbols are archived.