### PR TITLE
Fix misleading MouseButton link in button_mask's documentation

### DIFF
--- a/doc/classes/InputEventMouse.xml
+++ b/doc/classes/InputEventMouse.xml
@@ -11,7 +11,7 @@
 	</tutorials>
 	<members>
 		<member name="button_mask" type="int" setter="set_button_mask" getter="get_button_mask" enum="MouseButtonMask" is_bitfield="true" default="0">
-			The mouse button mask identifier, one of or a bitwise combination of the [enum MouseButton] button masks.
+			The mouse button mask identifier, one of or a bitwise combination of the [enum MouseButtonMask] button masks.
 		</member>
 		<member name="device" type="int" setter="set_device" getter="get_device" overrides="InputEvent" default="32" />
 		<member name="global_position" type="Vector2" setter="set_global_position" getter="get_global_position" default="Vector2(0, 0)">


### PR DESCRIPTION
## What problem(s) does this PR solve?

InputEventMouse.button_mask's documentation links to MouseButton with the implication that its members are the button masks, which is sadly not the case

## Additional information

Incorrectly using MouseButton even works for left and right, but not middle.