### PR TITLE
Fix 2D DDS files with mipmaps.

### DIFF
--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -722,7 +722,7 @@ static Vector<Ref<Image>> _dds_load_images_from_buffer(Ref<FileAccess> p_f, DDSF
 		r_mipmaps = 1;
 	}
 
-	return _dds_load_images(p_f, r_dds_format, r_width, r_height, r_mipmaps, r_pitch, r_flags, r_layer_count, r_dds_type & DDST_3D);
+	return _dds_load_images(p_f, r_dds_format, r_width, r_height, r_mipmaps, r_pitch, r_flags, r_layer_count, (r_dds_type & DDST_TYPE_MASK) == DDST_3D);
 }
 
 static Ref<Resource> _dds_load_from_buffer(Ref<FileAccess> p_f, Error *r_error, const String &p_path = "") {


### PR DESCRIPTION
The changes in 4f907cc7a0 incorrectly used the DDSType as a bitmask when it is an enumeration.  This results in it incorrectly loading mipmaps as a bunch of images, which results in only the first being used for the texture, giving you no mipmaps.

## What problem(s) does this PR solve?
This PR fix the issue described which was introduced in https://github.com/godotengine/godot/pull/117999

