### PR TITLE
Expose Shader::set_include_path to GDScript

### DIFF
--- a/doc/classes/Shader.xml
+++ b/doc/classes/Shader.xml
@@ -52,6 +52,13 @@
 				[b]Note:[/b] If the sampler array is used use [param index] to access the specified texture.
 			</description>
 		</method>
+		<method name="set_include_path">
+			<return type="void" />
+			<param index="0" name="path" type="String" />
+			<description>
+				Sets the include path for this shader. Used only if the shader does not have a resource path set, for example when created by code.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="code" type="String" setter="set_code" getter="get_code" default="&quot;&quot;">

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -280,6 +280,8 @@ void Shader::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_shader_uniform_list", "get_groups"), &Shader::_get_shader_uniform_list, DEFVAL(false));
 
+	ClassDB::bind_method(D_METHOD("set_include_path", "path"), &Shader::set_include_path);
+
 	ClassDB::bind_method(D_METHOD("inspect_native_shader_code"), &Shader::inspect_native_shader_code);
 	ClassDB::set_method_flags(get_class_static(), StringName("inspect_native_shader_code"), METHOD_FLAGS_DEFAULT | METHOD_FLAG_EDITOR);
 


### PR DESCRIPTION
## What problem(s) does this PR solve?
This PR enables generated shaders to have their include path set, from GDScript/GDExtensions. `Shader` does use its `Resource` `path` if no `include_path` is set but this can cause issues with the resource system, with colliding paths. This method is used to avoid this issue but was not previously exposed.

## Additional information
The change is tiny, there's not much to say. The documentation description is copied from the comment in `Shader::set_include_path`.