### PR TITLE
Suppress item selection events when updating script outline.

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -682,6 +682,9 @@ void DocumentOutline::_notification(int p_what) {
 }
 
 void DocumentOutline::_tree_selected() {
+	if (updating_outline) {
+		return;
+	}
 	Control *active_editor = script_editor->get_active_editor();
 	int line = tree->get_selected()->get_metadata(0);
 	if (TextEditorBase *teb = Object::cast_to<TextEditorBase>(active_editor)) {
@@ -713,6 +716,8 @@ void DocumentOutline::update_outline() {
 		selected = ""; // Script/doc changed, forget the last selection.
 	}
 	current_editor = active_editor;
+
+	updating_outline = true;
 
 	tree->clear();
 	tree->create_item();
@@ -818,6 +823,7 @@ void DocumentOutline::update_outline() {
 			}
 		}
 	}
+	updating_outline = false;
 }
 
 void DocumentOutline::update_visibility() {

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -130,6 +130,7 @@ class DocumentOutline : public VBoxContainer {
 	bool help_overview_enabled = false;
 
 	Control *current_editor = nullptr;
+	bool updating_outline = false;
 
 	void _toggle_sort(bool p_alphabetic_sort);
 	void _tree_selected();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/122906

## Additional information

Is it supposed to jump on outline item selection, and not on activation?