### PR TITLE
Do not count self when checking for open windows.

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4328,7 +4328,7 @@ void Viewport::set_embedding_subwindows(bool p_embed) {
 			Vector<DisplayServerEnums::WindowID> wl = DisplayServer::get_singleton()->get_window_list();
 			for (const DisplayServerEnums::WindowID &window_id : wl) {
 				const Window *w = Window::get_from_id(window_id);
-				if (w && is_ancestor_of(w)) {
+				if (w && w != this && is_ancestor_of(w)) {
 					// Prevent change when this viewport has child windows that are displayed as native windows.
 					allow_change = false;
 					break;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/122925

## Additional information

This seems to be caused by https://github.com/godotengine/godot/pull/111165, which changed `is_ancestor_of` to return `true` when passing self, not sure if this was an intentional and always desired change.
