### PR TITLE
[2.1] Various fixes as discussed on Bluesky - Fix issue with translation encoding and 2d collision

### DIFF
--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -772,7 +772,7 @@ Vector<String> TranslationServer::get_all_locale_names() {
 	const char **ptr = locale_names;
 
 	while (*ptr) {
-		locales.push_back(*ptr);
+		locales.push_back(String::utf8(*ptr));
 		ptr++;
 	}
 

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -87,7 +87,7 @@ void CollisionShape2D::_notification(int p_what) {
 			unparenting = false;
 			can_update_body = get_tree()->is_editor_hint();
 			if (!get_tree()->is_editor_hint()) {
-				_update_xform_in_parent();
+				// _update_xform_in_parent();
 				//display above all else
 				set_z_as_relative(false);
 				set_z(VS::CANVAS_ITEM_Z_MAX - 1);


### PR DESCRIPTION
Hey folks,

I know 2.1 is no longer maintained, but I discussed with @akien-mga on blueksy ( https://bsky.app/profile/akien.bsky.social/post/3mtw3oodoe227 ) about the fixes I've made for Godot 2.1

The first fix helps with encoding issues while the second helps with random crashes while placing 2D object with collision.

Thanks for your time
Cheers.