### PR TITLE
Fix other types ignored when quick open includes PackedScene

### DIFF
--- a/editor/gui/editor_quick_open_dialog.cpp
+++ b/editor/gui/editor_quick_open_dialog.cpp
@@ -747,7 +747,7 @@ void QuickOpenResultContainer::_add_candidate(QuickOpenResultCandidate &p_candid
 	String file_path = ResourceUID::get_singleton()->get_id_path(p_candidate.uid);
 
 	// Verify that a PackedScene is actually a "real" Scene if in a Open Scene context.
-	if (base_types[0] == SNAME("PackedScene")) {
+	if (base_types.size() == 1 && base_types[0] == SNAME("PackedScene")) {
 		static FixedVector<String, 3> valid_extensions = { "tscn", "scn", "res" };
 		bool is_valid_type = false;
 		for (const String &ext : valid_extensions) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Fixes regression from #118631
When quick opening for multiple types, if the first type is PackedScene, other types were ignored.

## Additional information

Test with
```GDScript
@tool
extends EditorScript

func _run() -> void:
	EditorInterface.popup_quick_open(func(p): print(p), ["PackedScene", "Script"])
```


<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
