### PR TITLE
Animation state events

### DIFF
--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -434,6 +434,75 @@
 				Sets the given marker's color.
 			</description>
 		</method>
+		<method name="state_event_track_get_key_duration" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="state_event_track_get_key_end_time" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="state_event_track_get_key_event" qualifiers="const">
+			<return type="Resource" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="state_event_track_get_key_start_time" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="state_event_track_insert_key">
+			<return type="int" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="time" type="float" />
+			<param index="2" name="duration" type="float" default="0.0" />
+			<param index="3" name="event" type="Resource" default="null" />
+			<description>
+			</description>
+		</method>
+		<method name="state_event_track_set_key_duration">
+			<return type="void" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<param index="2" name="duration" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="state_event_track_set_key_end_time">
+			<return type="void" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<param index="2" name="end_time" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="state_event_track_set_key_event">
+			<return type="void" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<param index="2" name="event" type="Resource" />
+			<description>
+			</description>
+		</method>
+		<method name="state_event_track_set_key_start_time">
+			<return type="void" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<param index="2" name="start_time" type="float" />
+			<description>
+			</description>
+		</method>
 		<method name="track_find_key" qualifiers="const">
 			<return type="int" />
 			<param index="0" name="track_idx" type="int" />
@@ -720,6 +789,8 @@
 		</constant>
 		<constant name="TYPE_ANIMATION" value="8" enum="TrackType">
 			Animation tracks play animations in other [AnimationPlayer] nodes.
+		</constant>
+		<constant name="TYPE_STATE_EVENT" value="9" enum="TrackType">
 		</constant>
 		<constant name="INTERPOLATION_NEAREST" value="0" enum="InterpolationType">
 			No interpolation (nearest value).

--- a/doc/classes/Animation.xml
+++ b/doc/classes/Animation.xml
@@ -439,6 +439,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="key_idx" type="int" />
 			<description>
+				Returns the duration of the key identified by [param key_idx] in seconds. The [param track_idx] must be the index of a State Event Track.
 			</description>
 		</method>
 		<method name="state_event_track_get_key_end_time" qualifiers="const">
@@ -446,6 +447,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="key_idx" type="int" />
 			<description>
+				Returns the end time (start + duration) of the key identified by [param key_idx]. The [param track_idx] must be the index of a State Event Track.
 			</description>
 		</method>
 		<method name="state_event_track_get_key_event" qualifiers="const">
@@ -453,6 +455,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="key_idx" type="int" />
 			<description>
+				Returns the [AnimationStateEvent] resource of the key identified by [param key_idx]. The [param track_idx] must be the index of a State Event Track.
 			</description>
 		</method>
 		<method name="state_event_track_get_key_start_time" qualifiers="const">
@@ -460,6 +463,7 @@
 			<param index="0" name="track_idx" type="int" />
 			<param index="1" name="key_idx" type="int" />
 			<description>
+				Returns the start time of the key identified by [param key_idx]. The [param track_idx] must be the index of a State Event Track.
 			</description>
 		</method>
 		<method name="state_event_track_insert_key">
@@ -469,6 +473,7 @@
 			<param index="2" name="duration" type="float" default="0.0" />
 			<param index="3" name="event" type="Resource" default="null" />
 			<description>
+				Inserts a State Event key at [param time] with [param duration] and [param event]. The [param track_idx] must be the index of a State Event Track. [param event] should be an [AnimationStateEvent] resource (or [code]null[/code]). Returns the new key index. Duration is clamped to at least [code]0.0001[/code] to ensure the strip is visible and triggers correctly.
 			</description>
 		</method>
 		<method name="state_event_track_set_key_duration">
@@ -477,6 +482,7 @@
 			<param index="1" name="key_idx" type="int" />
 			<param index="2" name="duration" type="float" />
 			<description>
+				Sets the duration of the key identified by [param key_idx]. The [param track_idx] must be the index of a State Event Track. Duration is clamped to at least [code]0.0001[/code].
 			</description>
 		</method>
 		<method name="state_event_track_set_key_end_time">
@@ -485,6 +491,7 @@
 			<param index="1" name="key_idx" type="int" />
 			<param index="2" name="end_time" type="float" />
 			<description>
+				Sets the end time of the key identified by [param key_idx]. This adjusts the duration so that [code]start + duration = end_time[/code]. The [param track_idx] must be the index of a State Event Track.
 			</description>
 		</method>
 		<method name="state_event_track_set_key_event">
@@ -493,6 +500,17 @@
 			<param index="1" name="key_idx" type="int" />
 			<param index="2" name="event" type="Resource" />
 			<description>
+				Sets the [AnimationStateEvent] resource for the key identified by [param key_idx]. The [param track_idx] must be the index of a State Event Track. Pass [code]null[/code] to clear.
+			</description>
+		</method>
+		<method name="state_event_track_set_key_start_and_duration">
+			<return type="void" />
+			<param index="0" name="track_idx" type="int" />
+			<param index="1" name="key_idx" type="int" />
+			<param index="2" name="start_time" type="float" />
+			<param index="3" name="duration" type="float" />
+			<description>
+				Atomically sets both start time and duration for the key identified by [param key_idx]. This is used by the editor to avoid intermediate invalid states and index corruption when resizing the start handle. The [param track_idx] must be the index of a State Event Track.
 			</description>
 		</method>
 		<method name="state_event_track_set_key_start_time">
@@ -501,6 +519,7 @@
 			<param index="1" name="key_idx" type="int" />
 			<param index="2" name="start_time" type="float" />
 			<description>
+				Sets the start time of the key identified by [param key_idx]. The key is re-sorted by time. The [param track_idx] must be the index of a State Event Track.
 			</description>
 		</method>
 		<method name="track_find_key" qualifiers="const">
@@ -791,6 +810,7 @@
 			Animation tracks play animations in other [AnimationPlayer] nodes.
 		</constant>
 		<constant name="TYPE_STATE_EVENT" value="9" enum="TrackType">
+			State Event tracks hold [AnimationStateEvent] resources over a duration interval. Each key defines a time strip with start and duration; while playback time is inside the interval, the track has a non-zero effective blend weight, and the weight meets the event's [member AnimationStateEvent.trigger_weight_threshold], the event's [method AnimationStateEvent._start], [method AnimationStateEvent._update], [method AnimationStateEvent._end] / [method AnimationStateEvent._cancel] lifecycle is driven by [AnimationMixer].
 		</constant>
 		<constant name="INTERPOLATION_NEAREST" value="0" enum="InterpolationType">
 			No interpolation (nearest value).

--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -229,7 +229,7 @@
 			<param index="2" name="update_only" type="bool" default="false" />
 			<description>
 				Seeks the animation to the [param seconds] point in time (in seconds). If [param update] is [code]true[/code], the animation updates too, otherwise it updates at process time. Events between the current frame and [param seconds] are skipped.
-				If [param update_only] is [code]true[/code], the method / audio / animation playback tracks will not be processed.
+				If [param update_only] is [code]true[/code], the method / audio / animation playback tracks will not be processed. State Event tracks will not start or update events, and any active State Events will be cancelled.
 				[b]Note:[/b] Seeking to the end of the animation doesn't emit [signal AnimationMixer.animation_finished]. If you want to skip animation and emit the signal, use [method AnimationMixer.advance].
 			</description>
 		</method>

--- a/doc/classes/AnimationStateContext.xml
+++ b/doc/classes/AnimationStateContext.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AnimationStateContext" inherits="RefCounted" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Runtime context passed to [AnimationStateEvent] callbacks.
+	</brief_description>
+	<description>
+		[AnimationStateContext] encapsulates live playback information (such as target node, active mixer, elapsed time, duration, frame delta, and blend weight) passed to [AnimationStateEvent] virtual methods ([method AnimationStateEvent._start], [method AnimationStateEvent._update], [method AnimationStateEvent._end], [method AnimationStateEvent._cancel]).
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="animation" type="Animation" setter="" getter="get_animation">
+			The [Animation] resource currently being played.
+		</member>
+		<member name="delta" type="float" setter="" getter="get_delta" default="0.0">
+			The frame delta time of the current playback tick.
+		</member>
+		<member name="duration" type="float" setter="" getter="get_duration" default="0.0">
+			The total duration (in seconds) of this state event keyframe.
+		</member>
+		<member name="elapsed" type="float" setter="" getter="get_elapsed" default="0.0">
+			The time elapsed (in seconds) since the state event started.
+		</member>
+		<member name="mixer" type="AnimationMixer" setter="" getter="get_mixer">
+			The [AnimationMixer] (or [AnimationPlayer] / [AnimationTree]) playing this animation.
+		</member>
+		<member name="target" type="Object" setter="" getter="get_target">
+			The target [Object] (usually a [Node]) bound to the animation track.
+		</member>
+		<member name="weight" type="float" setter="" getter="get_weight" default="1.0">
+			The current blend weight of the animation during playback.
+		</member>
+	</members>
+</class>

--- a/doc/classes/AnimationStateEvent.xml
+++ b/doc/classes/AnimationStateEvent.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AnimationStateEvent" inherits="Resource" api_type="core" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Base resource for duration-based state events in an [Animation] track.
+	</brief_description>
+	<description>
+		An [AnimationStateEvent] is a custom resource used within [constant Animation.TYPE_STATE_EVENT] tracks to execute continuous, lifecycle-based logic across an animation duration span.
+		By overriding [method _start], [method _update], [method _end], and [method _cancel], developers can implement state-driven behaviors such as active melee hitboxes, invulnerability frames, footstep audio, and visual trails without polling in [code]_process()[/code].
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_cancel" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="context" type="AnimationStateContext" />
+			<description>
+				Called when animation playback is interrupted, seeked away, stopped, or blended out before the state finishes naturally.
+			</description>
+		</method>
+		<method name="_end" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="context" type="AnimationStateContext" />
+			<description>
+				Called when animation playback naturally exits the state duration or when the animation finishes.
+			</description>
+		</method>
+		<method name="_start" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="context" type="AnimationStateContext" />
+			<description>
+				Called once when animation playback enters the keyframe's start time.
+			</description>
+		</method>
+		<method name="_update" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="context" type="AnimationStateContext" />
+			<param index="1" name="delta" type="float" />
+			<description>
+				Called every process frame while playback remains active within the state duration.
+			</description>
+		</method>
+	</methods>
+	<members>
+		<member name="event_name" type="StringName" setter="set_event_name" getter="get_event_name" default="&amp;&quot;&quot;">
+			The display name of the event shown on the timeline strip.
+		</member>
+		<member name="tag_color" type="Color" setter="set_tag_color" getter="get_tag_color" default="Color(0.3, 0.6, 0.9, 0.8)">
+			The color of the timeline strip rendered in the animation track editor.
+		</member>
+		<member name="trigger_weight_threshold" type="float" setter="set_trigger_weight_threshold" getter="get_trigger_weight_threshold" default="0.0">
+			The minimum blending weight threshold (between [code]0.0[/code] and [code]1.0[/code]) required for this event to trigger and execute during playback blending. If the animation's blend weight is below this threshold, the event will not start, and active events will be cancelled.
+		</member>
+	</members>
+</class>

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -2318,6 +2318,8 @@ void AnimationTrackEdit::_notification(int p_what) {
 						text = TTR("Audio Clips:");
 					} else if (animation->track_get_type(track) == Animation::TYPE_ANIMATION) {
 						text = TTR("Animation Clips:");
+					} else if (animation->track_get_type(track) == Animation::TYPE_STATE_EVENT) {
+						text = TTR("State Events:");
 					} else {
 						text += anim_path.get_concatenated_subnames();
 					}

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -434,6 +434,41 @@ bool AnimationTrackKeyEdit::_set(const StringName &p_name, const Variant &p_valu
 				return true;
 			}
 		} break;
+		case Animation::TYPE_STATE_EVENT: {
+			if (name == "event") {
+				Ref<Resource> event_res = p_value;
+
+				setting = true;
+				undo_redo->create_action(TTR("Animation Change Keyframe Event"), UndoRedo::MERGE_ENDS);
+				Ref<Resource> prev = animation->state_event_track_get_key_event(track, key);
+				undo_redo->add_do_method(animation.ptr(), "state_event_track_set_key_event", track, key, event_res);
+				undo_redo->add_undo_method(animation.ptr(), "state_event_track_set_key_event", track, key, prev);
+				undo_redo->add_do_method(this, "_update_obj", animation);
+				undo_redo->add_undo_method(this, "_update_obj", animation);
+				undo_redo->commit_action();
+
+				setting = false;
+				notify_change();
+				return true;
+			}
+
+			if (name == "duration") {
+				float duration = p_value;
+
+				setting = true;
+				undo_redo->create_action(TTR("Animation Change Keyframe Duration"), UndoRedo::MERGE_ENDS);
+				float prev = animation->state_event_track_get_key_duration(track, key);
+				undo_redo->add_do_method(animation.ptr(), "state_event_track_set_key_duration", track, key, duration);
+				undo_redo->add_undo_method(animation.ptr(), "state_event_track_set_key_duration", track, key, prev);
+				undo_redo->add_do_method(this, "_update_obj", animation);
+				undo_redo->add_undo_method(this, "_update_obj", animation);
+				undo_redo->commit_action();
+
+				setting = false;
+				notify_change();
+				return true;
+			}
+		} break;
 	}
 
 	return false;
@@ -546,6 +581,17 @@ bool AnimationTrackKeyEdit::_get(const StringName &p_name, Variant &r_ret) const
 				return true;
 			}
 
+		} break;
+		case Animation::TYPE_STATE_EVENT: {
+			if (name == "event") {
+				r_ret = animation->state_event_track_get_key_event(track, key);
+				return true;
+			}
+
+			if (name == "duration") {
+				r_ret = animation->state_event_track_get_key_duration(track, key);
+				return true;
+			}
 		} break;
 	}
 
@@ -667,6 +713,10 @@ void AnimationTrackKeyEdit::_get_property_list(List<PropertyInfo> *p_list) const
 
 			p_list->push_back(PropertyInfo(Variant::STRING_NAME, PNAME("animation"), PROPERTY_HINT_ENUM, animations));
 
+		} break;
+		case Animation::TYPE_STATE_EVENT: {
+			p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("event"), PROPERTY_HINT_RESOURCE_TYPE, "AnimationStateEvent"));
+			p_list->push_back(PropertyInfo(Variant::FLOAT, PNAME("duration"), PROPERTY_HINT_RANGE, "0.0001,3600,0.0001,or_greater"));
 		} break;
 	}
 
@@ -984,6 +1034,31 @@ bool AnimationMultiTrackKeyEdit::_set(const StringName &p_name, const Variant &p
 						update_obj = true;
 					}
 				} break;
+				case Animation::TYPE_STATE_EVENT: {
+					if (name == "event") {
+						Ref<Resource> event_res = p_value;
+
+						if (!setting) {
+							setting = true;
+							undo_redo->create_action(TTR("Animation Multi Change Keyframe Event"), UndoRedo::MERGE_ENDS);
+						}
+						Ref<Resource> prev = animation->state_event_track_get_key_event(track, key);
+						undo_redo->add_do_method(animation.ptr(), "state_event_track_set_key_event", track, key, event_res);
+						undo_redo->add_undo_method(animation.ptr(), "state_event_track_set_key_event", track, key, prev);
+						update_obj = true;
+					} else if (name == "duration") {
+						float duration = p_value;
+
+						if (!setting) {
+							setting = true;
+							undo_redo->create_action(TTR("Animation Multi Change Keyframe Duration"), UndoRedo::MERGE_ENDS);
+						}
+						float prev = animation->state_event_track_get_key_duration(track, key);
+						undo_redo->add_do_method(animation.ptr(), "state_event_track_set_key_duration", track, key, duration);
+						undo_redo->add_undo_method(animation.ptr(), "state_event_track_set_key_duration", track, key, prev);
+						update_obj = true;
+					}
+				} break;
 			}
 		}
 	}
