### PR TITLE
Set refresh rate on Android according to the Max FPS project setting

### DIFF
--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
@@ -565,11 +565,38 @@ class Godot private constructor(val context: Context) {
 					java.lang.Boolean.parseBoolean(GodotLib.getGlobal("display/window/per_pixel_transparency/allowed"))
 			Log.d(TAG, "Render view should be transparent: $shouldBeTransparent")
 
+			val activity = host.activity
+
+			val display = activity?.display
+			var highestRefreshRate = 60.0
+			if (display != null) {
+				val supportedRefreshRates = display.getSupportedRefreshRates()
+				for (refreshRate in supportedRefreshRates) {
+					Log.d(TAG, "Supported refresh rate: ${refreshRate} Hz")
+					highestRefreshRate = maxOf(highestRefreshRate, refreshRate.toDouble())
+				}
+
+				Log.d(TAG, "Highest supported refresh rate: ${highestRefreshRate} Hz")
+			}
+
+			// Some devices running Android 15 or later default to 60 Hz unless the app
+			// requests a higher refresh rate, even if the device supports higher refresh rates.
+			//
+			// Set refresh rate to match the FPS limit defined in the project settings.
+			// This improves battery life on devices with a refresh rate above 60 Hz,
+			// and avoids jitter on devices with a refresh rate that is not a multiple of 60 Hz.
+			var refreshRate = Integer.parseInt(GodotLib.getGlobal("application/run/max_fps"))
+			if (refreshRate == 0) {
+				// No FPS limit. Request the highest supported refresh rate to match Android <= 14 behavior.
+				refreshRate = highestRefreshRate.toInt()
+				Log.d(TAG, "Requesting refresh rate: ${refreshRate} Hz")
+			}
+
 			val nativeRenderer = getNativeRenderer()
 			if (nativeRenderer == "vulkan") {
-				renderView = GodotVulkanRenderView(this, godotInputHandler, shouldBeTransparent)
+				renderView = GodotVulkanRenderView(this, godotInputHandler, shouldBeTransparent, refreshRate)
 			} else if (nativeRenderer == "opengl3") {
-				renderView = GodotGLRenderView(this, godotInputHandler, xrMode, useDebugOpengl, shouldBeTransparent)
+				renderView = GodotGLRenderView(this, godotInputHandler, xrMode, useDebugOpengl, shouldBeTransparent, refreshRate)
 			} else {
 				throw IllegalStateException("No native renderer is available.")
 			}
@@ -588,7 +615,6 @@ class Godot private constructor(val context: Context) {
 			editText.setView(renderView)
 			io.setEdit(editText)
 
-			val activity = host.activity
 			// Listeners for keyboard height.
 			val topView = activity?.window?.decorView ?: providedContainerLayout
 			// Report the height of virtual keyboard as it changes during the animation.

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotGLRenderView.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotGLRenderView.java
@@ -46,11 +46,15 @@ import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.PixelFormat;
+import android.os.Build;
 import android.text.TextUtils;
+import android.util.Log;
 import android.util.SparseArray;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.PointerIcon;
+import android.view.Surface;
+import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 
 import androidx.annotation.Keep;
@@ -79,16 +83,18 @@ class GodotGLRenderView extends GLSurfaceView implements GodotRenderView {
 	private final Godot godot;
 	private final GodotInputHandler inputHandler;
 	private final GodotRenderer godotRenderer;
+	private final int mRefreshRate;
 	private final SparseArray<PointerIcon> customPointerIcons = new SparseArray<>();
 
-	public GodotGLRenderView(Godot godot, GodotInputHandler inputHandler, XRMode xrMode, boolean useDebugOpengl, boolean shouldBeTranslucent) {
+	public GodotGLRenderView(Godot godot, GodotInputHandler inputHandler, XRMode xrMode, boolean useDebugOpengl, boolean shouldBeTranslucent, int refreshRate) {
 		super(godot.getContext());
 
 		this.godot = godot;
 		this.inputHandler = inputHandler;
 		this.godotRenderer = new GodotRenderer();
+		mRefreshRate = refreshRate;
 		setPointerIcon(PointerIcon.getSystemIcon(getContext(), PointerIcon.TYPE_DEFAULT));
-		init(xrMode, shouldBeTranslucent, useDebugOpengl);
+		init(xrMode, shouldBeTranslucent, useDebugOpengl, refreshRate);
 	}
 
 	@Override
@@ -240,9 +246,10 @@ class GodotGLRenderView extends GLSurfaceView implements GodotRenderView {
 		return getPointerIcon();
 	}
 
-	private void init(XRMode xrMode, boolean translucent, boolean useDebugOpengl) {
+	private void init(XRMode xrMode, boolean translucent, boolean useDebugOpengl, int refreshRate) {
 		setPreserveEGLContextOnPause(true);
 		setFocusableInTouchMode(true);
+
 		switch (xrMode) {
 			case OPENXR:
 				// Replace the default egl config chooser.
@@ -281,6 +288,19 @@ class GodotGLRenderView extends GLSurfaceView implements GodotRenderView {
 						new RegularFallbackConfigChooser(8, 8, 8, 8, 24, 0,
 								new RegularConfigChooser(8, 8, 8, 8, 16, 0)));
 				break;
+		}
+	}
+
+	@Override
+	public void surfaceCreated(SurfaceHolder holder) {
+		super.surfaceCreated(holder);
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+			Log.i("Godot", "OpenGL: Setting frame rate to " + mRefreshRate);
+			holder.getSurface().setFrameRate(
+					mRefreshRate,
+					Surface.FRAME_RATE_COMPATIBILITY_DEFAULT,
+					Surface.CHANGE_FRAME_RATE_ALWAYS);
 		}
 	}
 

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotVulkanRenderView.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotVulkanRenderView.java
@@ -39,11 +39,15 @@ import android.content.res.AssetManager;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.PixelFormat;
+import android.os.Build;
 import android.text.TextUtils;
+import android.util.Log;
 import android.util.SparseArray;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.PointerIcon;
+import android.view.Surface;
+import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 
 import androidx.annotation.Keep;
@@ -54,20 +58,35 @@ class GodotVulkanRenderView extends VkSurfaceView implements GodotRenderView {
 	private final Godot godot;
 	private final GodotInputHandler mInputHandler;
 	private final VkRenderer mRenderer;
+	private final int mRefreshRate;
 	private final SparseArray<PointerIcon> customPointerIcons = new SparseArray<>();
 
-	public GodotVulkanRenderView(Godot godot, GodotInputHandler inputHandler, boolean shouldBeTranslucent) {
+	public GodotVulkanRenderView(Godot godot, GodotInputHandler inputHandler, boolean shouldBeTranslucent, int refreshRate) {
 		super(godot.getContext());
 
 		this.godot = godot;
 		mInputHandler = inputHandler;
 		mRenderer = new VkRenderer();
+		mRefreshRate = refreshRate;
 		setPointerIcon(PointerIcon.getSystemIcon(getContext(), PointerIcon.TYPE_DEFAULT));
 		setFocusableInTouchMode(true);
 		setClickable(false);
 
 		if (shouldBeTranslucent) {
 			this.getHolder().setFormat(PixelFormat.TRANSLUCENT);
+		}
+	}
+
+	@Override
+	public void surfaceCreated(SurfaceHolder holder) {
+		super.surfaceCreated(holder);
+
+		if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+			Log.i("Godot", "Vulkan: Setting frame rate to " + mRefreshRate);
+			holder.getSurface().setFrameRate(
+					mRefreshRate,
+					Surface.FRAME_RATE_COMPATIBILITY_DEFAULT,
+					Surface.CHANGE_FRAME_RATE_ALWAYS);
 		}
 	}
 


### PR DESCRIPTION
If Max FPS is 0 (no limit, the default), it will request the highest supported refresh rate on the display. This mimics Android <= 14 behavior on Android 15 and later to better match user expectations.

If Max FPS is above 0, the refresh rate that is closest to the FPS limit (determined by Android) will be requested. This improves battery life and avoids jitter if the display's maximum refresh rate is not a multiple of the FPS limit (e.g. 60 FPS games on 90 Hz displays).

Projects that wish to expose in-game FPS limit adjustments should keep the Max FPS project setting to 0 so that the highest refresh rate is requested.

- This closes https://github.com/godotengine/godot/issues/104179.

**Testing project:** [test_android_framerate.zip](https://github.com/user-attachments/files/31534480/test_android_framerate.zip)
<sub>Enable **Show frame rate** in the Android developer options to see the actual refresh rate the device is using.</sub>

### Some findings

On a Samsung Galaxy S26 Ultra running Android 16:

- This PR currently only has an effect in OpenGL, not Vulkan, despite the code being called in both (confirmed with adb prints). Disabling Swappy with `swappy=no` (in case it would take over the Android framerate API) does not resolve this.

- The refresh rate change takes effect roughly 3 seconds after the app starts (with no visible flash or interruption).

- The refresh rate seen by `DisplayServer.screen_get_refresh_rate()` is correctly updated at runtime.

- The FPS value passed to the API is rounded to the nearest available refresh rate. It will usually round down (109 rounds down to 80), but sometimes round up as well (110 rounds up to 120). This means that if you set a FPS cap of 90, the device will use a 80 Hz refresh rate, effectively limiting FPS to 80. To avoid this, we should only assign a lower-than-maximum refresh rate if the specified max FPS is on the list of refresh rates (or a multiple of it is there, for even frame pacing).

- If max FPS is set to 1000, the device will use a 60 Hz refresh rate. This does not occur with max FPS set to 999. We should probably treat `1000` as `0` here and use the maximum available refresh rate instead.

- These refresh rates are available as per adb printing:

```
Supported refresh rate: 120.00002 Hz
Supported refresh rate: 80.000015 Hz
Supported refresh rate: 60.00001 Hz
Supported refresh rate: 48.000008 Hz
Supported refresh rate: 40.000008 Hz
Supported refresh rate: 34.28572 Hz
Supported refresh rate: 30.000006 Hz
Supported refresh rate: 26.666672 Hz
Supported refresh rate: 24.000004 Hz
Supported refresh rate: 21.818184 Hz
Supported refresh rate: 20.000004 Hz
```

## TODO

- [ ] Make it functional in Vulkan.
- [ ] Apply refresh rate only if the max FPS is on the list of supported refresh rates (or if the max FPS is an even divisor of one of the available refresh rates, for even frame pacing).
- [ ] Test on a standalone XR device.
- [x] ~~Currently, it shows an error on startup: `Surface has already been released.`~~
  - ~~I'm not sure how to prevent this. I've tried to keep a reference to the Surface to avoid GC, but that doesn't suffice.~~
  - ~~We could use SurfaceControl instead as per the [framerate](https://developer.android.com/media/optimize/performance/frame-rate#basic-usage) documentation or even JNI in C++, but I'm not sure it's the right tool for the job here. cc @m4gr3d~~
    - Fixed in https://github.com/godotengine/godot/pull/122904/files/3de88c92d30818079fcdfe19cd8fc13911af6aad#diff-ff303a48946ea9c8dc05dbf6554ffdf52deac0425db6d4a1bf2a08ce5bdef2df.
  - Note that we use the framerate API directly instead of Swappy, as Swappy is only available in Vulkan.