### PR TITLE
Fix editor hanging when a GDExtension library is missing for the platform

### DIFF
--- a/core/extension/gdextension_manager.cpp
+++ b/core/extension/gdextension_manager.cpp
@@ -408,11 +408,19 @@ bool GDExtensionManager::ensure_extensions_loaded(const HashSet<String> &p_exten
 	}
 
 	bool needs_restart = false;
+#ifdef TOOLS_ENABLED
+	bool trigger_reload = false;
+#endif
 	for (const String &extension : extensions_added) {
 		GDExtensionManager::LoadStatus st = GDExtensionManager::get_singleton()->load_extension(extension);
 		if (st == GDExtensionManager::LOAD_STATUS_NEEDS_RESTART) {
 			needs_restart = true;
 		}
+#ifdef TOOLS_ENABLED
+		if (st == GDExtensionManager::LOAD_STATUS_OK) {
+			trigger_reload = true;
+		}
+#endif
 	}
 
 	for (const String &extension : extensions_removed) {
@@ -420,10 +428,15 @@ bool GDExtensionManager::ensure_extensions_loaded(const HashSet<String> &p_exten
 		if (st == GDExtensionManager::LOAD_STATUS_NEEDS_RESTART) {
 			needs_restart = true;
 		}
+#ifdef TOOLS_ENABLED
+		if (st == GDExtensionManager::LOAD_STATUS_OK) {
+			trigger_reload = true;
+		}
+#endif
 	}
 
 #ifdef TOOLS_ENABLED
-	if (extensions_added.size() || extensions_removed.size()) {
+	if (trigger_reload) {
 		// Emitting extensions_reloaded so EditorNode can reload Inspector and regenerate documentation.
 		emit_signal("extensions_reloaded");
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #122934

## Additional information

If a GDExtension does not provide a shared library for the editors operating system, an error appears and the GDExtension fails to load. However, even if the GDExtension fails to load it triggers these two lines in gdextension_manger.cpp:
```
emit_signal("extensions_reloaded");
callable_mp_static(&GDExtensionManager::_reload_all_scripts).call_deferred();
```
These can be quite expensive depending on the size of the project and lead to the editor freezing until it's done (3-4 seconds in my project). Since on any new file system scan it tries to load the extension again, it makes the editor unusable.

The change makes it so that only a successful GDExtension loading/unloading triggers these lines.
This is a fix to at least make the editor behave nicely, however some way of declaring supported OS's for a GDExtension would be nice to have to avoid this all together.