### PR TITLE
Allow Texture2DRD to specify RG8 texture semantics

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -4052,10 +4052,12 @@
 			<return type="RID" />
 			<param index="0" name="rd_texture" type="RID" />
 			<param index="1" name="layer_type" type="int" enum="RenderingServer.TextureLayeredType" default="0" />
+			<param index="2" name="format_hint" type="int" enum="Image.Format" default="49" />
 			<description>
 				Creates a new texture object based on a texture created directly on the [RenderingDevice]. If the texture contains layers, [param layer_type] is used to define the layer type.
 				Once finished with your RID, you will want to free the RID using the RenderingServer's [method free_rid] method.
 				[b]Note:[/b] The RenderingServer's [method free_rid] won't free the underlying [param rd_texture], you will want to free the [param rd_texture] using [method RenderingDevice.free_rid].
+				[b]Note:[/b] If [param format_hint] is [constant Image.FORMAT_RG8] and [param rd_texture] has format [constant RenderingDevice.DATA_FORMAT_R8G8_UNORM], the resulting texture is sampled using RG semantics.
 			</description>
 		</method>
 		<method name="texture_replace">

--- a/doc/classes/Texture2DRD.xml
+++ b/doc/classes/Texture2DRD.xml
@@ -12,6 +12,9 @@
 	</tutorials>
 	<members>
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="false" />
+		<member name="rg8_semantics" type="bool" setter="set_rg8_semantics" getter="get_rg8_semantics" default="false">
+			If [code]true[/code], [member texture_rd_rid] textures are sampled with format [constant RenderingDevice.DATA_FORMAT_R8G8_UNORM] using RG semantics.
+		</member>
 		<member name="texture_rd_rid" type="RID" setter="set_texture_rd_rid" getter="get_texture_rd_rid">
 			The RID of the texture object created on the [RenderingDevice].
 		</member>

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1992,7 +1992,7 @@ Size2 TextureStorage::texture_size_with_proxy(RID p_texture) {
 	}
 }
 
-void TextureStorage::texture_rd_initialize(RID p_texture, const RID &p_rd_texture, const RSE::TextureLayeredType p_layer_type) {
+void TextureStorage::texture_rd_initialize(RID p_texture, const RID &p_rd_texture, const RSE::TextureLayeredType p_layer_type, Image::Format p_format_hint) {
 }
 
 RID TextureStorage::texture_get_rd_texture(RID p_texture, bool p_srgb) const {

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -716,7 +716,7 @@ public:
 
 	virtual Size2 texture_size_with_proxy(RID p_proxy) override;
 
-	virtual void texture_rd_initialize(RID p_texture, const RID &p_rd_texture, const RSE::TextureLayeredType p_layer_type = RSE::TEXTURE_LAYERED_2D_ARRAY) override;
+	virtual void texture_rd_initialize(RID p_texture, const RID &p_rd_texture, const RSE::TextureLayeredType p_layer_type = RSE::TEXTURE_LAYERED_2D_ARRAY, Image::Format p_format_hint = Image::FORMAT_MAX) override;
 	virtual RID texture_get_rd_texture(RID p_texture, bool p_srgb = false) const override;
 	virtual uint64_t texture_get_native_handle(RID p_texture, bool p_srgb = false) const override;
 

--- a/misc/extension_api_validation/4.7-stable/GH-122983.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-122983.txt
@@ -1,0 +1,7 @@
+GH-122983
+--------------
+
+Validate extension JSON: Error: Field 'classes/RenderingServer/methods/texture_rd_create/arguments': size changed value in new API, from 2 to 3.
+
+Added optional "format_hint" argument to texture_rd_create.
+Compatibility method registered.

--- a/scene/resources/texture_rd.cpp
+++ b/scene/resources/texture_rd.cpp
@@ -42,6 +42,10 @@ void Texture2DRD::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_texture_rd_rid", "texture_rd_rid"), &Texture2DRD::set_texture_rd_rid);
 	ClassDB::bind_method(D_METHOD("get_texture_rd_rid"), &Texture2DRD::get_texture_rd_rid);
 
+	ClassDB::bind_method(D_METHOD("set_rg8_semantics", "rg8_semantics"), &Texture2DRD::set_rg8_semantics);
+	ClassDB::bind_method(D_METHOD("get_rg8_semantics"), &Texture2DRD::get_rg8_semantics);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "rg8_semantics"), "set_rg8_semantics", "get_rg8_semantics");
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "texture_rd_rid", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_texture_rd_rid", "get_texture_rd_rid");
 }
 
