### PR TITLE
Add `PanelContainerContextualGroup` for contextual toolbar

### DIFF
--- a/editor/gui/editor_toolbar_group.cpp
+++ b/editor/gui/editor_toolbar_group.cpp
@@ -42,8 +42,12 @@ EditorToolbarGroup::EditorToolbarGroup() {
 	add_child(hbox);
 }
 
-HBoxContainer *EditorToolbarGroup::create(Control *p_parent) {
+HBoxContainer *EditorToolbarGroup::create(Control *p_parent, bool p_contextual) {
 	EditorToolbarGroup *group = memnew(EditorToolbarGroup);
+	if (p_contextual) {
+		group->set_theme_type_variation("PanelContainerContextualGroup");
+	}
+
 	p_parent->add_child(group);
 
 	return group->get_hbox();

--- a/editor/gui/editor_toolbar_group.h
+++ b/editor/gui/editor_toolbar_group.h
@@ -42,7 +42,7 @@ class EditorToolbarGroup : public PanelContainer {
 public:
 	EditorToolbarGroup();
 
-	static HBoxContainer *create(Control *p_parent);
+	static HBoxContainer *create(Control *p_parent, bool p_contextual = false);
 
 	HBoxContainer *get_hbox() const { return hbox; }
 };

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -47,6 +47,7 @@
 #include "editor/editor_string_names.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/gui/editor_spin_slider.h"
+#include "editor/gui/editor_toolbar_group.h"
 #include "editor/plugins/editor_plugin_list.h"
 #include "editor/run/editor_run_bar.h"
 #include "editor/scene/3d/gizmos/audio_listener_3d_gizmo_plugin.h"
@@ -100,7 +101,6 @@
 #include "scene/gui/color_picker.h"
 #include "scene/gui/flow_container.h"
 #include "scene/gui/menu_button.h"
-#include "scene/gui/panel_container.h"
 #include "scene/gui/popup.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/separator.h"
@@ -2577,8 +2577,6 @@ void Node3DEditor::_update_theme() {
 	sun_color->set_custom_minimum_size(Size2(0, get_theme_constant(SNAME("inspector_property_height"), EditorStringName(Editor))));
 	environ_sky_color->set_custom_minimum_size(Size2(0, get_theme_constant(SNAME("inspector_property_height"), EditorStringName(Editor))));
 	environ_ground_color->set_custom_minimum_size(Size2(0, get_theme_constant(SNAME("inspector_property_height"), EditorStringName(Editor))));
-
-	context_toolbar_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("ContextualToolbar"), EditorStringName(EditorStyles)));
 }
 
 void Node3DEditor::_notification(int p_what) {
@@ -2763,7 +2761,7 @@ void Node3DEditor::_update_context_toolbar() {
 		sep->set_visible(!first_visible && child->is_visible());
 	}
 
-	context_toolbar_panel->set_visible(has_visible);
+	Object::cast_to<EditorToolbarGroup>(context_toolbar_hbox->get_parent())->set_visible(has_visible);
 }
 
 void Node3DEditor::set_can_preview(Camera3D *p_preview) {
@@ -3699,10 +3697,7 @@ Node3DEditor::Node3DEditor() {
 	main_flow->add_child(memnew(VSeparator));
 #endif
 
-	context_toolbar_panel = memnew(PanelContainer);
-	context_toolbar_hbox = memnew(HBoxContainer);
-	context_toolbar_panel->add_child(context_toolbar_hbox);
-	main_flow->add_child(context_toolbar_panel);
+	context_toolbar_hbox = EditorToolbarGroup::create(main_flow, true);
 
 	// Get the view menu popup and have it stay open when a checkable item is selected
 	p = view_layout_menu->get_popup();

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -263,7 +263,6 @@ private:
 	void _menu_gizmo_toggled(int p_option);
 	// Used for secondary menu items which are displayed depending on the currently selected node
 	// (such as MeshInstance's "Mesh" menu).
-	PanelContainer *context_toolbar_panel = nullptr;
 	HBoxContainer *context_toolbar_hbox = nullptr;
 	HashMap<Control *, VSeparator *> context_toolbar_separators;
 

--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -4478,12 +4478,10 @@ void CanvasItemEditor::_update_editor_settings() {
 	// with the red color.
 	const Color key_auto_color = EditorThemeManager::is_dark_icon_and_font() ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25);
 	key_auto_insert_button->add_theme_color_override("icon_pressed_color", key_auto_color.lerp(Color(1, 0, 0), 0.55));
-	animation_menu->set_button_icon(get_editor_theme_icon(SNAME("GuiTabMenuHl")));
+	animation_menu->set_button_icon(get_editor_theme_icon(SNAME("GuiDropdown")));
 
 	selection_rectangle_color = EDITOR_GET("editors/2d/selection_rectangle_color");
 	locked_selection_rectangle_color = EDITOR_GET("editors/2d/locked_selection_rectangle_color");
-
-	context_toolbar_panel->add_theme_style_override(SceneStringName(panel), get_theme_stylebox(SNAME("ContextualToolbar"), EditorStringName(EditorStyles)));
 
 	simple_panning = EDITOR_GET("editors/panning/simple_panning");
 	panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/2d_editor_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), simple_panning);
