### PR TITLE
[3.x] Force compiler to link `ClassDB` registered classes

### DIFF
--- a/core/class_db.h
+++ b/core/class_db.h
@@ -171,6 +171,13 @@ public:
 	static void register_class() {
 		GLOBAL_LOCK_FUNCTION;
 		static_assert(TypesAreSame<typename T::self_type, T>::value, "Class not declared properly, please use GDCLASS.");
+
+		// FORCE COMPILER INSTANTIATION:
+		// There is a bug with some compilers, that they aggressively strip classes
+		// from the binary, and cause errors at runtime.
+		// This line attempt to prevent this by forcing the compiler to link all classes.
+		(void)&T::get_class_static;
+
 		T::initialize_class();
 		ClassInfo *t = classes.getptr(T::get_class_static());
 		ERR_FAIL_COND(!t);


### PR DESCRIPTION
Attempt to force compilers to link all classes that have been registered with `ClassDB`.

May fix #122923.

## Explanation
This is a long shot, and the result of some investigation into the issue. It seems that some compilers, possibly particularly with link time optimization, may aggressively strip classes out of the binary, mistakenly thinking they are not used, when they may be required at runtime.

These lines can hopefully coax compilers to force linkage.

## Notes
* This was likely triggered by `blob_shadows` PR, but not _because_ of blob shadows, simply because it increased the size of the classes in `register_scene_types.cpp` in the translation unit, and hit a linking boundary.
* I'm not fully familiar with the mechanics of why this bug occurs (as I'm not super familiar with class db), but it seems to do with the toolchain, and I'm working on the assumption it is not due to static order initialization fiasco (SOIF), which was another possible culprit, because the classes are not linked in the binary, rather than it being a runtime issue.
* This may be responsible for some of the other issues in the past we've had reported where builds have not worked on certain compilers.
* I can't test this myself, it will need to be tested by someone who can replicate the bug, e.g. @ee-DavidC.
* DRAFT until tested.