### PR TITLE
Make main screen dock colors more readable

### DIFF
--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -1703,6 +1703,7 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 			main_screen_button_hover->set_content_margin((Side)i, p_config.button_style_hover->get_content_margin((Side)i));
 		}
 		p_theme->set_color("font_selected_color", "MainScreenContainer", p_config.accent_color);
+		p_theme->set_color("font_unselected_color", "MainScreenContainer", p_config.font_color);
 		p_theme->set_color("icon_selected_color", "MainScreenContainer", p_config.accent_color);
 		p_theme->set_stylebox("tab_unselected", "MainScreenContainer", menu_transparent_style);
 		p_theme->set_stylebox("tab_selected", "MainScreenContainer", menu_transparent_style);

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1733,6 +1733,7 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 
 		// Main menu.
 		p_theme->set_color("font_selected_color", "MainScreenContainer", p_config.accent_color);
+		p_theme->set_color("font_unselected_color", "MainScreenContainer", p_config.font_color);
 		p_theme->set_color("icon_selected_color", "MainScreenContainer", p_config.accent_color);
 		p_theme->set_stylebox("tab_unselected", "MainScreenContainer", p_config.base_empty_wide_style);
 		p_theme->set_stylebox("tab_selected", "MainScreenContainer", p_config.base_empty_wide_style);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Fixes https://github.com/godotengine/godot/issues/122902

Makes the colors of the main screen dock buttons more readable, similar to how they looked in 4.7 and earlier. Does the fix for both Modern and Classic themes


https://github.com/user-attachments/assets/1f5f5e22-990a-43ff-b82f-62662df39029