@@ -5752,7 +5750,7 @@ void CanvasItemEditor::_update_context_toolbar() {
 		sep->set_visible(!first_visible && child->is_visible());
 	}
 
-	context_toolbar_panel->set_visible(has_visible);
+	Object::cast_to<EditorToolbarGroup>(context_toolbar_hbox->get_parent())->set_visible(has_visible);
 }
 
 void CanvasItemEditor::add_control_to_left_panel(Control *p_control) {
@@ -6238,10 +6236,7 @@ CanvasItemEditor::CanvasItemEditor() {
 	main_flow->add_child(memnew(VSeparator));
 
 	// Contextual toolbars.
-	context_toolbar_panel = memnew(PanelContainer);
-	context_toolbar_hbox = memnew(HBoxContainer);
-	context_toolbar_panel->add_child(context_toolbar_hbox);
-	main_flow->add_child(context_toolbar_panel);
+	context_toolbar_hbox = EditorToolbarGroup::create(main_flow, true);
 
 	// Animation controls.
 	animation_hb = memnew(HBoxContainer);

--- a/editor/scene/canvas_item_editor_plugin.h
+++ b/editor/scene/canvas_item_editor_plugin.h
@@ -214,7 +214,6 @@ private:
 
 	// Used for secondary menu items which are displayed depending on the currently selected node
 	// (such as MeshInstance's "Mesh" menu).
-	PanelContainer *context_toolbar_panel = nullptr;
 	HBoxContainer *context_toolbar_hbox = nullptr;
 	HashMap<Control *, VSeparator *> context_toolbar_separators;
 

--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -1670,20 +1670,6 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		p_theme->set_constant("margin_left", "MainToolBarMargin", EDSCALE_RND(4));
 		p_theme->set_constant("margin_right", "MainToolBarMargin", EDSCALE_RND(4));
 
-		// 2D and 3D contextual toolbar.
-		// Use a custom stylebox to make contextual menu items stand out from the rest.
-		// This helps with editor usability as contextual menu items change when selecting nodes,
-		// even though it may not be immediately obvious at first.
-		Ref<StyleBoxFlat> toolbar_stylebox = memnew(StyleBoxFlat);
-		toolbar_stylebox->set_bg_color(p_config.accent_color * Color(1, 1, 1, 0.1));
-		toolbar_stylebox->set_anti_aliased(false);
-		// Add an underline to the StyleBox, but prevent its minimum vertical size from changing.
-		toolbar_stylebox->set_border_color(p_config.accent_color);
-		toolbar_stylebox->set_border_width(SIDE_BOTTOM, Math::round(EDSCALE_RND(2)));
-		toolbar_stylebox->set_content_margin(SIDE_BOTTOM, 0);
-		toolbar_stylebox->set_expand_margin_individual(EDSCALE_RND(4), EDSCALE_RND(2), EDSCALE_RND(4), EDSCALE_RND(4));
-		p_theme->set_stylebox("ContextualToolbar", EditorStringName(EditorStyles), toolbar_stylebox);
-
 		// Script editor.
 		p_theme->set_stylebox("ScriptEditor", EditorStringName(EditorStyles), EditorThemeManager::make_empty_stylebox(0, 0, 0, 0));
 
@@ -2080,16 +2066,21 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 			p_theme->set_stylebox(SceneStringName(panel), "PanelContainerTabbarInner", EditorThemeManager::make_empty_stylebox(0, 0, 0, 0));
 		}
 
-		// PanelContainerButtonGroup.
+		// PanelContainerButtonGroup & PanelContainerContextualGroup.
 		{
 			p_theme->set_type_variation("PanelContainerButtonGroup", "PanelContainer");
-
 			Ref<StyleBoxFlat> style_button_group = p_theme->get_stylebox(SNAME("tabbar_background"), SNAME("TabContainer"))->duplicate();
 			style_button_group->set_content_margin_all(p_config.base_margin * EDSCALE);
 			style_button_group->set_corner_radius_all(p_config.corner_radius);
 			style_button_group->set_bg_color(p_config.dark_color_1.lerp(p_config.mono_color, 0.15));
-
 			p_theme->set_stylebox(SceneStringName(panel), "PanelContainerButtonGroup", style_button_group);
+
+			p_theme->set_type_variation("PanelContainerContextualGroup", "PanelContainer");
+			Ref<StyleBoxFlat> style_context_group = style_button_group->duplicate();
+			style_context_group->set_bg_color(p_config.accent_color * Color(1, 1, 1, 0.1));
+			style_context_group->set_border_color(p_config.accent_color);
+			style_context_group->set_border_width(SIDE_BOTTOM, Math::round(EDSCALE_RND(2)));
+			p_theme->set_stylebox(SceneStringName(panel), "PanelContainerContextualGroup", style_context_group);
 		}
 
 		// VSeparatorButtonGroup.

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1713,15 +1713,6 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_constant("margin_top", "MainToolBarMargin", EDSCALE);
 		p_theme->set_constant("margin_bottom", "MainToolBarMargin", EDSCALE);
 
-		// 2D and 3D contextual toolbar.
-		// Use a custom stylebox to make contextual menu items stand out from the rest.
-		// This helps with editor usability as contextual menu items change when selecting nodes,
-		// even though it may not be immediately obvious at first.
-		Ref<StyleBoxFlat> toolbar_stylebox = p_config.base_style->duplicate();
-		toolbar_stylebox->set_bg_color(p_config.surface_higher_color);
-		toolbar_stylebox->set_content_margin_all(0);
-		p_theme->set_stylebox("ContextualToolbar", EditorStringName(EditorStyles), toolbar_stylebox);
-
 		// Script editor.
 		p_theme->set_stylebox("ScriptEditor", EditorStringName(EditorStyles), EditorThemeManager::make_empty_stylebox(0, 0, 0, 0));
 
@@ -2196,16 +2187,19 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 			p_theme->set_stylebox(SceneStringName(panel), "PanelContainerTabbarInner", style_tabbar_background_inner);
 		}
 
