### PR TITLE
Android Editor: Fix internal error shown when running project in editor

### DIFF
--- a/editor/run/editor_run.cpp
+++ b/editor/run/editor_run.cpp
@@ -111,6 +111,7 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie, const V
 		}
 	}
 
+#ifndef ANDROID_ENABLED
 	WindowPlacement window_placement = get_window_placement();
 	if (window_placement.position != Point2i(INT_MAX, INT_MAX)) {
 		args.push_back("--position");
@@ -122,6 +123,7 @@ Error EditorRun::run(const String &p_scene, const String &p_write_movie, const V
 	} else if (window_placement.force_fullscreen) {
 		args.push_back("--fullscreen");
 	}
+#endif
 
 	List<String> breakpoints;
 	EditorNode::get_editor_data().get_editor_breakpoints(&breakpoints);


### PR DESCRIPTION
<img width="1309" height="371" alt="Screenshot_20260829_185324" src="https://github.com/user-attachments/assets/3dfc057f-0dca-4269-8305-1583fbfa660c" />

These settings are not applicable in the Android Editor. This PR prevents these errors from being shown.
