### PR TITLE
Fix duplicate Toggle Comment context option

### DIFF
--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -2507,8 +2507,6 @@ void ScriptTextEditor::_text_edit_gui_input(const Ref<InputEvent> &p_ev) {
 
 void ScriptTextEditor::_make_ste_context_menu(bool p_selection, bool p_color, bool p_foldable, bool p_open_docs, const Vector2 &p_position) {
 	CodeEditorBase::_make_context_menu(p_selection, p_foldable, p_position, false);
-	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_comment"), EDIT_TOGGLE_COMMENT);
-	_popup_move_item(EDIT_UNINDENT, context_menu);
 
 	if (p_selection) {
 		context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/evaluate_selection"), EDIT_EVALUATE);


### PR DESCRIPTION

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/122941

## Additional information

- It was moved to `CodeEditorBase::_make_context_menu` in https://github.com/godotengine/godot/pull/115998
but I accidentally added it back here when rebasing https://github.com/godotengine/godot/pull/109104
