### PR TITLE
Fix `AudioStreamInteractive` so that it properly crossfades when set to "at end"

### DIFF
--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -710,9 +710,8 @@ void AudioStreamPlaybackInteractive::_queue(int p_to_clip_index, bool p_is_auto_
 					// Stream does not have a length.
 					src_fade_wait = 0;
 				} else if (transition.fade_mode == AudioStreamInteractive::FADE_CROSS) {
-					// Calculate total fade duration in seconds
 					float fade_time_sec = transition.fade_beats * beat_sec;
-					// Start the crossfade EARLY so it finishes exactly at 'end'
+					// Start the crossfade early so it finishes exactly at 'end'
 					src_fade_wait = MAX(0.0f, (end - current_pos) - fade_time_sec);
 				} else {
 					src_fade_wait = end - current_pos;
@@ -733,7 +732,7 @@ void AudioStreamPlaybackInteractive::_queue(int p_to_clip_index, bool p_is_auto_
 		if (transition.from_time == AudioStreamInteractive::TRANSITION_FROM_TIME_END && from_state.stream->get_length() > 0) {
 			float end = from_state.stream->get_length();
 			if (transition.fade_mode == AudioStreamInteractive::FADE_CROSS) {
-				// Start the crossfade EARLY so it finishes exactly at 'end'
+				// Start the crossfade early so it finishes exactly at 'end'
 				src_fade_wait = MAX(0.0f, (end - current_pos) - transition.fade_beats);
 			} else {
 				src_fade_wait = end - current_pos;

--- a/modules/interactive_music/audio_stream_interactive.cpp
+++ b/modules/interactive_music/audio_stream_interactive.cpp
@@ -709,6 +709,11 @@ void AudioStreamPlaybackInteractive::_queue(int p_to_clip_index, bool p_is_auto_
 				if (end == 0) {
 					// Stream does not have a length.
 					src_fade_wait = 0;
+				} else if (transition.fade_mode == AudioStreamInteractive::FADE_CROSS) {
+					// Calculate total fade duration in seconds
+					float fade_time_sec = transition.fade_beats * beat_sec;
+					// Start the crossfade EARLY so it finishes exactly at 'end'
+					src_fade_wait = MAX(0.0f, (end - current_pos) - fade_time_sec);
 				} else {
 					src_fade_wait = end - current_pos;
 				}
@@ -727,7 +732,12 @@ void AudioStreamPlaybackInteractive::_queue(int p_to_clip_index, bool p_is_auto_
 		// Source has no BPM, so just simple transition.
 		if (transition.from_time == AudioStreamInteractive::TRANSITION_FROM_TIME_END && from_state.stream->get_length() > 0) {
 			float end = from_state.stream->get_length();
-			src_fade_wait = end - current_pos;
+			if (transition.fade_mode == AudioStreamInteractive::FADE_CROSS) {
+				// Start the crossfade EARLY so it finishes exactly at 'end'
+				src_fade_wait = MAX(0.0f, (end - current_pos) - transition.fade_beats);
+			} else {
+				src_fade_wait = end - current_pos;
+			}
 			if (!from_state.stream->has_loop()) {
 				src_no_loop = true;
 			}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Fixes cross fades not starting until the stream finished when the Transition.fade_mode is set to FADE_CROSS and the Transition.from_time is set to TRANSITION_FROM_TIME_END. This caused a silent dead zone while the next track faded in.
- This fix now allows songs to loop perfectly or seamlessly transition from the end of one track to the start of the next.

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
- I asked Gemini "where in the code is the logic for cross fade transition" it told me to target lines 686 in the audio_stream_interactive.cpp so I looked there and added the logic I thought would resolve the dead zone during cross fades.