### PR TITLE
Fix wrong type for custom performance monitors added at runtime

### DIFF
--- a/editor/debugger/editor_performance_profiler.cpp
+++ b/editor/debugger/editor_performance_profiler.cpp
@@ -349,7 +349,6 @@ void EditorPerformanceProfiler::update_monitors(const Vector<StringName> &p_name
 		}
 	}
 
-	int index = 0;
 	for (const KeyValue<StringName, int> &E : names) {
 		String name = String(E.key).replace_first("custom:", "");
 		String base = "Custom";
@@ -357,9 +356,8 @@ void EditorPerformanceProfiler::update_monitors(const Vector<StringName> &p_name
 			base = name.get_slicec('/', 0);
 			name = name.get_slicec('/', 1);
 		}
-		Performance::MonitorType type = Performance::MonitorType(p_types[index]);
+		Performance::MonitorType type = Performance::MonitorType(p_types[E.value - Performance::MONITOR_MAX]);
 		monitors.insert(E.key, Monitor(name, base, E.value, type, nullptr));
-		index++;
 	}
 
 	_build_monitor_tree();


### PR DESCRIPTION
Fixes #122917. Diagnosis by @Chriz-code in the issue; this PR is their suggested fix, verified with before/after builds.

`EditorPerformanceProfiler::update_monitors()` receives the custom monitor names and their types as two arrays indexed the same way. It first records each monitor's index in `names` as `Performance::MONITOR_MAX + i`, then removes from
`names` every monitor it is already tracking (refreshing only their `frame_index`), and finally creates the remaining ones while walking a separate counter that starts at zero:

```cpp
Performance::MonitorType type = Performance::MonitorType(p_types[index]);
```

Once an already-tracked monitor has been filtered out, that counter no longer corresponds to the new monitor's own index in `p_types`, and the monitor is created with the type of whichever one sits at that offset.

The `names` map already carries that index, so it can be used directly:

```cpp
Performance::MonitorType type = Performance::MonitorType(p_types[E.value - Performance::MONITOR_MAX]);
```

`E.value - MONITOR_MAX` is the `i` the entry was inserted with, so it always falls within `[0, p_names.size())`.

Introduced in 1a8306bbc1 ("Allow custom monitors to select desired type"), which matches the issue being reproducible from 4.6 onwards.

### Testing

The debugger polls custom monitor names only once per second (`RemoteDebugger::PerformanceProfiler::tick()`), so the monitors have to be registered in separate polls for the offsets to shift.

```gdscript
extends Node

func _ready() -> void:
    Performance.add_custom_monitor(&"Repro/A", func(): return 1.0, [], Performance.MONITOR_TYPE_TIME)
    await get_tree().create_timer(1.5).timeout
    Performance.add_custom_monitor(&"Repro/B", func(): return 1.0, [], Performance.MONITOR_TYPE_PERCENTAGE)
    await get_tree().create_timer(1.5).timeout
    Performance.add_custom_monitor(&"Repro/C", func(): return 5.0 * 1024 * 1024, [], Performance.MONITOR_TYPE_MEMORY)
```

Run the project and open **Debugger > Monitors**:

| Monitor | Type passed | Before | After |
| --- | --- | --- | --- |
| `A` | `TIME` | `1000.00 ms` | `1000.00 ms` |
| `B` | `PERCENTAGE` | `1000.00 ms` | `100.00%` |
| `C` | `MEMORY` | `5242880000.00 ms` | `5.00 MiB` |