@@ -1116,6 +1191,18 @@ bool AnimationMultiTrackKeyEdit::_get(const StringName &p_name, Variant &r_ret) 
 				case Animation::TYPE_ANIMATION: {
 					if (name == "animation") {
 						r_ret = animation->animation_track_get_key_animation(track, key);
+						return true;
+					}
+
+				} break;
+				case Animation::TYPE_STATE_EVENT: {
+					if (name == "event") {
+						r_ret = animation->state_event_track_get_key_event(track, key);
+						return true;
+					}
+
+					if (name == "duration") {
+						r_ret = animation->state_event_track_get_key_duration(track, key);
 						return true;
 					}
 
@@ -1268,6 +1355,10 @@ void AnimationMultiTrackKeyEdit::_get_property_list(List<PropertyInfo> *p_list) 
 				animations += "[stop]";
 
 				p_list->push_back(PropertyInfo(Variant::STRING_NAME, "animation", PROPERTY_HINT_ENUM, animations));
+			} break;
+			case Animation::TYPE_STATE_EVENT: {
+				p_list->push_back(PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "AnimationStateEvent"));
+				p_list->push_back(PropertyInfo(Variant::FLOAT, "duration", PROPERTY_HINT_RANGE, "0.0001,3600,0.0001,or_greater"));
 			} break;
 		}
 	}
@@ -1472,6 +1563,7 @@ void AnimationTimelineEdit::_notification(int p_what) {
 			add_track->get_popup()->add_icon_item(get_editor_theme_icon(SNAME("KeyBezier")), TTRC("Bezier Curve Track..."));
 			add_track->get_popup()->add_icon_item(get_editor_theme_icon(SNAME("KeyAudio")), TTRC("Audio Playback Track..."));
 			add_track->get_popup()->add_icon_item(get_editor_theme_icon(SNAME("KeyAnimation")), TTRC("Animation Playback Track..."));
+			add_track->get_popup()->add_icon_item(get_editor_theme_icon(SNAME("KeyCall")), TTRC("State Event Track..."));
 
 			timeline_resize_rect.size = get_editor_theme_icon(SNAME("TimelineHandle"))->get_size();
 		} break;
@@ -2859,7 +2951,7 @@ bool AnimationTrackEdit::_is_value_key_valid(const Variant &p_key_value, Variant
 }
 
 Ref<Texture2D> AnimationTrackEdit::_get_key_type_icon() const {
-	const Ref<Texture2D> type_icons[9] = {
+	const Ref<Texture2D> type_icons[10] = {
 		get_editor_theme_icon(SNAME("KeyValue")),
 		get_editor_theme_icon(SNAME("KeyTrackPosition")),
 		get_editor_theme_icon(SNAME("KeyTrackRotation")),
@@ -2868,7 +2960,8 @@ Ref<Texture2D> AnimationTrackEdit::_get_key_type_icon() const {
 		get_editor_theme_icon(SNAME("KeyCall")),
 		get_editor_theme_icon(SNAME("KeyBezier")),
 		get_editor_theme_icon(SNAME("KeyAudio")),
-		get_editor_theme_icon(SNAME("KeyAnimation"))
+		get_editor_theme_icon(SNAME("KeyAnimation")),
+		get_editor_theme_icon(SNAME("KeyCall"))
 	};
 	return type_icons[animation->track_get_type(track)];
 }
@@ -3800,6 +3893,13 @@ AnimationTrackEdit *AnimationTrackEditPlugin::create_audio_track_edit() {
 AnimationTrackEdit *AnimationTrackEditPlugin::create_animation_track_edit(Object *p_object) {
 	if (get_script_instance()) {
 		return Object::cast_to<AnimationTrackEdit>(get_script_instance()->call("create_animation_track_edit", p_object).operator Object *());
+	}
+	return nullptr;
+}
+
+AnimationTrackEdit *AnimationTrackEditPlugin::create_state_event_track_edit() {
+	if (get_script_instance()) {
+		return Object::cast_to<AnimationTrackEdit>(get_script_instance()->call("create_state_event_track_edit").operator Object *());
 	}
 	return nullptr;
 }
@@ -5046,7 +5146,8 @@ AnimationTrackEditor::TrackIndices AnimationTrackEditor::_confirm_insert(InsertD
 		case Animation::TYPE_BLEND_SHAPE:
 		case Animation::TYPE_VALUE:
 		case Animation::TYPE_AUDIO:
-		case Animation::TYPE_ANIMATION: {
+		case Animation::TYPE_ANIMATION:
+		case Animation::TYPE_STATE_EVENT: {
 			value = p_id.value;
 
 		} break;
@@ -5308,6 +5409,15 @@ void AnimationTrackEditor::_update_tracks() {
 					if (track_edit) {
 						break;
 					}
+				}
+			}
+		}
+
+		if (animation->track_get_type(i) == Animation::TYPE_STATE_EVENT) {
+			for (int j = 0; j < track_edit_plugins.size(); j++) {
+				track_edit = track_edit_plugins.write[j]->create_state_event_track_edit();
+				if (track_edit) {
+					break;
 				}
 			}
 		}
@@ -5812,6 +5922,15 @@ void AnimationTrackEditor::_new_track_node_selected(NodePath p_path) {
 			undo_redo->commit_action();
 
 		} break;
+		case Animation::TYPE_STATE_EVENT: {
+			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+			undo_redo->create_action(TTR("Add State Event Track"));
+			undo_redo->add_do_method(animation.ptr(), "add_track", adding_track_type);
+			undo_redo->add_do_method(animation.ptr(), "track_set_path", animation->get_track_count(), path_to);
+			undo_redo->add_undo_method(animation.ptr(), "remove_track", animation->get_track_count());
+			undo_redo->commit_action();
+
+		} break;
 	}
 }
 
@@ -5852,6 +5971,9 @@ void AnimationTrackEditor::_add_track(int p_type) {
 		case Animation::TYPE_ANIMATION: {
 			valid_types.push_back(SNAME("AnimationPlayer"));
 			title_text = TTRC("Pick a node to play animation:");
+		} break;
+		case Animation::TYPE_STATE_EVENT: {
+			title_text = TTRC("Pick a target node for the State Event Track:");
 		} break;
 	}
 	pick_track->set_valid_types(valid_types);
@@ -6106,6 +6228,12 @@ void AnimationTrackEditor::_insert_key_from_track(float p_ofs, int p_track) {
 		} break;
 		case Animation::TYPE_ANIMATION: {
 			id.value = StringName("[stop]");
+		} break;
+		case Animation::TYPE_STATE_EVENT: {
+			Dictionary ek;
+			ek["event"] = Ref<Resource>();
+			ek["duration"] = 0.5;
+			id.value = ek;
 		} break;
 		default: {
 			// All track types should be handled by now.

--- a/editor/animation/animation_track_editor.h
+++ b/editor/animation/animation_track_editor.h
@@ -565,6 +565,7 @@ public:
 	virtual AnimationTrackEdit *create_value_track_edit(Object *p_object, Variant::Type p_type, const String &p_property, PropertyHint p_hint, const String &p_hint_string, int p_usage);
 	virtual AnimationTrackEdit *create_audio_track_edit();
 	virtual AnimationTrackEdit *create_animation_track_edit(Object *p_object);
+	virtual AnimationTrackEdit *create_state_event_track_edit();
 };
 
 class AnimationTrackKeyEdit;

--- a/editor/animation/animation_track_editor_plugins.cpp
+++ b/editor/animation/animation_track_editor_plugins.cpp
@@ -1415,12 +1415,11 @@ int AnimationTrackEditTypeStateEvent::get_key_height() const {
 }
 
 Rect2 AnimationTrackEditTypeStateEvent::get_key_rect(int p_index, float p_pixels_sec) {
-	float ofs = get_animation()->state_event_track_get_key_start_time(get_track(), p_index);
 	float duration = get_animation()->state_event_track_get_key_duration(get_track(), p_index);
 
 	int fh = get_key_height();
 	int h = get_size().height;
-	return Rect2(ofs * p_pixels_sec, (h - fh) / 2, MAX(5 * EDSCALE, duration * p_pixels_sec), fh);
+	return Rect2(0, (h - fh) / 2, MAX(5 * EDSCALE, duration * p_pixels_sec), fh);
 }
 
 bool AnimationTrackEditTypeStateEvent::is_key_selectable_by_distance() const {

--- a/editor/animation/animation_track_editor_plugins.cpp
+++ b/editor/animation/animation_track_editor_plugins.cpp
@@ -41,6 +41,7 @@
 #include "scene/2d/sprite_2d.h"
 #include "scene/3d/sprite_3d.h"
 #include "scene/animation/animation_player.h"
+#include "scene/resources/animation_state_event.h"
 #include "scene/resources/audio/audio_stream.h"
 #include "servers/rendering/rendering_server.h"
 
@@ -1394,4 +1395,262 @@ AnimationTrackEdit *AnimationTrackEditDefaultPlugin::create_animation_track_edit
 	AnimationTrackEditTypeAnimation *an = memnew(AnimationTrackEditTypeAnimation);
 	an->set_node(p_object);
 	return an;
+}
+
+AnimationTrackEdit *AnimationTrackEditDefaultPlugin::create_state_event_track_edit() {
+	return memnew(AnimationTrackEditTypeStateEvent);
+}
+
+// ----------------------------------------------------
+// AnimationTrackEditTypeStateEvent
+// ----------------------------------------------------
+
+AnimationTrackEditTypeStateEvent::AnimationTrackEditTypeStateEvent() {
+}
+
+int AnimationTrackEditTypeStateEvent::get_key_height() const {
+	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
+	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
+	return int(font->get_height(font_size) * 1.5);
+}
+
+Rect2 AnimationTrackEditTypeStateEvent::get_key_rect(int p_index, float p_pixels_sec) {
+	float ofs = get_animation()->state_event_track_get_key_start_time(get_track(), p_index);
+	float duration = get_animation()->state_event_track_get_key_duration(get_track(), p_index);
+
+	int fh = get_key_height();
+	int h = get_size().height;
+	return Rect2(ofs * p_pixels_sec, (h - fh) / 2, MAX(5 * EDSCALE, duration * p_pixels_sec), fh);
+}
+
+bool AnimationTrackEditTypeStateEvent::is_key_selectable_by_distance() const {
+	return false;
+}
+
+void AnimationTrackEditTypeStateEvent::draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) {
+	float duration = get_animation()->state_event_track_get_key_duration(get_track(), p_index);
+	Ref<AnimationStateEvent> event = get_animation()->state_event_track_get_key_event(get_track(), p_index);
+
+	int px_offset = 0;
+	float local_duration = duration;
+	if (len_resizing && p_index == len_resizing_index) {
+		float ofs_local = len_resizing_rel / get_timeline()->get_zoom_scale();
+		if (len_resizing_start) {
+			local_duration = MAX(0.0001, duration - ofs_local);
+			px_offset = ofs_local * p_pixels_sec;
+		} else {
+			local_duration = MAX(0.0001, duration + ofs_local);
+		}
+	}
+
+	int pixel_len = MAX(5 * EDSCALE, local_duration * p_pixels_sec);
+	int pixel_begin = px_offset + p_x;
+	int pixel_end = pixel_begin + pixel_len;
+
+	if (pixel_end < p_clip_left || pixel_begin > p_clip_right) {
+		return;
+	}
+
+	int from_x = MAX(pixel_begin, p_clip_left);
+	int to_x = MIN(pixel_end, p_clip_right);
+	if (to_x <= from_x) {
+		to_x = from_x + 1;
+	}
+
+	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
+	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
+	float fh = int(font->get_height(font_size) * 1.5);
+	int h = get_size().height;
+	Rect2 rect = Rect2(from_x, (h - fh) / 2, to_x - from_x, fh);
+
+	Color base_color = event.is_valid() ? event->get_tag_color() : Color(0.3, 0.6, 0.9, 0.85);
+	Color fill_color = base_color;
+	fill_color.a *= 0.45f;
+	draw_rect(rect, fill_color);
+
+	Color border_color = base_color;
+	border_color.a = 0.9f;
+	draw_rect(rect, border_color, false, 1.0);
+
+	// Draw left and right handle indicators
+	if (pixel_begin >= p_clip_left && pixel_begin <= p_clip_right) {
+		draw_rect(Rect2(pixel_begin, rect.position.y, 2 * EDSCALE, rect.size.y), border_color);
+	}
+	if (pixel_end >= p_clip_left && pixel_end <= p_clip_right) {
+		draw_rect(Rect2(pixel_end - 2 * EDSCALE, rect.position.y, 2 * EDSCALE, rect.size.y), border_color);
+	}
+
+	// Draw text label
+	String text;
+	if (event.is_valid()) {
+		if (event->get_event_name() != StringName()) {
+			text = String(event->get_event_name());
+		} else if (!event->get_name().is_empty()) {
+			text = event->get_name();
+		} else {
+			text = event->get_class();
+		}
+	} else {
+		text = TTR("[Empty Event]");
+	}
+
+	int text_padding = int(4 * EDSCALE);
+	int text_width = to_x - from_x - text_padding * 2;
+	if (text_width > 10) {
+		Point2 text_pos = Point2(from_x + text_padding, rect.position.y + (rect.size.y - font->get_height(font_size)) / 2 + font->get_ascent(font_size));
+		draw_string(font, text_pos, text, HORIZONTAL_ALIGNMENT_LEFT, text_width, font_size, Color(1, 1, 1, 0.95));
+	}
+
+	if (p_selected) {
+		Color accent = get_theme_color(SNAME("accent_color"), EditorStringName(Editor));
+		draw_rect(rect, accent, false, 2.0);
+	}
+}
+
+bool AnimationTrackEditTypeStateEvent::can_drop_data(const Point2 &p_point, const Variant &p_data) const {
+	if (p_point.x > get_timeline()->get_name_limit() && p_point.x < get_size().width - get_timeline()->get_buttons_width()) {
+		Dictionary drag_data = p_data;
+		if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
+			Ref<AnimationStateEvent> res = drag_data["resource"];
+			if (res.is_valid()) {
+				return true;
+			}
+		}
+
+		if (drag_data.has("type") && String(drag_data["type"]) == "files") {
+			Vector<String> files = drag_data["files"];
+			if (files.size() == 1) {
+				Ref<AnimationStateEvent> res = ResourceLoader::load(files[0]);
+				if (res.is_valid()) {
+					return true;
+				}
+			}
+		}
+	}
+
+	return AnimationTrackEdit::can_drop_data(p_point, p_data);
+}
+
+void AnimationTrackEditTypeStateEvent::drop_data(const Point2 &p_point, const Variant &p_data) {
+	if (p_point.x > get_timeline()->get_name_limit() && p_point.x < get_size().width - get_timeline()->get_buttons_width()) {
+		Ref<AnimationStateEvent> event_res;
+		Dictionary drag_data = p_data;
+		if (drag_data.has("type") && String(drag_data["type"]) == "resource") {
+			event_res = drag_data["resource"];
+		} else if (drag_data.has("type") && String(drag_data["type"]) == "files") {
+			Vector<String> files = drag_data["files"];
+			if (files.size() == 1) {
+				event_res = ResourceLoader::load(files[0]);
+			}
+		}
+
+		if (event_res.is_valid()) {
+			int x = p_point.x - get_timeline()->get_name_limit();
+			float ofs = x / get_timeline()->get_zoom_scale();
+			ofs += get_timeline()->get_value();
+			ofs = get_editor()->snap_time(ofs);
+
+			while (get_animation()->track_find_key(get_track(), ofs, Animation::FIND_MODE_APPROX) != -1) {
+				ofs += 0.0001;
+			}
+
+			EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+			undo_redo->create_action(TTR("Add State Event Key"));
+			undo_redo->add_do_method(get_animation().ptr(), "state_event_track_insert_key", get_track(), ofs, 0.5, event_res);
+			undo_redo->add_undo_method(get_animation().ptr(), "track_remove_key_at_time", get_track(), ofs);
+			undo_redo->commit_action();
+
+			queue_redraw();
+			return;
+		}
+	}
+
+	AnimationTrackEdit::drop_data(p_point, p_data);
+}
+
+void AnimationTrackEditTypeStateEvent::gui_input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_COND(p_event.is_null());
+
+	Ref<InputEventMouseMotion> mm = p_event;
+	if (!len_resizing && mm.is_valid()) {
+		bool use_hsize_cursor = false;
+		for (int i = 0; i < get_animation()->track_get_key_count(get_track()); i++) {
+			float duration = get_animation()->state_event_track_get_key_duration(get_track(), i);
+			float ofs = get_animation()->track_get_key_time(get_track(), i);
+
+			ofs -= get_timeline()->get_value();
+			ofs *= get_timeline()->get_zoom_scale();
+			ofs += get_timeline()->get_name_limit();
+
+			int end = ofs + MAX(5 * EDSCALE, duration * get_timeline()->get_zoom_scale());
+
+			if (end >= get_timeline()->get_name_limit() && end <= get_size().width - get_timeline()->get_buttons_width() && Math::abs(mm->get_position().x - end) < 5 * EDSCALE) {
+				len_resizing_start = false;
+				use_hsize_cursor = true;
+				len_resizing_index = i;
+			}
+
+			if (ofs >= get_timeline()->get_name_limit() && ofs <= get_size().width - get_timeline()->get_buttons_width() && Math::abs(mm->get_position().x - ofs) < 5 * EDSCALE) {
+				len_resizing_start = true;
+				use_hsize_cursor = true;
+				len_resizing_index = i;
+			}
+		}
+		over_drag_position = use_hsize_cursor;
+	}
+
+	if (len_resizing && mm.is_valid()) {
+		len_resizing_rel += mm->get_relative().x;
+		queue_redraw();
+		return;
+	}
+
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed() && over_drag_position) {
+		len_resizing = true;
+		len_resizing_from_px = mb->get_position().x;
+		len_resizing_rel = 0.0f;
+		queue_redraw();
+		return;
+	}
+
+	if (len_resizing && mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && !mb->is_pressed()) {
+		float prev_start = get_animation()->state_event_track_get_key_start_time(get_track(), len_resizing_index);
+		float prev_duration = get_animation()->state_event_track_get_key_duration(get_track(), len_resizing_index);
+		float ofs_local = len_resizing_rel / get_timeline()->get_zoom_scale();
+
+		float new_start = prev_start;
+		float new_duration = prev_duration;
+
+		if (len_resizing_start) {
+			new_start = get_editor()->snap_time(prev_start + ofs_local);
+			new_duration = MAX(0.0001, (prev_start + prev_duration) - new_start);
+		} else {
+			float new_end = get_editor()->snap_time((prev_start + prev_duration) + ofs_local);
+			new_duration = MAX(0.0001, new_end - prev_start);
+		}
+
+		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
+		undo_redo->create_action(TTR("Resize State Event Strip"));
+		if (len_resizing_start) {
+			undo_redo->add_do_method(get_animation().ptr(), "state_event_track_set_key_start_time", get_track(), len_resizing_index, new_start);
+			undo_redo->add_undo_method(get_animation().ptr(), "state_event_track_set_key_start_time", get_track(), len_resizing_index, prev_start);
+		}
+		undo_redo->add_do_method(get_animation().ptr(), "state_event_track_set_key_duration", get_track(), len_resizing_index, new_duration);
+		undo_redo->add_undo_method(get_animation().ptr(), "state_event_track_set_key_duration", get_track(), len_resizing_index, prev_duration);
+		undo_redo->commit_action();
+
+		len_resizing = false;
+		queue_redraw();
+		return;
+	}
+
+	AnimationTrackEdit::gui_input(p_event);
+}
+
+Control::CursorShape AnimationTrackEditTypeStateEvent::get_cursor_shape(const Point2 &p_pos) const {
+	if (over_drag_position || len_resizing) {
+		return Control::CURSOR_HSIZE;
+	}
+	return AnimationTrackEdit::get_cursor_shape(p_pos);
 }

