### PR TITLE
[TextServer] Determine locale direction based of script.

### DIFF
--- a/core/string/translation_server.cpp
+++ b/core/string/translation_server.cpp
@@ -100,6 +100,9 @@ void TranslationServer::init_locale_info() {
 		for (const String &s : scripts) {
 			set.insert(s);
 		}
+		if (!scripts.is_empty()) {
+			language_script_default[language_script_list[idx][0]] = scripts[0];
+		}
 		idx++;
 	}
 
@@ -241,6 +244,9 @@ TranslationServer::Locale::Locale(const TranslationServer &p_server, const Strin
 				}
 			}
 		}
+		if (script.is_empty() && language_script_default.has(language)) {
+			script = language_script_default[language];
+		}
 		if (!script.is_empty() && country.is_empty()) {
 			// Add conntry code based on script for some ambiguous cases.
 			for (int i = 0; i < p_server.locale_script_info.size(); i++) {
@@ -316,6 +322,16 @@ String TranslationServer::get_percent_sign(const String &p_locale) const {
 
 String TranslationServer::standardize_locale(const String &p_locale, bool p_add_defaults) const {
 	return Locale(*this, p_locale, p_add_defaults).operator String();
+}
+
+Dictionary TranslationServer::standardize_locale_dict(const String &p_locale, bool p_add_defaults) const {
+	Dictionary ret;
+	Locale l = Locale(*this, p_locale, p_add_defaults);
+	ret["language"] = l.language;
+	ret["script"] = l.script;
+	ret["country"] = l.country;
+	ret["variant"] = l.variant;
+	return ret;
 }
 
 int TranslationServer::compare_locales(const String &p_locale_a, const String &p_locale_b) const {

--- a/core/string/translation_server.h
+++ b/core/string/translation_server.h
@@ -93,6 +93,7 @@ class TranslationServer : public Object {
 	static inline HashMap<String, String> plural_rules_map;
 	static inline HashMap<String, int> num_system_map;
 	static inline HashMap<String, HashSet<String>> language_script_map;
+	static inline HashMap<String, String> language_script_default;
 
 	void init_locale_info();
 
@@ -154,6 +155,7 @@ public:
 	String get_percent_sign(const String &p_locale) const;
 
 	String standardize_locale(const String &p_locale, bool p_add_defaults = false) const;
+	Dictionary standardize_locale_dict(const String &p_locale, bool p_add_defaults = false) const;
 
 	int compare_locales(const String &p_locale_a, const String &p_locale_b) const;
 

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -515,8 +515,9 @@ bool TextServerAdvanced::_is_locale_using_support_data(const String &p_locale) c
 }
 
 bool TextServerAdvanced::_is_locale_right_to_left(const String &p_locale) const {
-	String l = p_locale.get_slicec('_', 0);
-	if ((l == "ar") || (l == "dv") || (l == "he") || (l == "fa") || (l == "ff") || (l == "ku") || (l == "ur")) {
+	ERR_FAIL_NULL_V(TranslationServer::get_singleton(), false);
+	String l = TranslationServer::get_singleton()->standardize_locale_dict(p_locale, true)["script"];
+	if ((l == "Adlm") || (l == "Arab") || (l == "Armi") || (l == "Avst") || (l == "Cprt") || (l == "Elym") || (l == "Hatr") || (l == "Hebr") || (l == "Hung") || (l == "Inds") || (l == "Khar") || (l == "Lydi") || (l == "Mand") || (l == "Mani") || (l == "Mend") || (l == "Merc") || (l == "Mero") || (l == "Narb") || (l == "Nbat") || (l == "Nkoo") || (l == "Orkh") || (l == "Palm") || (l == "Phli") || (l == "Phlp") || (l == "Phnx") || (l == "Prti") || (l == "Rohg") || (l == "Samr") || (l == "Sarb") || (l == "Sogo") || (l == "Syrc") || (l == "Thaa") || (l == "Yezi")) {
 		return true;
 	} else {
 		return false;

--- a/tests/core/string/test_translation_server.cpp
+++ b/tests/core/string/test_translation_server.cpp
@@ -121,11 +121,11 @@ TEST_CASE("[TranslationServer] Locale operations") {
 
 	CHECK(res == "de_DE");
 
-	// No added defaults.
+	// Add default script.
 	loc = "es_ES";
 	res = ts->standardize_locale(loc, true);
 
-	CHECK(res == "es_ES");
+	CHECK(res == "es_Latn_ES");
 
 	// Add default script.
 	loc = "az_AZ";
@@ -201,7 +201,7 @@ TEST_CASE("[TranslationServer] Comparing locales") {
 	// Mismatched country (-1).
 	res = ts->compare_locales(locale_a, locale_b);
 
-	CHECK(res == 4);
+	CHECK(res == 5);
 
 	locale_a = "es";
 	locale_b = "es-AR";
@@ -209,7 +209,7 @@ TEST_CASE("[TranslationServer] Comparing locales") {
 	// No country for one locale (+0).
 	res = ts->compare_locales(locale_a, locale_b);
 
-	CHECK(res == 5);
+	CHECK(res == 6);
 
 	locale_a = "es-EC";
 	locale_b = "fr-LU";

--- a/tests/servers/test_text_server.cpp
+++ b/tests/servers/test_text_server.cpp
@@ -58,6 +58,68 @@ TEST_SUITE("[TextServer]") {
 			}
 		}
 
+		SUBCASE("[TextServer] Locale direction") {
+			for (int i = 0; i < TextServerManager::get_singleton()->get_interface_count(); i++) {
+				Ref<TextServer> ts = TextServerManager::get_singleton()->get_interface(i);
+				CHECK_FALSE_MESSAGE(ts.is_null(), "Invalid TS interface.");
+
+				if (!ts->has_feature(TextServer::FEATURE_BIDI_LAYOUT)) {
+					continue;
+				}
+
+				CHECK_EQ(ts->is_locale_right_to_left("ar"), true);
+				CHECK_EQ(ts->is_locale_right_to_left("bg"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("bn"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("ca"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("cs"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("de"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("dv"), true);
+				CHECK_EQ(ts->is_locale_right_to_left("el"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("en"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("eo"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("es"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("et"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("fa"), true);
+				CHECK_EQ(ts->is_locale_right_to_left("fi"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("ff"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("fr"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("ga"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("he"), true);
+				CHECK_EQ(ts->is_locale_right_to_left("hu"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("id"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("it"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("ja"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("ka"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("ko"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("ku"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("nl"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("pl"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("pt"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("ro"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("ru"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("sk"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("sv"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("ta"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("th"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("tok"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("tr"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("uk"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("ur"), true);
+				CHECK_EQ(ts->is_locale_right_to_left("va"), false);
+
+				CHECK_EQ(ts->is_locale_right_to_left("ff_Latn"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("ff_Adlm"), true);
+				CHECK_EQ(ts->is_locale_right_to_left("ku_Latn"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("ku_Arab"), true);
+				CHECK_EQ(ts->is_locale_right_to_left("ku_Cyrl"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("zh_Hans"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("zh_Hant"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("ur_Latn"), false);
+				CHECK_EQ(ts->is_locale_right_to_left("az_IR"), true);
+				CHECK_EQ(ts->is_locale_right_to_left("az_AZ"), false);
+			}
+		}
+
 		SUBCASE("[TextServer] Text layout: Font fallback") {
 			for (int i = 0; i < TextServerManager::get_singleton()->get_interface_count(); i++) {
 				Ref<TextServer> ts = TextServerManager::get_singleton()->get_interface(i);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/15452

## Additional information

Some test were adjusted, since `standardize_locale` was changed to always add script code if `add_defaults`, it should not make any practical difference, since it is only used to compare locales.