### PR TITLE
Add support for defining C++ methods that answer GDVirtual calls

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1815,6 +1815,90 @@ void ClassDB::add_extension_class_virtual_method(const StringName &p_class, cons
 #endif // DEBUG_ENABLED
 }
 
+void ClassDB::add_virtual_method_answer(MethodBind *p_answer, const StringName &p_method_name) {
+	Locker::Lock lock(Locker::STATE_WRITE);
+
+	p_answer->set_name(p_method_name);
+
+	String instance_type = p_answer->get_instance_class();
+	ClassInfo *type = classes.getptr(instance_type);
+	if (!type) {
+		memdelete(p_answer);
+		ERR_FAIL_MSG(vformat("Couldn't bind virtual method answer '%s' for instance '%s'.", p_method_name, instance_type));
+	}
+
+	ClassInfo *answer_type = type;
+
+#ifdef DEBUG_ENABLED
+	MethodInfo *virtual_method = nullptr;
+	while (type) {
+		if (type->virtual_methods_map.has(p_method_name)) {
+			virtual_method = type->virtual_methods_map.getptr(p_method_name);
+			break;
+		}
+		type = type->inherits_ptr;
+	}
+	if (!virtual_method) {
+		memdelete(p_answer);
+		ERR_FAIL_MSG(vformat("Virtual method answer '%s' for instance '%s' doesn't have a corresponding virtual method.", p_method_name, instance_type));
+	}
+
+	if (virtual_method->arguments.size() != p_answer->get_argument_count()) {
+		memdelete(p_answer);
+		ERR_FAIL_MSG(vformat("Virtual method answer '%s' for instance '%s' has a different argument count than the corresponding virtual method.", p_method_name, instance_type));
+	}
+	for (int i = 0; i < virtual_method->arguments.size(); i++) {
+		if (virtual_method->arguments[i].type != p_answer->get_argument_type(i)) {
+			memdelete(p_answer);
+			ERR_FAIL_MSG(vformat("Virtual method answer '%s' for instance '%s' has a different argument type for argument %d than the corresponding virtual method.", p_method_name, instance_type, i));
+		}
+	}
+#endif // DEBUG_ENABLED
+
+	if (answer_type->virtual_methods_answers.has(p_method_name)) {
+		memdelete(p_answer);
+		ERR_FAIL_MSG(vformat("Virtual method answer '%s' for instance '%s' already exists.", p_method_name, instance_type));
+	}
+
+	answer_type->virtual_methods_answers[p_method_name] = p_answer;
+}
+
+bool ClassDB::has_virtual_method_answer(const StringName &p_class, const StringName &p_method) {
+	Locker::Lock lock(Locker::STATE_READ);
+
+	ClassInfo *type = classes.getptr(p_class);
+	if (!type) {
+		return false;
+	}
+
+	while (type) {
+		if (type->virtual_methods_answers.has(p_method)) {
+			return true;
+		}
+		type = type->inherits_ptr;
+	}
+
+	return false;
+}
+
+const MethodBind *ClassDB::get_virtual_method_answer(const StringName &p_class, const StringName &p_method) {
+	Locker::Lock lock(Locker::STATE_READ);
+
+	ClassInfo *type = classes.getptr(p_class);
+	if (!type) {
+		return nullptr;
+	}
+
+	while (type) {
+		if (type->virtual_methods_answers.has(p_method)) {
+			return type->virtual_methods_answers[p_method];
+		}
+		type = type->inherits_ptr;
+	}
+
+	return nullptr;
+}
+
 void ClassDB::set_class_enabled(const StringName &p_class, bool p_enable) {
 	Locker::Lock lock(Locker::STATE_WRITE);
 
@@ -2090,6 +2174,12 @@ void ClassDB::cleanup() {
 	//OBJTYPE_LOCK; hah not here
 
 	for (KeyValue<StringName, ClassInfo> &E : classes) {
+		ClassInfo &ci = E.value;
+
+		for (const KeyValue<StringName, MethodBind *> &F : ci.virtual_methods_answers) {
+			memdelete(F.value);
+		}
+
 		if (E.value.gdextension) {
 			WARN_PRINT(vformat("Extension class '%s' is still registered at exit; its GDExtension did not unregister it.", E.key));
 			gdtype_leaked_autorelease_pool.push_back(E.value.gdtype); // We created it; we need to clear it.

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -127,6 +127,7 @@ public:
 		List<StringName> dependency_list;
 #endif
 
+		HashMap<StringName, MethodBind *> virtual_methods_answers;
 		HashMap<StringName, Vector<uint32_t>> virtual_methods_compat;
 
 		bool disabled = false;
@@ -477,6 +478,18 @@ public:
 	static void get_virtual_methods(const StringName &p_class, List<MethodInfo> *p_methods, bool p_no_inheritance = false);
 	static void add_extension_class_virtual_method(const StringName &p_class, const GDExtensionClassVirtualMethodInfo *p_method_info);
 	static Vector<uint32_t> get_virtual_method_compatibility_hashes(const StringName &p_class, const StringName &p_name);
+
+	template <typename M>
+	static void bind_virtual_method_answer(const StringName &p_method_name, M p_method) {
+		Locker::Lock lock(Locker::STATE_WRITE);
+		MethodBind *bind = create_method_bind(p_method);
+		ERR_FAIL_NULL(bind);
+		add_virtual_method_answer(bind, p_method_name);
+	}
+
+	static void add_virtual_method_answer(MethodBind *p_answer, const StringName &p_method_name);
+	static bool has_virtual_method_answer(const StringName &p_class, const StringName &p_method);
+	static const MethodBind *get_virtual_method_answer(const StringName &p_class, const StringName &p_method);
 
 	static void bind_integer_constant(const StringName &p_class, const StringName &p_enum, const StringName &p_name, int64_t p_constant, bool p_is_bitfield = false);
 	static void get_integer_constant_list(const StringName &p_class, List<String> *p_constants, bool p_no_inheritance = false);

--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -14,6 +14,20 @@ script_has_method = """ScriptInstance *_script_instance = ((Object *)(this))->ge
 			return true;\\
 		}"""
 
+cpp_call = """if (_gdvirtual_is_method_overridden(_gdvirtual_##$VARNAME##_sn)) {\\
+			Callable::CallError ce;\\
+			$CALLSIARGS\\
+			$CALLSIBEGINconst_cast<self_type *>(this)->_gdvirtual_call_method(_gdvirtual_##$VARNAME##_sn, $CALLSIARGPASS, ce);\\
+			if (ce.error == Callable::CallError::CALL_OK) {\\
+				$CALLSIRET\\
+				return true;\\
+			}\\
+		}"""
+
+cpp_has_method = """if (_gdvirtual_is_method_overridden(_gdvirtual_##$VARNAME##_sn)) {\\
+			return true;\\
+		}"""
+
 proto = """#define GDVIRTUAL$VER($ALIAS $RET m_name $ARG)\\
 	mutable void *_gdvirtual_##$VARNAME = nullptr;\\
 	_FORCE_INLINE_ bool _gdvirtual_##$VARNAME##_call($CALLARGS) $CONST {\\
@@ -36,6 +50,7 @@ proto = """#define GDVIRTUAL$VER($ALIAS $RET m_name $ARG)\\
 				return true;\\
 			}\\
 		}\\
+		$CPPCALL\\
 		$REQCHECK\\
 		$RVOID\\
 		return false;\\
@@ -51,6 +66,7 @@ proto = """#define GDVIRTUAL$VER($ALIAS $RET m_name $ARG)\\
 				return true;\\
 			}\\
 		}\\
+		$CPPHASMETHOD\\
 		return false;\\
 	}\\
 	_FORCE_INLINE_ static MethodInfo _gdvirtual_##$VARNAME##_get_method_info() {\\
@@ -72,6 +88,8 @@ def generate_version(argcount, const=False, returns=False, required=False, compa
     else:
         s = s.replace("$SCRIPTCALL", script_call)
         s = s.replace("$SCRIPTHASMETHOD", script_has_method)
+    s = s.replace("$CPPCALL", cpp_call)
+    s = s.replace("$CPPHASMETHOD", cpp_has_method)
 
     sproto = str(argcount)
     method_info = ""

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -986,6 +986,22 @@ void Object::_gdvirtual_init_method_ptr(uint32_t p_compat_hash, void *&r_fn_ptr,
 	r_fn_ptr = fn_ptr;
 }
 
+bool Object::_gdvirtual_is_method_overridden(const StringName &p_fn_name) const {
+	return ClassDB::has_virtual_method_answer(get_class_name(), p_fn_name);
+}
+
+Variant Object::_gdvirtual_call_method(const StringName &p_fn_name, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+	const MethodBind *mb = ClassDB::get_virtual_method_answer(get_class_name(), p_fn_name);
+	if (!mb) {
+		r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
+		return Variant();
+	}
+
+	OBJ_DEBUG_LOCK
+
+	return mb->call(this, p_args, p_argcount, r_error);
+}
+
 void Object::_notification_forward(int p_notification) {
 	// Notify classes starting with Object and ending with most derived subclass.
 	// e.g. Object -> Node -> Node3D

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -521,6 +521,8 @@ protected:
 
 	// Used in gdvirtual.gen.h
 	void _gdvirtual_init_method_ptr(uint32_t p_compat_hash, void *&r_fn_ptr, const StringName &p_fn_name, bool p_compat) const;
+	bool _gdvirtual_is_method_overridden(const StringName &p_fn_name) const;
+	Variant _gdvirtual_call_method(const StringName &p_fn_name, const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 
 	friend class GDExtensionMethodBind;
 	_ALWAYS_INLINE_ const ObjectGDExtension *_get_extension() const { return _extension; }

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -47,7 +47,7 @@ static inline Color _select_color(const Color &p_override_color, const Color &p_
 	return p_override_color.a > 0 ? p_override_color : p_default_color;
 }
 
-Size2 TabBar::get_minimum_size() const {
+Size2 TabBar::_get_minimum_size() const {
 	Size2 ms;
 	Size2 combined_max = get_combined_maximum_size();
 
@@ -2338,6 +2338,8 @@ void TabBar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_deselect_enabled", "enabled"), &TabBar::set_deselect_enabled);
 	ClassDB::bind_method(D_METHOD("get_deselect_enabled"), &TabBar::get_deselect_enabled);
 	ClassDB::bind_method(D_METHOD("clear_tabs"), &TabBar::clear_tabs);
+
+	ClassDB::bind_virtual_method_answer("_get_minimum_size", &TabBar::_get_minimum_size);
 
 	ADD_SIGNAL(MethodInfo("tab_selected", PropertyInfo(Variant::INT, "tab")));
 	ADD_SIGNAL(MethodInfo("tab_changed", PropertyInfo(Variant::INT, "tab")));

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -210,6 +210,8 @@ private:
 	void _accessibility_action_scroll_into_view(const Variant &p_data, int p_index);
 	void _accessibility_action_focus(const Variant &p_data, int p_index);
 
+	Size2 _get_minimum_size() const;
+
 protected:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	virtual String get_tooltip(const Point2 &p_pos) const override;
@@ -345,7 +347,6 @@ public:
 	void set_switch_on_release(bool p_switch) { switch_on_release = p_switch; }
 
 	Rect2 get_tab_rect(int p_tab) const;
-	Size2 get_minimum_size() const override;
 	Size2 get_desired_size() const override;
 
 	TabBar();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/15456

With these changes, engine methods can be defined as answering GDVirtual calls.
This lets us migrate some methods in derived types from hard overrides to the virtual chain, letting users override that behavior.

<table>
<tr> <td> </td> <td> Before </td> <td> After </td> <td> Diff </td> </tr>
<tr> <td> 

`base_class.h` </td> 
<td>

```cpp
class BaseClass : public Object {
public:
  virtual void virtual_method();
  GDVIRTUAL0(_virtual_method)
}
```
</td>
<td>

```cpp
class BaseClass : public Object {
public:
  void virtual_method();
  GDVIRTUAL0(_virtual_method)
}
```
</td>
<td> 

The `virtual_method` is no longer defined as a C++ virtual method. </td> </tr>
<tr> <td>

`base_class.cpp` </td>
<td>

```cpp
void BaseClass::virtual_method() {
  GDVIRTUAL_CALL(_virtual_method);
}

void BaseClass::_bind_methods() {
  ClassDB::bind_method( \
      D_METHOD("virtual_method"), \
      &BaseClass::virtual_method);
  GDVIRTUAL_BIND(_virtual_method, \
      "_virtual_method");
```
</td>
<td>

```cpp
void BaseClass::virtual_method() {
  GDVIRTUAL_CALL(_virtual_method);
}

void BaseClass::_bind_methods() {
  ClassDB::bind_method( \
      D_METHOD("virtual_method"), \
      &BaseClass::virtual_method);
  GDVIRTUAL_BIND(_virtual_method, \
      "_virtual_method");
```
</td>
<td> Nothing changes. </td> </tr>
<tr> <td>

`derived_class.h` </td>
<td>

```cpp
class DerivedClass : public BaseClass {
public:
  virtual void virtual_method() override;
}
```
</td>
<td>

```cpp
class DerivedClass : public BaseClass {
private:
  void _virtual_method();
}
```
</td>
<td>

The `virtual_method()` gets replaced with a private `_virtual_method()`. </td> </tr>
<tr> <td>

`derived_class.cpp` </td>
<td>

```cpp
void DerivedClass::virtual_method() {
  // DerivedClass's implementation
}
```
</td>
<td>

```cpp
void DerivedClass::_virtual_method() {
  // DerivedClass's implementation
}

void DerivedClass::_bind_methods() {
  ClassDB::bind_virtual_method_answer( \
      "_virtual_method", \
      &DerivedClass::_virtual_method);
}
```
</td>
<td>

The now-private `_virtual_method()` is bound as an answer method in `_bind_methods()`. </td> </tr>
<tr> <td>

`my_base_class.gd` </td>
<td>

```gdscript
extends BaseClass

func _virtual_method() -> void:
  # Custom implementation
  # Will get called
```
</td>
<td>

```gdscript
extends BaseClass

func _virtual_method() -> void:
  # Custom implementation
  # Will get called
```
</td>
<td> Nothing changes. </td> </tr>
<tr> <td>

`my_derived_class.gd` </td>
<td>

```gdscript
extends DerivedClass

func _virtual_method() -> void:
  # Custom implementation
  # Will never get called
```
</td>
<td>

```gdscript
extends DerivedClass

func _virtual_method() -> void:
  # Custom implementation
  # Will get called
```
</td>
<td>

The user-defined override of `_virtual_method` in a class extending `DerivedClass` now gets called.
</td> </tr>
</table>

For example, the following is currently not possible:
```gdscript
class_name MySuperCoolTabBar
extends TabBar

func _get_minimum_size() -> Vector2:
  # Compute minimum size of MySuperCoolTabBar
  return ms
```
since the user-defined `_get_minimum_size()` does not get called as `TabBar`'s override of `get_minimum_size()` does not call the GDVirtual method.
This prevents users from deriving `TabBar` to create their own stylized subclass that returns a different (likely larger) dynamic minimum size than the default `TabBar` class.
This applies to most `Control` subtypes, preventing users from using our engine-defined classes as bases for their own custom classes.

## Additional information

In debug builds, these "answering methods" are checked against the registered `GDVIRTUAL` methods to ensure argument parity.

Ideally, we would have engine tests for this behavior; however, I'm not sure which test suite to put them in. Ideal test coverage would include calling from C++, GDExtension, and a script language (GDScript). 

Currently, as shown in the test project, GDScript throws an error when trying to call `super._virtual_method()` if the `super` type is an engine class, saying it isn't implemented. Ideally, it would check whether the declared super type implements it; I'm not familiar enough with GDScript internals to fix that myself. 
We obviously cannot check whether the `Object` it gets added to at runtime implements it either; however, that is not necessary, since the call will go through if any type up the hierarchy (including the declared super type in the script) answers it. 
This creates a one-way limitation: a user declaring a script that extends type A but attaches it to type B (a descendant of type A) cannot use `super._virtual_method()` if only type B defines an answer, but not type A. This is, in my opinion, a perfectly reasonable limitation.

This is applied to `TabBar`'s implementation of `_get_minimum_size()` in the example commit 2 (which will be removed before merge), and can be tested using the associated basic test project: 
[test-virtuals.zip](https://github.com/user-attachments/files/31601076/test-virtuals.zip)

Prime targets for migrating to this new system would be the `get_minimum_size()` and `get_maximum_size()` overrides in `Control` types, as well as `get_desired_size()` (currently internal only, but not for long). Certain notifications, like `Container::SORT_CHILDREN`, would do better as virtual chains too, letting users choose whether and when to use the super type's implementation in their own implementation. 
I don't know which other areas of the engine would benefit, since I am most familiar with the GUI elements, but I am sure users can find other use cases.

The naming scheme is not final in any way, it's what I felt represented the chain the best, but it is not standard (typically these would be called overrides/implementations). 

The storage of the methods is currently implemented in `ClassDB` since virtual methods as a whole are stored there at the moment. I would be more than willing to migrate it all to `GDType`, either as a PR before this one or as a follow-up if that is the approach we want to pursue.