### PR TITLE
Fix main screen container index on Android

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -9212,12 +9212,7 @@ EditorNode::EditorNode() {
 	right_menu_hb->set_mouse_filter(Control::MOUSE_FILTER_STOP);
 	title_bar->add_child(right_menu_hb);
 
-	// FIXME: There has to be a simpler way to determine correct index.
-#ifdef ANDROID_ENABLED
-	title_bar->move_child(editor_main_screen->get_internal_container(), title_bar->get_child_count() / 2);
-#else
-	title_bar->move_child(editor_main_screen->get_internal_container(), left_menu_spacer ? 3 : 2);
-#endif
+	title_bar->move_child(editor_main_screen->get_internal_container(), left_spacer->get_index());
 
 	renderer = memnew(OptionButton);
 	renderer->set_flat(true);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #122861

## Additional information

I have some idea how to remove this hack, but for now this is a safer fix.

EDIT:
Nevermind, removing the hack was really simple in the end. I tested all known title bar layouts and it seems to work in all cases.
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