--- a/editor/animation/animation_track_editor_plugins.cpp
+++ b/editor/animation/animation_track_editor_plugins.cpp
@@ -1623,6 +1623,25 @@ void AnimationTrackEditTypeStateEvent::gui_input(const Ref<InputEvent> &p_event)
 
 		if (len_resizing_start) {
 			new_start = get_editor()->snap_time(prev_start + ofs_local);
+			// Clamp to preserve sorted order and avoid index corruption on undo/redo.
+			int key_count = get_animation()->track_get_key_count(get_track());
+			if (len_resizing_index > 0) {
+				double prev_key_end = get_animation()->state_event_track_get_key_end_time(get_track(), len_resizing_index - 1);
+				double prev_key_start = get_animation()->state_event_track_get_key_start_time(get_track(), len_resizing_index - 1);
+				double min_start = MAX(prev_key_start + 0.0001, prev_key_end - prev_duration + 0.0001);
+				// Allow overlapping but keep ordering: must stay after previous start.
+				min_start = MAX(min_start, prev_key_start + 0.0001);
+				if (new_start < min_start) {
+					new_start = min_start;
+				}
+			}
+			if (len_resizing_index + 1 < key_count) {
+				double next_start = get_animation()->state_event_track_get_key_start_time(get_track(), len_resizing_index + 1);
+				if (new_start >= next_start) {
+					new_start = next_start - 0.0001;
+				}
+			}
+			new_start = MAX(0.0, new_start);
 			new_duration = MAX(0.0001, (prev_start + prev_duration) - new_start);
 		} else {
 			float new_end = get_editor()->snap_time((prev_start + prev_duration) + ofs_local);
@@ -1632,11 +1651,12 @@ void AnimationTrackEditTypeStateEvent::gui_input(const Ref<InputEvent> &p_event)
 		EditorUndoRedoManager *undo_redo = EditorUndoRedoManager::get_singleton();
 		undo_redo->create_action(TTR("Resize State Event Strip"));
 		if (len_resizing_start) {
-			undo_redo->add_do_method(get_animation().ptr(), "state_event_track_set_key_start_time", get_track(), len_resizing_index, new_start);
-			undo_redo->add_undo_method(get_animation().ptr(), "state_event_track_set_key_start_time", get_track(), len_resizing_index, prev_start);
+			undo_redo->add_do_method(get_animation().ptr(), "state_event_track_set_key_start_and_duration", get_track(), len_resizing_index, new_start, new_duration);
+			undo_redo->add_undo_method(get_animation().ptr(), "state_event_track_set_key_start_and_duration", get_track(), len_resizing_index, prev_start, prev_duration);
+		} else {
+			undo_redo->add_do_method(get_animation().ptr(), "state_event_track_set_key_duration", get_track(), len_resizing_index, new_duration);
+			undo_redo->add_undo_method(get_animation().ptr(), "state_event_track_set_key_duration", get_track(), len_resizing_index, prev_duration);
 		}
-		undo_redo->add_do_method(get_animation().ptr(), "state_event_track_set_key_duration", get_track(), len_resizing_index, new_duration);
-		undo_redo->add_undo_method(get_animation().ptr(), "state_event_track_set_key_duration", get_track(), len_resizing_index, prev_duration);
 		undo_redo->commit_action();
 
 		len_resizing = false;

--- a/editor/animation/animation_track_editor_plugins.h
+++ b/editor/animation/animation_track_editor_plugins.h
@@ -153,6 +153,32 @@ public:
 	virtual void draw_key_link(int p_index_from, int p_index_to, float p_pixels_sec, int p_x, int p_next_x, int p_clip_left, int p_clip_right) override;
 };
 
+class AnimationTrackEditTypeStateEvent : public AnimationTrackEdit {
+	GDCLASS(AnimationTrackEditTypeStateEvent, AnimationTrackEdit);
+
+	bool len_resizing = false;
+	bool len_resizing_start = false;
+	int len_resizing_index = 0;
+	float len_resizing_from_px = 0.0f;
+	float len_resizing_rel = 0.0f;
+	bool over_drag_position = false;
+
+public:
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
+
+	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
+	virtual void drop_data(const Point2 &p_point, const Variant &p_data) override;
+
+	virtual int get_key_height() const override;
+	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
+	virtual bool is_key_selectable_by_distance() const override;
+	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+
+	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
+
+	AnimationTrackEditTypeStateEvent();
+};
+
 class AnimationTrackEditDefaultPlugin : public AnimationTrackEditPlugin {
 	GDCLASS(AnimationTrackEditDefaultPlugin, AnimationTrackEditPlugin);
 
@@ -160,4 +186,5 @@ public:
 	virtual AnimationTrackEdit *create_value_track_edit(Object *p_object, Variant::Type p_type, const String &p_property, PropertyHint p_hint, const String &p_hint_string, int p_usage) override;
 	virtual AnimationTrackEdit *create_audio_track_edit() override;
 	virtual AnimationTrackEdit *create_animation_track_edit(Object *p_object) override;
+	virtual AnimationTrackEdit *create_state_event_track_edit() override;
 };

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -1932,12 +1932,16 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 					for (int k = 0; k < key_count; k++) {
 						double k_start = a->state_event_track_get_key_start_time(i, k);
 						double k_end = a->state_event_track_get_key_end_time(i, k);
-						
+						Ref<AnimationStateEvent> ev = a->state_event_track_get_key_event(i, k);
+
 						bool is_active = false;
 						if (time >= k_start && time < k_end) {
-							is_active = true;
+							// Only play a Animation State Event if the threshold is high enough
+							if (ev.is_null() || blend >= ev->get_trigger_weight_threshold()) {
+								is_active = true;
+							}
 						}
-						
+
 						if (is_active) {
 							keys_should_be_active.insert(k);
 						}
@@ -1955,9 +1959,9 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 								} else {
 									double k_start = a->state_event_track_get_key_start_time(i, k);
 									double k_end = a->state_event_track_get_key_end_time(i, k);
-									if (!backward && time >= k_end) {
+									if (!backward && (time >= k_end || looped_flag != Animation::LOOPED_FLAG_NONE)) {
 										ev->end(ctx);
-									} else if (backward && time <= k_start) {
+									} else if (backward && (time <= k_start || looped_flag != Animation::LOOPED_FLAG_NONE)) {
 										ev->end(ctx);
 									} else {
 										ev->cancel(ctx);

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -930,6 +930,11 @@ bool AnimationMixer::_update_caches() {
 						track = track_animation;
 
 					} break;
+					case Animation::TYPE_STATE_EVENT: {
+						TrackCacheStateEvent *track_se = memnew(TrackCacheStateEvent);
+						track_se->object_id = child->get_instance_id();
+						track = track_se;
+					} break;
 					default: {
 						ERR_PRINT("Animation corrupted (invalid track type).");
 						continue;
@@ -1904,6 +1909,100 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						}
 					}
 				} break;
+				case Animation::TYPE_STATE_EVENT: {
+					if (p_update_only) {
+						continue;
+					}
+					TrackCacheStateEvent *t = static_cast<TrackCacheStateEvent *>(track);
+					Object *t_obj = ObjectDB::get_instance(t->object_id);
+					Node *node = t_obj ? Object::cast_to<Node>(t_obj) : nullptr;
+					if (!t_obj || !node) {
+						continue;
+					}
+
+					ObjectID oid = a->get_instance_id();
+					if (!t->active_events.has(oid)) {
+						t->active_events[oid] = AHashMap<int, TrackCacheStateEvent::ActiveEvent>();
+					}
+					AHashMap<int, TrackCacheStateEvent::ActiveEvent> &map = t->active_events[oid];
+
+					int key_count = a->track_get_key_count(i);
+					HashSet<int> keys_should_be_active;
+
+					for (int k = 0; k < key_count; k++) {
+						double k_start = a->state_event_track_get_key_start_time(i, k);
+						double k_end = a->state_event_track_get_key_end_time(i, k);
+						
+						bool is_active = false;
+						if (time >= k_start && time < k_end) {
+							is_active = true;
+						}
+						
+						if (is_active) {
+							keys_should_be_active.insert(k);
+						}
+					}
+
+					LocalVector<int> to_remove;
+					for (const KeyValue<int, TrackCacheStateEvent::ActiveEvent> &E : map) {
+						int k = E.key;
+						if (!keys_should_be_active.has(k)) {
+							Ref<AnimationStateContext> ctx = E.value.context;
+							Ref<AnimationStateEvent> ev = E.value.event_res;
+							if (ev.is_valid() && ctx.is_valid()) {
+								if (seeked) {
+									ev->cancel(ctx);
+								} else {
+									double k_start = a->state_event_track_get_key_start_time(i, k);
+									double k_end = a->state_event_track_get_key_end_time(i, k);
+									if (!backward && time >= k_end) {
+										ev->end(ctx);
+									} else if (backward && time <= k_start) {
+										ev->end(ctx);
+									} else {
+										ev->cancel(ctx);
+									}
+								}
+							}
+							to_remove.push_back(k);
+						}
+					}
+					for (int k : to_remove) {
+						map.erase(k);
+					}
+
+					for (int k : keys_should_be_active) {
+						double k_start = a->state_event_track_get_key_start_time(i, k);
+						double k_dur = a->state_event_track_get_key_duration(i, k);
+						double elapsed = time - k_start;
+
+						if (!map.has(k)) {
+							TrackCacheStateEvent::ActiveEvent ae;
+							ae.event_res = a->state_event_track_get_key_event(i, k);
+							if (ae.event_res.is_valid()) {
+								ae.context.instantiate();
+								ae.context->set_target(node);
+								ae.context->set_mixer(this);
+								ae.context->set_animation(a);
+								ae.context->set_duration(k_dur);
+								ae.context->set_elapsed(elapsed);
+								ae.context->set_delta(delta);
+								ae.context->set_weight(blend);
+								ae.event_res->start(ae.context);
+								ae.started = true;
+							}
+							map[k] = ae;
+						} else {
+							TrackCacheStateEvent::ActiveEvent &ae = map[k];
+							if (ae.event_res.is_valid() && ae.context.is_valid()) {
+								ae.context->set_elapsed(elapsed);
+								ae.context->set_delta(delta);
+								ae.context->set_weight(blend);
+								ae.event_res->update(ae.context, delta);
+							}
+						}
+					}
+				} break;
 			}
 		}
 	}
@@ -2628,7 +2727,8 @@ AnimationMixer::TrackCache *AnimatedValuesBackup::get_cache_copy(AnimationMixer:
 		}
 
 		case Animation::TYPE_METHOD:
