### PR TITLE
Fix local scale application in AnimationMixer

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1955,7 +1955,7 @@ void AnimationMixer::_blend_apply() {
 						return;
 					}
 					if (t->loc_used && t->rot_used && t->scale_used) {
-						Transform3D transform = Transform3D(Basis(t->rot).scaled(t->scale), t->loc);
+						Transform3D transform = Transform3D(Basis(t->rot).scaled_local(t->scale), t->loc);
 						t_node_3d->set_transform(transform);
 					} else {
 						if (t->loc_used) {


### PR DESCRIPTION
Fixes #121158.

When position, rotation, and scale tracks are all applied to a Node3D, the AnimationMixer would combine them into a single Transform3D.

The problem was that the combined path used Basis::scaled(), which applies scaling in parent space. This was different from how Node3D's relative scale worked and from the previous behavior of applying position, rotation, and scale separately.


Testing:
- Reproduced #121158 using the provided MRP on Windows.
- Verified the MRP reports the expected scale after this change.

AI Usage: I used AI for debugging guidance and to help understand the relevant Godot code paths. I wrote the production fix myself (Basis::scaled() → Basis::scaled_local()).