### PR TITLE
Make script editor gain focus when button is pressed

### DIFF
--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -37,6 +37,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
 #include "editor/gui/window_wrapper.h"
+#include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_settings.h"
 #include "editor/themes/editor_scale.h"
 #include "scene/gui/box_container.h"
@@ -1032,6 +1033,9 @@ void DockShortcutHandler::shortcut_input(const Ref<InputEvent> &p_event) {
 			DockTabContainer *dock_container = dock->get_parent_container();
 			if (dock_container) {
 				dock_container->dock_focused(dock, was_visible);
+			}
+			if (Object::cast_to<ScriptEditor>(dock)) {
+				ScriptEditor::get_singleton()->focus_editor();
 			}
 			get_viewport()->set_input_as_handled();
 			break;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Fixes https://github.com/godotengine/godot/issues/122908

Supersedes https://github.com/godotengine/godot/pull/121203, which only added the functionality to refocus the script text area when the script tab was already selected.

Makes the script editor gain focus when the hotkey `editor/editor_script` is used. 

Currently only focuses the text area with the hotkey, just clicking the script tab does not focus it (I was having trouble finding the spot for this in the code, would appreciate some insight from others).

https://github.com/user-attachments/assets/bbe8c32b-1e4a-4fea-b369-0fd99e48c318
