### PR TITLE
Fix compiling for Linux Arm64 GCC in GLES3 mesh storage

### DIFF
--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -229,9 +229,8 @@ void MeshStorage::mesh_add_surface(RID p_mesh, const RenderingServerTypes::Surfa
 		// If we do this, then the last normal will read past the end of the array. So we need to pad the array with dummy data.
 		if (!(new_surface.format & RSE::ARRAY_FLAG_COMPRESS_ATTRIBUTES) && (new_surface.format & RSE::ARRAY_FORMAT_NORMAL) && !(new_surface.format & RSE::ARRAY_FORMAT_TANGENT)) {
 			// Unfortunately, we need to copy the buffer, which is fine as doing a resize triggers a CoW anyway.
-			Vector<uint8_t> new_vertex_data;
+			Vector<uint8_t> new_vertex_data = new_surface.vertex_data;
 			new_vertex_data.resize_initialized(new_surface.vertex_data.size() + sizeof(uint16_t) * 2);
-			memcpy(new_vertex_data.ptrw(), new_surface.vertex_data.ptr(), new_surface.vertex_data.size());
 			GLES3::Utilities::get_singleton()->buffer_allocate_data(GL_ARRAY_BUFFER, s->vertex_buffer, new_vertex_data.size(), new_vertex_data.ptr(), (s->format & RSE::ARRAY_FLAG_USE_DYNAMIC_UPDATE) ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW, "Mesh vertex buffer");
 			s->vertex_buffer_size = new_vertex_data.size();
 		} else {


### PR DESCRIPTION
## What problem(s) does this PR solve?

When compiling on Linux Arm64 with GCC with all warnings enabled, this error happens:

```
In file included from /usr/include/string.h:580,
                 from /usr/include/c++/15/cstring:48,
                 from ./core/typedefs.h:53,
                 from ./core/error/error_macros.h:40,
                 from ./core/templates/local_vector.h:33,
                 from drivers/gles3/storage/mesh_storage.h:35,
                 from drivers/gles3/storage/mesh_storage.cpp:31:
In function 'void* memcpy(void*, const void*, size_t)',
    inlined from 'virtual void GLES3::MeshStorage::mesh_add_surface(RID, const RenderingServerTypes::SurfaceData&)' at drivers/gles3/storage/mesh_storage.cpp:234:10:
/usr/include/aarch64-linux-gnu/bits/string_fortified.h:29:33: error: 'void* __builtin_memcpy(void*, const void*, long unsigned int)' pointer overflow between offset 0 and size 18446744073709551612 [-Werror=array-bounds=]
   29 |   return __builtin___memcpy_chk (__dest, __src, __len,
      |          ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
   30 |                                  __glibc_objsize0 (__dest));
      |                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~
```

The specific array bounds pointer overflow described here is... not actually possible to occur, but GCC complains about it anyway, and for some reason only on arm64.

The fix: Instead of using `memcpy`, just use the CoW behavior of `Vector<>` directly. The comment already states this:

```
// Unfortunately, we need to copy the buffer, which is fine as doing a resize triggers a CoW anyway.
```

## Additional information

I used AI to identify the problem: I threw the stack trace at it and said fix, then I investigated myself. In this case, the basic solution in this PR is the same as what the AI generated.