### PR TITLE
`GodotPhysics2D`: Use `LocalVector` where CoW is not needed

### DIFF
--- a/modules/godot_physics_2d/godot_body_2d.cpp
+++ b/modules/godot_physics_2d/godot_body_2d.cpp
@@ -426,7 +426,7 @@ void GodotBody2D::integrate_forces(real_t p_step) {
 
 	ERR_FAIL_NULL(get_space());
 
-	int ac = areas.size();
+	uint32_t ac = areas.size();
 
 	bool gravity_done = false;
 	bool linear_damp_done = false;
@@ -442,7 +442,7 @@ void GodotBody2D::integrate_forces(real_t p_step) {
 	// Combine gravity and damping from overlapping areas in priority order.
 	if (ac) {
 		areas.sort();
-		const AreaCMP *aa = &areas[0];
+		const AreaCMP *aa = areas.ptr();
 		for (int i = ac - 1; i >= 0 && !stopped; i--) {
 			if (!gravity_done) {
 				PS2DE::AreaSpaceOverrideMode area_gravity_mode = (PS2DE::AreaSpaceOverrideMode)(int)aa[i].area->get_param(PS2DE::AREA_PARAM_GRAVITY_OVERRIDE_MODE);

--- a/modules/godot_physics_2d/godot_body_2d.h
+++ b/modules/godot_physics_2d/godot_body_2d.h
@@ -121,7 +121,7 @@ class GodotBody2D : public GodotCollisionObject2D {
 		}
 	};
 
-	Vector<AreaCMP> areas;
+	LocalVector<AreaCMP> areas;
 
 	struct Contact {
 		Vector2 local_pos;
@@ -137,7 +137,7 @@ class GodotBody2D : public GodotCollisionObject2D {
 		Vector2 impulse;
 	};
 
-	Vector<Contact> contacts; //no contacts by default
+	LocalVector<Contact> contacts; // No contacts by default.
 	int contact_count = 0;
 
 	Callable body_state_callback;
@@ -166,7 +166,7 @@ public:
 	_FORCE_INLINE_ void add_area(GodotArea2D *p_area) {
 		int index = areas.find(AreaCMP(p_area));
 		if (index > -1) {
-			areas.write[index].refCount += 1;
+			areas[index].refCount += 1;
 		} else {
 			areas.ordered_insert(AreaCMP(p_area));
 		}
@@ -175,7 +175,7 @@ public:
 	_FORCE_INLINE_ void remove_area(GodotArea2D *p_area) {
 		int index = areas.find(AreaCMP(p_area));
 		if (index > -1) {
-			areas.write[index].refCount -= 1;
+			areas[index].refCount -= 1;
 			if (areas[index].refCount < 1) {
 				areas.remove_at(index);
 			}
@@ -351,7 +351,7 @@ void GodotBody2D::add_contact(const Vector2 &p_local_pos, const Vector2 &p_local
 		return;
 	}
 
-	Contact *c = contacts.ptrw();
+	Contact *c = contacts.ptr();
 
 	int idx = -1;
 

--- a/modules/godot_physics_2d/godot_collision_object_2d.cpp
+++ b/modules/godot_physics_2d/godot_collision_object_2d.cpp
@@ -51,10 +51,10 @@ void GodotCollisionObject2D::add_shape(GodotShape2D *p_shape, const Transform2D 
 	}
 }
 
-void GodotCollisionObject2D::set_shape(int p_index, GodotShape2D *p_shape) {
-	ERR_FAIL_INDEX(p_index, shapes.size());
+void GodotCollisionObject2D::set_shape(uint32_t p_index, GodotShape2D *p_shape) {
+	ERR_FAIL_UNSIGNED_INDEX(p_index, shapes.size());
 	shapes[p_index].shape->remove_owner(this);
-	shapes.write[p_index].shape = p_shape;
+	shapes[p_index].shape = p_shape;
 
 	p_shape->add_owner(this);
 
@@ -63,21 +63,21 @@ void GodotCollisionObject2D::set_shape(int p_index, GodotShape2D *p_shape) {
 	}
 }
 
-void GodotCollisionObject2D::set_shape_transform(int p_index, const Transform2D &p_transform) {
-	ERR_FAIL_INDEX(p_index, shapes.size());
+void GodotCollisionObject2D::set_shape_transform(uint32_t p_index, const Transform2D &p_transform) {
+	ERR_FAIL_UNSIGNED_INDEX(p_index, shapes.size());
 
-	shapes.write[p_index].xform = p_transform;
-	shapes.write[p_index].xform_inv = p_transform.affine_inverse();
+	shapes[p_index].xform = p_transform;
+	shapes[p_index].xform_inv = p_transform.affine_inverse();
 
 	if (!pending_shape_update_list.in_list()) {
 		GodotPhysicsServer2D::godot_singleton->pending_shape_update_list.add(&pending_shape_update_list);
 	}
 }
 
-void GodotCollisionObject2D::set_shape_disabled(int p_idx, bool p_disabled) {
-	ERR_FAIL_INDEX(p_idx, shapes.size());
+void GodotCollisionObject2D::set_shape_disabled(uint32_t p_idx, bool p_disabled) {
+	ERR_FAIL_UNSIGNED_INDEX(p_idx, shapes.size());
 
-	GodotCollisionObject2D::Shape &shape = shapes.write[p_idx];
+	GodotCollisionObject2D::Shape &shape = shapes[p_idx];
 	if (shape.disabled == p_disabled) {
 		return;
 	}
@@ -103,24 +103,24 @@ void GodotCollisionObject2D::set_shape_disabled(int p_idx, bool p_disabled) {
 
 void GodotCollisionObject2D::remove_shape(GodotShape2D *p_shape) {
 	//remove a shape, all the times it appears
-	for (int i = 0; i < shapes.size(); i++) {
+	for (uint32_t i = 0; i < shapes.size(); i++) {
 		if (shapes[i].shape == p_shape) {
-			remove_shape(i);
+			remove_shape_by_index(i);
 			i--;
 		}
 	}
 }
 
-void GodotCollisionObject2D::remove_shape(int p_index) {
-	//remove anything from shape to be erased to end, so subindices don't change
-	ERR_FAIL_INDEX(p_index, shapes.size());
-	for (int i = p_index; i < shapes.size(); i++) {
+void GodotCollisionObject2D::remove_shape_by_index(uint32_t p_index) {
+	// Remove anything from shape to be erased to end, so subindices don't change.
+	ERR_FAIL_UNSIGNED_INDEX(p_index, shapes.size());
+	for (uint32_t i = p_index; i < shapes.size(); i++) {
 		if (shapes[i].bpid == 0) {
 			continue;
 		}
 		//should never get here with a null owner
 		space->get_broadphase()->remove(shapes[i].bpid);
-		shapes.write[i].bpid = 0;
+		shapes[i].bpid = 0;
 	}
 	shapes[p_index].shape->remove_owner(this);
 	shapes.remove_at(p_index);
@@ -141,8 +141,7 @@ void GodotCollisionObject2D::_set_static(bool p_static) {
 	if (!space) {
 		return;
 	}
-	for (int i = 0; i < get_shape_count(); i++) {
-		const Shape &s = shapes[i];
+	for (Shape &s : shapes) {
 		if (s.bpid > 0) {
 			space->get_broadphase()->set_static(s.bpid, _static);
 		}
@@ -150,8 +149,7 @@ void GodotCollisionObject2D::_set_static(bool p_static) {
 }
 
 void GodotCollisionObject2D::_unregister_shapes() {
-	for (int i = 0; i < shapes.size(); i++) {
-		Shape &s = shapes.write[i];
+	for (Shape &s : shapes) {
 		if (s.bpid > 0) {
 			space->get_broadphase()->remove(s.bpid);
 			s.bpid = 0;
@@ -164,8 +162,8 @@ void GodotCollisionObject2D::_update_shapes() {
 		return;
 	}
 
-	for (int i = 0; i < shapes.size(); i++) {
-		Shape &s = shapes.write[i];
+	for (uint32_t i = 0; i < shapes.size(); i++) {
+		Shape &s = shapes[i];
 		if (s.disabled) {
 			continue;
 		}
@@ -191,8 +189,8 @@ void GodotCollisionObject2D::_update_shapes_with_motion(const Vector2 &p_motion)
 		return;
 	}
 
-	for (int i = 0; i < shapes.size(); i++) {
-		Shape &s = shapes.write[i];
+	for (uint32_t i = 0; i < shapes.size(); i++) {
+		Shape &s = shapes[i];
 		if (s.disabled) {
 			continue;
 		}
@@ -220,8 +218,7 @@ void GodotCollisionObject2D::_set_space(GodotSpace2D *p_space) {
 	if (old_space) {
 		old_space->remove_object(this);
 
-		for (int i = 0; i < shapes.size(); i++) {
-			Shape &s = shapes.write[i];
+		for (Shape &s : shapes) {
 			if (s.bpid) {
 				old_space->get_broadphase()->remove(s.bpid);
 				s.bpid = 0;

--- a/modules/godot_physics_2d/godot_collision_object_2d.h
+++ b/modules/godot_physics_2d/godot_collision_object_2d.h
@@ -34,6 +34,7 @@
 #include "godot_shape_2d.h"
 
 #include "core/object/object_id.h"
+#include "core/templates/local_vector.h"
 #include "core/templates/self_list.h"
 
 class GodotSpace2D;
@@ -64,7 +65,7 @@ private:
 		Vector2 one_way_collision_direction = Vector2(0.0, 1.0);
 	};
 
-	Vector<Shape> shapes;
+	LocalVector<Shape> shapes;
 	GodotSpace2D *space = nullptr;
 	Transform2D transform;
 	Transform2D inv_transform;
@@ -109,24 +110,24 @@ public:
 
 	_FORCE_INLINE_ Type get_type() const { return type; }
 	void add_shape(GodotShape2D *p_shape, const Transform2D &p_transform = Transform2D(), bool p_disabled = false);
-	void set_shape(int p_index, GodotShape2D *p_shape);
-	void set_shape_transform(int p_index, const Transform2D &p_transform);
+	void set_shape(uint32_t p_index, GodotShape2D *p_shape);
+	void set_shape_transform(uint32_t p_index, const Transform2D &p_transform);
 
 	_FORCE_INLINE_ int get_shape_count() const { return shapes.size(); }
-	_FORCE_INLINE_ GodotShape2D *get_shape(int p_index) const {
-		CRASH_BAD_INDEX(p_index, shapes.size());
+	_FORCE_INLINE_ GodotShape2D *get_shape(uint32_t p_index) const {
+		CRASH_BAD_UNSIGNED_INDEX(p_index, shapes.size());
 		return shapes[p_index].shape;
 	}
-	_FORCE_INLINE_ const Transform2D &get_shape_transform(int p_index) const {
-		CRASH_BAD_INDEX(p_index, shapes.size());
+	_FORCE_INLINE_ const Transform2D &get_shape_transform(uint32_t p_index) const {
+		CRASH_BAD_UNSIGNED_INDEX(p_index, shapes.size());
 		return shapes[p_index].xform;
 	}
-	_FORCE_INLINE_ const Transform2D &get_shape_inv_transform(int p_index) const {
-		CRASH_BAD_INDEX(p_index, shapes.size());
+	_FORCE_INLINE_ const Transform2D &get_shape_inv_transform(uint32_t p_index) const {
+		CRASH_BAD_UNSIGNED_INDEX(p_index, shapes.size());
 		return shapes[p_index].xform_inv;
 	}
-	_FORCE_INLINE_ const Rect2 &get_shape_aabb(int p_index) const {
-		CRASH_BAD_INDEX(p_index, shapes.size());
+	_FORCE_INLINE_ const Rect2 &get_shape_aabb(uint32_t p_index) const {
+		CRASH_BAD_UNSIGNED_INDEX(p_index, shapes.size());
 		return shapes[p_index].aabb_cache;
 	}
 
@@ -134,30 +135,30 @@ public:
 	_FORCE_INLINE_ const Transform2D &get_inv_transform() const { return inv_transform; }
 	_FORCE_INLINE_ GodotSpace2D *get_space() const { return space; }
 
-	void set_shape_disabled(int p_idx, bool p_disabled);
-	_FORCE_INLINE_ bool is_shape_disabled(int p_idx) const {
-		ERR_FAIL_INDEX_V(p_idx, shapes.size(), false);
+	void set_shape_disabled(uint32_t p_idx, bool p_disabled);
+	_FORCE_INLINE_ bool is_shape_disabled(uint32_t p_idx) const {
+		ERR_FAIL_UNSIGNED_INDEX_V(p_idx, shapes.size(), false);
 		return shapes[p_idx].disabled;
 	}
 
-	_FORCE_INLINE_ void set_shape_as_one_way_collision(int p_idx, bool p_one_way_collision, real_t p_margin, const Vector2 &p_direction) {
-		CRASH_BAD_INDEX(p_idx, shapes.size());
-		shapes.write[p_idx].one_way_collision = p_one_way_collision;
-		shapes.write[p_idx].one_way_collision_margin = p_margin;
-		shapes.write[p_idx].one_way_collision_direction = p_direction;
+	_FORCE_INLINE_ void set_shape_as_one_way_collision(uint32_t p_idx, bool p_one_way_collision, real_t p_margin, const Vector2 &p_direction) {
+		CRASH_BAD_UNSIGNED_INDEX(p_idx, shapes.size());
+		shapes[p_idx].one_way_collision = p_one_way_collision;
+		shapes[p_idx].one_way_collision_margin = p_margin;
+		shapes[p_idx].one_way_collision_direction = p_direction;
 	}
-	_FORCE_INLINE_ bool is_shape_set_as_one_way_collision(int p_idx) const {
-		CRASH_BAD_INDEX(p_idx, shapes.size());
+	_FORCE_INLINE_ bool is_shape_set_as_one_way_collision(uint32_t p_idx) const {
+		CRASH_BAD_UNSIGNED_INDEX(p_idx, shapes.size());
 		return shapes[p_idx].one_way_collision;
 	}
 
-	_FORCE_INLINE_ real_t get_shape_one_way_collision_margin(int p_idx) const {
-		CRASH_BAD_INDEX(p_idx, shapes.size());
+	_FORCE_INLINE_ real_t get_shape_one_way_collision_margin(uint32_t p_idx) const {
+		CRASH_BAD_UNSIGNED_INDEX(p_idx, shapes.size());
 		return shapes[p_idx].one_way_collision_margin;
 	}
 
-	Vector2 get_shape_one_way_collision_direction(int p_idx) const {
-		CRASH_BAD_INDEX(p_idx, shapes.size());
+	Vector2 get_shape_one_way_collision_direction(uint32_t p_idx) const {
+		CRASH_BAD_UNSIGNED_INDEX(p_idx, shapes.size());
 		return shapes[p_idx].one_way_collision_direction;
 	}
 
@@ -181,7 +182,7 @@ public:
 	_FORCE_INLINE_ real_t get_collision_priority() const { return collision_priority; }
 
 	void remove_shape(GodotShape2D *p_shape) override;
-	void remove_shape(int p_index);
+	void remove_shape_by_index(uint32_t p_index);
 
 	virtual void set_space(GodotSpace2D *p_space) = 0;
 

--- a/modules/godot_physics_2d/godot_physics_server_2d.cpp
+++ b/modules/godot_physics_2d/godot_physics_server_2d.cpp
@@ -384,7 +384,7 @@ void GodotPhysicsServer2D::area_remove_shape(RID p_area, int p_shape_idx) {
 	GodotArea2D *area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
-	area->remove_shape(p_shape_idx);
+	area->remove_shape_by_index(p_shape_idx);
 }
 
 void GodotPhysicsServer2D::area_clear_shapes(RID p_area) {
@@ -392,7 +392,7 @@ void GodotPhysicsServer2D::area_clear_shapes(RID p_area) {
 	ERR_FAIL_NULL(area);
 
 	while (area->get_shape_count()) {
-		area->remove_shape(0);
+		area->remove_shape_by_index(0);
 	}
 }
 
@@ -634,7 +634,7 @@ void GodotPhysicsServer2D::body_remove_shape(RID p_body, int p_shape_idx) {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
-	body->remove_shape(p_shape_idx);
+	body->remove_shape_by_index(p_shape_idx);
 }
 
 void GodotPhysicsServer2D::body_clear_shapes(RID p_body) {
@@ -642,7 +642,7 @@ void GodotPhysicsServer2D::body_clear_shapes(RID p_body) {
 	ERR_FAIL_NULL(body);
 
 	while (body->get_shape_count()) {
-		body->remove_shape(0);
+		body->remove_shape_by_index(0);
 	}
 }
 
@@ -1237,7 +1237,7 @@ void GodotPhysicsServer2D::free_rid(RID p_rid) {
 		body_set_space(p_rid, RID());
 
 		while (body->get_shape_count()) {
-			body->remove_shape(0);
+			body->remove_shape_by_index(0);
 		}
 
 		body_owner.free(p_rid);
@@ -1249,7 +1249,7 @@ void GodotPhysicsServer2D::free_rid(RID p_rid) {
 		area->set_space(nullptr);
 
 		while (area->get_shape_count()) {
-			area->remove_shape(0);
+			area->remove_shape_by_index(0);
 		}
 
 		area_owner.free(p_rid);

--- a/modules/godot_physics_2d/godot_shape_2d.cpp
+++ b/modules/godot_physics_2d/godot_shape_2d.cpp
@@ -648,7 +648,7 @@ GodotConvexPolygonShape2D::~GodotConvexPolygonShape2D() {
 void GodotConcavePolygonShape2D::get_supports(const Vector2 &p_normal, Vector2 *r_supports, int &r_amount) const {
 	real_t d = -1e10;
 	int idx = -1;
-	for (int i = 0; i < points.size(); i++) {
+	for (uint32_t i = 0; i < points.size(); i++) {
 		real_t ld = p_normal.dot(points[i]);
 		if (ld > d) {
 			d = ld;
@@ -694,9 +694,9 @@ bool GodotConcavePolygonShape2D::intersect_segment(const Vector2 &p_begin, const
 
 	int level = 0;
 
-	const Segment *segmentptr = &segments[0];
-	const Vector2 *pointptr = &points[0];
-	const BVH *bvhptr = &bvh[0];
+	const Segment *segmentptr = segments.ptr();
+	const Vector2 *pointptr = points.ptr();
+	const BVH *bvhptr = bvh.ptr();
 
 	stack[0] = 0;
 	while (true) {
@@ -773,7 +773,7 @@ bool GodotConcavePolygonShape2D::intersect_segment(const Vector2 &p_begin, const
 	return inters;
 }
 
-int GodotConcavePolygonShape2D::_generate_bvh(BVH *p_bvh, int p_len, int p_depth) {
+uint32_t GodotConcavePolygonShape2D::_generate_bvh(BVH *p_bvh, int p_len, int p_depth) {
 	if (p_len == 1) {
 		bvh_depth = MAX(p_depth, bvh_depth);
 		bvh.push_back(*p_bvh);
@@ -800,13 +800,13 @@ int GodotConcavePolygonShape2D::_generate_bvh(BVH *p_bvh, int p_len, int p_depth
 
 	BVH node;
 	node.aabb = global_aabb;
-	int node_idx = bvh.size();
+	uint32_t node_idx = bvh.size();
 	bvh.push_back(node);
 
-	int l = _generate_bvh(p_bvh, median, p_depth + 1);
-	int r = _generate_bvh(&p_bvh[median], p_len - median, p_depth + 1);
-	bvh.write[node_idx].left = l;
-	bvh.write[node_idx].right = r;
+	uint32_t l = _generate_bvh(p_bvh, median, p_depth + 1);
+	uint32_t r = _generate_bvh(&p_bvh[median], p_len - median, p_depth + 1);
+	bvh[node_idx].left = l;
+	bvh[node_idx].right = r;
 
 	return node_idx;
 }
@@ -867,19 +867,19 @@ void GodotConcavePolygonShape2D::set_data(const Variant &p_data) {
 		aabb_new.position = pointmap.begin()->key;
 		for (const KeyValue<Point2, int> &E : pointmap) {
 			aabb_new.expand_to(E.key);
-			points.write[E.value] = E.key;
+			points[E.value] = E.key;
 		}
 
-		Vector<BVH> main_vbh;
-		main_vbh.resize(segments.size());
-		for (int i = 0; i < main_vbh.size(); i++) {
-			main_vbh.write[i].aabb.position = points[segments[i].points[0]];
-			main_vbh.write[i].aabb.expand_to(points[segments[i].points[1]]);
-			main_vbh.write[i].left = -1;
-			main_vbh.write[i].right = i;
+		LocalVector<BVH> main_vbh;
+		main_vbh.resize_uninitialized(segments.size());
+		for (uint32_t i = 0; i < main_vbh.size(); i++) {
+			main_vbh[i].aabb.position = points[segments[i].points[0]];
+			main_vbh[i].aabb.expand_to(points[segments[i].points[1]]);
+			main_vbh[i].left = -1;
+			main_vbh[i].right = i;
 		}
 
-		_generate_bvh(main_vbh.ptrw(), main_vbh.size(), 1);
+		_generate_bvh(main_vbh.ptr(), main_vbh.size(), 1);
 
 	} else {
 		//dictionary with arrays
@@ -890,10 +890,10 @@ void GodotConcavePolygonShape2D::set_data(const Variant &p_data) {
 
 Variant GodotConcavePolygonShape2D::get_data() const {
 	Vector<Vector2> rsegments;
-	int len = segments.size();
+	uint32_t len = segments.size();
 	rsegments.resize(len * 2);
 	Vector2 *w = rsegments.ptrw();
-	for (int i = 0; i < len; i++) {
+	for (uint32_t i = 0; i < len; i++) {
 		w[(i << 1) + 0] = points[segments[i].points[0]];
 		w[(i << 1) + 1] = points[segments[i].points[1]];
 	}
@@ -926,9 +926,9 @@ void GodotConcavePolygonShape2D::cull(const Rect2 &p_local_aabb, QueryCallback p
 
 	int level = 0;
 
-	const Segment *segmentptr = &segments[0];
-	const Vector2 *pointptr = &points[0];
-	const BVH *bvhptr = &bvh[0];
+	const Segment *segmentptr = segments.ptr();
+	const Vector2 *pointptr = points.ptr();
+	const BVH *bvhptr = bvh.ptr();
 
 	stack[0] = 0;
 	while (true) {

--- a/modules/godot_physics_2d/godot_shape_2d.h
+++ b/modules/godot_physics_2d/godot_shape_2d.h
@@ -33,6 +33,7 @@
 #include "core/math/rect2.h"
 #include "core/math/transform_2d.h"
 #include "core/templates/hash_map.h"
+#include "core/templates/local_vector.h"
 #include "core/templates/rid.h"
 #include "servers/physics_2d/physics_server_2d_enums.h"
 
@@ -482,15 +483,15 @@ class GodotConcavePolygonShape2D : public GodotConcaveShape2D {
 		int points[2] = {};
 	};
 
-	Vector<Segment> segments;
-	Vector<Point2> points;
+	LocalVector<Segment> segments;
+	LocalVector<Point2> points;
 
 	struct BVH {
 		Rect2 aabb;
 		int left = 0, right = 0;
 	};
 
-	Vector<BVH> bvh;
+	LocalVector<BVH> bvh;
 	int bvh_depth = 0;
 
 	struct BVH_CompareX {
@@ -505,7 +506,7 @@ class GodotConcavePolygonShape2D : public GodotConcaveShape2D {
 		}
 	};
 
-	int _generate_bvh(BVH *p_bvh, int p_len, int p_depth);
+	uint32_t _generate_bvh(BVH *p_bvh, int p_len, int p_depth);
 
 public:
 	virtual PS2DE::ShapeType get_type() const override { return PS2DE::SHAPE_CONCAVE_POLYGON; }


### PR DESCRIPTION
## What problem(s) does this PR solve?

Several `Vector`s in `GodotPhysics2D` are never copied, making its CoW functionality unused overhead (although not significant). Those were changed to `LocalVector`.

Also:
- Replaces instances of `&my_vector[0]` with `ptr()`.
- Converts a few index loops to range-based loops where appropriate.

## Additional information

I consider this mostly housekeeping. I still did run the physics 2D suite from [Godot Benchmarks](https://github.com/godotengine/godot-benchmarks/) to catch possible regressions.

<details>
<summary>Tests</summary>

### System info
Godot v4.8.dev (bfc77b24e) - CachyOS Linux #1 SMP PREEMPT_DYNAMIC Thu, 20 Aug 2026 21:06:41 +0000 on Wayland - X11 display driver, Multi-window, 1 monitor (1920x1080 @ 143.88 Hz) - Vulkan (Forward+) - dedicated NVIDIA GeForce GTX 1650 (nvidia; 610.57.04) - 11th Gen Intel(R) Core(TM) i5-11400H @ 2.70GHz (12 threads) - 15.39 GiB memory - PulseAudio (44100 Hz, Stereo/mono)

### Build command
`scons -j8 target=template_release production=yes`
- Also used the latest version of the [official SDK](https://github.com/godotengine/buildroot/) for compilation.

Run command: `godot -- --run-benchmarks --include-benchmarks="physics/*2d*"`

### Result
Sum of 20 alternated runs, so the `a` and `b` are 20 times their usual values. Note that even with many runs, results tend to oscillate a lot (one `a_div_b` in this list lower than 0.9 could have appeared higher than 1.1 in one run).
```json
{
	"category": "Physics > Area 2d",
	"name": "1000 Area 2d",
	"results": {
		"idle": {
			"a": 1058.89,
			"b": 1070.8600000000001,
			"a_div_b": 0.9888220682442149
		},
		"physics": {
			"a": 194.70500000000004,
			"b": 196.68599999999998,
			"a_div_b": 0.9899281087621898
		},
		"time": {
			"a": 0.6730000000000004,
			"b": 0.7160000000000002,
			"a_div_b": 0.9399441340782125
		}
	}
}
{
	"category": "Physics > Character Body 2d",
	"name": "1000 Character Bodies 2d",
	"results": {
		"idle": {
			"a": 353.32000000000005,
			"b": 348.21000000000004,
			"a_div_b": 1.0146750524109016
		},
		"physics": {
			"a": 365.28,
			"b": 382.21000000000004,
			"a_div_b": 0.9557049789382799
		},
		"time": {
			"a": 0.4210000000000001,
			"b": 0.4230000000000001,
			"a_div_b": 0.9952718676122931
		}
	}
}
{
	"category": "Physics > Raycast 2d",
	"name": "10 000 Raycast 2d",
	"results": {
		"time": {
			"a": 726.0200000000001,
			"b": 725.66,
			"a_div_b": 1.0004961001019763
		}
	}
}
{
	"category": "Physics > Rigid Body 2d",
	"name": "2000 Rigid Body 2d Circles",
	"results": {
		"idle": {
			"a": 744.7499999999999,
			"b": 741.7400000000001,
			"a_div_b": 1.004058025723299
		},
		"physics": {
			"a": 221.99999999999994,
			"b": 230.67,
			"a_div_b": 0.9624138379503184
		},
		"time": {
			"a": 115.77700000000002,
			"b": 113.78,
			"a_div_b": 1.0175514150114258
		}
	}
}
{
	"category": "Physics > Rigid Body 2d",
	"name": "2000 Rigid Body 2d Continuous",
	"results": {
		"idle": {
			"a": 968.5799999999999,
			"b": 973.55,
			"a_div_b": 0.9948949720096554
		},
		"physics": {
			"a": 234.39999999999998,
			"b": 237.66000000000003,
			"a_div_b": 0.986282925187242
		},
		"time": {
			"a": 111.737,
			"b": 110.71799999999999,
			"a_div_b": 1.0092035622030746
		}
	}
}
{
	"category": "Physics > Rigid Body 2d",
	"name": "2000 Rigid Body 2d Mixed",
	"results": {
		"idle": {
			"a": 959.1099999999999,
			"b": 958.74,
			"a_div_b": 1.0003859231908545
		},
		"physics": {
			"a": 264.54,
			"b": 260.67999999999995,
			"a_div_b": 1.0148074267300908
		},
		"time": {
			"a": 116.264,
			"b": 117.231,
			"a_div_b": 0.9917513285735002
		}
	}
}
{
	"category": "Physics > Rigid Body 2d",
	"name": "2000 Rigid Body 2d Squares",
	"results": {
		"idle": {
			"a": 1015.95,
			"b": 1015.78,
			"a_div_b": 1.0001673590738154
		},
		"physics": {
			"a": 288.15000000000003,
			"b": 293.03000000000003,
			"a_div_b": 0.9833464150428284
		},
		"time": {
			"a": 97.693,
			"b": 97.72199999999998,
			"a_div_b": 0.9997032398027058
		}
	}
}
{
	"category": "Physics > Rigid Body 2d",
	"name": "2000 Rigid Body 2d Unbound",
	"results": {
		"idle": {
			"a": 1015.83,
			"b": 1009.04,
			"a_div_b": 1.0067291683184016
		},
		"physics": {
			"a": 246.72000000000003,
			"b": 239.45999999999998,
			"a_div_b": 1.0303182159859687
		},
		"time": {
			"a": 107.05199999999999,
			"b": 106.83799999999998,
			"a_div_b": 1.00200303262884
		}
	}
}
{
	"category": "Physics > Rigid Body 2d",
	"name": "2000 Rigid Body 2d Unique",
	"results": {
		"idle": {
			"a": 314.52000000000004,
			"b": 306.94999999999993,
			"a_div_b": 1.0246619970679267
		},
		"physics": {
			"a": 259.57000000000005,
			"b": 264.68,
			"a_div_b": 0.9806936678252987
		},
		"time": {
			"a": 147.345,
			"b": 139.41299999999998,
			"a_div_b": 1.056895698392546
		}
	}
}
```
</details>

Both `template_release` and `template_debug` builds decreased by 12 KiB in size.