### PR TITLE
Fix unintended encryption in PCKPacker test

### DIFF
--- a/tests/core/io/test_pck_packer.cpp
+++ b/tests/core/io/test_pck_packer.cpp
@@ -89,7 +89,7 @@ TEST_CASE("[PCKPacker] Pack a PCK file with some files and directories") {
 	const String base_dir = OS::get_singleton()->get_executable_path().get_base_dir();
 
 	CHECK_MESSAGE(
-			pck_packer.add_file("version.py", base_dir.path_join("../version.py"), "version.py") == OK,
+			pck_packer.add_file("version.py", base_dir.path_join("../version.py")) == OK,
 			"Adding a file to the PCK should return an OK error code.");
 	CHECK_MESSAGE(
 			pck_packer.add_file("some/directories with spaces/to/create/icon.png", base_dir.path_join("../misc/logo/icon.png")) == OK,


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #N/A — this is a standalone test correction.
- Fixes the `PCKPacker` test passing `"version.py"` as the third argument to `add_file()`.
- The third argument of `PCKPacker::add_file()` is `bool p_encrypt`, so the non-empty string is implicitly converted to `true`.
- This unintentionally exercises the encrypted file path for `version.py`.
- Remove the invalid argument so the test uses the default non-encrypted behavior.

## Additional information

N/A

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