-		case Animation::TYPE_ANIMATION: {
+		case Animation::TYPE_ANIMATION:
+		case Animation::TYPE_STATE_EVENT: {
 			// Nothing to do here.
 		} break;
 	}

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -584,11 +584,30 @@ bool AnimationMixer::is_dummy() const {
 /* -------------------------------------------- */
 
 void AnimationMixer::_clear_caches(bool p_clear_track_cache) {
+	if (state_event_callback_in_progress) {
+		state_event_clear_caches_pending = true;
+		return;
+	}
+
 	_init_root_motion_cache();
 	_clear_audio_streams();
 	_clear_playing_caches();
 	capture_cache.clear();
+
+	LocalVector<TrackCacheStateEvent::ActiveEvent> state_events_to_cancel;
+	for (KeyValue<Animation::TrackCacheID, TrackCache *> &K : track_cache) {
+		if (K.value->type == Animation::TYPE_STATE_EVENT) {
+			TrackCacheStateEvent *se = static_cast<TrackCacheStateEvent *>(K.value);
+			se->take_all_active_events(state_events_to_cancel);
+		}
+	}
+	_cancel_state_events(state_events_to_cancel);
+	bool clear_caches_pending = state_event_clear_caches_pending;
+	state_event_clear_caches_pending = false;
 	if (!p_clear_track_cache) {
+		if (clear_caches_pending) {
+			_clear_caches();
+		}
 		return;
 	}
 	for (KeyValue<Animation::TrackCacheID, TrackCache *> &K : track_cache) {
@@ -721,6 +740,11 @@ bool AnimationMixer::_update_caches() {
 			// If not valid, delete track.
 			if (track && (track->type != track_cache_type || ObjectDB::get_instance(track->object_id) == nullptr)) {
 				playing_caches.erase(track);
+				if (track->type == Animation::TYPE_STATE_EVENT) {
+					LocalVector<TrackCacheStateEvent::ActiveEvent> state_events_to_cancel;
+					static_cast<TrackCacheStateEvent *>(track)->take_all_active_events(state_events_to_cancel);
+					_cancel_state_events(state_events_to_cancel);
+				}
 				memdelete(track);
 				track_cache.erase(track_unique_id);
 				track = nullptr;
@@ -931,8 +955,19 @@ bool AnimationMixer::_update_caches() {
 
 					} break;
 					case Animation::TYPE_STATE_EVENT: {
+						if (resource.is_valid() || !leftover_path.is_empty()) {
+							if (check_path) {
+								WARN_PRINT_ED(mixer_name + ": '" + String(E) + "', StateEvent track does not support sub-resources or subpaths: '" + String(path) + "'. Expected Node path. This track will be ignored.");
+							}
+							continue;
+						}
+						Node *node_target = Object::cast_to<Node>(child);
+						if (!node_target) {
+							ERR_PRINT(mixer_name + ": '" + String(E) + "', StateEvent track does not point to a Node: '" + String(path) + "'.");
+							continue;
+						}
 						TrackCacheStateEvent *track_se = memnew(TrackCacheStateEvent);
-						track_se->object_id = child->get_instance_id();
+						track_se->object_id = node_target->get_instance_id();
 						track = track_se;
 					} break;
 					default: {
@@ -990,7 +1025,14 @@ bool AnimationMixer::_update_caches() {
 	}
 
 	for (const Animation::TrackCacheID &unique_id : to_delete) {
-		memdelete(track_cache[unique_id]);
+		TrackCache *tc = track_cache[unique_id];
+		LocalVector<TrackCacheStateEvent::ActiveEvent> state_events_to_cancel;
+		if (tc->type == Animation::TYPE_STATE_EVENT) {
+			TrackCacheStateEvent *se = static_cast<TrackCacheStateEvent *>(tc);
+			se->take_all_active_events(state_events_to_cancel);
+		}
+		_cancel_state_events(state_events_to_cancel);
+		memdelete(tc);
 		track_cache.erase(unique_id);
 	}
 
@@ -1241,8 +1283,11 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 #ifdef TOOLS_ENABLED
 	bool can_call = is_inside_tree() && !Engine::get_singleton()->is_editor_hint();
 #endif // TOOLS_ENABLED
+	HashSet<ObjectID> seen_instance_ids;
 	for (const AnimationInstance &ai : animation_instances) {
 		const Ref<Animation> &a = ai.animation;
+		ObjectID instance_id = ObjectID(ai.playback_info.instance_id ? ai.playback_info.instance_id : a->get_instance_id());
+		seen_instance_ids.insert(instance_id);
 		double time = ai.playback_info.time;
 		double delta = ai.playback_info.delta;
 		double start = ai.playback_info.start;
@@ -1283,15 +1328,19 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 				blend = weight;
 			}
 
+			Animation::TrackType ttype = animation_track->type;
 			if (!deterministic) {
 				// If non-deterministic, do normalization.
 				// It would be better to make this if statement outside the for loop, but come here since too much code...
 				if (Math::is_zero_approx(track->total_weight)) {
-					continue;
+					if (ttype != Animation::TYPE_STATE_EVENT) {
+						continue;
+					}
+					blend = 0.0;
+				} else {
+					blend = blend / track->total_weight;
 				}
-				blend = blend / track->total_weight;
 			}
-			Animation::TrackType ttype = animation_track->type;
 			track->root_motion = root_motion_track == animation_track->path;
 			switch (ttype) {
 				case Animation::TYPE_POSITION_3D: {
@@ -1910,9 +1959,6 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 					}
 				} break;
 				case Animation::TYPE_STATE_EVENT: {
-					if (p_update_only) {
-						continue;
-					}
 					TrackCacheStateEvent *t = static_cast<TrackCacheStateEvent *>(track);
 					Object *t_obj = ObjectDB::get_instance(t->object_id);
 					Node *node = t_obj ? Object::cast_to<Node>(t_obj) : nullptr;
@@ -1920,11 +1966,24 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						continue;
 					}
 
-					ObjectID oid = a->get_instance_id();
-					if (!t->active_events.has(oid)) {
-						t->active_events[oid] = AHashMap<int, TrackCacheStateEvent::ActiveEvent>();
+					ObjectID instance_id = ObjectID(ai.playback_info.instance_id ? ai.playback_info.instance_id : a->get_instance_id());
+					if (p_update_only) {
+						LocalVector<TrackCacheStateEvent::ActiveEvent> state_events_to_cancel;
+						t->take_events_for_animation(instance_id, state_events_to_cancel);
+						_cancel_state_events(state_events_to_cancel);
+						continue;
 					}
-					AHashMap<int, TrackCacheStateEvent::ActiveEvent> &map = t->active_events[oid];
+#ifdef TOOLS_ENABLED
+					if (!can_call) {
+						LocalVector<TrackCacheStateEvent::ActiveEvent> state_events_to_clear;
+						t->take_events_for_animation(instance_id, state_events_to_clear);
+						continue;
+					}
+#endif // TOOLS_ENABLED
+					if (!t->active_events.has(instance_id)) {
+						t->active_events[instance_id] = AHashMap<uint64_t, TrackCacheStateEvent::ActiveEvent>();
+					}
+					AHashMap<uint64_t, TrackCacheStateEvent::ActiveEvent> &map = t->active_events[instance_id];
 
 					int key_count = a->track_get_key_count(i);
 					HashSet<int> keys_should_be_active;
@@ -1937,7 +1996,7 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						bool is_active = false;
 						if (time >= k_start && time < k_end) {
 							// Only play a Animation State Event if the threshold is high enough
-							if (ev.is_null() || blend >= ev->get_trigger_weight_threshold()) {
+							if (!Math::is_zero_approx(blend) && (ev.is_null() || blend >= ev->get_trigger_weight_threshold())) {
 								is_active = true;
 							}
 						}
@@ -1947,32 +2006,94 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						}
 					}
 
-					LocalVector<int> to_remove;
-					for (const KeyValue<int, TrackCacheStateEvent::ActiveEvent> &E : map) {
-						int k = E.key;
+					// Handle events that were completely skipped due to large delta (e.g. advance(1.0) jumping over 0.2-0.6).
+					// Detect keys whose start was crossed during the travelled interval but whose end is already behind us.
+					if (!seeked && !Math::is_zero_approx(delta)) {
+						LocalVector<int> crossed;
+						a->track_get_key_indices_in_range(i, time, delta, start, end, &crossed, looped_flag);
+						for (int ck : crossed) {
+							if (keys_should_be_active.has(ck)) {
+								continue;
+							}
+							Ref<AnimationStateEvent> ev2 = a->state_event_track_get_key_event(i, ck);
+							if (Math::is_zero_approx(blend) || (ev2.is_valid() && blend < ev2->get_trigger_weight_threshold())) {
+								continue;
+							}
+							double ks = a->state_event_track_get_key_start_time(i, ck);
+							double ke = a->state_event_track_get_key_end_time(i, ck);
+							bool skipped_whole = false;
+							if (!backward && time >= ke && ke > ks) {
+								skipped_whole = true;
+							} else if (backward && time < ks) {
+								skipped_whole = true;
+							}
+							if (skipped_whole) {
+								Ref<AnimationStateEvent> ev = ev2;
+								if (ev.is_valid()) {
+									Ref<AnimationStateContext> ctx;
+									ctx.instantiate();
+									ctx->set_target(node);
+									ctx->set_mixer(this);
+									ctx->set_animation(a);
+									double dur = a->state_event_track_get_key_duration(i, ck);
+									ctx->set_duration(dur);
+									ctx->set_elapsed(backward ? dur : 0.0);
+									ctx->set_delta(delta);
+									ctx->set_weight(blend);
+									_state_event_start(ev, ctx);
+									ctx->set_elapsed(backward ? 0.0 : dur);
+									_state_event_end(ev, ctx);
+								} else if (ev.is_null()) {
+									// Null event still counts as traversed but no callbacks.
+								}
+							}
+						}
+					}
+
+					LocalVector<uint64_t> to_remove;
+					LocalVector<TrackCacheStateEvent::ActiveEvent> to_end;
+					LocalVector<TrackCacheStateEvent::ActiveEvent> to_cancel;
+					for (const KeyValue<uint64_t, TrackCacheStateEvent::ActiveEvent> &E : map) {
+						if (uint32_t(E.key >> 32) != uint32_t(i)) {
+							continue;
+						}
+						int k = int(uint32_t(E.key));
 						if (!keys_should_be_active.has(k)) {
 							Ref<AnimationStateContext> ctx = E.value.context;
 							Ref<AnimationStateEvent> ev = E.value.event_res;
 							if (ev.is_valid() && ctx.is_valid()) {
 								if (seeked) {
-									ev->cancel(ctx);
+									to_cancel.push_back(E.value);
 								} else {
 									double k_start = a->state_event_track_get_key_start_time(i, k);
 									double k_end = a->state_event_track_get_key_end_time(i, k);
-									if (!backward && (time >= k_end || looped_flag != Animation::LOOPED_FLAG_NONE)) {
-										ev->end(ctx);
+									bool below_threshold = Math::is_zero_approx(blend) || blend < ev->get_trigger_weight_threshold();
+									if (below_threshold) {
+										to_cancel.push_back(E.value);
+									} else if (!backward && (time >= k_end || looped_flag != Animation::LOOPED_FLAG_NONE)) {
+										ctx->set_elapsed(a->state_event_track_get_key_duration(i, k));
+										ctx->set_delta(delta);
+										ctx->set_weight(blend);
+										to_end.push_back(E.value);
 									} else if (backward && (time <= k_start || looped_flag != Animation::LOOPED_FLAG_NONE)) {
-										ev->end(ctx);
+										ctx->set_elapsed(0.0);
+										ctx->set_delta(delta);
+										ctx->set_weight(blend);
+										to_end.push_back(E.value);
 									} else {
-										ev->cancel(ctx);
+										to_cancel.push_back(E.value);
 									}
 								}
 							}
-							to_remove.push_back(k);
+							to_remove.push_back(E.key);
 						}
 					}
-					for (int k : to_remove) {
+					for (uint64_t k : to_remove) {
 						map.erase(k);
+					}
+					_cancel_state_events(to_cancel);
+					for (const TrackCacheStateEvent::ActiveEvent &E : to_end) {
+						_state_event_end(E.event_res, E.context);
 					}
 
 					for (int k : keys_should_be_active) {
@@ -1980,7 +2101,8 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 						double k_dur = a->state_event_track_get_key_duration(i, k);
 						double elapsed = time - k_start;
 
-						if (!map.has(k)) {
+						uint64_t active_key = TrackCacheStateEvent::make_active_key(i, k);
+						if (!map.has(active_key)) {
 							TrackCacheStateEvent::ActiveEvent ae;
 							ae.event_res = a->state_event_track_get_key_event(i, k);
 							if (ae.event_res.is_valid()) {
@@ -1992,23 +2114,34 @@ void AnimationMixer::_blend_process(double p_delta, bool p_update_only) {
 								ae.context->set_elapsed(elapsed);
 								ae.context->set_delta(delta);
 								ae.context->set_weight(blend);
-								ae.event_res->start(ae.context);
 								ae.started = true;
 							}
-							map[k] = ae;
+							map[active_key] = ae;
+							_state_event_start(ae.event_res, ae.context);
 						} else {
-							TrackCacheStateEvent::ActiveEvent &ae = map[k];
+							TrackCacheStateEvent::ActiveEvent ae = map[active_key];
 							if (ae.event_res.is_valid() && ae.context.is_valid()) {
 								ae.context->set_elapsed(elapsed);
 								ae.context->set_delta(delta);
 								ae.context->set_weight(blend);
-								ae.event_res->update(ae.context, delta);
+								_state_event_update(ae.event_res, ae.context, delta);
 							}
 						}
 					}
 				} break;
 			}
 		}
+	}
+	for (KeyValue<Animation::TrackCacheID, TrackCache *> &K : track_cache) {
+		if (K.value->type != Animation::TYPE_STATE_EVENT) {
+			continue;
+		}
+		LocalVector<TrackCacheStateEvent::ActiveEvent> state_events_to_cancel;
+		static_cast<TrackCacheStateEvent *>(K.value)->take_events_not_in(seen_instance_ids, state_events_to_cancel);
+		_cancel_state_events(state_events_to_cancel);
+	}
+	if (state_event_clear_caches_pending) {
+		_clear_caches();
 	}
 	is_GDVIRTUAL_CALL_post_process_key_value = true;
 }
@@ -2206,6 +2339,59 @@ void AnimationMixer::_call_object(ObjectID p_object_id, const StringName &p_meth
 		Callable::CallError ce;
 		t_obj->callp(p_method, argptrs, argcount, ce);
 	}
+}
+
+void AnimationMixer::_state_event_start(const Ref<AnimationStateEvent> &p_event, const Ref<AnimationStateContext> &p_context) {
+	if (p_event.is_null() || p_context.is_null()) {
+		return;
+	}
+	bool was_in_progress = state_event_callback_in_progress;
+	state_event_callback_in_progress = true;
+	p_event->start(p_context);
+	state_event_callback_in_progress = was_in_progress;
+}
+
+void AnimationMixer::_state_event_update(const Ref<AnimationStateEvent> &p_event, const Ref<AnimationStateContext> &p_context, double p_delta) {
+	if (p_event.is_null() || p_context.is_null()) {
+		return;
+	}
+	bool was_in_progress = state_event_callback_in_progress;
+	state_event_callback_in_progress = true;
+	p_event->update(p_context, p_delta);
+	state_event_callback_in_progress = was_in_progress;
+}
+
+void AnimationMixer::_state_event_end(const Ref<AnimationStateEvent> &p_event, const Ref<AnimationStateContext> &p_context) {
+	if (p_event.is_null() || p_context.is_null()) {
+		return;
+	}
+	bool was_in_progress = state_event_callback_in_progress;
+	state_event_callback_in_progress = true;
+	p_event->end(p_context);
+	state_event_callback_in_progress = was_in_progress;
+}
+
+void AnimationMixer::_state_event_cancel(const Ref<AnimationStateEvent> &p_event, const Ref<AnimationStateContext> &p_context) {
+	if (p_event.is_null() || p_context.is_null()) {
+		return;
+	}
+	bool was_in_progress = state_event_callback_in_progress;
+	state_event_callback_in_progress = true;
+	p_event->cancel(p_context);
+	state_event_callback_in_progress = was_in_progress;
+}
+
+void AnimationMixer::_cancel_state_events(LocalVector<TrackCacheStateEvent::ActiveEvent> &p_events) {
+#ifdef TOOLS_ENABLED
+	if (!is_inside_tree() || Engine::get_singleton()->is_editor_hint()) {
+		p_events.clear();
+		return;
+	}
+#endif // TOOLS_ENABLED
+	for (const TrackCacheStateEvent::ActiveEvent &E : p_events) {
+		_state_event_cancel(E.event_res, E.context);
+	}
+	p_events.clear();
 }
 
 void AnimationMixer::make_animation_instance(const StringName &p_name, const PlaybackInfo &p_playback_info) {

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -34,8 +34,8 @@
 #include "scene/animation/tween.h"
 #include "scene/main/node.h"
 #include "scene/resources/animation.h"
-#include "scene/resources/animation_state_event.h"
 #include "scene/resources/animation_library.h"
+#include "scene/resources/animation_state_event.h"
 #include "scene/resources/audio/audio_stream_polyphonic.h"
 
 class AnimatedValuesBackup;

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -92,6 +92,7 @@ public:
 		Animation::LoopedFlag looped_flag = Animation::LOOPED_FLAG_NONE;
 		real_t weight = 0.0;
 		LocalVector<real_t> *track_weights = nullptr;
+		uint64_t instance_id = 0;
 	};
 
 	struct AnimationInstance {
@@ -310,8 +311,8 @@ protected:
 			Ref<AnimationStateContext> context;
 			bool started = false;
 		};
-		// Map from animation instance ID and key index to active event instance
-		AHashMap<ObjectID, AHashMap<int, ActiveEvent>> active_events;
+		// Map from playback instance ID and source track/key index to active event instance.
+		AHashMap<ObjectID, AHashMap<uint64_t, ActiveEvent>> active_events;
 
 		TrackCacheStateEvent(const TrackCacheStateEvent &p_other) :
 				TrackCache(p_other),
@@ -321,13 +322,43 @@ protected:
 			type = Animation::TYPE_STATE_EVENT;
 		}
 
-		~TrackCacheStateEvent() override {
-			for (KeyValue<ObjectID, AHashMap<int, ActiveEvent>> &E : active_events) {
-				for (KeyValue<int, ActiveEvent> &ae : E.value) {
-					if (ae.value.event_res.is_valid() && ae.value.context.is_valid()) {
-						ae.value.event_res->cancel(ae.value.context);
-					}
+		static uint64_t make_active_key(int p_track, int p_key) {
+			return (uint64_t(uint32_t(p_track)) << 32) | uint32_t(p_key);
+		}
+
+		void take_all_active_events(LocalVector<ActiveEvent> &r_events) {
+			for (const KeyValue<ObjectID, AHashMap<uint64_t, ActiveEvent>> &E : active_events) {
+				for (const KeyValue<uint64_t, ActiveEvent> &ae : E.value) {
+					r_events.push_back(ae.value);
 				}
+			}
+			active_events.clear();
+		}
+
+		void take_events_for_animation(ObjectID p_animation_id, LocalVector<ActiveEvent> &r_events) {
+			AHashMap<uint64_t, ActiveEvent> *events = active_events.getptr(p_animation_id);
+			if (!events) {
+				return;
+			}
+			for (const KeyValue<uint64_t, ActiveEvent> &E : *events) {
+				r_events.push_back(E.value);
+			}
+			active_events.erase(p_animation_id);
+		}
+
+		void take_events_not_in(const HashSet<ObjectID> &p_valid_ids, LocalVector<ActiveEvent> &r_events) {
+			LocalVector<ObjectID> to_erase;
+			for (const KeyValue<ObjectID, AHashMap<uint64_t, ActiveEvent>> &E : active_events) {
+				if (p_valid_ids.has(E.key)) {
+					continue;
+				}
+				for (const KeyValue<uint64_t, ActiveEvent> &ae : E.value) {
+					r_events.push_back(ae.value);
+				}
+				to_erase.push_back(E.key);
+			}
+			for (ObjectID id : to_erase) {
+				active_events.erase(id);
 			}
 		}
 	};
@@ -352,6 +383,8 @@ protected:
 	/* ---- Blending processor ---- */
 	LocalVector<AnimationInstance> animation_instances;
 	uint64_t animation_instance_weight_pass_counter = 0;
+	bool state_event_callback_in_progress = false;
+	bool state_event_clear_caches_pending = false;
 	AHashMap<NodePath, int> track_map;
 	uint64_t track_map_version = 1;
 	int track_count = 0;
@@ -402,6 +435,11 @@ protected:
 	void _blend_apply();
 	virtual void _blend_post_process();
 	void _call_object(ObjectID p_object_id, const StringName &p_method, const Vector<Variant> &p_params, bool p_deferred);
+	void _state_event_start(const Ref<AnimationStateEvent> &p_event, const Ref<AnimationStateContext> &p_context);
+	void _state_event_update(const Ref<AnimationStateEvent> &p_event, const Ref<AnimationStateContext> &p_context, double p_delta);
+	void _state_event_end(const Ref<AnimationStateEvent> &p_event, const Ref<AnimationStateContext> &p_context);
+	void _state_event_cancel(const Ref<AnimationStateEvent> &p_event, const Ref<AnimationStateContext> &p_context);
+	void _cancel_state_events(LocalVector<TrackCacheStateEvent::ActiveEvent> &p_events);
 
 	/* ---- Capture feature ---- */
 	struct CaptureCache {

--- a/scene/animation/animation_mixer.h
+++ b/scene/animation/animation_mixer.h
@@ -34,6 +34,7 @@
 #include "scene/animation/tween.h"
 #include "scene/main/node.h"
 #include "scene/resources/animation.h"
+#include "scene/resources/animation_state_event.h"
 #include "scene/resources/animation_library.h"
 #include "scene/resources/audio/audio_stream_polyphonic.h"
 
@@ -300,6 +301,34 @@ protected:
 
 		TrackCacheAnimation() {
 			type = Animation::TYPE_ANIMATION;
+		}
+	};
+
+	struct TrackCacheStateEvent : public TrackCache {
+		struct ActiveEvent {
+			Ref<AnimationStateEvent> event_res;
+			Ref<AnimationStateContext> context;
+			bool started = false;
+		};
+		// Map from animation instance ID and key index to active event instance
+		AHashMap<ObjectID, AHashMap<int, ActiveEvent>> active_events;
+
+		TrackCacheStateEvent(const TrackCacheStateEvent &p_other) :
+				TrackCache(p_other),
+				active_events(p_other.active_events) {}
+
+		TrackCacheStateEvent() {
+			type = Animation::TYPE_STATE_EVENT;
+		}
+
+		~TrackCacheStateEvent() override {
+			for (KeyValue<ObjectID, AHashMap<int, ActiveEvent>> &E : active_events) {
+				for (KeyValue<int, ActiveEvent> &ae : E.value) {
+					if (ae.value.event_res.is_valid() && ae.value.context.is_valid()) {
+						ae.value.event_res->cancel(ae.value.context);
+					}
+				}
+			}
 		}
 	};
 

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -253,6 +253,7 @@ void AnimationPlayer::_process_playback_data(PlaybackData &cd, double p_delta, f
 	pi.is_external_seeking = !p_internal_seeked && !p_started;
 	pi.looped_flag = looped_flag;
 	pi.weight = p_blend;
+	pi.instance_id = cd.instance_id;
 	make_animation_instance(cd.animation_name, pi);
 }
 
@@ -542,6 +543,7 @@ void AnimationPlayer::play_section(const StringName &p_name, double p_start_time
 		}
 	}
 
+	c.current.instance_id = ++playback_instance_id;
 	c.seeked = false;
 	c.started = true;
 

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -82,6 +82,7 @@ private:
 			}
 			return end_time;
 		}
+		uint64_t instance_id = 0;
 	};
 
 	struct Blend {
@@ -128,6 +129,7 @@ private:
 
 	bool movie_quit_on_finish = false;
 	bool clear_cache_on_stop = true;
+	uint64_t playback_instance_id = 0;
 
 	void _play(const StringName &p_name, double p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);
 	void _capture(const StringName &p_name, bool p_from_end = false, double p_duration = -1.0, Tween::TransitionType p_trans_type = Tween::TRANS_LINEAR, Tween::EaseType p_ease_type = Tween::EASE_IN);

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -104,6 +104,7 @@ void AnimationNode::get_child_nodes(LocalVector<ChildNode> *r_child_nodes) {
 
 void AnimationNode::blend_animation(ProcessState &p_process_state, AnimationNodeInstance &p_instance, const StringName &p_animation, AnimationMixer::PlaybackInfo &p_playback_info) {
 	p_playback_info.track_weights = &p_instance.track_weights;
+	p_playback_info.instance_id = reinterpret_cast<uintptr_t>(&p_instance);
 	p_process_state.tree->make_animation_instance(p_animation, p_playback_info);
 }
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -112,6 +112,7 @@
 #include "scene/main/viewport.h"
 #include "scene/main/window.h"
 #include "scene/resources/animation_library.h"
+#include "scene/resources/animation_state_event.h"
 #include "scene/resources/atlas_texture.h"
 #include "scene/resources/audio/audio_stream.h"
 #include "scene/resources/audio/audio_stream_microphone.h"
@@ -985,6 +986,8 @@ void register_scene_types() {
 
 	GDREGISTER_CLASS(Animation);
 	GDREGISTER_CLASS(AnimationLibrary);
+	GDREGISTER_CLASS(AnimationStateContext);
+	GDREGISTER_CLASS(AnimationStateEvent);
 
 	GDREGISTER_ABSTRACT_CLASS(Font);
 	GDREGISTER_CLASS(FontFile);

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -4049,7 +4049,7 @@ int Animation::state_event_track_insert_key(int p_track, double p_time, double p
 
 	StateEventKey k;
 	k.time = p_time;
-	k.duration = MAX(0.0, p_duration);
+	k.duration = MAX(0.0001, p_duration);
 	k.event = p_event;
 
 	int ret = _insert(p_time, et->events, k);
@@ -4065,7 +4065,7 @@ void Animation::state_event_track_set_key_duration(int p_track, int p_key, doubl
 	StateEventTrack *et = static_cast<StateEventTrack *>(t);
 	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key, et->events.size());
 
-	et->events[p_key].duration = MAX(0.0, p_duration);
+	et->events[p_key].duration = MAX(0.0001, p_duration);
 	emit_changed();
 }
 
@@ -4096,7 +4096,7 @@ void Animation::state_event_track_set_key_end_time(int p_track, int p_key, doubl
 	StateEventTrack *et = static_cast<StateEventTrack *>(t);
 	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key, et->events.size());
 
-	double new_duration = MAX(0.0, p_end_time - et->events[p_key].time);
+	double new_duration = MAX(0.0001, p_end_time - et->events[p_key].time);
 	state_event_track_set_key_duration(p_track, p_key, new_duration);
 }
 
@@ -4109,6 +4109,22 @@ double Animation::state_event_track_get_key_end_time(int p_track, int p_key) con
 	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key, et->events.size(), 0.0);
 
 	return et->events[p_key].time + et->events[p_key].duration;
+}
+
+void Animation::state_event_track_set_key_start_and_duration(int p_track, int p_key, double p_start_time, double p_duration) {
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
+	Track *t = tracks[p_track];
+	ERR_FAIL_COND(t->type != TYPE_STATE_EVENT);
+
+	StateEventTrack *et = static_cast<StateEventTrack *>(t);
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key, et->events.size());
+
+	StateEventKey key = et->events[p_key];
+	key.time = p_start_time;
+	key.duration = MAX(0.0001, p_duration);
+	et->events.remove_at(p_key);
+	_insert(p_start_time, et->events, key);
+	emit_changed();
 }
 
 void Animation::state_event_track_set_key_event(int p_track, int p_key, const Ref<Resource> &p_event) {
@@ -4334,6 +4350,7 @@ void Animation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("state_event_track_get_key_start_time", "track_idx", "key_idx"), &Animation::state_event_track_get_key_start_time);
 	ClassDB::bind_method(D_METHOD("state_event_track_set_key_end_time", "track_idx", "key_idx", "end_time"), &Animation::state_event_track_set_key_end_time);
 	ClassDB::bind_method(D_METHOD("state_event_track_get_key_end_time", "track_idx", "key_idx"), &Animation::state_event_track_get_key_end_time);
+	ClassDB::bind_method(D_METHOD("state_event_track_set_key_start_and_duration", "track_idx", "key_idx", "start_time", "duration"), &Animation::state_event_track_set_key_start_and_duration);
 	ClassDB::bind_method(D_METHOD("state_event_track_set_key_event", "track_idx", "key_idx", "event"), &Animation::state_event_track_set_key_event);
 	ClassDB::bind_method(D_METHOD("state_event_track_get_key_event", "track_idx", "key_idx"), &Animation::state_event_track_get_key_event);
 

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -105,6 +105,8 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 				add_track(TYPE_AUDIO);
 			} else if (type == "animation") {
 				add_track(TYPE_ANIMATION);
+			} else if (type == "state_event") {
+				add_track(TYPE_STATE_EVENT);
 			} else {
 				return false;
 			}
