### PR TITLE
Make dock color and spacing closer to 4.7

### DIFF
--- a/editor/themes/theme_classic.cpp
+++ b/editor/themes/theme_classic.cpp
@@ -1705,10 +1705,12 @@ void ThemeClassic::populate_editor_styles(const Ref<EditorTheme> &p_theme, Edito
 		p_theme->set_color("font_selected_color", "MainScreenContainer", p_config.accent_color);
 		p_theme->set_color("font_unselected_color", "MainScreenContainer", p_config.font_color);
 		p_theme->set_color("icon_selected_color", "MainScreenContainer", p_config.accent_color);
+		p_theme->set_color("icon_unselected_color", "MainScreenContainer", Color(1, 1, 1, 1));
+		p_theme->set_constant("h_separation", "MainScreenContainer", 4);
 		p_theme->set_stylebox("tab_unselected", "MainScreenContainer", menu_transparent_style);
 		p_theme->set_stylebox("tab_selected", "MainScreenContainer", menu_transparent_style);
 		p_theme->set_stylebox("tab_hovered", "MainScreenContainer", main_screen_button_hover);
-		p_theme->set_constant("tab_separation", "MainScreenContainer", 8 * EDSCALE);
+		p_theme->set_constant("tab_separation", "MainScreenContainer", 4 * EDSCALE);
 
 		p_theme->set_type_variation("MainMenuBar", "FlatMenuButton");
 		p_theme->set_stylebox(CoreStringName(normal), "MainMenuBar", menu_transparent_style);

--- a/editor/themes/theme_modern.cpp
+++ b/editor/themes/theme_modern.cpp
@@ -1735,6 +1735,8 @@ void ThemeModern::populate_editor_styles(const Ref<EditorTheme> &p_theme, Editor
 		p_theme->set_color("font_selected_color", "MainScreenContainer", p_config.accent_color);
 		p_theme->set_color("font_unselected_color", "MainScreenContainer", p_config.font_color);
 		p_theme->set_color("icon_selected_color", "MainScreenContainer", p_config.accent_color);
+		p_theme->set_color("icon_unselected_color", "MainScreenContainer", p_config.icon_normal_color);
+		p_theme->set_constant("h_separation", "MainScreenContainer", 4);
 		p_theme->set_stylebox("tab_unselected", "MainScreenContainer", p_config.base_empty_wide_style);
 		p_theme->set_stylebox("tab_selected", "MainScreenContainer", p_config.base_empty_wide_style);
 		p_theme->set_stylebox("tab_hovered", "MainScreenContainer", p_config.base_empty_wide_style);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Follow up to https://github.com/godotengine/godot/pull/122903

Addresses @YeldhamDev's comment on that PR https://github.com/godotengine/godot/pull/122903#pullrequestreview-5048098727

The vertical alignment of the icon has changed slightly, but I think that can be a follow up PR.


https://github.com/user-attachments/assets/0233e984-0d8f-4008-b62b-c1888c8e8134



## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
