### PR TITLE
Fix audio muting in AnimationMixer when blending animations

### DIFF
--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -36,6 +36,7 @@
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/string/string_name.h"
+#include "core/typedefs.h"
 #include "scene/2d/audio_stream_player_2d.h"
 #include "scene/animation/animation_player.h"
 #include "scene/audio/audio_stream_player.h"
@@ -2028,7 +2029,7 @@ void AnimationMixer::_blend_apply() {
 				LocalVector<ObjectID> erase_maps;
 				for (KeyValue<ObjectID, PlayingAudioTrackInfo> &L : t->playing_streams) {
 					PlayingAudioTrackInfo &track_info = L.value;
-					float db = Math::linear_to_db(track_info.use_blend ? track_info.volume : 1.0);
+					float db = Math::linear_to_db(track_info.use_blend ? CLAMP(track_info.volume, 0.0f, 1.0f) : 1.0);
 					LocalVector<int> erase_streams;
 					AHashMap<int, PlayingAudioStreamInfo> &map = track_info.stream_info;
 					for (const KeyValue<int, PlayingAudioStreamInfo> &M : map) {

--- a/scene/animation/animation_mixer.cpp
+++ b/scene/animation/animation_mixer.cpp
@@ -36,7 +36,6 @@
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
 #include "core/string/string_name.h"
-#include "core/typedefs.h"
 #include "scene/2d/audio_stream_player_2d.h"
 #include "scene/animation/animation_player.h"
 #include "scene/audio/audio_stream_player.h"


### PR DESCRIPTION
## What problem(s) does this PR solve?

When blending animations with audio tracks in a **BlendSpace2D**, the audio volume can become a very small negative number. This happens because of small rounding errors in the blend calculation near the edges of the triangulation. When this negative number is passed to `Math::linear_to_db()`, it produces `NaN`. Because `NaN` spreads to everything it touches in the audio mix, this makes all audio go silent. Calling `AnimationMixer::clear_caches() `fixes it temporarily by rebuilding the audio cache.

- Closes #109119

## Additional information

**AI disclosure:** I used GitHub Copilot while investigating this issue reading through AudioServer/AnimationMixer/AudioStreamPlaybackPolyphonic source, and testing hypotheses about the root cause. 
I confirmed the root cause and the fix myself through myown debugging and testing in my own project.