@@ -443,6 +445,39 @@ bool Animation::_set(const StringName &p_name, const Variant &p_value) {
 				}
 
 				return true;
+			} else if (track_get_type(track) == TYPE_STATE_EVENT) {
+				StateEventTrack *et = static_cast<StateEventTrack *>(tracks[track]);
+				Dictionary d = p_value;
+				ERR_FAIL_COND_V(!d.has("times"), false);
+				ERR_FAIL_COND_V(!d.has("events"), false);
+
+				Vector<real_t> times = d["times"];
+				Array events = d["events"];
+				Vector<real_t> durations;
+				if (d.has("durations")) {
+					durations = d["durations"];
+				}
+
+				ERR_FAIL_COND_V(events.size() != times.size(), false);
+
+				if (times.size()) {
+					int valcount = times.size();
+
+					const real_t *rt = times.ptr();
+					const real_t *rd = durations.size() == valcount ? durations.ptr() : nullptr;
+
+					et->events.resize(valcount);
+
+					for (int i = 0; i < valcount; i++) {
+						StateEventKey ek;
+						ek.time = rt[i];
+						ek.duration = rd ? rd[i] : 0.0;
+						ek.event = events[i];
+						et->events[i] = ek;
+					}
+				}
+
+				return true;
 			} else {
 				return false;
 			}
@@ -539,6 +574,9 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 					break;
 				case TYPE_ANIMATION:
 					r_ret = "animation";
+					break;
+				case TYPE_STATE_EVENT:
+					r_ret = "state_event";
 					break;
 			}
 
