### PR TITLE
make_rst.py: Escape `[` if it precedes a closing tag

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2341,13 +2341,13 @@
 			Z key.
 		</constant>
 		<constant name="KEY_BRACKETLEFT" value="91" enum="Key" keywords="open square bracket">
-			Left bracket ([code][lb][/code]) key.
+			Left bracket ([code skip-lint][[/code]) key.
 		</constant>
 		<constant name="KEY_BACKSLASH" value="92" enum="Key">
 			Backslash ([code]\[/code]) key.
 		</constant>
 		<constant name="KEY_BRACKETRIGHT" value="93" enum="Key" keywords="close square bracket">
-			Right bracket ([code][rb][/code]) key.
+			Right bracket ([code]][/code]) key.
 		</constant>
 		<constant name="KEY_ASCIICIRCUM" value="94" enum="Key" keywords="caret">
 			Caret ([code]^[/code]) key.

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -1960,7 +1960,16 @@ def format_text_block(
             if inside_code:
                 # Exiting codeblocks and inline code tags.
 
-                if tag_state.closing and tag_state.name == inside_code_tag:
+                # Escape opening square bracket if it immediately precedes a closing tag
+                if tag_text and tag_text.startswith("[/"):
+                    if not ignore_code_warnings:
+                        print_warning(
+                            f'{state.current_class}.xml: Found possibly misformatted tag "[{tag_state.raw}]" in {context_name}. {code_warning_if_intended_string}',
+                            state,
+                        )
+                    tag_text = "["
+                    post_text = text[pos + 1 :]
+                elif tag_state.closing and tag_state.name == inside_code_tag:
                     if is_in_tagset(tag_state.name, RESERVED_CODEBLOCK_TAGS):
                         tag_text = ""
                         state.reserved_tag_check.add_closing_tag(tag_state.name)
@@ -2048,7 +2057,9 @@ def format_text_block(
                 ignore_code_warnings = "skip-lint" in tag_state.arguments.split(" ")
 
             elif is_in_tagset(tag_state.name, ["code"]):
-                tag_text = "``"
+                # Escape formatting which can break rST, e.g. "(``)``".
+                # This cannot be done with an f-string because Python < 3.12 doesn't allow \ escapes.
+                tag_text = ("\\ " if pre_text.endswith("(") else "") + "``"
                 state.reserved_tag_check.add_opening_tag(tag_state.name)
 
                 inside_code = True


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

`make_rst.py` does not properly handle cases like `[code][[/code]`, as it parses the second tag as `[[/code]`, which doesn't close the opening `[code]`. However, `[lb]` is not the proper solution in this case, as it is only intended to be used outside code (inline or block). This PR escapes the lone opening `[` and allows re-parsing the closing tag on its own, and triggers a warning unless `skip-lint` is added, which is what I did for `@GlobalScope.KEY_BRACKETLEFT`.

## Additional information

I found this by chance while stumbling upon [KEY_BRACKETLEFT](https://docs.godotengine.org/en/latest/classes/class_@globalscope.html#class-globalscope-constant-key-bracketleft), which uses `[lb]` (and `[rb]` is used for KEY_BRACKETRIGHT, although `]` works fine even without this PR). This is the single instance I found by grepping all the XML files in doc/classes.

All .rst files are identical before and after the change, except `@GlobalScope`'s KEY_BRACKETLEFT and KEY_BRACKETRIGHT which now contain ``` ``[`` ``` and ``` ``]`` ``` as expected.