### PR TITLE
Add `scene_painted` signal to `ScenePaint2DEditor`

### DIFF
--- a/doc/classes/ScenePaint2DEditor.xml
+++ b/doc/classes/ScenePaint2DEditor.xml
@@ -43,4 +43,26 @@
 			</description>
 		</method>
 	</methods>
+	<signals>
+		<signal name="scene_painted">
+			<param index="0" name="node" type="Node2D" />
+			<description>
+				Emitted for each new node created during drawing.
+				[b]Example:[/b]
+				[codeblocks]
+				[gdscript]
+				@tool
+				extends EditorPlugin
+
+				func _enter_tree():
+					EditorInterface.get_scene_paint_2d().scene_painted.connect(_on_scene_painted)
+
+				func _on_scene_painted(node: Node2D):
+					# Set random rotation when drawing nodes.
+					node.rotation = randf_range(0, 360)
+				[/gdscript]
+				[/codeblocks]
+			</description>
+		</signal>
+	</signals>
 </class>

--- a/editor/scene/2d/scene_paint_2d_editor_plugin.cpp
+++ b/editor/scene/2d/scene_paint_2d_editor_plugin.cpp
@@ -403,6 +403,7 @@ void ScenePaint2DEditor::_add_node_at_pos() {
 		undo_redo->add_do_method(node_2d, "set_global_position", pos);
 		undo_redo->add_undo_method(node, "remove_child", node_2d);
 		undo_redo->commit_action(false);
+		emit_signal(SNAME("scene_painted"), node_2d);
 	}
 
 	CanvasItemEditor::get_singleton()->update_viewport();
@@ -763,6 +764,7 @@ void ScenePaint2DEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("unregister_scene_provider", "control"), &ScenePaint2DEditor::unregister_scene_provider);
 	ClassDB::bind_method(D_METHOD("set_painted_scene", "scene"), &ScenePaint2DEditor::set_painted_scene);
 	ClassDB::bind_method(D_METHOD("get_painted_scene"), &ScenePaint2DEditor::get_painted_scene);
+	ADD_SIGNAL(MethodInfo("scene_painted", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_RESOURCE_TYPE, Node2D::get_class_static())));
 }
 
 void ScenePaint2DEditor::_notification(int p_what) {


### PR DESCRIPTION
Adds a new signal to `ScenePaint2DEditor` that is emitted when drawing, as discussed with KoBeWi [here](https://github.com/godotengine/godot-proposals/issues/15439#issuecomment-5462806287).

This allows you to conveniently control how nodes are created, such as random rotation, scale, color, and so on.

Example:
```
@tool
extends Node2D

var _paint_editor

func _enter_tree() -> void:
	_paint_editor = EditorInterface.get_scene_paint_2d()
	_paint_editor.connect("scene_painted", _on_scene_painted)

func _on_scene_painted(node: Node2D) -> void:
	print(node.name)
	node.rotation = randf_range(0,360)
	var sc_rnd = randf_range(0.5,1.5)
	node.scale =  Vector2(sc_rnd,sc_rnd)
	node.modulate = Color(randf_range(0,1),randf_range(0,1),randf_range(0,1))
```

## What problem(s) does this PR solve?

- Closes [Add the ability to randomize rotation and scale in 2D node drawing mode](https://github.com/godotengine/godot-proposals/issues/15439)

For level designers and artists, there's also an additional PR (#122859 )  that removes the need for programming.