@@ -855,6 +893,39 @@ bool Animation::_get(const StringName &p_name, Variant &r_ret) const {
 				r_ret = d;
 
 				return true;
+			} else if (track_get_type(track) == TYPE_STATE_EVENT) {
+				const StateEventTrack *et = static_cast<const StateEventTrack *>(tracks[track]);
+
+				Dictionary d;
+
+				Vector<real_t> key_times;
+				Vector<real_t> key_durations;
+				Array key_events;
+
+				int kk = et->events.size();
+
+				key_times.resize(kk);
+				key_durations.resize(kk);
+				key_events.resize(kk);
+
+				real_t *wti = key_times.ptrw();
+				real_t *wdu = key_durations.ptrw();
+
+				const StateEventKey *vls = et->events.ptr();
+
+				for (int i = 0; i < kk; i++) {
+					wti[i] = vls[i].time;
+					wdu[i] = vls[i].duration;
+					key_events[i] = vls[i].event;
+				}
+
+				d["times"] = key_times;
+				d["durations"] = key_durations;
+				d["events"] = key_events;
+
+				r_ret = d;
+
+				return true;
 			}
 		} else {
 			return false;
@@ -935,6 +1006,10 @@ int Animation::add_track(TrackType p_type, int p_at_pos) {
 			tracks.insert(p_at_pos, memnew(AnimationTrack));
 
 		} break;
+		case TYPE_STATE_EVENT: {
+			tracks.insert(p_at_pos, memnew(StateEventTrack));
+
+		} break;
 		default: {
 			ERR_PRINT("Unknown track type");
 		}
@@ -995,6 +1070,11 @@ void Animation::remove_track(int p_track) {
 		case TYPE_ANIMATION: {
 			AnimationTrack *an = static_cast<AnimationTrack *>(t);
 			an->values.clear();
+
+		} break;
+		case TYPE_STATE_EVENT: {
+			StateEventTrack *et = static_cast<StateEventTrack *>(t);
+			et->events.clear();
 
 		} break;
 	}
@@ -1533,6 +1613,12 @@ void Animation::track_remove_key(int p_track, int p_idx) {
 			an->values.remove_at(p_idx);
 
 		} break;
+		case TYPE_STATE_EVENT: {
+			StateEventTrack *et = static_cast<StateEventTrack *>(t);
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_idx, et->events.size());
+			et->events.remove_at(p_idx);
+
+		} break;
 	}
 
 	emit_changed();
@@ -1711,6 +1797,18 @@ int Animation::track_find_key(int p_track, double p_time, FindMode p_find_mode, 
 			return k;
 
 		} break;
+		case TYPE_STATE_EVENT: {
+			const StateEventTrack *et = static_cast<const StateEventTrack *>(t);
+			int k = _find(et->events, p_time, p_backward, p_limit);
+			if ((uint32_t)k >= et->events.size()) {
+				return -1;
+			}
+			if ((p_find_mode == FIND_MODE_APPROX && !Math::is_equal_approx(et->events[k].time, p_time)) || (p_find_mode == FIND_MODE_EXACT && et->events[k].time != p_time)) {
+				return -1;
+			}
+			return k;
+
+		} break;
 	}
 
 	return -1;
@@ -1826,6 +1924,24 @@ int Animation::track_insert_key(int p_track, double p_time, const Variant &p_key
 			ret = _insert(p_time, at->values, ak);
 
 		} break;
+		case TYPE_STATE_EVENT: {
+			StateEventTrack *et = static_cast<StateEventTrack *>(t);
+
+			StateEventKey ek;
+			ek.time = p_time;
+			ek.transition = p_transition;
+			if (p_key.get_type() == Variant::DICTIONARY) {
+				Dictionary d = p_key;
+				ek.duration = d.has("duration") ? double(d["duration"]) : 0.0;
+				ek.event = d.has("event") ? Ref<Resource>(d["event"]) : Ref<Resource>();
+			} else {
+				ek.event = p_key;
+				ek.duration = 0.0;
+			}
+
+			ret = _insert(p_time, et->events, ek);
+
+		} break;
 	}
 
 	emit_changed();
@@ -1886,6 +2002,10 @@ int Animation::track_get_key_count(int p_track) const {
 		case TYPE_ANIMATION: {
 			AnimationTrack *at = static_cast<AnimationTrack *>(t);
 			return at->values.size();
+		} break;
+		case TYPE_STATE_EVENT: {
+			const StateEventTrack *et = static_cast<const StateEventTrack *>(t);
+			return et->events.size();
 		} break;
 	}
 
@@ -1962,6 +2082,16 @@ Variant Animation::track_get_key_value(int p_track, int p_key_idx) const {
 			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, at->values.size(), Variant());
 
 			return at->values[p_key_idx].value;
+
+		} break;
+		case TYPE_STATE_EVENT: {
+			const StateEventTrack *et = static_cast<const StateEventTrack *>(t);
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, et->events.size(), Variant());
+
+			Dictionary k;
+			k["duration"] = et->events[p_key_idx].duration;
+			k["event"] = et->events[p_key_idx].event;
+			return k;
 
 		} break;
 	}
@@ -2050,6 +2180,12 @@ double Animation::track_get_key_time(int p_track, int p_key_idx) const {
 			AnimationTrack *at = static_cast<AnimationTrack *>(t);
 			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, at->values.size(), -1);
 			return at->values[p_key_idx].time;
+
+		} break;
+		case TYPE_STATE_EVENT: {
+			const StateEventTrack *et = static_cast<const StateEventTrack *>(t);
+			ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key_idx, et->events.size(), -1);
+			return et->events[p_key_idx].time;
 
 		} break;
 	}
@@ -2147,6 +2283,15 @@ void Animation::track_set_key_time(int p_track, int p_key_idx, double p_time) {
 			_insert(p_time, at->values, key);
 			return;
 		}
+		case TYPE_STATE_EVENT: {
+			StateEventTrack *et = static_cast<StateEventTrack *>(t);
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, et->events.size());
+			StateEventKey key = et->events[p_key_idx];
+			key.time = p_time;
+			et->events.remove_at(p_key_idx);
+			_insert(p_time, et->events, key);
+			return;
+		}
 	}
 
 	ERR_FAIL();
@@ -2209,6 +2354,9 @@ real_t Animation::track_get_key_transition(int p_track, int p_key_idx) const {
 		} break;
 		case TYPE_ANIMATION: {
 			return 1; //animation does not really use transitions
+		} break;
+		case TYPE_STATE_EVENT: {
+			return 1; //state_event does not really use transitions
 		} break;
 	}
 
@@ -2339,6 +2487,23 @@ void Animation::track_set_key_value(int p_track, int p_key_idx, const Variant &p
 			at->values[p_key_idx].value = p_value;
 
 		} break;
+		case TYPE_STATE_EVENT: {
+			StateEventTrack *et = static_cast<StateEventTrack *>(t);
+			ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key_idx, et->events.size());
+
+			if (p_value.get_type() == Variant::DICTIONARY) {
+				Dictionary k = p_value;
+				if (k.has("duration")) {
+					et->events[p_key_idx].duration = k["duration"];
+				}
+				if (k.has("event")) {
+					et->events[p_key_idx].event = k["event"];
+				}
+			} else {
+				et->events[p_key_idx].event = p_value;
+			}
+
+		} break;
 	}
 
 	emit_changed();
@@ -2387,7 +2552,8 @@ void Animation::track_set_key_transition(int p_track, int p_key_idx, real_t p_tr
 		} break;
 		case TYPE_BEZIER:
 		case TYPE_AUDIO:
-		case TYPE_ANIMATION: {
+		case TYPE_ANIMATION:
+		case TYPE_STATE_EVENT: {
 			// they don't use transition
 		} break;
 	}
@@ -2979,6 +3145,16 @@ void Animation::track_get_key_indices_in_range(int p_track, double p_time, doubl
 							_track_get_key_indices_in_range(an->values, from_time, anim_end, r_indices, is_backward);
 						}
 					} break;
+					case TYPE_STATE_EVENT: {
+						const StateEventTrack *et = static_cast<const StateEventTrack *>(t);
+						if (!is_backward) {
+							_track_get_key_indices_in_range(et->events, from_time, anim_end, r_indices, is_backward);
+							_track_get_key_indices_in_range(et->events, anim_start, to_time, r_indices, is_backward);
+						} else {
+							_track_get_key_indices_in_range(et->events, anim_start, to_time, r_indices, is_backward);
+							_track_get_key_indices_in_range(et->events, from_time, anim_end, r_indices, is_backward);
+						}
+					} break;
 				}
 				return;
 			}
@@ -3074,6 +3250,11 @@ void Animation::track_get_key_indices_in_range(int p_track, double p_time, doubl
 						_track_get_key_indices_in_range(an->values, start, from_time, r_indices, true);
 						_track_get_key_indices_in_range(an->values, start, to_time, r_indices, false);
 					} break;
+					case TYPE_STATE_EVENT: {
+						const StateEventTrack *et = static_cast<const StateEventTrack *>(t);
+						_track_get_key_indices_in_range(et->events, start, from_time, r_indices, true);
+						_track_get_key_indices_in_range(et->events, start, to_time, r_indices, false);
+					} break;
 				}
 				return;
 			}
@@ -3145,6 +3326,11 @@ void Animation::track_get_key_indices_in_range(int p_track, double p_time, doubl
 						_track_get_key_indices_in_range(an->values, from_time, end, r_indices, false);
 						_track_get_key_indices_in_range(an->values, to_time, end, r_indices, true);
 					} break;
+					case TYPE_STATE_EVENT: {
+						const StateEventTrack *et = static_cast<const StateEventTrack *>(t);
+						_track_get_key_indices_in_range(et->events, from_time, end, r_indices, false);
+						_track_get_key_indices_in_range(et->events, to_time, end, r_indices, true);
+					} break;
 				}
 				return;
 			}
@@ -3209,6 +3395,10 @@ void Animation::track_get_key_indices_in_range(int p_track, double p_time, doubl
 		case TYPE_ANIMATION: {
 			const AnimationTrack *an = static_cast<const AnimationTrack *>(t);
 			_track_get_key_indices_in_range(an->values, from_time, to_time, r_indices, is_backward);
+		} break;
+		case TYPE_STATE_EVENT: {
+			const StateEventTrack *et = static_cast<const StateEventTrack *>(t);
+			_track_get_key_indices_in_range(et->events, from_time, to_time, r_indices, is_backward);
 		} break;
 	}
 }
@@ -3848,6 +4038,102 @@ StringName Animation::animation_track_get_key_animation(int p_track, int p_key) 
 	return at->values[p_key].value;
 }
 
