### PR TITLE
[Docs] Use Unicode box drawing characters instead of plus and minus.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -923,12 +923,12 @@
 			<description>
 				Returns the ID of the window at the specified screen [param position] (in pixels). On multi-monitor setups, the screen position is relative to the virtual desktop area. On multi-monitor setups with different screen resolutions or orientations, the origin may be located outside any display like this:
 				[codeblock lang=text]
-				* (0, 0)        +-------+
-				                |       |
-				+-------------+ |       |
-				|             | |       |
-				|             | |       |
-				+-------------+ +-------+
+				* (0, 0)        ┌───────┐
+				                │       │
+				┌─────────────┐ │       │
+				│             │ │       │
+				│             │ │       │
+				└─────────────┘ └───────┘
 				[/codeblock]
 			</description>
 		</method>
@@ -1827,12 +1827,12 @@
 			<description>
 				Returns the screen's top-left corner position in pixels. Returns [constant Vector2i.ZERO] if [param screen] is invalid. On multi-monitor setups, the screen position is relative to the virtual desktop area. On multi-monitor setups with different screen resolutions or orientations, the origin might be located outside any display like this:
 				[codeblock lang=text]
-				* (0, 0)        +-------+
-				                |       |
-				+-------------+ |       |
-				|             | |       |
-				|             | |       |
-				+-------------+ +-------+
+				* (0, 0)        ┌───────┐
+				                │       │
+				┌─────────────┐ │       │
+				│             │ │       │
+				│             │ │       │
+				└─────────────┘ └───────┘
 				[/codeblock]
 				See also [method screen_get_size].
 				[b]Note:[/b] One of the following constants can be used as [param screen]: [constant SCREEN_OF_MAIN_WINDOW], [constant SCREEN_PRIMARY], [constant SCREEN_WITH_MOUSE_FOCUS], or [constant SCREEN_WITH_KEYBOARD_FOCUS].
@@ -2589,12 +2589,12 @@
 			<description>
 				Sets the position of the given window to [param position]. On multi-monitor setups, the screen position is relative to the virtual desktop area. On multi-monitor setups with different screen resolutions or orientations, the origin may be located outside any display like this:
 				[codeblock lang=text]
-				* (0, 0)        +-------+
-				                |       |
-				+-------------+ |       |
-				|             | |       |
-				|             | |       |
-				+-------------+ +-------+
+				* (0, 0)        ┌───────┐
+				                │       │
+				┌─────────────┐ │       │
+				│             │ │       │
+				│             │ │       │
+				└─────────────┘ └───────┘
 				[/codeblock]
 				See also [method window_get_position] and [method window_set_size].
 				[b]Note:[/b] It's recommended to change this value using [member Window.position] instead.

--- a/doc/classes/InputEventKey.xml
+++ b/doc/classes/InputEventKey.xml
@@ -68,20 +68,20 @@
 			For keyboard layouts with a single label on the key, it is equivalent to [member keycode].
 			To get a human-readable representation of the [InputEventKey], use [code]OS.get_keycode_string(event.key_label)[/code] where [code]event[/code] is the [InputEventKey].
 			[codeblock lang=text]
-			+-----+ +-----+
-			| Q   | | Q   | - "Q" - keycode
-			|   Й | |  ض | - "Й" and "ض" - key_label
-			+-----+ +-----+
+			┌─────┐ ┌─────┐
+			│ Q   │ │ Q   │ - "Q" - keycode
+			│   Й │ │  ض │ - "Й" and "ض" - key_label
+			└─────┘ └─────┘
 			[/codeblock]
 		</member>
 		<member name="keycode" type="int" setter="set_keycode" getter="get_keycode" enum="Key" default="0">
 			Latin label printed on the key in the current keyboard layout, which corresponds to one of the [enum Key] constants. Key codes are meant for shortcuts expressed with a standard Latin keyboard, such as [kbd]Ctrl + S[/kbd] for a "Save" shortcut.
 			To get a human-readable representation of the [InputEventKey], use [code]OS.get_keycode_string(event.keycode)[/code] where [code]event[/code] is the [InputEventKey].
 			[codeblock lang=text]
-			+-----+ +-----+
-			| Q   | | Q   | - "Q" - keycode
-			|   Й | |  ض | - "Й" and "ض" - key_label
-			+-----+ +-----+
+			┌─────┐ ┌─────┐
+			│ Q   │ │ Q   │ - "Q" - keycode
+			│   Й │ │  ض │ - "Й" and "ض" - key_label
+			└─────┘ └─────┘
 			[/codeblock]
 		</member>
 		<member name="location" type="int" setter="set_location" getter="get_location" enum="KeyLocation" default="0">


### PR DESCRIPTION
## What problem(s) does this PR solve?

Replaces `+-+` boxes with Unicode box drawing characters in the key event docs.

Before:
<img width="555" height="198" alt="Screenshot 2026-08-27 at 23 20 27" src="https://github.com/user-attachments/assets/28f54ef2-32bb-4509-afb0-d04d21bb0571" />
<img width="566" height="202" alt="Screenshot 2026-08-27 at 23 28 58" src="https://github.com/user-attachments/assets/fb35b38c-e438-4b23-90fc-fd2303374089" />

After:
<img width="555" height="198" alt="Screenshot 2026-08-27 at 23 27 14" src="https://github.com/user-attachments/assets/01fc8b49-614d-41cd-bb9f-9b1e8bcb879a" />
<img width="566" height="202" alt="Screenshot 2026-08-27 at 23 46 42" src="https://github.com/user-attachments/assets/1c9c1c8d-6bf8-429d-8928-51cb7b8dc40a" />
