### PR TITLE
Use paths for autoload export dependencies

### DIFF
--- a/editor/export/editor_export_platform.cpp
+++ b/editor/export/editor_export_platform.cpp
@@ -1341,7 +1341,7 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 				autoload_path = autoload_path.substr(1);
 			}
 
-			_export_find_dependencies(autoload_path, paths);
+			_export_find_dependencies(ResourceUID::ensure_path(autoload_path), paths);
 		}
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Might fix #122930
I didn't test mono build, so needs testing whether it fixes the whole issue.

## Additional information

When the option to export Scenes with dependencies is selected, the editor will additionally export all autoloads. It will however load them directly from project settings, which were recently changed to use UIDs instead of paths. Sending UID as path to `_export_file()` is not really expected. And the C# export plugin certainly does not expect it.
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