+// State Event Track
+
+int Animation::state_event_track_insert_key(int p_track, double p_time, double p_duration, const Ref<Resource> &p_event) {
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), -1);
+	Track *t = tracks[p_track];
+	ERR_FAIL_COND_V(t->type != TYPE_STATE_EVENT, -1);
+
+	StateEventTrack *et = static_cast<StateEventTrack *>(t);
+
+	StateEventKey k;
+	k.time = p_time;
+	k.duration = MAX(0.0, p_duration);
+	k.event = p_event;
+
+	int ret = _insert(p_time, et->events, k);
+	emit_changed();
+	return ret;
+}
+
+void Animation::state_event_track_set_key_duration(int p_track, int p_key, double p_duration) {
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
+	Track *t = tracks[p_track];
+	ERR_FAIL_COND(t->type != TYPE_STATE_EVENT);
+
+	StateEventTrack *et = static_cast<StateEventTrack *>(t);
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key, et->events.size());
+
+	et->events[p_key].duration = MAX(0.0, p_duration);
+	emit_changed();
+}
+
+double Animation::state_event_track_get_key_duration(int p_track, int p_key) const {
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), 0.0);
+	Track *t = tracks[p_track];
+	ERR_FAIL_COND_V(t->type != TYPE_STATE_EVENT, 0.0);
+
+	const StateEventTrack *et = static_cast<const StateEventTrack *>(t);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key, et->events.size(), 0.0);
+
+	return et->events[p_key].duration;
+}
+
+void Animation::state_event_track_set_key_start_time(int p_track, int p_key, double p_start_time) {
+	track_set_key_time(p_track, p_key, p_start_time);
+}
+
+double Animation::state_event_track_get_key_start_time(int p_track, int p_key) const {
+	return track_get_key_time(p_track, p_key);
+}
+
+void Animation::state_event_track_set_key_end_time(int p_track, int p_key, double p_end_time) {
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
+	Track *t = tracks[p_track];
+	ERR_FAIL_COND(t->type != TYPE_STATE_EVENT);
+
+	StateEventTrack *et = static_cast<StateEventTrack *>(t);
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key, et->events.size());
+
+	double new_duration = MAX(0.0, p_end_time - et->events[p_key].time);
+	state_event_track_set_key_duration(p_track, p_key, new_duration);
+}
+
+double Animation::state_event_track_get_key_end_time(int p_track, int p_key) const {
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), 0.0);
+	Track *t = tracks[p_track];
+	ERR_FAIL_COND_V(t->type != TYPE_STATE_EVENT, 0.0);
+
+	const StateEventTrack *et = static_cast<const StateEventTrack *>(t);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key, et->events.size(), 0.0);
+
+	return et->events[p_key].time + et->events[p_key].duration;
+}
+
+void Animation::state_event_track_set_key_event(int p_track, int p_key, const Ref<Resource> &p_event) {
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_track, tracks.size());
+	Track *t = tracks[p_track];
+	ERR_FAIL_COND(t->type != TYPE_STATE_EVENT);
+
+	StateEventTrack *et = static_cast<StateEventTrack *>(t);
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_key, et->events.size());
+
+	et->events[p_key].event = p_event;
+	emit_changed();
+}
+
+Ref<Resource> Animation::state_event_track_get_key_event(int p_track, int p_key) const {
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_track, tracks.size(), Ref<Resource>());
+	Track *t = tracks[p_track];
+	ERR_FAIL_COND_V(t->type != TYPE_STATE_EVENT, Ref<Resource>());
+
+	const StateEventTrack *et = static_cast<const StateEventTrack *>(t);
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_key, et->events.size(), Ref<Resource>());
+
+	return et->events[p_key].event;
+}
+
 void Animation::set_length(double p_length) {
 	if (p_length < ANIM_MIN_LENGTH) {
 		p_length = ANIM_MIN_LENGTH;
@@ -4041,6 +4327,16 @@ void Animation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("animation_track_set_key_animation", "track_idx", "key_idx", "animation"), &Animation::animation_track_set_key_animation);
 	ClassDB::bind_method(D_METHOD("animation_track_get_key_animation", "track_idx", "key_idx"), &Animation::animation_track_get_key_animation);
 
+	ClassDB::bind_method(D_METHOD("state_event_track_insert_key", "track_idx", "time", "duration", "event"), &Animation::state_event_track_insert_key, DEFVAL(0.0), DEFVAL(Ref<Resource>()));
+	ClassDB::bind_method(D_METHOD("state_event_track_set_key_duration", "track_idx", "key_idx", "duration"), &Animation::state_event_track_set_key_duration);
+	ClassDB::bind_method(D_METHOD("state_event_track_get_key_duration", "track_idx", "key_idx"), &Animation::state_event_track_get_key_duration);
+	ClassDB::bind_method(D_METHOD("state_event_track_set_key_start_time", "track_idx", "key_idx", "start_time"), &Animation::state_event_track_set_key_start_time);
+	ClassDB::bind_method(D_METHOD("state_event_track_get_key_start_time", "track_idx", "key_idx"), &Animation::state_event_track_get_key_start_time);
+	ClassDB::bind_method(D_METHOD("state_event_track_set_key_end_time", "track_idx", "key_idx", "end_time"), &Animation::state_event_track_set_key_end_time);
+	ClassDB::bind_method(D_METHOD("state_event_track_get_key_end_time", "track_idx", "key_idx"), &Animation::state_event_track_get_key_end_time);
+	ClassDB::bind_method(D_METHOD("state_event_track_set_key_event", "track_idx", "key_idx", "event"), &Animation::state_event_track_set_key_event);
+	ClassDB::bind_method(D_METHOD("state_event_track_get_key_event", "track_idx", "key_idx"), &Animation::state_event_track_get_key_event);
+
 	ClassDB::bind_method(D_METHOD("add_marker", "name", "time"), &Animation::add_marker);
 	ClassDB::bind_method(D_METHOD("remove_marker", "name"), &Animation::remove_marker);
 	ClassDB::bind_method(D_METHOD("has_marker", "name"), &Animation::has_marker);
@@ -4083,6 +4379,7 @@ void Animation::_bind_methods() {
 	BIND_ENUM_CONSTANT(TYPE_BEZIER);
 	BIND_ENUM_CONSTANT(TYPE_AUDIO);
 	BIND_ENUM_CONSTANT(TYPE_ANIMATION);
+	BIND_ENUM_CONSTANT(TYPE_STATE_EVENT);
 
 	BIND_ENUM_CONSTANT(INTERPOLATION_NEAREST);
 	BIND_ENUM_CONSTANT(INTERPOLATION_LINEAR);

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -55,6 +55,7 @@ public:
 		TYPE_BEZIER, // Bezier curve.
 		TYPE_AUDIO,
 		TYPE_ANIMATION,
+		TYPE_STATE_EVENT, // Animation State Event
 	};
 
 	enum InterpolationType : uint8_t {
@@ -255,6 +256,21 @@ private:
 	LocalVector<MarkerKey> marker_names; // time -> name
 	HashMap<StringName, double> marker_times; // name -> time
 	HashMap<StringName, Color> marker_colors; // name -> color
+
+	/* STATE EVENT TRACK */
+
+	struct StateEventKey : public Key {
+		Ref<Resource> event;
+		double duration = 0.0;
+	};
+
+	struct StateEventTrack : public Track {
+		LocalVector<StateEventKey> events;
+
+		StateEventTrack() {
+			type = TYPE_STATE_EVENT;
+		}
+	};
 
 	LocalVector<Track *> tracks;
 #ifdef TOOLS_ENABLED
@@ -508,6 +524,16 @@ public:
 	int animation_track_insert_key(int p_track, double p_time, const StringName &p_animation);
 	void animation_track_set_key_animation(int p_track, int p_key, const StringName &p_animation);
 	StringName animation_track_get_key_animation(int p_track, int p_key) const;
+
+	int state_event_track_insert_key(int p_track, double p_time, double p_duration, const Ref<Resource> &p_event);
+	void state_event_track_set_key_duration(int p_track, int p_key, double p_duration);
+	double state_event_track_get_key_duration(int p_track, int p_key) const;
+	void state_event_track_set_key_start_time(int p_track, int p_key, double p_start_time);
+	double state_event_track_get_key_start_time(int p_track, int p_key) const;
+	void state_event_track_set_key_end_time(int p_track, int p_key, double p_end_time);
+	double state_event_track_get_key_end_time(int p_track, int p_key) const;
+	void state_event_track_set_key_event(int p_track, int p_key, const Ref<Resource> &p_event);
+	Ref<Resource> state_event_track_get_key_event(int p_track, int p_key) const;
 
 	void track_set_interpolation_loop_wrap(int p_track, bool p_enable);
 	bool track_get_interpolation_loop_wrap(int p_track) const;

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -532,6 +532,7 @@ public:
 	double state_event_track_get_key_start_time(int p_track, int p_key) const;
 	void state_event_track_set_key_end_time(int p_track, int p_key, double p_end_time);
 	double state_event_track_get_key_end_time(int p_track, int p_key) const;
+	void state_event_track_set_key_start_and_duration(int p_track, int p_key, double p_start_time, double p_duration);
 	void state_event_track_set_key_event(int p_track, int p_key, const Ref<Resource> &p_event);
 	Ref<Resource> state_event_track_get_key_event(int p_track, int p_key) const;
 

--- a/scene/resources/animation_state_event.cpp
+++ b/scene/resources/animation_state_event.cpp
@@ -98,8 +98,12 @@ void AnimationStateEvent::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_tag_color", "color"), &AnimationStateEvent::set_tag_color);
 	ClassDB::bind_method(D_METHOD("get_tag_color"), &AnimationStateEvent::get_tag_color);
 
+	ClassDB::bind_method(D_METHOD("set_trigger_weight_threshold", "threshold"), &AnimationStateEvent::set_trigger_weight_threshold);
+	ClassDB::bind_method(D_METHOD("get_trigger_weight_threshold"), &AnimationStateEvent::get_trigger_weight_threshold);
+
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "event_name"), "set_event_name", "get_event_name");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "tag_color"), "set_tag_color", "get_tag_color");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "trigger_weight_threshold", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_trigger_weight_threshold", "get_trigger_weight_threshold");
 }
 
 void AnimationStateEvent::set_event_name(const StringName &p_name) {
@@ -116,6 +120,14 @@ void AnimationStateEvent::set_tag_color(const Color &p_color) {
 
 Color AnimationStateEvent::get_tag_color() const {
 	return tag_color;
+}
+
+void AnimationStateEvent::set_trigger_weight_threshold(double p_threshold) {
+	trigger_weight_threshold = p_threshold;
+}
+
+double AnimationStateEvent::get_trigger_weight_threshold() const {
+	return trigger_weight_threshold;
 }
 
 void AnimationStateEvent::start(const Ref<AnimationStateContext> &p_context) {

--- a/scene/resources/animation_state_event.cpp
+++ b/scene/resources/animation_state_event.cpp
@@ -123,7 +123,7 @@ Color AnimationStateEvent::get_tag_color() const {
 }
 
 void AnimationStateEvent::set_trigger_weight_threshold(double p_threshold) {
-	trigger_weight_threshold = p_threshold;
+	trigger_weight_threshold = CLAMP(p_threshold, 0.0, 1.0);
 }
 
 double AnimationStateEvent::get_trigger_weight_threshold() const {

--- a/scene/resources/animation_state_event.cpp
+++ b/scene/resources/animation_state_event.cpp
@@ -1,0 +1,135 @@
+#include "animation_state_event.h"
+
+#include "core/object/class_db.h"
+#include "scene/animation/animation_mixer.h"
+#include "scene/resources/animation.h"
+
+// ----------------------------------------------------
+// AnimationStateContext
+// ----------------------------------------------------
+
+void AnimationStateContext::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_target"), &AnimationStateContext::get_target);
+	ClassDB::bind_method(D_METHOD("get_mixer"), &AnimationStateContext::get_mixer);
+	ClassDB::bind_method(D_METHOD("get_animation"), &AnimationStateContext::get_animation);
+	ClassDB::bind_method(D_METHOD("get_delta"), &AnimationStateContext::get_delta);
+	ClassDB::bind_method(D_METHOD("get_elapsed"), &AnimationStateContext::get_elapsed);
+	ClassDB::bind_method(D_METHOD("get_duration"), &AnimationStateContext::get_duration);
+	ClassDB::bind_method(D_METHOD("get_weight"), &AnimationStateContext::get_weight);
+
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "target"), "", "get_target");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mixer"), "", "get_mixer");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "animation"), "", "get_animation");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "delta"), "", "get_delta");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "elapsed"), "", "get_elapsed");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "duration"), "", "get_duration");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "weight"), "", "get_weight");
+}
+
+void AnimationStateContext::set_target(Object *p_target) {
+	target_id = p_target ? p_target->get_instance_id() : ObjectID();
+}
+
+Object *AnimationStateContext::get_target() const {
+	return ObjectDB::get_instance(target_id);
+}
+
+void AnimationStateContext::set_mixer(AnimationMixer *p_mixer) {
+	mixer_id = p_mixer ? p_mixer->get_instance_id() : ObjectID();
+}
+
+AnimationMixer *AnimationStateContext::get_mixer() const {
+	return ObjectDB::get_instance<AnimationMixer>(mixer_id);
+}
+
+void AnimationStateContext::set_animation(const Ref<Animation> &p_animation) {
+	animation = p_animation;
+}
+
+Ref<Animation> AnimationStateContext::get_animation() const {
+	return animation;
+}
+
+void AnimationStateContext::set_delta(double p_delta) {
+	delta = p_delta;
+}
+
+double AnimationStateContext::get_delta() const {
+	return delta;
+}
+
+void AnimationStateContext::set_elapsed(double p_elapsed) {
+	elapsed = p_elapsed;
+}
+
+double AnimationStateContext::get_elapsed() const {
+	return elapsed;
+}
+
+void AnimationStateContext::set_duration(double p_duration) {
+	duration = p_duration;
+}
+
+double AnimationStateContext::get_duration() const {
+	return duration;
+}
+
+void AnimationStateContext::set_weight(real_t p_weight) {
+	weight = p_weight;
+}
+
+real_t AnimationStateContext::get_weight() const {
+	return weight;
+}
+
+// ----------------------------------------------------
+// AnimationStateEvent
+// ----------------------------------------------------
+
+void AnimationStateEvent::_bind_methods() {
+	GDVIRTUAL_BIND(_start, "context");
+	GDVIRTUAL_BIND(_update, "context", "delta");
+	GDVIRTUAL_BIND(_end, "context");
+	GDVIRTUAL_BIND(_cancel, "context");
+
+	ClassDB::bind_method(D_METHOD("set_event_name", "name"), &AnimationStateEvent::set_event_name);
+	ClassDB::bind_method(D_METHOD("get_event_name"), &AnimationStateEvent::get_event_name);
+
+	ClassDB::bind_method(D_METHOD("set_tag_color", "color"), &AnimationStateEvent::set_tag_color);
+	ClassDB::bind_method(D_METHOD("get_tag_color"), &AnimationStateEvent::get_tag_color);
+
+	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "event_name"), "set_event_name", "get_event_name");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "tag_color"), "set_tag_color", "get_tag_color");
+}
+
+void AnimationStateEvent::set_event_name(const StringName &p_name) {
+	event_name = p_name;
+}
+
+StringName AnimationStateEvent::get_event_name() const {
+	return event_name;
+}
+
+void AnimationStateEvent::set_tag_color(const Color &p_color) {
+	tag_color = p_color;
+}
+
+Color AnimationStateEvent::get_tag_color() const {
+	return tag_color;
+}
+
+void AnimationStateEvent::start(const Ref<AnimationStateContext> &p_context) {
+	GDVIRTUAL_CALL(_start, p_context);
+}
+
+void AnimationStateEvent::update(const Ref<AnimationStateContext> &p_context, double p_delta) {
+	GDVIRTUAL_CALL(_update, p_context, p_delta);
+}
+
+void AnimationStateEvent::end(const Ref<AnimationStateContext> &p_context) {
+	GDVIRTUAL_CALL(_end, p_context);
+}
+
+void AnimationStateEvent::cancel(const Ref<AnimationStateContext> &p_context) {
+	GDVIRTUAL_CALL(_cancel, p_context);
+}

--- a/scene/resources/animation_state_event.h
+++ b/scene/resources/animation_state_event.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "core/io/resource.h"
+#include "core/object/gdvirtual.gen.h"
+
+class AnimationMixer;
+class Animation;
+
+class AnimationStateContext : public RefCounted {
+	GDCLASS(AnimationStateContext, RefCounted);
+
+private:
+	ObjectID target_id;
+	ObjectID mixer_id;
+	Ref<Animation> animation;
+	double delta = 0.0;
+	double elapsed = 0.0;
+	double duration = 0.0;
+	real_t weight = 1.0;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_target(Object *p_target);
+	Object *get_target() const;
+
+	void set_mixer(AnimationMixer *p_mixer);
+	AnimationMixer *get_mixer() const;
+
+	void set_animation(const Ref<Animation> &p_animation);
+	Ref<Animation> get_animation() const;
+
+	void set_delta(double p_delta);
+	double get_delta() const;
+
+	void set_elapsed(double p_elapsed);
+	double get_elapsed() const;
+
+	void set_duration(double p_duration);
+	double get_duration() const;
+
+	void set_weight(real_t p_weight);
+	real_t get_weight() const;
+};
+
+class AnimationStateEvent : public Resource {
+	GDCLASS(AnimationStateEvent, Resource);
+
+protected:
+	static void _bind_methods();
+
+	GDVIRTUAL1(_start, Ref<AnimationStateContext>)
+	GDVIRTUAL2(_update, Ref<AnimationStateContext>, double)
+	GDVIRTUAL1(_end, Ref<AnimationStateContext>)
+	GDVIRTUAL1(_cancel, Ref<AnimationStateContext>)
+
+public:
+	StringName event_name;
+	Color tag_color = Color(0.3, 0.6, 0.9, 0.8);
+
+	void set_event_name(const StringName &p_name);
+	StringName get_event_name() const;
+
+	void set_tag_color(const Color &p_color);
+	Color get_tag_color() const;
+
+	virtual void start(const Ref<AnimationStateContext> &p_context);
+	virtual void update(const Ref<AnimationStateContext> &p_context, double p_delta);
+	virtual void end(const Ref<AnimationStateContext> &p_context);
+	virtual void cancel(const Ref<AnimationStateContext> &p_context);
+};

