### PR TITLE
[3.x] Fix some UB / uninitialized vars

### DIFF
--- a/core/hashfuncs.h
+++ b/core/hashfuncs.h
@@ -81,7 +81,7 @@ static inline uint32_t hash_one_uint64(uint64_t p_int) {
 	v = v ^ (v >> 11);
 	v = v + (v << 6);
 	v = v ^ (v >> 22);
-	return (int)v;
+	return (uint32_t)v;
 }
 
 static inline uint32_t hash_djb2_one_float(double p_in, uint32_t p_prev = 5381) {

--- a/core/pooled_list.h
+++ b/core/pooled_list.h
@@ -185,7 +185,7 @@ public:
 		U list_id = _active_map[p_id];
 
 		// zero the _active map to detect bugs (only in debug?)
-		_active_map[p_id] = -1;
+		_active_map[p_id] = (U)-1;
 
 		_active_list.remove_unordered(list_id);
 

--- a/core/rid_handle.h
+++ b/core/rid_handle.h
@@ -108,7 +108,7 @@ public:
 	}
 	bool is_valid() const { return _id != 0; }
 
-	uint32_t get_id() const { return _id ? _handle_data : 0; }
+	uint32_t get_id() const { return _id ? (uint32_t)_handle_data : 0; }
 };
 
 class RID : public RID_Handle {

--- a/core/variant.cpp
+++ b/core/variant.cpp
@@ -2554,7 +2554,7 @@ uint32_t Variant::recursive_hash(int p_recursion_count) const {
 			return _data._bool ? 1 : 0;
 		} break;
 		case INT: {
-			return _data._int;
+			return (uint32_t)_data._int;
 		} break;
 		case REAL: {
 			return hash_djb2_one_float(_data._real);

--- a/drivers/gles_common/rasterizer_canvas_batcher.h
+++ b/drivers/gles_common/rasterizer_canvas_batcher.h
@@ -528,7 +528,7 @@ public:
 		typename T_STORAGE::Shader *shader_cache;
 		bool rebind_shader;
 		bool prev_use_skeleton;
-		bool prev_distance_field;
+		bool prev_distance_field = false;
 		int last_blend_mode;
 		RID canvas_last_material;
 		Color final_modulate;

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -38,6 +38,7 @@
 #include "servers/audio/audio_effect.h"
 
 #include <atomic>
+#include <cstdint>
 
 class AudioDriverDummy;
 class AudioStream;
@@ -131,7 +132,7 @@ class AudioDriverManager {
 	};
 
 public:
-	enum MuteFlags {
+	enum MuteFlags : uint32_t {
 		// User enables or disables audio, e.g. via button in editor.
 		MUTE_FLAG_DISABLED = 1 << 0,
 		// Whether app is in focus.


### PR DESCRIPTION
Fixes an uninitialized read in the batching, and some false positive UB reports for ubsan.

Fixes #122431.

## Notes
* Using -1 is fairly common for unused, but you can't e.g. use `UINT32_MAX` in a template where U can be custom, so casting to (U) is likely the best fix
* The fix to the hash func will produce the same binary behaviour
* I did initially start going through the batching to ensure all values were zeroed, but it should really be a separate PR, as batching is very performance sensitive, and many vars aren't zeroed _on purpose_, so this needs profile guiding.

