### PR TITLE
Fix texture streaming setting warnings.

### DIFF
--- a/modules/texture_streaming/register_types.cpp
+++ b/modules/texture_streaming/register_types.cpp
@@ -40,6 +40,10 @@
 static TextureStreaming *_texture_streaming_server = nullptr;
 
 void initialize_texture_streaming_module(ModuleInitializationLevel p_level) {
+	if (p_level == MODULE_INITIALIZATION_LEVEL_CORE) {
+		TextureStreaming::register_project_settings();
+	}
+
 	if (p_level == MODULE_INITIALIZATION_LEVEL_SCENE) {
 		GDREGISTER_CLASS(TextureStreaming);
 

--- a/modules/texture_streaming/texture_streaming.cpp
+++ b/modules/texture_streaming/texture_streaming.cpp
@@ -221,9 +221,7 @@ RID TextureStreaming::material_set_textures(RID p_feedback_rid, const Vector<RID
 	return p_feedback_rid;
 }
 
-TextureStreaming::TextureStreaming() {
-	singleton = this;
-
+void TextureStreaming::register_project_settings() {
 	// Global settings
 	GLOBAL_DEF_RST("rendering/textures/streaming/enabled", false);
 	GLOBAL_DEF(PropertyInfo(Variant::BOOL, "rendering/textures/streaming/memory_budget_enabled"), false);
@@ -237,6 +235,10 @@ TextureStreaming::TextureStreaming() {
 	// Inactivity decay: time per mip level of decay in milliseconds.
 	// The first decay happens after one rate period. Set to 0 to disable decay.
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/textures/streaming/inactivity_decay_rate_ms", PROPERTY_HINT_RANGE, "0,60000,100,or_greater"), 5000);
+}
+
+TextureStreaming::TextureStreaming() {
+	singleton = this;
 
 	// Load initial settings.
 	setting_streaming_is_enabled = GLOBAL_GET("rendering/textures/streaming/enabled");

--- a/modules/texture_streaming/texture_streaming.h
+++ b/modules/texture_streaming/texture_streaming.h
@@ -620,6 +620,8 @@ private:
 public:
 	static TextureStreaming *get_singleton();
 
+	static void register_project_settings();
+
 	// Feedback Buffer API
 	uint32_t feedback_buffer_material_index(RID p_material);
 	RID feedback_buffer_get_uniform_rid();


### PR DESCRIPTION
The settings are checked by some shader compiles before the module is initialized which results in some warnings because they have not been defined yet.

Allow settings to be initalized earlier to prevent the warning.

## What problem(s) does this PR solve?

- Closes #122928