--- a/scene/resources/animation_state_event.h
+++ b/scene/resources/animation_state_event.h
@@ -47,6 +47,11 @@ public:
 class AnimationStateEvent : public Resource {
 	GDCLASS(AnimationStateEvent, Resource);
 
+private:
+	StringName event_name;
+	Color tag_color = Color(0.3, 0.6, 0.9, 0.8);
+	double trigger_weight_threshold = 0.0;
+
 protected:
 	static void _bind_methods();
 
@@ -56,9 +61,6 @@ protected:
 	GDVIRTUAL1(_cancel, Ref<AnimationStateContext>)
 
 public:
-	StringName event_name;
-	Color tag_color = Color(0.3, 0.6, 0.9, 0.8);
-	double trigger_weight_threshold = 0.0;
 
 	void set_event_name(const StringName &p_name);
 	StringName get_event_name() const;

--- a/scene/resources/animation_state_event.h
+++ b/scene/resources/animation_state_event.h
@@ -58,12 +58,16 @@ protected:
 public:
 	StringName event_name;
 	Color tag_color = Color(0.3, 0.6, 0.9, 0.8);
+	double trigger_weight_threshold = 0.0;
 
 	void set_event_name(const StringName &p_name);
 	StringName get_event_name() const;
 
 	void set_tag_color(const Color &p_color);
 	Color get_tag_color() const;
+
+	void set_trigger_weight_threshold(double p_threshold);
+	double get_trigger_weight_threshold() const;
 
 	virtual void start(const Ref<AnimationStateContext> &p_context);
 	virtual void update(const Ref<AnimationStateContext> &p_context, double p_delta);

--- a/tests/scene/test_animation.cpp
+++ b/tests/scene/test_animation.cpp
@@ -33,6 +33,7 @@
 TEST_FORCE_LINK(test_animation)
 
 #include "scene/resources/animation.h"
+#include "scene/resources/animation_state_event.h"
 
 namespace TestAnimation {
 
@@ -306,6 +307,66 @@ TEST_CASE("[Animation] Create Bezier track") {
 	CHECK(animation->try_scale_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
 	CHECK(animation->try_blend_shape_track_interpolate(0, 0.0, nullptr) == ERR_INVALID_PARAMETER);
 	ERR_PRINT_ON;
+}
+
+TEST_CASE("[Animation] Create State Event track") {
+	Ref<Animation> animation = memnew(Animation);
+	const int track_index = animation->add_track(Animation::TYPE_STATE_EVENT);
+	CHECK(track_index == 0);
+	CHECK(animation->track_get_type(0) == Animation::TYPE_STATE_EVENT);
+	animation->track_set_path(track_index, NodePath("Player"));
+
+	Ref<AnimationStateEvent> event = memnew(AnimationStateEvent);
+	event->set_event_name("AttackHitbox");
+	event->set_trigger_weight_threshold(0.25);
+
+	animation->state_event_track_insert_key(track_index, 0.2, 0.4, event);
+
+	CHECK(animation->get_track_count() == 1);
+	CHECK(animation->track_get_key_count(0) == 1);
+	CHECK(animation->state_event_track_get_key_start_time(0, 0) == doctest::Approx(0.2));
+	CHECK(animation->state_event_track_get_key_duration(0, 0) == doctest::Approx(0.4));
+	CHECK(animation->state_event_track_get_key_end_time(0, 0) == doctest::Approx(0.6));
+
+	Ref<AnimationStateEvent> fetched_event = animation->state_event_track_get_key_event(0, 0);
+	CHECK(fetched_event.is_valid());
+	CHECK(fetched_event->get_event_name() == StringName("AttackHitbox"));
+	CHECK(fetched_event->get_trigger_weight_threshold() == doctest::Approx(0.25));
+
+	// Test modifying start time, duration, and end time.
+	animation->state_event_track_set_key_duration(0, 0, 0.5);
+	CHECK(animation->state_event_track_get_key_duration(0, 0) == doctest::Approx(0.5));
+	CHECK(animation->state_event_track_get_key_end_time(0, 0) == doctest::Approx(0.7));
+
+	animation->state_event_track_set_key_start_time(0, 0, 0.3);
+	CHECK(animation->state_event_track_get_key_start_time(0, 0) == doctest::Approx(0.3));
+	CHECK(animation->state_event_track_get_key_end_time(0, 0) == doctest::Approx(0.8));
+
+	animation->state_event_track_set_key_end_time(0, 0, 1.0);
+	CHECK(animation->state_event_track_get_key_end_time(0, 0) == doctest::Approx(1.0));
+	CHECK(animation->state_event_track_get_key_duration(0, 0) == doctest::Approx(0.7));
+}
+
+TEST_CASE("[AnimationStateEvent] Properties and threshold") {
+	Ref<AnimationStateEvent> event = memnew(AnimationStateEvent);
+	event->set_event_name("CustomState");
+	event->set_tag_color(Color(1.0, 0.0, 0.0, 1.0));
+	event->set_trigger_weight_threshold(0.5);
+
+	CHECK(event->get_event_name() == StringName("CustomState"));
+	CHECK(event->get_tag_color() == Color(1.0, 0.0, 0.0, 1.0));
+	CHECK(event->get_trigger_weight_threshold() == doctest::Approx(0.5));
+
+	Ref<AnimationStateContext> context = memnew(AnimationStateContext);
+	context->set_duration(1.5);
+	context->set_elapsed(0.5);
+	context->set_delta(0.016);
+	context->set_weight(0.8);
+
+	CHECK(context->get_duration() == doctest::Approx(1.5));
+	CHECK(context->get_elapsed() == doctest::Approx(0.5));
+	CHECK(context->get_delta() == doctest::Approx(0.016));
+	CHECK(context->get_weight() == doctest::Approx(real_t(0.8)));
 }
 
 } // namespace TestAnimation

--- a/tests/scene/test_animation_player.cpp
+++ b/tests/scene/test_animation_player.cpp
@@ -33,9 +33,35 @@
 TEST_FORCE_LINK(test_animation_player)
 
 #include "scene/animation/animation_player.h"
+#include "scene/main/scene_tree.h"
+#include "scene/main/window.h"
 #include "scene/resources/animation.h"
+#include "scene/resources/animation_state_event.h"
 
 namespace TestAnimationPlayer {
+
+class MockTestStateEvent : public AnimationStateEvent {
+	GDCLASS(MockTestStateEvent, AnimationStateEvent);
+
+public:
+	int start_calls = 0;
+	int update_calls = 0;
+	int end_calls = 0;
+	int cancel_calls = 0;
+
+	virtual void start(const Ref<AnimationStateContext> &p_context) override {
+		start_calls++;
+	}
+	virtual void update(const Ref<AnimationStateContext> &p_context, double p_delta) override {
+		update_calls++;
+	}
+	virtual void end(const Ref<AnimationStateContext> &p_context) override {
+		end_calls++;
+	}
+	virtual void cancel(const Ref<AnimationStateContext> &p_context) override {
+		cancel_calls++;
+	}
+};
 
 TEST_CASE("[AnimationPlayer] get & set default_blend_time") {
 	AnimationPlayer *animation_player = memnew(AnimationPlayer);
@@ -60,6 +86,63 @@ TEST_CASE("[AnimationPlayer] get & set blend_time") {
 	animation_player->set_blend_time(anim1, anim2, 4.0);
 	CHECK(animation_player->get_blend_time(anim1, anim2) == doctest::Approx(4.0f));
 	memdelete(animation_player);
+}
+
+TEST_CASE("[SceneTree][AnimationPlayer] State Event playback lifecycle") {
+	Node *root = memnew(Node);
+	SceneTree::get_singleton()->get_root()->add_child(root);
+
+	AnimationPlayer *player = memnew(AnimationPlayer);
+	root->add_child(player);
+	player->set_root_node(NodePath(".."));
+
+	Ref<Animation> anim = memnew(Animation);
+	anim->set_length(1.0);
+	int track = anim->add_track(Animation::TYPE_STATE_EVENT);
+	anim->track_set_path(track, NodePath("."));
+
+	Ref<MockTestStateEvent> event = memnew(MockTestStateEvent);
+	anim->state_event_track_insert_key(track, 0.2, 0.4, event);
+
+	Ref<AnimationLibrary> lib = memnew(AnimationLibrary);
+	lib->add_animation("test", anim);
+	player->add_animation_library("", lib);
+
+	player->play("test");
+
+	// Step to 0.1s -> Before key
+	player->advance(0.1);
+	CHECK(event->start_calls == 0);
+	CHECK(event->update_calls == 0);
+	CHECK(event->end_calls == 0);
+
+	// Step to 0.3s -> Key is now active (0.2s - 0.6s)
+	player->advance(0.2);
+	CHECK(event->start_calls == 1);
+	CHECK(event->update_calls == 0);
+	CHECK(event->end_calls == 0);
+
+	// Step to 0.4s -> Key continues active
+	player->advance(0.1);
+	CHECK(event->start_calls == 1);
+	CHECK(event->update_calls == 1);
+	CHECK(event->end_calls == 0);
+
+	// Step to 0.7s -> Key finishes naturally
+	player->advance(0.3);
+	CHECK(event->start_calls == 1);
+	CHECK(event->update_calls == 1);
+	CHECK(event->end_calls == 1);
+
+	// Test cancellation when seeked away during active window
+	player->seek(0.3, true);
+	CHECK(event->start_calls == 2);
+	player->stop();
+	CHECK(event->cancel_calls == 1);
+
+	SceneTree::get_singleton()->get_root()->remove_child(root);
+	memdelete(player);
+	memdelete(root);
 }
 
 } // namespace TestAnimationPlayer

--- a/tests/scene/test_animation_player.cpp
+++ b/tests/scene/test_animation_player.cpp
@@ -48,6 +48,8 @@ public:
 	int update_calls = 0;
 	int end_calls = 0;
 	int cancel_calls = 0;
+	double end_elapsed = 0.0;
+	bool clear_caches_on_cancel = false;
 
 	virtual void start(const Ref<AnimationStateContext> &p_context) override {
 		start_calls++;
@@ -57,9 +59,13 @@ public:
 	}
 	virtual void end(const Ref<AnimationStateContext> &p_context) override {
 		end_calls++;
+		end_elapsed = p_context->get_elapsed();
 	}
 	virtual void cancel(const Ref<AnimationStateContext> &p_context) override {
 		cancel_calls++;
+		if (clear_caches_on_cancel) {
+			p_context->get_mixer()->clear_caches();
+		}
 	}
 };
 
@@ -133,12 +139,147 @@ TEST_CASE("[SceneTree][AnimationPlayer] State Event playback lifecycle") {
 	CHECK(event->start_calls == 1);
 	CHECK(event->update_calls == 1);
 	CHECK(event->end_calls == 1);
+	CHECK(event->end_elapsed == doctest::Approx(0.4));
 
 	// Test cancellation when seeked away during active window
 	player->seek(0.3, true);
 	CHECK(event->start_calls == 2);
 	player->stop();
 	CHECK(event->cancel_calls == 1);
+
+	SceneTree::get_singleton()->get_root()->remove_child(root);
+	memdelete(player);
+	memdelete(root);
+}
+
+TEST_CASE("[SceneTree][AnimationPlayer] State Event cleanup with retained caches") {
+	Node *root = memnew(Node);
+	SceneTree::get_singleton()->get_root()->add_child(root);
+
+	AnimationPlayer *player = memnew(AnimationPlayer);
+	root->add_child(player);
+	player->set_root_node(NodePath(".."));
+	player->set_clear_cache_on_stop_enabled(false);
+
+	Ref<Animation> anim = memnew(Animation);
+	anim->set_length(1.0);
+	int track = anim->add_track(Animation::TYPE_STATE_EVENT);
+	anim->track_set_path(track, NodePath("."));
+	Ref<MockTestStateEvent> event = memnew(MockTestStateEvent);
+	anim->state_event_track_insert_key(track, 0.2, 0.4, event);
+
+	Ref<AnimationLibrary> lib = memnew(AnimationLibrary);
+	lib->add_animation("test", anim);
+	player->add_animation_library("", lib);
+
+	player->play("test");
+	player->advance(0.3);
+	CHECK(event->start_calls == 1);
+
+	player->stop();
+	CHECK(event->cancel_calls == 1);
+
+	player->play("test");
+	player->advance(0.3);
+	CHECK(event->start_calls == 2);
+
+	SceneTree::get_singleton()->get_root()->remove_child(root);
+	memdelete(player);
+	memdelete(root);
+}
+
+TEST_CASE("[SceneTree][AnimationPlayer] State Event update-only seek cleanup") {
+	Node *root = memnew(Node);
+	SceneTree::get_singleton()->get_root()->add_child(root);
+
+	AnimationPlayer *player = memnew(AnimationPlayer);
+	root->add_child(player);
+	player->set_root_node(NodePath(".."));
+
+	Ref<Animation> anim = memnew(Animation);
+	anim->set_length(1.0);
+	int track = anim->add_track(Animation::TYPE_STATE_EVENT);
+	anim->track_set_path(track, NodePath("."));
+	Ref<MockTestStateEvent> event = memnew(MockTestStateEvent);
+	anim->state_event_track_insert_key(track, 0.2, 0.4, event);
+
+	Ref<AnimationLibrary> lib = memnew(AnimationLibrary);
+	lib->add_animation("test", anim);
+	player->add_animation_library("", lib);
+
+	player->play("test");
+	player->advance(0.3);
+	CHECK(event->start_calls == 1);
+
+	player->seek(0.0, true, true);
+	CHECK(event->cancel_calls == 1);
+
+	player->advance(0.3);
+	CHECK(event->start_calls == 2);
+
+	SceneTree::get_singleton()->get_root()->remove_child(root);
+	memdelete(player);
+	memdelete(root);
+}
+
+TEST_CASE("[SceneTree][AnimationPlayer] State Event callbacks can clear caches") {
+	Node *root = memnew(Node);
+	SceneTree::get_singleton()->get_root()->add_child(root);
+
+	AnimationPlayer *player = memnew(AnimationPlayer);
+	root->add_child(player);
+	player->set_root_node(NodePath(".."));
+
+	Ref<Animation> anim = memnew(Animation);
+	anim->set_length(1.0);
+	int track = anim->add_track(Animation::TYPE_STATE_EVENT);
+	anim->track_set_path(track, NodePath("."));
+	Ref<MockTestStateEvent> event = memnew(MockTestStateEvent);
+	event->clear_caches_on_cancel = true;
+	anim->state_event_track_insert_key(track, 0.2, 0.4, event);
+
+	Ref<AnimationLibrary> lib = memnew(AnimationLibrary);
+	lib->add_animation("test", anim);
+	player->add_animation_library("", lib);
+
+	player->play("test");
+	player->advance(0.3);
+	player->stop();
+	CHECK(event->cancel_calls == 1);
+
+	SceneTree::get_singleton()->get_root()->remove_child(root);
+	memdelete(player);
+	memdelete(root);
+}
+
+TEST_CASE("[SceneTree][AnimationPlayer] State Event tracks keep independent state") {
+	Node *root = memnew(Node);
+	SceneTree::get_singleton()->get_root()->add_child(root);
+
+	AnimationPlayer *player = memnew(AnimationPlayer);
+	root->add_child(player);
+	player->set_root_node(NodePath(".."));
+
+	Ref<Animation> anim = memnew(Animation);
+	anim->set_length(1.0);
+	int first_track = anim->add_track(Animation::TYPE_STATE_EVENT);
+	int second_track = anim->add_track(Animation::TYPE_STATE_EVENT);
+	anim->track_set_path(first_track, NodePath("."));
+	anim->track_set_path(second_track, NodePath("."));
+
+	Ref<MockTestStateEvent> first_event = memnew(MockTestStateEvent);
+	Ref<MockTestStateEvent> second_event = memnew(MockTestStateEvent);
+	anim->state_event_track_insert_key(first_track, 0.2, 0.4, first_event);
+	anim->state_event_track_insert_key(second_track, 0.2, 0.4, second_event);
+
+	Ref<AnimationLibrary> lib = memnew(AnimationLibrary);
+	lib->add_animation("test", anim);
+	player->add_animation_library("", lib);
+
+	player->play("test");
+	player->advance(0.3);
+	CHECK(first_event->start_calls == 1);
+	CHECK(second_event->start_calls == 1);
 
 	SceneTree::get_singleton()->get_root()->remove_child(root);
 	memdelete(player);


### PR DESCRIPTION
## What Problems does this PR Solve?
- Adds support for stateful Animation Events through `AnimationStateEvent` tracks.
- Allows events to implement `_start()`, `_process()`, `_end()`, and `_cancel()` callbacks.
- Works with the AnimationPlayer, AnimationTree blending, interruptions, reverse Animation Playback and seeking.
- Prevents Events from triggering when the blend weight is below a configured threshold.
- Adds a Playback track and key identity handling so simultaneous animations do not interfere with eachother. 

Proposal: https://github.com/godotengine/godot-proposals/issues/15423

## Additional information
This PR introduces a new `AnimationStateEvent` resource and State Event animation track support.

State Events are stateful rather than one-shot callbacks. An active event can be started, processed over multiple frames, ended normally, or cancelled when playback is interrupted.
The implementation also tracks playback-instance and source-key identity separately. This prevents simultaneous AnimationPlayer or AnimationTree instances using the same Animation resource from sharing or cancelling each others events.

This was very much inspired by Unreal Engines `AnimNotifyState`, which i really missed when switching to Godot. This is particulary useful for more Animation driven games, like Soulslikes for example.

## Tests
Currently Tests cover these cases:
- Events being cancelled when stopping with them in cache.
-  update_only  seeking clearing active events.
- Calling cache cleanup from inside the callbacks.
- Correct elapsed values.
- Reverse playbacks.
- Independent State Event tracks.
- Separate playback instances using the same animation resources.
- Blend-source removal.
- Zero-weight branches.
- Lifecycle behavior during Evaluation in the Editor.

## Review
I would really like if someone more familiar with the AnimationTree and Blending looks through that part of the implementation as i personally only use the AnimationPlayer when making my games, so might not catch some edge cases.

## AI Disclosure
AI was used for implementation assistance, debugging, code review, investigation of edge cases, and explanation of the Godot codebase. The Models i used were GPT 5.6 Luna and Gemini 3.7 Flash.
I reviewed, tested and iterated on the generated changes.