@@ -51,6 +55,21 @@ int Texture2DRD::get_width() const {
 
 int Texture2DRD::get_height() const {
 	return size.height;
+}
+
+void Texture2DRD::set_rg8_semantics(bool p_rg8_semantics) {
+	if (rg8_semantics == p_rg8_semantics) {
+		return;
+	}
+	rg8_semantics = p_rg8_semantics;
+	if (texture_rd_rid.is_valid()) {
+		set_texture_rd_rid(texture_rd_rid); // recreate to ensure that the semantics are correct
+	}
+	emit_changed();
+}
+
+bool Texture2DRD::get_rg8_semantics() const {
+	return rg8_semantics;
 }
 
 RID Texture2DRD::get_rid() const {
@@ -104,10 +123,12 @@ void Texture2DRD::_set_texture_rd_rid(RID p_texture_rd_rid) {
 
 	texture_rd_rid = p_texture_rd_rid;
 
+	const Image::Format format_hint = rg8_semantics ? Image::FORMAT_RG8 : Image::FORMAT_MAX;
+
 	if (texture_rid.is_valid()) {
-		RS::get_singleton()->texture_replace(texture_rid, RS::get_singleton()->texture_rd_create(p_texture_rd_rid));
+		RS::get_singleton()->texture_replace(texture_rid, RS::get_singleton()->texture_rd_create(p_texture_rd_rid, RSE::TEXTURE_LAYERED_2D_ARRAY, format_hint));
 	} else {
-		texture_rid = RS::get_singleton()->texture_rd_create(p_texture_rd_rid);
+		texture_rid = RS::get_singleton()->texture_rd_create(p_texture_rd_rid, RSE::TEXTURE_LAYERED_2D_ARRAY, format_hint);
 	}
 
 	notify_property_list_changed();

--- a/scene/resources/texture_rd.h
+++ b/scene/resources/texture_rd.h
@@ -44,6 +44,7 @@ class Texture2DRD : public Texture2D {
 	mutable RID texture_rid;
 	RID texture_rd_rid;
 	Size2i size;
+	bool rg8_semantics = false;
 
 protected:
 	static void _bind_methods();
@@ -53,6 +54,9 @@ public:
 	virtual int get_height() const override;
 	virtual RID get_rid() const override;
 	virtual bool has_alpha() const override;
+
+	void set_rg8_semantics(bool p_rg8_semantics);
+	bool get_rg8_semantics() const;
 
 	virtual Ref<Image> get_image() const override;
 

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -135,7 +135,7 @@ public:
 
 	virtual Size2 texture_size_with_proxy(RID p_proxy) override { return Size2(); }
 
-	virtual void texture_rd_initialize(RID p_texture, const RID &p_rd_texture, const RSE::TextureLayeredType p_layer_type = RSE::TEXTURE_LAYERED_2D_ARRAY) override {}
+	virtual void texture_rd_initialize(RID p_texture, const RID &p_rd_texture, const RSE::TextureLayeredType p_layer_type = RSE::TEXTURE_LAYERED_2D_ARRAY, Image::Format p_format_hint = Image::FORMAT_MAX) override {}
 	virtual RID texture_get_rd_texture(RID p_texture, bool p_srgb = false) const override { return RID(); }
 	virtual uint64_t texture_get_native_handle(RID p_texture, bool p_srgb = false) const override { return 0; }
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -2228,7 +2228,7 @@ Size2 TextureStorage::texture_size_with_proxy(RID p_proxy) {
 	return texture_2d_get_size(p_proxy);
 }
 
-void TextureStorage::texture_rd_initialize(RID p_texture, const RID &p_rd_texture, const RSE::TextureLayeredType p_layer_type) {
+void TextureStorage::texture_rd_initialize(RID p_texture, const RID &p_rd_texture, const RSE::TextureLayeredType p_layer_type, Image::Format p_format_hint) {
 	ERR_FAIL_COND(!RD::get_singleton()->texture_is_valid(p_rd_texture));
 
 	// TODO : investigate if we can support this, will need to be able to obtain the order and obtain the slice info
@@ -2240,6 +2240,13 @@ void TextureStorage::texture_rd_initialize(RID p_texture, const RID &p_rd_textur
 	TextureFromRDFormat imfmt;
 	_texture_format_from_rd(tf.format, imfmt);
 	ERR_FAIL_COND(imfmt.image_format == Image::FORMAT_MAX);
+	if (p_format_hint == Image::FORMAT_RG8 && tf.format == RD::DATA_FORMAT_R8G8_UNORM) {
+		imfmt.image_format = Image::FORMAT_RG8;
+		imfmt.swizzle_r = RD::TEXTURE_SWIZZLE_R;
+		imfmt.swizzle_g = RD::TEXTURE_SWIZZLE_G;
+		imfmt.swizzle_b = RD::TEXTURE_SWIZZLE_ZERO;
+		imfmt.swizzle_a = RD::TEXTURE_SWIZZLE_ONE;
+	}
 
 	Texture texture;
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -642,7 +642,7 @@ public:
 
 	virtual Size2 texture_size_with_proxy(RID p_proxy) override;
 
-	virtual void texture_rd_initialize(RID p_texture, const RID &p_rd_texture, const RSE::TextureLayeredType p_layer_type = RSE::TEXTURE_LAYERED_2D_ARRAY) override;
+	virtual void texture_rd_initialize(RID p_texture, const RID &p_rd_texture, const RSE::TextureLayeredType p_layer_type = RSE::TEXTURE_LAYERED_2D_ARRAY, Image::Format p_format_hint = Image::FORMAT_MAX) override;
 
 	virtual RID texture_get_rd_texture(RID p_texture, bool p_srgb = false) const override;
 	virtual uint64_t texture_get_native_handle(RID p_texture, bool p_srgb = false) const override;

--- a/servers/rendering/rendering_server.compat.inc
+++ b/servers/rendering/rendering_server.compat.inc
@@ -70,6 +70,10 @@ void RenderingServer::_particles_request_process_time_bind_compat_109142(RID p_p
 	particles_request_process_time(p_particles, p_request_process_time, 0.0);
 }
 
+RID RenderingServer::_texture_rd_create_bind_compat_122983(RID p_rd_texture, RSE::TextureLayeredType p_layer_type) {
+	return texture_rd_create(p_rd_texture, p_layer_type, Image::FORMAT_MAX);
+}
+
 void RenderingServer::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("multimesh_allocate_data", "multimesh", "instances", "transform_format", "color_format", "custom_data_format"), &RenderingServer::_multimesh_allocate_data_bind_compat_99455, DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_compatibility_method(D_METHOD("environment_set_fog", "env", "enable", "light_color", "light_energy", "sun_scatter", "density", "height", "height_density", "aerial_perspective", "sky_affect"), &RenderingServer::_environment_set_fog_bind_compat_84792);
@@ -80,6 +84,7 @@ void RenderingServer::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("instance_reset_physics_interpolation", "instance"), &RenderingServer::_instance_reset_physics_interpolation_bind_compat_104269);
 	ClassDB::bind_compatibility_method(D_METHOD("viewport_set_size", "viewport", "width", "height"), &RenderingServer::_viewport_set_size_bind_compat_115799);
 	ClassDB::bind_compatibility_method(D_METHOD("particles_request_process_time", "particles", "process_time"), &RenderingServer::_particles_request_process_time_bind_compat_109142);
+	ClassDB::bind_compatibility_method(D_METHOD("texture_rd_create", "rd_texture", "layer_type"), &RenderingServer::_texture_rd_create_bind_compat_122983, DEFVAL(RSE::TEXTURE_LAYERED_2D_ARRAY));
 }
 
 #endif // DISABLE_DEPRECATED

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -2297,7 +2297,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("texture_get_format", "texture"), &RenderingServer::texture_get_format);
 
 	ClassDB::bind_method(D_METHOD("texture_set_force_redraw_if_visible", "texture", "enable"), &RenderingServer::texture_set_force_redraw_if_visible);
-	ClassDB::bind_method(D_METHOD("texture_rd_create", "rd_texture", "layer_type"), &RenderingServer::texture_rd_create, DEFVAL(RSE::TEXTURE_LAYERED_2D_ARRAY));
+	ClassDB::bind_method(D_METHOD("texture_rd_create", "rd_texture", "layer_type", "format_hint"), &RenderingServer::texture_rd_create, DEFVAL(RSE::TEXTURE_LAYERED_2D_ARRAY), DEFVAL(Image::FORMAT_MAX));
 	ClassDB::bind_method(D_METHOD("texture_get_rd_texture", "texture", "srgb"), &RenderingServer::texture_get_rd_texture, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("texture_get_native_handle", "texture", "srgb"), &RenderingServer::texture_get_native_handle, DEFVAL(false));
 

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -97,6 +97,7 @@ protected:
 	void _instance_reset_physics_interpolation_bind_compat_104269(RID p_instance);
 	void _viewport_set_size_bind_compat_115799(RID p_viewport, int p_width, int p_height);
 	void _particles_request_process_time_bind_compat_109142(RID p_particles, real_t p_request_process_time);
+	RID _texture_rd_create_bind_compat_122983(RID p_rd_texture, RSE::TextureLayeredType p_layer_type);
 
 	static void _bind_compatibility_methods();
 #endif
@@ -156,7 +157,7 @@ public:
 
 	virtual void texture_set_force_redraw_if_visible(RID p_texture, bool p_enable) = 0;
 
-	virtual RID texture_rd_create(const RID &p_rd_texture, const RSE::TextureLayeredType p_layer_type = RSE::TEXTURE_LAYERED_2D_ARRAY) = 0;
+	virtual RID texture_rd_create(const RID &p_rd_texture, const RSE::TextureLayeredType p_layer_type = RSE::TEXTURE_LAYERED_2D_ARRAY, Image::Format p_format_hint = Image::FORMAT_MAX) = 0;
 	virtual RID texture_get_rd_texture(RID p_texture, bool p_srgb = false) const = 0;
 	virtual uint64_t texture_get_native_handle(RID p_texture, bool p_srgb = false) const = 0;
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -264,7 +264,7 @@ public:
 	FUNC1(texture_debug_usage, List<RenderingServerTypes::TextureInfo> *)
 
 	FUNC2(texture_set_force_redraw_if_visible, RID, bool)
-	FUNCRIDTEX2(texture_rd, const RID &, const RSE::TextureLayeredType)
+	FUNCRIDTEX3(texture_rd, const RID &, const RSE::TextureLayeredType, Image::Format)
 	FUNC2RC(RID, texture_get_rd_texture, RID, bool)
 	FUNC2RC(uint64_t, texture_get_native_handle, RID, bool)
 

--- a/servers/rendering/storage/texture_storage.h
+++ b/servers/rendering/storage/texture_storage.h
@@ -112,7 +112,7 @@ public:
 
 	virtual Size2 texture_size_with_proxy(RID p_proxy) = 0;
 
-	virtual void texture_rd_initialize(RID p_texture, const RID &p_rd_texture, const RSE::TextureLayeredType p_layer_type = RSE::TEXTURE_LAYERED_2D_ARRAY) = 0;
+	virtual void texture_rd_initialize(RID p_texture, const RID &p_rd_texture, const RSE::TextureLayeredType p_layer_type = RSE::TEXTURE_LAYERED_2D_ARRAY, Image::Format p_format_hint = Image::FORMAT_MAX) = 0;
 	virtual RID texture_get_rd_texture(RID p_texture, bool p_srgb = false) const = 0;
 	virtual uint64_t texture_get_native_handle(RID p_texture, bool p_srgb = false) const = 0;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #122954

## Additional information

**Summary of changes:**

- added a rg8_semantics boolean to the Texture2DRD that would resolve the ambiguity between semantics.
- documented the new changes in the Texture2DRD and RenderingServer docs