### PR TITLE
NoisePreview: Fix preview not updaing after "3D" toggle change

### DIFF
--- a/modules/noise/editor/noise_editor_plugin.cpp
+++ b/modules/noise/editor/noise_editor_plugin.cpp
@@ -91,6 +91,7 @@ private:
 		} else {
 			_noise->remove_meta("_preview_in_3d_space_");
 		}
+		update_preview();
 	}
 
 	void _notification(int p_what) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

I don't think an issue is open, but here's the short explanation:

If the 3D space view is toggled on or off, the preview doesn't update, but rather when some other property is changed later. This is bad because of two reasons:
- The "3D" button appears to do nothing
- A sudden unexpected change when the user does change something else later

This simply updates the preview after the toggle change.

## Additional information

https://github.com/user-attachments/assets/9ffea55a-2f07-4809-ada3-b322d0310779

No AI was used.