### PR TITLE
Clarify that multi_bounce_occlusion is supported in Forward+ only

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3171,6 +3171,7 @@
 		</member>
 		<member name="rendering/lights_and_shadows/multi_bounce_occlusion/enabled" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], approximates local multi-bounce global illumination in ambient occlusion by integrating albedo information.
+			[b]Note:[/b] Multi-bounce occlusion is only supported in the Forward+ rendering method.
 		</member>
 		<member name="rendering/lights_and_shadows/positional_shadow/atlas_16_bits" type="bool" setter="" getter="" default="true">
 			Use 16 bits for the omni/spot shadow depth map. Enabling this results in shadows having less precision and may result in shadow acne, but can lead to performance improvements on some devices.


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Follow up #115426

## Additional information

As a last-minute change, this feature was made exclusive to Forward+ because Mobile does not support SSAO and Compatibility applies SSAO in post-processing.
