### PR TITLE
Show the lightmap probes affecting a dynamic object while being selected

### DIFF
--- a/editor/scene/3d/gizmos/lightmap_gi_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/lightmap_gi_gizmo_plugin.cpp
@@ -30,10 +30,15 @@
 
 #include "lightmap_gi_gizmo_plugin.h"
 
+#include "core/variant/typed_array.h"
 #include "editor/editor_node.h"
 #include "editor/editor_string_names.h"
+#include "editor/scene/3d/node_3d_editor_gizmos.h"
 #include "editor/settings/editor_settings.h"
 #include "scene/3d/lightmap_gi.h"
+#include "scene/3d/visual_instance_3d.h"
+#include "scene/main/node.h"
+#include "scene/main/scene_tree.h"
 
 LightmapGIGizmoPlugin::LightmapGIGizmoPlugin() {
 	// NOTE: This gizmo only renders solid spheres for previewing indirect lighting on dynamic objects.
@@ -59,8 +64,62 @@ LightmapGIGizmoPlugin::LightmapGIGizmoPlugin() {
 	create_icon_material("baked_indirect_light_icon", EditorNode::get_singleton()->get_editor_theme()->get_icon(SNAME("GizmoLightmapGI"), EditorStringName(EditorIcons)));
 }
 
+LightmapGI *LightmapGIGizmoPlugin::_find_lightmap_node_for(Node3D *p_node) {
+	LightmapGI *lightmap_node = Object::cast_to<LightmapGI>(p_node);
+
+	if (lightmap_node == nullptr) {
+		// Find the first LightmapGI node which capture bounds contains the selected node.
+		Node *root = EditorNode::get_singleton()->get_edited_scene();
+		TypedArray<Node> candidates = root->find_children("*", "LightmapGI");
+		if (candidates.is_empty()) {
+			return nullptr;
+		}
+		for (int i = 0; i < candidates.size(); ++i) {
+			LightmapGI *candidate = Object::cast_to<LightmapGI>(candidates[i]);
+			Ref<LightmapGIData> lm_data = candidate->get_light_data();
+			if (lm_data.is_null()) {
+				continue;
+			}
+
+			if (!candidate->get_global_transform().xform(lm_data->get_capture_bounds()).has_point(p_node->get_global_position())) {
+				continue;
+			}
+
+			lightmap_node = candidate;
+			break;
+		}
+	}
+
+	return lightmap_node;
+}
+
+Ref<EditorNode3DGizmo> LightmapGIGizmoPlugin::create_gizmo(Node3D *p_spatial) {
+	Ref<LightmapGIGizmo> ret;
+
+	if (!has_gizmo(p_spatial)) {
+		return ret;
+	}
+
+	LightmapGI *lightmap_node = _find_lightmap_node_for(p_spatial);
+
+	if (lightmap_node != nullptr) {
+		ret.instantiate(lightmap_node);
+	}
+
+	return ret;
+}
+
 bool LightmapGIGizmoPlugin::has_gizmo(Node3D *p_spatial) {
-	return Object::cast_to<LightmapGI>(p_spatial) != nullptr;
+	bool success = Object::cast_to<LightmapGI>(p_spatial) != nullptr;
+	if (!success) {
+		GeometryInstance3D *obj = Object::cast_to<GeometryInstance3D>(p_spatial);
+		if (obj != nullptr) {
+			if (obj->get_gi_mode() == GeometryInstance3D::GI_MODE_DYNAMIC) {
+				success = true;
+			}
+		}
+	}
+	return success;
 }
 
 String LightmapGIGizmoPlugin::get_gizmo_name() const {
@@ -72,17 +131,66 @@ int LightmapGIGizmoPlugin::get_priority() const {
 }
 
 void LightmapGIGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
-	Ref<Material> icon = get_material("baked_indirect_light_icon", p_gizmo);
-	LightmapGI *baker = Object::cast_to<LightmapGI>(p_gizmo->get_node_3d());
-	Ref<LightmapGIData> data = baker->get_light_data();
-
 	p_gizmo->clear();
 
-	p_gizmo->add_unscaled_billboard(icon, 0.05);
-
-	if (data.is_null() || !p_gizmo->is_selected()) {
+	if (!p_gizmo->is_selected()) {
 		return;
 	}
+	LightmapGIGizmo *lightmap_gi_gizmo = Object::cast_to<LightmapGIGizmo>(p_gizmo);
+
+	if (lightmap_gi_gizmo == nullptr) {
+		return;
+	}
+
+	Node3D *node_3d = p_gizmo->get_node_3d();
+
+	LightmapGI *baker = lightmap_gi_gizmo->get_lightmap_node();
+
+	if (baker == nullptr) {
+		// The LightmapGI node may have changed. Let's search again.
+		baker = _find_lightmap_node_for(node_3d);
+		lightmap_gi_gizmo->set_lightmap_node(baker);
+		if (baker == nullptr) {
+			return;
+		}
+	}
+
+	if (!baker->is_visible_in_tree()) {
+		// baker is not visible so don't show the probes either.
+		return;
+	}
+
+	bool show_all = false;
+
+	if (baker == node_3d) {
+		// Add the LightmapGI icon only if the selected node is a LightmapGI
+		Ref<Material> icon = get_material("baked_indirect_light_icon", p_gizmo);
+		p_gizmo->add_unscaled_billboard(icon, 0.05);
+
+		show_all = true;
+	}
+
+	Ref<LightmapGIData> data = baker->get_light_data();
+
+	if (data.is_null()) {
+		return;
+	}
+
+	if (!show_all && !baker->get_global_transform().xform(data->get_capture_bounds()).has_point(node_3d->get_global_position())) {
+		// The selected node isn't a LightmapGI and it's outside of the current LightmapGI bounds. Search if it's in another LightmapGI bounds.
+		baker = _find_lightmap_node_for(node_3d);
+		lightmap_gi_gizmo->set_lightmap_node(baker);
+		if (baker == nullptr) {
+			return;
+		}
+		data = baker->get_light_data();
+		if (data.is_null()) {
+			return;
+		}
+	}
+
+	// Gizmos add_*() are relative to the selected Node3D which is the LightmapGI node we found before.
+	p_gizmo->set_node_3d(baker);
 
 	Ref<Material> material_lines = get_material("lightmap_lines", p_gizmo);
 	Ref<Material> material_probes = get_material("lightmap_probe_material", p_gizmo);
@@ -90,16 +198,24 @@ void LightmapGIGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	Vector<Vector3> lines;
 	HashSet<Vector2i> lines_found;
 
-	Vector<Vector3> points = data->get_capture_points();
+	Vector<Vector3> points;
+	Vector<Color> sh;
+	Vector<int> tetrahedrons;
+
+	points = data->get_capture_points();
 	if (points.is_empty()) {
 		return;
 	}
-	Vector<Color> sh = data->get_capture_sh();
+	sh = data->get_capture_sh();
 	if (sh.size() != points.size() * 9) {
 		return;
 	}
 
-	Vector<int> tetrahedrons = data->get_capture_tetrahedra();
+	if (show_all) {
+		tetrahedrons = data->get_capture_tetrahedra();
+	} else {
+		tetrahedrons = data->get_tetrahedron_at_position(baker->get_global_transform().affine_inverse().xform(node_3d->get_global_position()));
+	}
 
 	for (int i = 0; i < tetrahedrons.size(); i += 4) {
 		for (int j = 0; j < 4; j++) {
@@ -122,6 +238,10 @@ void LightmapGIGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 
 	p_gizmo->add_lines(lines, material_lines);
+
+	if (!show_all) {
+		points = { points[tetrahedrons[0]], points[tetrahedrons[1]], points[tetrahedrons[2]], points[tetrahedrons[3]] };
+	}
 
 	int stack_count = 8;
 	int sector_count = 16;
@@ -146,11 +266,15 @@ void LightmapGIGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 		for (int p = 0; p < points.size(); p++) {
 			int vertex_base = vertices.size();
+			int sh_idx = p;
+			if (!show_all) {
+				sh_idx = tetrahedrons[p];
+			}
 			Vector3 sh_col[9];
 			for (int i = 0; i < 9; i++) {
-				sh_col[i].x = sh[p * 9 + i].r;
-				sh_col[i].y = sh[p * 9 + i].g;
-				sh_col[i].z = sh[p * 9 + i].b;
+				sh_col[i].x = sh[sh_idx * 9 + i].r;
+				sh_col[i].y = sh[sh_idx * 9 + i].g;
+				sh_col[i].z = sh[sh_idx * 9 + i].b;
 			}
 
 			for (int i = 0; i <= stack_count; ++i) {
@@ -220,5 +344,30 @@ void LightmapGIGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		mesh->surface_set_material(0, material_probes);
 
 		p_gizmo->add_mesh(mesh);
+
+		// Revert back to the original gizmo's Node3D.
+		p_gizmo->set_node_3d(node_3d);
 	}
+}
+
+LightmapGI *LightmapGIGizmo::get_lightmap_node() const {
+	return lightmap_node;
+}
+
+void LightmapGIGizmo::set_lightmap_node(LightmapGI *p_lightmap) {
+	lightmap_node = p_lightmap;
+}
+
+void LightmapGIGizmo::transform() {
+	if (Object::cast_to<LightmapGI>(get_node_3d()) == nullptr) {
+		// not a LightmapGI node so just redraw
+		redraw();
+	} else {
+		// It's a LightmapGI node so transform it as usual
+		EditorNode3DGizmo::transform();
+	}
+}
+
+LightmapGIGizmo::LightmapGIGizmo(LightmapGI *p_lightmap) {
+	lightmap_node = p_lightmap;
 }

--- a/editor/scene/3d/gizmos/lightmap_gi_gizmo_plugin.h
+++ b/editor/scene/3d/gizmos/lightmap_gi_gizmo_plugin.h
@@ -31,11 +31,17 @@
 #pragma once
 
 #include "editor/scene/3d/node_3d_editor_gizmos.h"
+#include "scene/3d/lightmap_gi.h"
 
 class LightmapGIGizmoPlugin : public EditorNode3DGizmoPlugin {
 	GDCLASS(LightmapGIGizmoPlugin, EditorNode3DGizmoPlugin);
 
 	float probe_size = 0.4f;
+
+	LightmapGI *_find_lightmap_node_for(Node3D *p_node);
+
+protected:
+	Ref<EditorNode3DGizmo> create_gizmo(Node3D *p_spatial) override;
 
 public:
 	bool has_gizmo(Node3D *p_spatial) override;
@@ -44,4 +50,17 @@ public:
 	void redraw(EditorNode3DGizmo *p_gizmo) override;
 
 	LightmapGIGizmoPlugin();
+};
+
+class LightmapGIGizmo : public EditorNode3DGizmo {
+	GDCLASS(LightmapGIGizmo, EditorNode3DGizmo);
+
+private:
+	LightmapGI *lightmap_node = nullptr;
+
+public:
+	LightmapGI *get_lightmap_node() const;
+	void set_lightmap_node(LightmapGI *p_lightmap = nullptr);
+	void transform() override;
+	LightmapGIGizmo(LightmapGI *p_lightmap = nullptr);
 };

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
+#include "core/error/error_macros.h"
 #include "core/io/config_file.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
@@ -39,6 +40,7 @@
 #include "core/math/geometry_3d.h"
 #include "core/object/class_db.h"
 #include "core/object/object.h"
+#include "core/variant/variant.h"
 #include "scene/3d/light_3d.h"
 #include "scene/3d/lightmap_probe.h"
 #include "scene/3d/mesh_instance_3d.h"
@@ -289,6 +291,92 @@ bool LightmapGIData::is_interior() const {
 
 float LightmapGIData::get_baked_exposure() const {
 	return baked_exposure;
+}
+
+PackedInt32Array LightmapGIData::get_tetrahedron_at_position(const Vector3 &p_position) {
+	static_assert(sizeof(LightmapGIData::BSP) == 24);
+
+	PackedInt32Array tetrahedra = get_capture_tetrahedra();
+	PackedInt32Array bsp_tree = get_capture_bsp_tree();
+
+	ERR_FAIL_COND_V_MSG(tetrahedra.is_empty() || bsp_tree.is_empty(), PackedInt32Array(), "LightmapGIData does not contain baked data.");
+
+	const LightmapGIData::BSP *bsp = (const LightmapGIData::BSP *)bsp_tree.ptr();
+	int32_t node = 0;
+	while (node >= 0) {
+		if (Plane(bsp[node].plane[0], bsp[node].plane[1], bsp[node].plane[2], bsp[node].plane[3]).is_point_over(p_position)) {
+#ifdef DEBUG_ENABLED
+			ERR_FAIL_COND_V(bsp[node].over >= 0 && bsp[node].over < node, PackedInt32Array());
+#endif
+
+			node = bsp[node].over;
+		} else {
+#ifdef DEBUG_ENABLED
+			ERR_FAIL_COND_V(bsp[node].under >= 0 && bsp[node].under < node, PackedInt32Array());
+#endif
+			node = bsp[node].under;
+		}
+	}
+
+	if (node == LightmapGIData::BSP::EMPTY_LEAF) {
+		return PackedInt32Array(); // Nothing could be done.
+	}
+
+	node = Math::abs(node) - 1;
+
+	PackedInt32Array ret;
+
+	for (int i = 0; i < 4; i++) {
+		ret.push_back(tetrahedra[node * 4 + i]);
+	}
+
+	return ret;
+}
+
+PackedVector3Array LightmapGIData::get_capture_probes_at_position(const Vector3 &p_position) {
+	PackedVector3Array points = get_capture_points();
+
+	ERR_FAIL_COND_V_MSG(points.is_empty(), PackedVector3Array(), "LightmapGIData does not contain baked data.");
+
+	PackedInt32Array tetrahedron = get_tetrahedron_at_position(p_position);
+
+	if (tetrahedron.size() != 4) {
+		return PackedVector3Array();
+	}
+
+	return { points[tetrahedron[0]], points[tetrahedron[1]], points[tetrahedron[2]], points[tetrahedron[3]] };
+}
+
+PackedColorArray LightmapGIData::get_capture_spherical_harmonics_at_position(const Vector3 &p_position) {
+	PackedColorArray ret;
+	for (int i = 0; i < 9; ++i) {
+		ret.push_back(Color(0, 0, 0, 0));
+	}
+
+	PackedVector3Array points = get_capture_points();
+	PackedColorArray point_sh = get_capture_sh();
+
+	ERR_FAIL_COND_V_MSG(points.is_empty() || point_sh.is_empty(), ret, "LightmapGIData does not contain baked data.");
+
+	PackedInt32Array tetrahedron = get_tetrahedron_at_position(p_position);
+
+	if (tetrahedron.size() != 4) {
+		return ret;
+	}
+
+	const Color *sh_colors[4]{ &point_sh[tetrahedron[0] * 9], &point_sh[tetrahedron[1] * 9], &point_sh[tetrahedron[2] * 9], &point_sh[tetrahedron[3] * 9] };
+	Color barycentric = Geometry3D::tetrahedron_get_barycentric_coords(points[0], points[1], points[2], points[3], p_position);
+
+	Color *ret_ptrw = ret.ptrw();
+
+	for (int i = 0; i < 4; i++) {
+		float c = CLAMP(barycentric[i], 0.0, 1.0);
+		for (int j = 0; j < 9; j++) {
+			ret_ptrw[j] += sh_colors[i][j] * c;
+		}
+	}
+
+	return ret;
 }
 
 void LightmapGIData::_set_probe_data(const Dictionary &p_data) {

--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -32,6 +32,8 @@
 
 #include "core/io/resource.h"
 #include "core/templates/local_vector.h"
+#include "core/variant/typed_array.h"
+#include "core/variant/variant.h"
 #include "scene/3d/lightmapper.h"
 #include "scene/3d/visual_instance_3d.h"
 
@@ -79,6 +81,12 @@ private:
 		int slice_index = 0;
 	};
 
+	struct BSP {
+		static const int32_t EMPTY_LEAF = INT32_MIN;
+		float plane[4];
+		int32_t over = EMPTY_LEAF, under = EMPTY_LEAF;
+	};
+
 	Vector<User> users;
 
 	void _set_user_data(const Array &p_data);
@@ -120,6 +128,10 @@ public:
 
 	bool is_interior() const;
 	float get_baked_exposure() const;
+
+	PackedInt32Array get_tetrahedron_at_position(const Vector3 &p_position);
+	PackedVector3Array get_capture_probes_at_position(const Vector3 &p_position);
+	PackedColorArray get_capture_spherical_harmonics_at_position(const Vector3 &p_position);
 
 	void set_capture_data(const AABB &p_bounds, bool p_interior, const PackedVector3Array &p_points, const PackedColorArray &p_point_sh, const PackedInt32Array &p_tetrahedra, const PackedInt32Array &p_bsp_tree, float p_baked_exposure, uint32_t p_lightprobe_hash);
 	PackedVector3Array get_capture_points() const;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Implements the last point of this comment https://github.com/godotengine/godot-proposals/issues/7938#issuecomment-1751875865

> when you select and move a dynamic object the probes that affect it are shown for debugging

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

This PR only shows the probes affecting a dynamic object from the first `LightmapGI` the dynamic object is part of:

[Screencast_20260829_101439.webm](https://github.com/user-attachments/assets/85ee802f-1f30-4784-be63-c68f0247631f)


Also, a question, I added a couple extra methods to LightmapGIData to get the information needed to show the probes:

```
	PackedInt32Array get_tetrahedron_at_position(const Vector3 &p_position);
	PackedVector3Array get_capture_probes_at_position(const Vector3 &p_position);
	PackedColorArray get_capture_spherical_harmonics_at_position(const Vector3 &p_position);
```

Should these methods be exposed to scripting?