### PR TITLE
Fix register_scene_types.cpp not compiling when disable_physics_3d=yes

### DIFF
--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -745,9 +745,9 @@ void register_scene_types() {
 	GDREGISTER_CLASS(PhysicalBoneSimulator3D);
 	GDREGISTER_CLASS(PhysicalBone3D);
 	GDREGISTER_CLASS(SoftBody3D);
-#endif // PHYSICS_3D_DISABLED
 
 	GDREGISTER_CLASS(BoneSpreader3D);
+#endif // PHYSICS_3D_DISABLED
 	GDREGISTER_CLASS(BoneAttachment3D);
 	GDREGISTER_CLASS(LookAtModifier3D);
 #ifndef DISABLE_DEPRECATED


### PR DESCRIPTION
## Commit Message

`BoneSpreader3D` class isn't found when we compile with `disable_physics_3d=yes`, as we don't include `one_spreader_3d.h` when `disable_physics_3d=yes`, this fixes the issue by _not_ registering BoneSpreader3D Class when we've `disable_physics_3d=yes`.

## Use of AI
No AI was used in the process of making these changes.