-		// PanelContainerButtonGroup.
+		// PanelContainerButtonGroup & PanelContainerContextualGroup.
 		{
 			p_theme->set_type_variation("PanelContainerButtonGroup", "PanelContainer");
-
 			Ref<StyleBoxFlat> style_button_group = p_theme->get_stylebox(SNAME("tabbar_background"), SNAME("TabContainer"))->duplicate();
 			style_button_group->set_content_margin_all(p_config.base_margin * EDSCALE);
 			style_button_group->set_corner_radius_all(p_config.corner_radius > 0 ? (p_config.corner_radius + p_config.base_margin) * EDSCALE : 0);
 			style_button_group->set_bg_color(p_config.surface_lower_color.lerp(p_config.mono_color_inv, 0.15).lightened(0.02));
-
 			p_theme->set_stylebox(SceneStringName(panel), "PanelContainerButtonGroup", style_button_group);
+
+			p_theme->set_type_variation("PanelContainerContextualGroup", "PanelContainer");
+			Ref<StyleBoxFlat> style_context_group = style_button_group->duplicate();
+			style_context_group->set_bg_color(p_config.surface_higher_color);
+			p_theme->set_stylebox(SceneStringName(panel), "PanelContainerContextualGroup", style_context_group);
 		}
 
 		// VSeparatorButtonGroup.


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

N/A

## Additional information

(Should be merged after https://github.com/godotengine/godot/pull/121065, if accepted).

Applying the design philosophy from https://github.com/godotengine/godot/pull/118664 to the contextual toolbars, retaining the original color. 

_Side note:_ should the `Path3D` "Options" be replaced with the down arrow?

| Before | After |
| ------------- | ------------- |
| <video src=https://github.com/user-attachments/assets/0b7967c7-76c6-4c51-87eb-20d7926dcb4a></video> | <video src=https://github.com/user-attachments/assets/5d571b4e-e27d-462c-848c-ff44804141b9></video> |

--

| Before (Classic) | After (Classic) |
| ------------- | ------------- |
| <img width="887" height="175" alt="image" src="https://github.com/user-attachments/assets/47a11fe5-1b18-4e52-88be-4de72cd1c65c" /> | <img width="912" height="205" alt="image" src="https://github.com/user-attachments/assets/151186eb-2fed-4aec-85d8-7815fdf11dad" /> |