### PR TITLE
Add shader uniform hints `no_storage` and `no_editor`

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -234,6 +234,8 @@ const char *ShaderLanguage::token_names[TK_MAX] = {
 	"FILTER_LINEAR_MIPMAP_ANISOTROPIC",
 	"REPEAT_ENABLE",
 	"REPEAT_DISABLE",
+	"NO_STORAGE",
+	"NO_EDITOR",
 	"SHADER_TYPE",
 	"CURSOR",
 	"ERROR",
@@ -411,6 +413,11 @@ const ShaderLanguage::KeyWord ShaderLanguage::keyword_list[] = {
 	{ TK_FILTER_LINEAR_MIPMAP_ANISOTROPIC, "filter_linear_mipmap_anisotropic", CF_UNSPECIFIED, {}, {} },
 	{ TK_REPEAT_ENABLE, "repeat_enable", CF_UNSPECIFIED, {}, {} },
 	{ TK_REPEAT_DISABLE, "repeat_disable", CF_UNSPECIFIED, {}, {} },
+
+	// usage flags
+
+	{ TK_HINT_NO_STORAGE, "no_storage", CF_UNSPECIFIED, {}, {} },
+	{ TK_HINT_NO_EDITOR, "no_editor", CF_UNSPECIFIED, {}, {} },
 
 	{ TK_ERROR, nullptr, CF_UNSPECIFIED, {}, {} }
 };
@@ -1307,6 +1314,21 @@ String ShaderLanguage::get_texture_repeat_name(TextureRepeat p_repeat) {
 	return result;
 }
 
+String ShaderLanguage::get_unset_property_usage_name(PropertyUsageFlags p_usage) {
+	String result;
+	switch (p_usage) {
+		case PROPERTY_USAGE_STORAGE: {
+			result = "no_storage";
+		} break;
+		case PROPERTY_USAGE_EDITOR: {
+			result = "no_editor";
+		} break;
+		default: {
+		} break;
+	}
+	return result;
+}
+
 bool ShaderLanguage::is_token_nonvoid_datatype(TokenType p_type) {
 	return is_token_datatype(p_type) && p_type != TK_TYPE_VOID;
 }
@@ -1320,6 +1342,7 @@ void ShaderLanguage::clear() {
 	current_uniform_filter = FILTER_DEFAULT;
 	current_uniform_repeat = REPEAT_DEFAULT;
 	current_uniform_instance_index_defined = false;
+	current_property_usage = PROPERTY_USAGE_DEFAULT;
 
 	completion_type = COMPLETION_NONE;
 	completion_block = nullptr;
@@ -5250,6 +5273,7 @@ PropertyInfo ShaderLanguage::uniform_to_property_info(const ShaderNode::Uniform 
 		case ShaderLanguage::TYPE_MAX:
 			break;
 	}
+	pi.usage = p_uniform.property_usage;
 	return pi;
 }
 
@@ -9918,6 +9942,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 							ShaderNode::Uniform::Hint new_hint = ShaderNode::Uniform::HINT_NONE;
 							TextureFilter new_filter = FILTER_DEFAULT;
 							TextureRepeat new_repeat = REPEAT_DEFAULT;
+							PropertyUsageFlags unset_property_usage = PROPERTY_USAGE_NONE;
 
 							switch (tk.type) {
 								case TK_HINT_SOURCE_COLOR: {
@@ -10066,6 +10091,12 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 									}
 
 									new_hint = ShaderNode::Uniform::HINT_ENUM;
+								} break;
+								case TK_HINT_NO_STORAGE: {
+									unset_property_usage = PROPERTY_USAGE_STORAGE;
+								} break;
+								case TK_HINT_NO_EDITOR: {
+									unset_property_usage = PROPERTY_USAGE_EDITOR;
 								} break;
 								case TK_HINT_INSTANCE_INDEX: {
 									if (custom_instance_index != -1) {
@@ -10222,6 +10253,16 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 								}
 							}
 
+							if (unset_property_usage != PROPERTY_USAGE_NONE) {
+								if (!(uniform.property_usage & unset_property_usage)) {
+									_set_error(vformat(RTR("Duplicated property usage flag '%s'."), get_unset_property_usage_name(unset_property_usage)));
+									return ERR_PARSE_ERROR;
+								} else {
+									uniform.property_usage &= ~unset_property_usage;
+									current_property_usage = uniform.property_usage;
+								}
+							}
+
 							if (new_filter != FILTER_DEFAULT) {
 								if (uniform.filter != FILTER_DEFAULT) {
 									if (uniform.filter == new_filter) {
@@ -10319,6 +10360,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 					current_uniform_filter = FILTER_DEFAULT;
 					current_uniform_repeat = REPEAT_DEFAULT;
 					current_uniform_instance_index_defined = false;
+					current_property_usage = PROPERTY_USAGE_DEFAULT;
 				} else { // varying
 					ShaderNode::Varying varying;
 					varying.type = type;
@@ -12222,6 +12264,12 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 				ScriptLanguage::CodeCompletionOption option("instance_index", ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT);
 				option.insert_text = "instance_index(0)";
 				r_options->push_back(option);
+			}
+			if (current_property_usage & PROPERTY_USAGE_STORAGE) {
+				r_options->push_back({ "no_storage", ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT });
+			}
+			if (current_property_usage & PROPERTY_USAGE_EDITOR) {
+				r_options->push_back({ "no_editor", ScriptLanguage::CODE_COMPLETION_KIND_PLAIN_TEXT });
 			}
 		} break;
 	}

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/object/property_info.h"
 #include "core/object/script_language.h"
 #include "core/string/string_name.h"
 #include "core/string/ustring.h"
@@ -195,6 +196,8 @@ public:
 		TK_FILTER_LINEAR_MIPMAP_ANISOTROPIC,
 		TK_REPEAT_ENABLE,
 		TK_REPEAT_DISABLE,
+		TK_HINT_NO_STORAGE,
+		TK_HINT_NO_EDITOR,
 		TK_SHADER_TYPE,
 		TK_CURSOR,
 		TK_ERROR,
@@ -709,6 +712,7 @@ public:
 			TextureRepeat repeat = REPEAT_DEFAULT;
 			float hint_range[3];
 			PackedStringArray hint_enum_names;
+			uint32_t property_usage = PROPERTY_USAGE_DEFAULT;
 			int instance_index = 0;
 			String group;
 
@@ -845,6 +849,7 @@ public:
 	static String get_uniform_hint_name(ShaderNode::Uniform::Hint p_hint);
 	static String get_texture_filter_name(TextureFilter p_filter);
 	static String get_texture_repeat_name(TextureRepeat p_repeat);
+	static String get_unset_property_usage_name(PropertyUsageFlags p_usage);
 	static bool is_token_nonvoid_datatype(TokenType p_type);
 	static bool is_token_operator(TokenType p_type);
 	static bool is_token_operator_assign(TokenType p_type);
@@ -1183,6 +1188,7 @@ private:
 	TextureFilter current_uniform_filter = FILTER_DEFAULT;
 	TextureRepeat current_uniform_repeat = REPEAT_DEFAULT;
 	bool current_uniform_instance_index_defined = false;
+	uint32_t current_property_usage = PROPERTY_USAGE_DEFAULT;
 	int completion_line = 0;
 	BlockNode *completion_block = nullptr;
 	DataType completion_base;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/15338. That proposal explains the rationale for this PR.

## Additional information

Demo project: [shader_usage_flags_demo.zip](https://github.com/user-attachments/files/31552787/shader_usage_flags_demo.zip)

Given these uniforms:

```
uniform float time_default;
uniform float time_no_editor: no_editor;
uniform float time_no_storage: no_storage;
uniform float time_no_storage_no_editor: no_storage, no_editor;
```

The ones with `no_storage` are omitted from the .tres file:

```
$ cat BlinkMaterial.tres 
[gd_resource type="ShaderMaterial" format=3 uid="uid://ck2ph3hs1ssks"]

[ext_resource type="Shader" uid="uid://clwvqil7dntbw" path="res://BlinkMaterial.gdshader" id="1_c8a3m"]

[resource]
shader = ExtResource("1_c8a3m")
shader_parameter/time_default = 60.05209100000178
shader_parameter/time_no_editor = 60.05209100000178
```

The ones with `no_editor` are not visible in the inspector:

<img width="439" height="372" alt="2026-08-28T13:40:09_439x372" src="https://github.com/user-attachments/assets/b5692c36-f792-4a37-b8d3-14fa7ede27ac" />

Completion:

<img width="466" height="133" alt="2026-08-28T13:41:14_466x133" src="https://github.com/user-attachments/assets/deb3f936-b780-4cc3-a66e-571763483562" />

Error reporting:

<img width="516" height="83" alt="2026-08-28T13:41:36_516x83" src="https://github.com/user-attachments/assets/cc8099e9-f59d-41cd-ba1f-ca5b0c2d9134" />