### PR TITLE
Hide Textures button when texture streaming is disabled

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -2336,9 +2336,10 @@ void Node3DEditor::_textures_button_pressed() {
 
 void Node3DEditor::_textures_button_update_state() {
 	const bool texture_streaming_enabled = GLOBAL_GET("rendering/textures/streaming/enabled");
-	textures_button->set_disabled(!texture_streaming_enabled);
 
 	if (!texture_streaming_enabled) {
+		textures_button->hide();
+		textures_button_separator->hide();
 		textures_popup->hide();
 	}
 }
@@ -3690,13 +3691,14 @@ Node3DEditor::Node3DEditor() {
 
 #ifdef MODULE_TEXTURE_STREAMING_ENABLED
 	textures_button = memnew(Button);
+	textures_button_separator = memnew(VSeparator);
 	textures_button->set_text(TTRC("Textures"));
 	textures_button->set_tooltip_text(TTRC("Edit texture streaming quality settings."));
 	textures_button->set_theme_type_variation(SceneStringName(FlatButton));
 	textures_button->connect(SceneStringName(pressed), callable_mp(this, &Node3DEditor::_textures_button_pressed));
 
 	main_flow->add_child(textures_button);
-	main_flow->add_child(memnew(VSeparator));
+	main_flow->add_child(textures_button_separator);
 #endif
 
 	context_toolbar_panel = memnew(PanelContainer);

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -372,6 +372,7 @@ private:
 	EditorSpinSlider *textures_min_lod_slider = nullptr;
 	CheckBox *textures_budget_enable = nullptr;
 	EditorSpinSlider *textures_budget_slider = nullptr;
+	VSeparator *textures_button_separator = nullptr;
 
 	enum TextureQualityPreset {
 		TEXTURE_QUALITY_VERY_LOW,


### PR DESCRIPTION
## What problem(s) does this PR solve?

- See https://github.com/godotengine/godot/pull/113429#issuecomment-5443819464

## Additional information

I think the most logical approach is to hide instead of disable the "Textures" toolbar button, so we don't confuse users who don't use the texture streaming system. If anyone disagrees with this solution, please feel free to propose alternative ones.
