### PR TITLE
`GodotPhysics3D`: Use `LocalVector` where CoW is not needed

### DIFF
--- a/modules/godot_physics_3d/godot_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_body_3d.cpp
@@ -481,7 +481,7 @@ void GodotBody3D::integrate_forces(real_t p_step) {
 
 	ERR_FAIL_NULL(get_space());
 
-	int ac = areas.size();
+	uint32_t ac = areas.size();
 
 	bool gravity_done = false;
 	bool linear_damp_done = false;
@@ -497,7 +497,7 @@ void GodotBody3D::integrate_forces(real_t p_step) {
 	// Combine gravity and damping from overlapping areas in priority order.
 	if (ac) {
 		areas.sort();
-		const AreaCMP *aa = &areas[0];
+		const AreaCMP *aa = areas.ptr();
 		for (int i = ac - 1; i >= 0 && !stopped; i--) {
 			if (!gravity_done) {
 				PS3DE::AreaSpaceOverrideMode area_gravity_mode = (PS3DE::AreaSpaceOverrideMode)(int)aa[i].area->get_param(PS3DE::AREA_PARAM_GRAVITY_OVERRIDE_MODE);

--- a/modules/godot_physics_3d/godot_body_3d.h
+++ b/modules/godot_physics_3d/godot_body_3d.h
@@ -114,7 +114,7 @@ class GodotBody3D : public GodotCollisionObject3D {
 
 	HashMap<GodotConstraint3D *, int> constraint_map;
 
-	Vector<AreaCMP> areas;
+	LocalVector<AreaCMP> areas;
 
 	struct Contact {
 		Vector3 local_pos;
@@ -130,7 +130,7 @@ class GodotBody3D : public GodotCollisionObject3D {
 		Vector3 impulse;
 	};
 
-	Vector<Contact> contacts; //no contacts by default
+	LocalVector<Contact> contacts; // No contacts by default.
 	int contact_count = 0;
 
 	Callable body_state_callback;
@@ -159,7 +159,7 @@ public:
 	_FORCE_INLINE_ void add_area(GodotArea3D *p_area) {
 		int index = areas.find(AreaCMP(p_area));
 		if (index > -1) {
-			areas.write[index].refCount += 1;
+			areas[index].refCount += 1;
 		} else {
 			areas.ordered_insert(AreaCMP(p_area));
 		}
@@ -168,7 +168,7 @@ public:
 	_FORCE_INLINE_ void remove_area(GodotArea3D *p_area) {
 		int index = areas.find(AreaCMP(p_area));
 		if (index > -1) {
-			areas.write[index].refCount -= 1;
+			areas[index].refCount -= 1;
 			if (areas[index].refCount < 1) {
 				areas.remove_at(index);
 			}
@@ -357,7 +357,7 @@ void GodotBody3D::add_contact(const Vector3 &p_local_pos, const Vector3 &p_local
 		return;
 	}
 
-	Contact *c = contacts.ptrw();
+	Contact *c = contacts.ptr();
 
 	int idx = -1;
 

--- a/modules/godot_physics_3d/godot_collision_object_3d.cpp
+++ b/modules/godot_physics_3d/godot_collision_object_3d.cpp
@@ -48,10 +48,10 @@ void GodotCollisionObject3D::add_shape(GodotShape3D *p_shape, const Transform3D 
 	}
 }
 
-void GodotCollisionObject3D::set_shape(int p_index, GodotShape3D *p_shape) {
-	ERR_FAIL_INDEX(p_index, shapes.size());
+void GodotCollisionObject3D::set_shape(uint32_t p_index, GodotShape3D *p_shape) {
+	ERR_FAIL_UNSIGNED_INDEX(p_index, shapes.size());
 	shapes[p_index].shape->remove_owner(this);
-	shapes.write[p_index].shape = p_shape;
+	shapes[p_index].shape = p_shape;
 
 	p_shape->add_owner(this);
 	if (!pending_shape_update_list.in_list()) {
@@ -59,20 +59,20 @@ void GodotCollisionObject3D::set_shape(int p_index, GodotShape3D *p_shape) {
 	}
 }
 
-void GodotCollisionObject3D::set_shape_transform(int p_index, const Transform3D &p_transform) {
-	ERR_FAIL_INDEX(p_index, shapes.size());
+void GodotCollisionObject3D::set_shape_transform(uint32_t p_index, const Transform3D &p_transform) {
+	ERR_FAIL_UNSIGNED_INDEX(p_index, shapes.size());
 
-	shapes.write[p_index].xform = p_transform;
-	shapes.write[p_index].xform_inv = p_transform.affine_inverse();
+	shapes[p_index].xform = p_transform;
+	shapes[p_index].xform_inv = p_transform.affine_inverse();
 	if (!pending_shape_update_list.in_list()) {
 		GodotPhysicsServer3D::godot_singleton->pending_shape_update_list.add(&pending_shape_update_list);
 	}
 }
 
-void GodotCollisionObject3D::set_shape_disabled(int p_idx, bool p_disabled) {
-	ERR_FAIL_INDEX(p_idx, shapes.size());
+void GodotCollisionObject3D::set_shape_disabled(uint32_t p_idx, bool p_disabled) {
+	ERR_FAIL_UNSIGNED_INDEX(p_idx, shapes.size());
 
-	GodotCollisionObject3D::Shape &shape = shapes.write[p_idx];
+	GodotCollisionObject3D::Shape &shape = shapes[p_idx];
 	if (shape.disabled == p_disabled) {
 		return;
 	}
@@ -97,25 +97,25 @@ void GodotCollisionObject3D::set_shape_disabled(int p_idx, bool p_disabled) {
 }
 
 void GodotCollisionObject3D::remove_shape(GodotShape3D *p_shape) {
-	//remove a shape, all the times it appears
-	for (int i = 0; i < shapes.size(); i++) {
+	// Remove a shape, all the times it appears.
+	for (uint32_t i = 0; i < shapes.size(); i++) {
 		if (shapes[i].shape == p_shape) {
-			remove_shape(i);
+			remove_shape_by_index(i);
 			i--;
 		}
 	}
 }
 
-void GodotCollisionObject3D::remove_shape(int p_index) {
-	//remove anything from shape to be erased to end, so subindices don't change
-	ERR_FAIL_INDEX(p_index, shapes.size());
-	for (int i = p_index; i < shapes.size(); i++) {
+void GodotCollisionObject3D::remove_shape_by_index(uint32_t p_index) {
+	// Remove anything from shape to be erased to end, so subindices don't change.
+	ERR_FAIL_UNSIGNED_INDEX(p_index, shapes.size());
+	for (uint32_t i = p_index; i < shapes.size(); i++) {
 		if (shapes[i].bpid == 0) {
 			continue;
 		}
 		//should never get here with a null owner
 		space->get_broadphase()->remove(shapes[i].bpid);
-		shapes.write[i].bpid = 0;
+		shapes[i].bpid = 0;
 	}
 	shapes[p_index].shape->remove_owner(this);
 	shapes.remove_at(p_index);
@@ -134,8 +134,7 @@ void GodotCollisionObject3D::_set_static(bool p_static) {
 	if (!space) {
 		return;
 	}
-	for (int i = 0; i < get_shape_count(); i++) {
-		const Shape &s = shapes[i];
+	for (Shape &s : shapes) {
 		if (s.bpid > 0) {
 			space->get_broadphase()->set_static(s.bpid, _static);
 		}
@@ -143,8 +142,7 @@ void GodotCollisionObject3D::_set_static(bool p_static) {
 }
 
 void GodotCollisionObject3D::_unregister_shapes() {
-	for (int i = 0; i < shapes.size(); i++) {
-		Shape &s = shapes.write[i];
+	for (Shape &s : shapes) {
 		if (s.bpid > 0) {
 			space->get_broadphase()->remove(s.bpid);
 			s.bpid = 0;
@@ -157,8 +155,8 @@ void GodotCollisionObject3D::_update_shapes() {
 		return;
 	}
 
-	for (int i = 0; i < shapes.size(); i++) {
-		Shape &s = shapes.write[i];
+	for (uint32_t i = 0; i < shapes.size(); i++) {
+		Shape &s = shapes[i];
 		if (s.disabled) {
 			continue;
 		}
@@ -187,8 +185,8 @@ void GodotCollisionObject3D::_update_shapes_with_motion(const Vector3 &p_motion)
 		return;
 	}
 
-	for (int i = 0; i < shapes.size(); i++) {
-		Shape &s = shapes.write[i];
+	for (uint32_t i = 0; i < shapes.size(); i++) {
+		Shape &s = shapes[i];
 		if (s.disabled) {
 			continue;
 		}
@@ -216,8 +214,7 @@ void GodotCollisionObject3D::_set_space(GodotSpace3D *p_space) {
 	if (old_space) {
 		old_space->remove_object(this);
 
-		for (int i = 0; i < shapes.size(); i++) {
-			Shape &s = shapes.write[i];
+		for (Shape &s : shapes) {
 			if (s.bpid) {
 				old_space->get_broadphase()->remove(s.bpid);
 				s.bpid = 0;

--- a/modules/godot_physics_3d/godot_collision_object_3d.h
+++ b/modules/godot_physics_3d/godot_collision_object_3d.h
@@ -69,7 +69,7 @@ private:
 		bool disabled = false;
 	};
 
-	Vector<Shape> shapes;
+	LocalVector<Shape> shapes;
 	GodotSpace3D *space = nullptr;
 	Transform3D transform;
 	Transform3D inv_transform;
@@ -115,27 +115,27 @@ public:
 
 	_FORCE_INLINE_ Type get_type() const { return type; }
 	void add_shape(GodotShape3D *p_shape, const Transform3D &p_transform = Transform3D(), bool p_disabled = false);
-	void set_shape(int p_index, GodotShape3D *p_shape);
-	void set_shape_transform(int p_index, const Transform3D &p_transform);
+	void set_shape(uint32_t p_index, GodotShape3D *p_shape);
+	void set_shape_transform(uint32_t p_index, const Transform3D &p_transform);
 	_FORCE_INLINE_ int get_shape_count() const { return shapes.size(); }
-	_FORCE_INLINE_ GodotShape3D *get_shape(int p_index) const {
-		CRASH_BAD_INDEX(p_index, shapes.size());
+	_FORCE_INLINE_ GodotShape3D *get_shape(uint32_t p_index) const {
+		CRASH_BAD_UNSIGNED_INDEX(p_index, shapes.size());
 		return shapes[p_index].shape;
 	}
-	_FORCE_INLINE_ const Transform3D &get_shape_transform(int p_index) const {
-		CRASH_BAD_INDEX(p_index, shapes.size());
+	_FORCE_INLINE_ const Transform3D &get_shape_transform(uint32_t p_index) const {
+		CRASH_BAD_UNSIGNED_INDEX(p_index, shapes.size());
 		return shapes[p_index].xform;
 	}
-	_FORCE_INLINE_ const Transform3D &get_shape_inv_transform(int p_index) const {
-		CRASH_BAD_INDEX(p_index, shapes.size());
+	_FORCE_INLINE_ const Transform3D &get_shape_inv_transform(uint32_t p_index) const {
+		CRASH_BAD_UNSIGNED_INDEX(p_index, shapes.size());
 		return shapes[p_index].xform_inv;
 	}
-	_FORCE_INLINE_ const AABB &get_shape_aabb(int p_index) const {
-		CRASH_BAD_INDEX(p_index, shapes.size());
+	_FORCE_INLINE_ const AABB &get_shape_aabb(uint32_t p_index) const {
+		CRASH_BAD_UNSIGNED_INDEX(p_index, shapes.size());
 		return shapes[p_index].aabb_cache;
 	}
-	_FORCE_INLINE_ real_t get_shape_area(int p_index) const {
-		CRASH_BAD_INDEX(p_index, shapes.size());
+	_FORCE_INLINE_ real_t get_shape_area(uint32_t p_index) const {
+		CRASH_BAD_UNSIGNED_INDEX(p_index, shapes.size());
 		return shapes[p_index].area_cache;
 	}
 
@@ -146,9 +146,9 @@ public:
 	_FORCE_INLINE_ void set_ray_pickable(bool p_enable) { ray_pickable = p_enable; }
 	_FORCE_INLINE_ bool is_ray_pickable() const { return ray_pickable; }
 
-	void set_shape_disabled(int p_idx, bool p_disabled);
-	_FORCE_INLINE_ bool is_shape_disabled(int p_idx) const {
-		ERR_FAIL_INDEX_V(p_idx, shapes.size(), false);
+	void set_shape_disabled(uint32_t p_idx, bool p_disabled);
+	_FORCE_INLINE_ bool is_shape_disabled(uint32_t p_idx) const {
+		ERR_FAIL_UNSIGNED_INDEX_V(p_idx, shapes.size(), false);
 		return shapes[p_idx].disabled;
 	}
 
@@ -180,7 +180,7 @@ public:
 	}
 
 	void remove_shape(GodotShape3D *p_shape) override;
-	void remove_shape(int p_index);
+	void remove_shape_by_index(uint32_t p_index);
 
 	virtual void set_space(GodotSpace3D *p_space) = 0;
 

--- a/modules/godot_physics_3d/godot_physics_server_3d.cpp
+++ b/modules/godot_physics_3d/godot_physics_server_3d.cpp
@@ -306,7 +306,7 @@ void GodotPhysicsServer3D::area_remove_shape(RID p_area, int p_shape_idx) {
 	GodotArea3D *area = area_owner.get_or_null(p_area);
 	ERR_FAIL_NULL(area);
 
-	area->remove_shape(p_shape_idx);
+	area->remove_shape_by_index(p_shape_idx);
 }
 
 void GodotPhysicsServer3D::area_clear_shapes(RID p_area) {
@@ -314,7 +314,7 @@ void GodotPhysicsServer3D::area_clear_shapes(RID p_area) {
 	ERR_FAIL_NULL(area);
 
 	while (area->get_shape_count()) {
-		area->remove_shape(0);
+		area->remove_shape_by_index(0);
 	}
 }
 
@@ -553,7 +553,7 @@ void GodotPhysicsServer3D::body_remove_shape(RID p_body, int p_shape_idx) {
 	GodotBody3D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_NULL(body);
 
-	body->remove_shape(p_shape_idx);
+	body->remove_shape_by_index(p_shape_idx);
 }
 
 void GodotPhysicsServer3D::body_clear_shapes(RID p_body) {
@@ -561,7 +561,7 @@ void GodotPhysicsServer3D::body_clear_shapes(RID p_body) {
 	ERR_FAIL_NULL(body);
 
 	while (body->get_shape_count()) {
-		body->remove_shape(0);
+		body->remove_shape_by_index(0);
 	}
 }
 
@@ -1634,7 +1634,7 @@ void GodotPhysicsServer3D::free_rid(RID p_rid) {
 		body->set_space(nullptr);
 
 		while (body->get_shape_count()) {
-			body->remove_shape(0);
+			body->remove_shape_by_index(0);
 		}
 
 		body_owner.free(p_rid);
@@ -1652,7 +1652,7 @@ void GodotPhysicsServer3D::free_rid(RID p_rid) {
 		area->set_space(nullptr);
 
 		while (area->get_shape_count()) {
-			area->remove_shape(0);
+			area->remove_shape_by_index(0);
 		}
 
 		area_owner.free(p_rid);

--- a/modules/godot_physics_3d/godot_shape_3d.cpp
+++ b/modules/godot_physics_3d/godot_shape_3d.cpp
@@ -1273,11 +1273,11 @@ Vector<Vector3> GodotConcavePolygonShape3D::get_faces() const {
 	Vector<Vector3> rfaces;
 	rfaces.resize(faces.size() * 3);
 
-	for (int i = 0; i < faces.size(); i++) {
-		Face f = faces.get(i);
+	for (uint32_t i = 0; i < faces.size(); i++) {
+		Face f = faces[i];
 
 		for (int j = 0; j < 3; j++) {
-			rfaces.set(i * 3 + j, vertices.get(f.indices[j]));
+			rfaces.set(i * 3 + j, vertices[f.indices[j]]);
 		}
 	}
 
@@ -1285,7 +1285,7 @@ Vector<Vector3> GodotConcavePolygonShape3D::get_faces() const {
 }
 
 void GodotConcavePolygonShape3D::project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const {
-	int count = vertices.size();
+	uint32_t count = vertices.size();
 	if (count == 0) {
 		r_min = 0;
 		r_max = 0;
@@ -1293,7 +1293,7 @@ void GodotConcavePolygonShape3D::project_range(const Vector3 &p_normal, const Tr
 	}
 	const Vector3 *vptr = vertices.ptr();
 
-	for (int i = 0; i < count; i++) {
+	for (uint32_t i = 0; i < count; i++) {
 		real_t d = p_normal.dot(p_transform.xform(vptr[i]));
 
 		if (i == 0 || d > r_max) {
@@ -1306,7 +1306,7 @@ void GodotConcavePolygonShape3D::project_range(const Vector3 &p_normal, const Tr
 }
 
 Vector3 GodotConcavePolygonShape3D::get_support(const Vector3 &p_normal) const {
-	int count = vertices.size();
+	uint32_t count = vertices.size();
 	if (count == 0) {
 		return Vector3();
 	}
@@ -1318,7 +1318,7 @@ Vector3 GodotConcavePolygonShape3D::get_support(const Vector3 &p_normal) const {
 	int vert_support_idx = -1;
 	real_t support_max = 0;
 
-	for (int i = 0; i < count; i++) {
+	for (uint32_t i = 0; i < count; i++) {
 		real_t d = n.dot(vptr[i]);
 
 		if (i == 0 || d > support_max) {
@@ -1611,11 +1611,11 @@ void GodotConcavePolygonShape3D::_setup(const Vector<Vector3> &p_faces, bool p_b
 	_Volume_BVH_Element *bvh_arrayw = bvh_array.ptrw();
 
 	faces.resize(src_face_count);
-	Face *facesw = faces.ptrw();
+	Face *facesw = faces.ptr();
 
 	vertices.resize(src_face_count * 3);
 
-	Vector3 *verticesw = vertices.ptrw();
+	Vector3 *verticesw = vertices.ptr();
 
 	AABB _aabb;
 
@@ -1644,10 +1644,8 @@ void GodotConcavePolygonShape3D::_setup(const Vector<Vector3> &p_faces, bool p_b
 
 	bvh.resize(count + 1);
 
-	BVH *bvh_arrayw2 = bvh.ptrw();
-
 	int idx = 0;
-	_fill_bvh(bvh_tree, bvh_arrayw2, idx);
+	_fill_bvh(bvh_tree, bvh.ptr(), idx);
 
 	backface_collision = p_backface_collision;
 

--- a/modules/godot_physics_3d/godot_shape_3d.h
+++ b/modules/godot_physics_3d/godot_shape_3d.h
@@ -315,8 +315,8 @@ struct GodotConcavePolygonShape3D : public GodotConcaveShape3D {
 		int indices[3] = {};
 	};
 
-	Vector<Face> faces;
-	Vector<Vector3> vertices;
+	LocalVector<Face> faces;
+	LocalVector<Vector3> vertices;
 
 	struct BVH {
 		AABB aabb;
@@ -326,7 +326,7 @@ struct GodotConcavePolygonShape3D : public GodotConcaveShape3D {
 		int face_index = 0;
 	};
 
-	Vector<BVH> bvh;
+	LocalVector<BVH> bvh;
 
 	struct _CullParams {
 		AABB aabb;

--- a/modules/godot_physics_3d/godot_soft_body_3d.cpp
+++ b/modules/godot_physics_3d/godot_soft_body_3d.cpp
@@ -1017,7 +1017,7 @@ void GodotSoftBody3D::predict_motion(real_t p_delta) {
 	int ac = areas.size();
 	if (ac) {
 		areas.sort();
-		const AreaCMP *aa = &areas[0];
+		const AreaCMP *aa = areas.ptr();
 		for (int i = ac - 1; i >= 0; i--) {
 			if (!gravity_done) {
 				PS3DE::AreaSpaceOverrideMode area_gravity_mode = (PS3DE::AreaSpaceOverrideMode)(int)aa[i].area->get_param(PS3DE::AREA_PARAM_GRAVITY_OVERRIDE_MODE);

--- a/modules/godot_physics_3d/godot_soft_body_3d.h
+++ b/modules/godot_physics_3d/godot_soft_body_3d.h
@@ -106,7 +106,7 @@ class GodotSoftBody3D : public GodotCollisionObject3D {
 
 	HashSet<GodotConstraint3D *> constraints;
 
-	Vector<AreaCMP> areas;
+	LocalVector<AreaCMP> areas;
 
 	VSet<RID> exceptions;
 
@@ -138,7 +138,7 @@ public:
 	_FORCE_INLINE_ void add_area(GodotArea3D *p_area) {
 		int index = areas.find(AreaCMP(p_area));
 		if (index > -1) {
-			areas.write[index].refCount += 1;
+			areas[index].refCount += 1;
 		} else {
 			areas.ordered_insert(AreaCMP(p_area));
 		}
@@ -147,7 +147,7 @@ public:
 	_FORCE_INLINE_ void remove_area(GodotArea3D *p_area) {
 		int index = areas.find(AreaCMP(p_area));
 		if (index > -1) {
-			areas.write[index].refCount -= 1;
+			areas[index].refCount -= 1;
 			if (areas[index].refCount < 1) {
 				areas.remove_at(index);
 			}


### PR DESCRIPTION
## What problem(s) does this PR solve?

Same as #122957, but for `GodotPhysics3D`.

Several `Vector`s in `GodotPhysics3D` are never copied, making its CoW functionality unused overhead (although not that significant). Those were changed to `LocalVector`.

Also:
- Replaces instances of `&my_vector[0]` with `ptr()`.
- Converts a few index loops to range-based loops where appropriate.
- As discussed in the other PR, remove a potential footgun (two versions of `GodotCollisionObject3D::remove_shape()` where one takes a pointer and the other takes an integer).

## Additional information

I consider this mostly housekeeping and should have insignificant performance improvements or regressions. `target=template_release production=yes` builds decreased by 16 KiB in size on Linux with the [official SDK](https://github.com/godotengine/buildroot/).

Although `GodotPhysics3D` is mostly overshadowed by Jolt, at least the in-house one may be kept in order.