### PR TITLE
Add `vibrate_on_long_press` to `Control` node

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1384,6 +1384,13 @@ bool InputEventScreenTouch::is_double_tap() const {
 	return double_tap;
 }
 
+void InputEventScreenTouch::set_long_press(bool p_long_press) {
+	long_press = p_long_press;
+}
+bool InputEventScreenTouch::is_long_press() const {
+	return long_press;
+}
+
 RequiredResult<InputEvent> InputEventScreenTouch::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
 	Ref<InputEventScreenTouch> st;
 	st.instantiate();
@@ -1394,6 +1401,7 @@ RequiredResult<InputEvent> InputEventScreenTouch::xformed_by(const Transform2D &
 	st->set_pressed(pressed);
 	st->set_canceled(canceled);
 	st->set_double_tap(double_tap);
+	st->set_long_press(long_press);
 
 	st->merge_meta_from(this);
 
@@ -1410,7 +1418,8 @@ String InputEventScreenTouch::_to_string() {
 	String p = pressed ? "true" : "false";
 	String canceled_state = canceled ? "true" : "false";
 	String double_tap_string = double_tap ? "true" : "false";
-	return vformat("InputEventScreenTouch: index=%d, pressed=%s, canceled=%s, position=(%s), double_tap=%s", index, p, canceled_state, String(get_position()), double_tap_string);
+	String long_press_string = long_press ? "true" : "false";
+	return vformat("InputEventScreenTouch: index=%d, pressed=%s, canceled=%s, position=(%s), double_tap=%s", index, p, canceled_state, String(get_position()), double_tap_string, long_press_string);
 }
 
 void InputEventScreenTouch::_bind_methods() {
@@ -1426,11 +1435,15 @@ void InputEventScreenTouch::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_double_tap", "double_tap"), &InputEventScreenTouch::set_double_tap);
 	ClassDB::bind_method(D_METHOD("is_double_tap"), &InputEventScreenTouch::is_double_tap);
 
+	ClassDB::bind_method(D_METHOD("set_long_press", "long_press"), &InputEventScreenTouch::set_long_press);
+	ClassDB::bind_method(D_METHOD("is_long_press"), &InputEventScreenTouch::is_long_press);
+
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "index"), "set_index", "get_index");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position", PROPERTY_HINT_NONE, "suffix:px"), "set_position", "get_position");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "canceled"), "set_canceled", "is_canceled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "double_tap"), "set_double_tap", "is_double_tap");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "long_press"), "set_long_press", "is_long_press");
 }
 
 ///////////////////////////////////

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -374,6 +374,7 @@ class InputEventScreenTouch : public InputEventFromWindow {
 	int index = 0;
 	Vector2 pos;
 	bool double_tap = false;
+	bool long_press = false;
 
 protected:
 	static void _bind_methods();
@@ -390,6 +391,9 @@ public:
 
 	void set_double_tap(bool p_double_tap);
 	bool is_double_tap() const;
+
+	void set_long_press(bool p_double_tap);
+	bool is_long_press() const;
 
 	virtual RequiredResult<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 	virtual String as_text() const override;

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1276,6 +1276,10 @@
 		<member name="translation_context" type="StringName" setter="set_translation_context" getter="get_translation_context" default="&amp;&quot;&quot;">
 			The translation context used when translating this control's displayed text, if it has any. Also used when generating translation templates.
 		</member>
+		<member name="vibrate_on_long_press" type="bool" setter="set_vibrate_on_long_press" getter="is_vibrate_on_long_press" default="true">
+			If [code]true[/code], the device will vibrate when a touch input triggers a long-press.
+			[b]Node:[/b] This is only supported on Android.
+		</member>
 	</members>
 	<signals>
 		<signal name="focus_entered">

--- a/doc/classes/InputEventScreenTouch.xml
+++ b/doc/classes/InputEventScreenTouch.xml
@@ -19,6 +19,10 @@
 		<member name="index" type="int" setter="set_index" getter="get_index" default="0">
 			The touch index in the case of a multi-touch event. One index = one finger.
 		</member>
+		<member name="long_press" type="bool" setter="set_long_press" getter="is_long_press" default="false">
+			If [code]true[/code], the touch's state is a long press.
+			[b]Note:[/b] This is only supported on Android.
+		</member>
 		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
 			The touch position in the viewport the node is in, using the coordinate system of this viewport.
 		</member>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1698,8 +1698,9 @@
 		<member name="input_devices/pointing/android/disable_scroll_deadzone" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], disables the scroll deadzone on Android, allowing even very small scroll movements to be registered. This may increase scroll sensitivity but can also lead to unintended scrolling from slight finger movements.
 		</member>
-		<member name="input_devices/pointing/android/enable_long_press_as_right_click" type="bool" setter="" getter="" default="false">
+		<member name="input_devices/pointing/android/enable_long_press_as_right_click" type="bool" setter="" getter="" default="false" deprecated="This will be removed in future versions, use [member InputEventScreenTouch.long_press] instead.">
 			If [code]true[/code], long press events on an Android touchscreen are transformed into right click events.
+			[b]Note:[/b] Some control nodes might ignore this event, use [member InputEventScreenTouch.long_press] instead.
 		</member>
 		<member name="input_devices/pointing/android/enable_pan_and_scale_gestures" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], multi-touch pan and scale gestures are enabled on Android devices.

--- a/platform/android/android_input_handler.cpp
+++ b/platform/android/android_input_handler.cpp
@@ -264,13 +264,13 @@ void AndroidInputHandler::process_touch_event(int p_event, int p_pointer, const 
 	}
 }
 
-void AndroidInputHandler::_cancel_mouse_event_info(bool p_source_mouse_relative) {
+void AndroidInputHandler::_cancel_mouse_event_info(bool p_source_mouse_relative, bool p_emulated) {
 	buttons_state = BitField<MouseButtonMask>();
-	_parse_mouse_event_info(BitField<MouseButtonMask>(), false, true, false, p_source_mouse_relative);
+	_parse_mouse_event_info(BitField<MouseButtonMask>(), false, true, false, p_source_mouse_relative, p_emulated);
 	mouse_event_info.valid = false;
 }
 
-void AndroidInputHandler::_parse_mouse_event_info(BitField<MouseButtonMask> event_buttons_mask, bool p_pressed, bool p_canceled, bool p_double_click, bool p_source_mouse_relative) {
+void AndroidInputHandler::_parse_mouse_event_info(BitField<MouseButtonMask> event_buttons_mask, bool p_pressed, bool p_canceled, bool p_double_click, bool p_source_mouse_relative, bool p_emulated) {
 	if (!mouse_event_info.valid) {
 		return;
 	}
@@ -295,15 +295,18 @@ void AndroidInputHandler::_parse_mouse_event_info(BitField<MouseButtonMask> even
 	ev->set_button_index(_button_index_from_mask(changed_button_mask));
 	ev->set_button_mask(event_buttons_mask);
 	ev->set_double_click(p_double_click);
+	if (p_emulated) {
+		ev->set_device(InputEvent::DEVICE_ID_EMULATION);
+	}
 	Input::get_singleton()->parse_input_event(ev);
 }
 
-void AndroidInputHandler::_release_mouse_event_info(bool p_source_mouse_relative) {
-	_parse_mouse_event_info(BitField<MouseButtonMask>(), false, false, false, p_source_mouse_relative);
+void AndroidInputHandler::_release_mouse_event_info(bool p_source_mouse_relative, bool p_emulated) {
+	_parse_mouse_event_info(BitField<MouseButtonMask>(), false, false, false, p_source_mouse_relative, p_emulated);
 	mouse_event_info.valid = false;
 }
 
-void AndroidInputHandler::process_mouse_event(int p_event_action, int p_event_android_buttons_mask, Point2 p_event_pos, Vector2 p_delta, bool p_double_click, bool p_source_mouse_relative, float p_pressure, Vector2 p_tilt) {
+void AndroidInputHandler::process_mouse_event(int p_event_action, int p_event_android_buttons_mask, Point2 p_event_pos, Vector2 p_delta, bool p_double_click, bool p_source_mouse_relative, float p_pressure, Vector2 p_tilt, bool p_emulated) {
 	BitField<MouseButtonMask> event_buttons_mask = _android_button_mask_to_godot_button_mask(p_event_android_buttons_mask);
 	switch (p_event_action) {
 		case AMOTION_EVENT_ACTION_HOVER_MOVE: // hover move
@@ -317,6 +320,9 @@ void AndroidInputHandler::process_mouse_event(int p_event_action, int p_event_an
 			ev->set_global_position(p_event_pos);
 			ev->set_relative(p_event_pos - hover_prev_pos);
 			ev->set_relative_screen_position(ev->get_relative());
+			if (p_emulated) {
+				ev->set_device(InputEvent::DEVICE_ID_EMULATION);
+			}
 			Input::get_singleton()->parse_input_event(ev);
 			hover_prev_pos = p_event_pos;
 		} break;
@@ -325,20 +331,24 @@ void AndroidInputHandler::process_mouse_event(int p_event_action, int p_event_an
 		case AMOTION_EVENT_ACTION_BUTTON_PRESS: {
 			// Release any remaining touches or mouse event
 			_release_mouse_event_info();
-			_release_all_touch();
+			if (!p_emulated) {
+				// In case of emulation, preserve touch state so one can ignore the emulated mouse event and continue interacting via touch.
+				// p_emulated = true, is set only for emulated right clicks.
+				_release_all_touch();
+			}
 
 			mouse_event_info.valid = true;
 			mouse_event_info.pos = p_event_pos;
-			_parse_mouse_event_info(event_buttons_mask, true, false, p_double_click, p_source_mouse_relative);
+			_parse_mouse_event_info(event_buttons_mask, true, false, p_double_click, p_source_mouse_relative, p_emulated);
 		} break;
 
 		case AMOTION_EVENT_ACTION_CANCEL: {
-			_cancel_mouse_event_info(p_source_mouse_relative);
+			_cancel_mouse_event_info(p_source_mouse_relative, p_emulated);
 		} break;
 
 		case AMOTION_EVENT_ACTION_UP:
 		case AMOTION_EVENT_ACTION_BUTTON_RELEASE: {
-			_release_mouse_event_info(p_source_mouse_relative);
+			_release_mouse_event_info(p_source_mouse_relative, p_emulated);
 		} break;
 
 		case AMOTION_EVENT_ACTION_MOVE: {
@@ -365,6 +375,9 @@ void AndroidInputHandler::process_mouse_event(int p_event_action, int p_event_an
 			ev->set_button_mask(event_buttons_mask);
 			ev->set_pressure(p_pressure);
 			ev->set_tilt(p_tilt);
+			if (p_emulated) {
+				ev->set_device(InputEvent::DEVICE_ID_EMULATION);
+			}
 			Input::get_singleton()->parse_input_event(ev);
 		} break;
 
@@ -380,6 +393,9 @@ void AndroidInputHandler::process_mouse_event(int p_event_action, int p_event_an
 				ev->set_global_position(p_event_pos);
 			}
 			ev->set_pressed(true);
+			if (p_emulated) {
+				ev->set_device(InputEvent::DEVICE_ID_EMULATION);
+			}
 			buttons_state = event_buttons_mask;
 			if (p_delta.y > 0) {
 				_wheel_button_click(event_buttons_mask, ev, MouseButton::WHEEL_UP, p_delta.y);

--- a/platform/android/android_input_handler.cpp
+++ b/platform/android/android_input_handler.cpp
@@ -157,6 +157,7 @@ void AndroidInputHandler::_parse_all_touch(bool p_pressed, bool p_canceled) {
 			ev->set_canceled(p_canceled);
 			ev->set_position(touch[i].pos);
 			ev->set_double_tap(touch[i].double_tap);
+			ev->set_long_press(touch[i].long_press);
 			Input::get_singleton()->parse_input_event(ev);
 		}
 	}
@@ -181,6 +182,7 @@ void AndroidInputHandler::process_touch_event(int p_event, int p_pointer, const 
 				touch.write[i].pressure = p_points[i].pressure;
 				touch.write[i].tilt = p_points[i].tilt;
 				touch.write[i].double_tap = p_points[i].double_tap;
+				touch.write[i].long_press = p_points[i].long_press;
 			}
 
 			//send touch

--- a/platform/android/android_input_handler.h
+++ b/platform/android/android_input_handler.h
@@ -44,6 +44,7 @@ public:
 		float pressure = 0;
 		Vector2 tilt;
 		bool double_tap = false;
+		bool long_press = false;
 	};
 
 	struct MouseEventInfo {

--- a/platform/android/android_input_handler.h
+++ b/platform/android/android_input_handler.h
@@ -86,11 +86,11 @@ private:
 
 	void _wheel_button_click(BitField<MouseButtonMask> event_buttons_mask, const Ref<InputEventMouseButton> &ev, MouseButton wheel_button, float factor);
 
-	void _parse_mouse_event_info(BitField<MouseButtonMask> event_buttons_mask, bool p_pressed, bool p_canceled, bool p_double_click, bool p_source_mouse_relative);
+	void _parse_mouse_event_info(BitField<MouseButtonMask> event_buttons_mask, bool p_pressed, bool p_canceled, bool p_double_click, bool p_source_mouse_relative, bool p_emulated);
 
-	void _release_mouse_event_info(bool p_source_mouse_relative = false);
+	void _release_mouse_event_info(bool p_source_mouse_relative = false, bool emulated = false);
 
-	void _cancel_mouse_event_info(bool p_source_mouse_relative = false);
+	void _cancel_mouse_event_info(bool p_source_mouse_relative = false, bool emulated = false);
 
 	void _parse_all_touch(bool p_pressed, bool p_canceled = false);
 
@@ -99,7 +99,7 @@ private:
 	void _cancel_all_touch();
 
 public:
-	void process_mouse_event(int p_event_action, int p_event_android_buttons_mask, Point2 p_event_pos, Vector2 p_delta, bool p_double_click, bool p_source_mouse_relative, float p_pressure, Vector2 p_tilt);
+	void process_mouse_event(int p_event_action, int p_event_android_buttons_mask, Point2 p_event_pos, Vector2 p_delta, bool p_double_click, bool p_source_mouse_relative, float p_pressure, Vector2 p_tilt, bool p_emulated);
 	void process_touch_event(int p_event, int p_pointer, const Vector<TouchPos> &p_points);
 	void process_magnify(Point2 p_pos, float p_factor);
 	void process_pan(Point2 p_pos, Vector2 p_delta);

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -468,7 +468,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 
 	override fun onGodotSetupCompleted() {
 		super.onGodotSetupCompleted()
-		val longPressEnabled = enableLongPressGestures()
+		val rightClickEmulationEnabled = enableRightClickEmulation()
 		val panScaleEnabled = enablePanAndScaleGestures()
 		val overrideVolumeButtonsEnabled = overrideVolumeButtons()
 		val hapticEnabled = enableHapticOnLongPress()
@@ -476,7 +476,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 		runOnUiThread {
 			// Enable long press, panning and scaling gestures
 			godotFragment?.godot?.renderView?.inputHandler?.apply {
-				enableLongPress(longPressEnabled)
+				enableRightClickEmulation(rightClickEmulationEnabled)
 				enablePanningAndScalingGestures(panScaleEnabled)
 				setOverrideVolumeButtons(overrideVolumeButtonsEnabled)
 				enableHapticFeedback(hapticEnabled)
@@ -755,7 +755,7 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 	/**
 	 * Enable long press gestures for the Godot Android editor.
 	 */
-	protected open fun enableLongPressGestures() =
+	protected open fun enableRightClickEmulation() =
 		java.lang.Boolean.parseBoolean(GodotLib.getEditorSetting("interface/touchscreen/enable_long_press_as_right_click"))
 
 	/**

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotGame.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotGame.kt
@@ -50,7 +50,7 @@ abstract class BaseGodotGame: GodotEditor() {
 
 	override fun overrideVolumeButtons() = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/override_volume_buttons"))
 
-	override fun enableLongPressGestures() = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_long_press_as_right_click"))
+	override fun enableRightClickEmulation() = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_long_press_as_right_click"))
 
 	override fun enablePanAndScaleGestures() = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_pan_and_scale_gestures"))
 

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
@@ -830,7 +830,7 @@ class Godot private constructor(val context: Context) {
 		Log.v(TAG, "OnGodotSetupCompleted")
 
 		// These properties are defined after Godot setup completion, so we retrieve them here.
-		val longPressEnabled = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_long_press_as_right_click"))
+		val rightClickEmulataionEnabled = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_long_press_as_right_click"))
 		val panScaleEnabled = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/enable_pan_and_scale_gestures"))
 		val rotaryInputAxisValue = GodotLib.getGlobal("input_devices/pointing/android/rotary_input_scroll_axis")
 		val overrideVolumeButtons = java.lang.Boolean.parseBoolean(GodotLib.getGlobal("input_devices/pointing/android/override_volume_buttons"))
@@ -838,7 +838,7 @@ class Godot private constructor(val context: Context) {
 
 		runOnHostThread {
 			godotInputHandler.apply {
-				enableLongPress(longPressEnabled)
+				enableRightClickEmulation(rightClickEmulataionEnabled)
 				enablePanningAndScalingGestures(panScaleEnabled)
 				setOverrideVolumeButtons(overrideVolumeButtons)
 				disableScrollDeadzone(scrollDeadzoneDisabled)

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotLib.java
@@ -116,7 +116,7 @@ public class GodotLib {
 	/**
 	 * Dispatch mouse events
 	 */
-	public static native void dispatchMouseEvent(int event, int buttonMask, float x, float y, float deltaX, float deltaY, boolean doubleClick, boolean sourceMouseRelative, float pressure, float tiltX, float tiltY);
+	public static native void dispatchMouseEvent(int event, int buttonMask, float x, float y, float deltaX, float deltaY, boolean doubleClick, boolean sourceMouseRelative, float pressure, float tiltX, float tiltY, boolean emulated);
 
 	public static native void magnify(float x, float y, float factor);
 

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/GodotLib.java
@@ -111,7 +111,7 @@ public class GodotLib {
 	/**
 	 * Forward touch events.
 	 */
-	public static native void dispatchTouchEvent(int event, int pointer, int pointerCount, float[] positions, boolean doubleTap);
+	public static native void dispatchTouchEvent(int event, int pointer, int pointerCount, float[] positions, boolean doubleTap, boolean longPress);
 
 	/**
 	 * Dispatch mouse events

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotGestureHandler.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotGestureHandler.kt
@@ -59,7 +59,7 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 
 	var scrollDeadzoneDisabled = false
 
-	var longPressEnabled = false
+	var rightClickEmulation = false
 
 	/**
 	 * Enable haptic feedback on long-press right-click
@@ -69,7 +69,8 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 	private var nextDownIsDoubleTap = false
 	private var dragInProgress = false
 	private var scaleInProgress = false
-	private var contextClickInProgress = false
+	private var longPressInProgress = false
+	private var emulatedRightClickInProgress = false
 	private var pointerCaptureInProgress = false
 
 	private var lastDragX: Float = 0.0f
@@ -92,11 +93,11 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 			if (hapticFeedbackEnabled) {
 				inputHandler.performHapticFeedback()
 			}
-			contextClickRouter(event)
+			handleLongPress(event)
 		}
 	}
 
-	private fun contextClickRouter(event: MotionEvent) {
+	private fun handleLongPress(event: MotionEvent) {
 		if (scaleInProgress || nextDownIsDoubleTap) {
 			return
 		}
@@ -104,14 +105,19 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 		// Cancel the previous down event
 		inputHandler.handleMotionEvent(event, MotionEvent.ACTION_CANCEL)
 
-		// Turn a context click into a single tap right mouse button click.
-		inputHandler.handleMouseEvent(
-			event,
-			MotionEvent.ACTION_DOWN,
-			MotionEvent.BUTTON_SECONDARY,
-			false
-		)
-		contextClickInProgress = true
+		inputHandler.handleTouchEvent(event, event.action, false, true)
+		longPressInProgress = true
+
+		if (rightClickEmulation) {
+			// Turn a long press into a single tap right mouse button click.
+			inputHandler.handleMouseEvent(
+				event,
+				MotionEvent.ACTION_DOWN,
+				MotionEvent.BUTTON_SECONDARY,
+				false
+			)
+			emulatedRightClickInProgress = true
+		}
 	}
 
 	fun onPointerCaptureChange(hasCapture: Boolean) {
@@ -144,17 +150,22 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 			return true
 		}
 
-		if (pointerCaptureInProgress || dragInProgress || contextClickInProgress) {
-			if (contextClickInProgress || GodotInputHandler.isMouseEvent(event)) {
+		if (pointerCaptureInProgress || dragInProgress || emulatedRightClickInProgress) {
+			if (GodotInputHandler.isMouseEvent(event)) {
 				// This may be an ACTION_BUTTON_RELEASE event which we don't handle,
 				// so we convert it to an ACTION_UP event.
 				inputHandler.handleMouseEvent(event, MotionEvent.ACTION_UP)
+			} else if (emulatedRightClickInProgress) {
+				inputHandler.handleMouseEvent(event, MotionEvent.ACTION_UP)
+				// Handling both touch and emulated mouse, so one can ignore the emulated mouse event and continue interacting via touch.
+				inputHandler.handleTouchEvent(event)
 			} else {
 				inputHandler.handleTouchEvent(event)
 			}
 			pointerCaptureInProgress = false
 			dragInProgress = false
-			contextClickInProgress = false
+			longPressInProgress = false
+			emulatedRightClickInProgress = false
 			lastDragX = 0.0f
 			lastDragY = 0.0f
 			return true
@@ -164,14 +175,20 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 	}
 
 	private fun onActionMove(event: MotionEvent): Boolean {
-		if (contextClickInProgress) {
+		var emulatedClickHandled = false
+		if (emulatedRightClickInProgress) {
 			inputHandler.handleMouseEvent(event, event.actionMasked, MotionEvent.BUTTON_SECONDARY, false)
-			return true
-		} else if (scrollDeadzoneDisabled && !scaleInProgress) {
+			emulatedClickHandled = true
+		}
+
+		if ((scrollDeadzoneDisabled || longPressInProgress) && !scaleInProgress) {
 			// The 'onScroll' event is triggered with a long delay.
 			// Force the 'InputEventScreenDrag' event earlier here.
 			// We don't toggle 'dragInProgress' here so that the scaling logic can override the drag operation if needed.
 			// Once the 'onScroll' event kicks-in, 'dragInProgress' will be properly set.
+
+			// Long press drag doesn't invoke `onScroll` event, handling it here.
+
 			if (lastDragX != event.getX(0) || lastDragY != event.getY(0)) {
 				lastDragX = event.getX(0)
 				lastDragY = event.getY(0)
@@ -179,15 +196,15 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 				return true
 			}
 		}
-		return false
+		return emulatedClickHandled
 	}
 
 	override fun onDoubleTapEvent(event: MotionEvent): Boolean {
 		if (event.actionMasked == MotionEvent.ACTION_UP) {
 			nextDownIsDoubleTap = false
 
-			// Long press is restored to its previous value.
-			inputHandler.gestureDetector.setIsLongpressEnabled(longPressEnabled)
+			// Re-enable Long press.
+			inputHandler.gestureDetector.setIsLongpressEnabled(true)
 
 			inputHandler.handleMotionEvent(event, event.actionMasked, true)
 		} else if (event.actionMasked == MotionEvent.ACTION_MOVE && !(scalingEnabled && inputHandler.scaleGestureDetector.isQuickScaleEnabled)) {

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotGestureHandler.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotGestureHandler.kt
@@ -114,7 +114,8 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 				event,
 				MotionEvent.ACTION_DOWN,
 				MotionEvent.BUTTON_SECONDARY,
-				false
+				false,
+				true
 			)
 			emulatedRightClickInProgress = true
 		}
@@ -156,7 +157,7 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 				// so we convert it to an ACTION_UP event.
 				inputHandler.handleMouseEvent(event, MotionEvent.ACTION_UP)
 			} else if (emulatedRightClickInProgress) {
-				inputHandler.handleMouseEvent(event, MotionEvent.ACTION_UP)
+				inputHandler.handleMouseEvent(event, MotionEvent.ACTION_UP, event.buttonState, false, true)
 				// Handling both touch and emulated mouse, so one can ignore the emulated mouse event and continue interacting via touch.
 				inputHandler.handleTouchEvent(event)
 			} else {
@@ -177,7 +178,7 @@ internal class GodotGestureHandler(private val inputHandler: GodotInputHandler) 
 	private fun onActionMove(event: MotionEvent): Boolean {
 		var emulatedClickHandled = false
 		if (emulatedRightClickInProgress) {
-			inputHandler.handleMouseEvent(event, event.actionMasked, MotionEvent.BUTTON_SECONDARY, false)
+			inputHandler.handleMouseEvent(event, event.actionMasked, MotionEvent.BUTTON_SECONDARY, false, true)
 			emulatedClickHandled = true
 		}
 

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotInputHandler.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotInputHandler.java
@@ -610,10 +610,10 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 	}
 
 	boolean handleMouseEvent(final MotionEvent event, int eventActionOverride, boolean doubleTap) {
-		return handleMouseEvent(event, eventActionOverride, event.getButtonState(), doubleTap);
+		return handleMouseEvent(event, eventActionOverride, event.getButtonState(), doubleTap, false);
 	}
 
-	boolean handleMouseEvent(final MotionEvent event, int eventActionOverride, int buttonMaskOverride, boolean doubleTap) {
+	boolean handleMouseEvent(final MotionEvent event, int eventActionOverride, int buttonMaskOverride, boolean doubleTap, boolean emulatedRightClick) {
 		final float x = event.getX();
 		final float y = event.getY();
 
@@ -639,14 +639,14 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 		if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.O) {
 			sourceMouseRelative = event.isFromSource(InputDevice.SOURCE_MOUSE_RELATIVE);
 		}
-		return handleMouseEvent(eventActionOverride, buttonMaskOverride, x, y, horizontalFactor, verticalFactor, doubleTap, sourceMouseRelative, pressure, getEventTiltX(event), getEventTiltY(event));
+		return handleMouseEvent(eventActionOverride, buttonMaskOverride, x, y, horizontalFactor, verticalFactor, doubleTap, sourceMouseRelative, pressure, getEventTiltX(event), getEventTiltY(event), emulatedRightClick);
 	}
 
 	boolean handleMouseEvent(int eventAction, boolean sourceMouseRelative) {
-		return handleMouseEvent(eventAction, 0, 0f, 0f, 0f, 0f, false, sourceMouseRelative, 1f, 0f, 0f);
+		return handleMouseEvent(eventAction, 0, 0f, 0f, 0f, 0f, false, sourceMouseRelative, 1f, 0f, 0f, false);
 	}
 
-	boolean handleMouseEvent(int eventAction, int buttonsMask, float x, float y, float deltaX, float deltaY, boolean doubleClick, boolean sourceMouseRelative, float pressure, float tiltX, float tiltY) {
+	boolean handleMouseEvent(int eventAction, int buttonsMask, float x, float y, float deltaX, float deltaY, boolean doubleClick, boolean sourceMouseRelative, float pressure, float tiltX, float tiltY, boolean emulated) {
 		InputEventRunnable runnable = InputEventRunnable.obtain();
 		if (runnable == null) {
 			return false;
@@ -679,7 +679,7 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 			case MotionEvent.ACTION_HOVER_MOVE:
 			case MotionEvent.ACTION_MOVE:
 			case MotionEvent.ACTION_SCROLL: {
-				runnable.setMouseEvent(eventAction, buttonsMask, x, y, deltaX, deltaY, doubleClick, sourceMouseRelative, pressure, tiltX, tiltY);
+				runnable.setMouseEvent(eventAction, buttonsMask, x, y, deltaX, deltaY, doubleClick, sourceMouseRelative, pressure, tiltX, tiltY, emulated);
 				dispatchInputEventRunnable(runnable);
 				return true;
 			}

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotInputHandler.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/GodotInputHandler.java
@@ -112,7 +112,7 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 
 		this.godotGestureHandler = new GodotGestureHandler(this);
 		this.gestureDetector = new GestureDetector(context, godotGestureHandler);
-		enableLongPress(false);
+		this.gestureDetector.setIsLongpressEnabled(true);
 
 		this.scaleGestureDetector = new ScaleGestureDetector(context, godotGestureHandler);
 		this.scaleGestureDetector.setStylusScaleEnabled(true);
@@ -126,9 +126,8 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 	/**
 	 * Enable long press events. This is false by default.
 	 */
-	public void enableLongPress(boolean enable) {
-		this.gestureDetector.setIsLongpressEnabled(enable);
-		this.godotGestureHandler.setLongPressEnabled(enable);
+	public void enableRightClickEmulation(boolean enable) {
+		this.godotGestureHandler.setRightClickEmulation(enable);
 	}
 
 	/**
@@ -693,10 +692,14 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 	}
 
 	boolean handleTouchEvent(final MotionEvent event, int eventActionOverride) {
-		return handleTouchEvent(event, eventActionOverride, false);
+		return handleTouchEvent(event, eventActionOverride, false, false);
 	}
 
 	boolean handleTouchEvent(final MotionEvent event, int eventActionOverride, boolean doubleTap) {
+		return handleTouchEvent(event, eventActionOverride, doubleTap, false);
+	}
+
+	boolean handleTouchEvent(final MotionEvent event, int eventActionOverride, boolean doubleTap, boolean longPress) {
 		if (event.getPointerCount() == 0) {
 			return true;
 		}
@@ -713,7 +716,7 @@ public class GodotInputHandler implements InputManager.InputDeviceListener, Sens
 			case MotionEvent.ACTION_MOVE:
 			case MotionEvent.ACTION_POINTER_UP:
 			case MotionEvent.ACTION_POINTER_DOWN: {
-				runnable.setTouchEvent(event, eventActionOverride, doubleTap);
+				runnable.setTouchEvent(event, eventActionOverride, doubleTap, longPress);
 				dispatchInputEventRunnable(runnable);
 				return true;
 			}

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/InputEventRunnable.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/InputEventRunnable.java
@@ -128,6 +128,7 @@ final class InputEventRunnable implements Runnable {
 	// common touch / mouse fields
 	private int eventAction;
 	private boolean doubleTap;
+	private boolean longPress;
 
 	// Mouse event fields and setter
 	private int buttonsMask;
@@ -154,10 +155,11 @@ final class InputEventRunnable implements Runnable {
 	private int actionPointerId;
 	private int pointerCount;
 	private final float[] positions = new float[MAX_TOUCH_POINTER_COUNT * 6]; // pointerId1, x1, y1, pressure1, tiltX1, tiltY1, pointerId2, etc...
-	void setTouchEvent(MotionEvent event, int eventAction, boolean doubleTap) {
+	void setTouchEvent(MotionEvent event, int eventAction, boolean doubleTap, boolean longPress) {
 		this.currentEventType = EventType.TOUCH;
 		this.eventAction = eventAction;
 		this.doubleTap = doubleTap;
+		this.longPress = longPress;
 		this.actionPointerId = event.getPointerId(event.getActionIndex());
 		this.pointerCount = Math.min(event.getPointerCount(), MAX_TOUCH_POINTER_COUNT);
 		for (int i = 0; i < pointerCount; i++) {
@@ -287,7 +289,8 @@ final class InputEventRunnable implements Runnable {
 							actionPointerId,
 							pointerCount,
 							positions,
-							doubleTap);
+							doubleTap,
+							longPress);
 					break;
 
 				case MAGNIFY:

--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/input/InputEventRunnable.java
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/input/InputEventRunnable.java
@@ -136,7 +136,8 @@ final class InputEventRunnable implements Runnable {
 	private float pressure;
 	private float tiltX;
 	private float tiltY;
-	void setMouseEvent(int eventAction, int buttonsMask, float x, float y, float deltaX, float deltaY, boolean doubleClick, boolean sourceMouseRelative, float pressure, float tiltX, float tiltY) {
+	private boolean emulated;
+	void setMouseEvent(int eventAction, int buttonsMask, float x, float y, float deltaX, float deltaY, boolean doubleClick, boolean sourceMouseRelative, float pressure, float tiltX, float tiltY, boolean emulated) {
 		this.currentEventType = EventType.MOUSE;
 		this.eventAction = eventAction;
 		this.buttonsMask = buttonsMask;
@@ -149,6 +150,7 @@ final class InputEventRunnable implements Runnable {
 		this.pressure = pressure;
 		this.tiltX = tiltX;
 		this.tiltY = tiltY;
+		this.emulated = emulated;
 	}
 
 	// Touch event fields and setter
@@ -280,7 +282,8 @@ final class InputEventRunnable implements Runnable {
 							sourceMouseRelative,
 							pressure,
 							tiltX,
-							tiltY);
+							tiltY,
+							emulated);
 					break;
 
 				case TOUCH:

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -357,12 +357,12 @@ JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env,
 }
 
 // Called on the UI thread
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchMouseEvent(JNIEnv *env, jclass clazz, jint p_event_type, jint p_button_mask, jfloat p_x, jfloat p_y, jfloat p_delta_x, jfloat p_delta_y, jboolean p_double_click, jboolean p_source_mouse_relative, jfloat p_pressure, jfloat p_tilt_x, jfloat p_tilt_y) {
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchMouseEvent(JNIEnv *env, jclass clazz, jint p_event_type, jint p_button_mask, jfloat p_x, jfloat p_y, jfloat p_delta_x, jfloat p_delta_y, jboolean p_double_click, jboolean p_source_mouse_relative, jfloat p_pressure, jfloat p_tilt_x, jfloat p_tilt_y, jboolean p_emulated) {
 	if (step.get() <= STEP_SETUP) {
 		return;
 	}
 
-	input_handler->process_mouse_event(p_event_type, p_button_mask, Point2(p_x, p_y), Vector2(p_delta_x, p_delta_y), p_double_click, p_source_mouse_relative, p_pressure, Vector2(p_tilt_x, p_tilt_y));
+	input_handler->process_mouse_event(p_event_type, p_button_mask, Point2(p_x, p_y), Vector2(p_delta_x, p_delta_y), p_double_click, p_source_mouse_relative, p_pressure, Vector2(p_tilt_x, p_tilt_y), p_emulated);
 }
 
 // Called on the UI thread

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -366,7 +366,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchMouseEvent(JN
 }
 
 // Called on the UI thread
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchTouchEvent(JNIEnv *env, jclass clazz, jint ev, jint pointer, jint pointer_count, jfloatArray position, jboolean p_double_tap) {
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchTouchEvent(JNIEnv *env, jclass clazz, jint ev, jint pointer, jint pointer_count, jfloatArray position, jboolean p_double_tap, jboolean p_long_press) {
 	if (step.get() <= STEP_SETUP) {
 		return;
 	}
@@ -381,6 +381,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchTouchEvent(JN
 		tp.pressure = p[3];
 		tp.tilt = Vector2(p[4], p[5]);
 		tp.double_tap = p_double_tap;
+		tp.long_press = p_long_press;
 		points.push_back(tp);
 	}
 

--- a/platform/android/java_godot_lib_jni.h
+++ b/platform/android/java_godot_lib_jni.h
@@ -44,7 +44,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_newcontext(JNIEnv *en
 JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env, jclass clazz);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_ttsCallback(JNIEnv *env, jclass clazz, jint event, jlong id, jint pos);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_back(JNIEnv *env, jclass clazz);
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchMouseEvent(JNIEnv *env, jclass clazz, jint p_event_type, jint p_button_mask, jfloat p_x, jfloat p_y, jfloat p_delta_x, jfloat p_delta_y, jboolean p_double_click, jboolean p_source_mouse_relative, jfloat p_pressure, jfloat p_tilt_x, jfloat p_tilt_y);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchMouseEvent(JNIEnv *env, jclass clazz, jint p_event_type, jint p_button_mask, jfloat p_x, jfloat p_y, jfloat p_delta_x, jfloat p_delta_y, jboolean p_double_click, jboolean p_source_mouse_relative, jfloat p_pressure, jfloat p_tilt_x, jfloat p_tilt_y, jboolean p_emulated);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchTouchEvent(JNIEnv *env, jclass clazz, jint ev, jint pointer, jint pointer_count, jfloatArray positions, jboolean p_double_tap, jboolean p_long_press);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_magnify(JNIEnv *env, jclass clazz, jfloat p_x, jfloat p_y, jfloat p_factor);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_pan(JNIEnv *env, jclass clazz, jfloat p_x, jfloat p_y, jfloat p_delta_x, jfloat p_delta_y);

--- a/platform/android/java_godot_lib_jni.h
+++ b/platform/android/java_godot_lib_jni.h
@@ -45,7 +45,7 @@ JNIEXPORT jboolean JNICALL Java_org_godotengine_godot_GodotLib_step(JNIEnv *env,
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_ttsCallback(JNIEnv *env, jclass clazz, jint event, jlong id, jint pos);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_back(JNIEnv *env, jclass clazz);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchMouseEvent(JNIEnv *env, jclass clazz, jint p_event_type, jint p_button_mask, jfloat p_x, jfloat p_y, jfloat p_delta_x, jfloat p_delta_y, jboolean p_double_click, jboolean p_source_mouse_relative, jfloat p_pressure, jfloat p_tilt_x, jfloat p_tilt_y);
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchTouchEvent(JNIEnv *env, jclass clazz, jint ev, jint pointer, jint pointer_count, jfloatArray positions, jboolean p_double_tap);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_dispatchTouchEvent(JNIEnv *env, jclass clazz, jint ev, jint pointer, jint pointer_count, jfloatArray positions, jboolean p_double_tap, jboolean p_long_press);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_magnify(JNIEnv *env, jclass clazz, jfloat p_x, jfloat p_y, jfloat p_factor);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_pan(JNIEnv *env, jclass clazz, jfloat p_x, jfloat p_y, jfloat p_delta_x, jfloat p_delta_y);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_key(JNIEnv *env, jclass clazz, jint p_physical_keycode, jint p_unicode, jint p_key_label, jboolean p_pressed, jboolean p_echo);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2576,6 +2576,11 @@ Transform2D Control::get_offset_transform() const {
 // Input events.
 
 void Control::_call_gui_input(const Ref<InputEvent> &p_event) {
+	Ref<InputEventScreenTouch> touch = p_event;
+	if (data.vibrate_on_long_press && touch.is_valid() && touch->is_pressed() && touch->is_long_press()) {
+		OS::get_singleton()->vibrate_handheld(80);
+	}
+
 	if (p_event->get_device() != InputEvent::DEVICE_ID_INTERNAL) {
 		emit_signal(SceneStringName(gui_input), p_event); // Signal should be first, so it's possible to override an event (and then accept it).
 	}
@@ -2727,6 +2732,19 @@ Node *Control::get_shortcut_context() const {
 	Node *ctx_node = Object::cast_to<Node>(ctx_obj);
 
 	return ctx_node;
+}
+
+void Control::set_vibrate_on_long_press(bool p_enable) {
+	ERR_MAIN_THREAD_GUARD;
+	if (data.vibrate_on_long_press == p_enable) {
+		return;
+	}
+	data.vibrate_on_long_press = p_enable;
+}
+
+bool Control::is_vibrate_on_long_press() const {
+	ERR_READ_THREAD_GUARD_V(false);
+	return data.vibrate_on_long_press;
 }
 
 bool Control::is_focus_owner_in_shortcut_context() const {
@@ -4943,6 +4961,9 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_shortcut_context", "node"), &Control::set_shortcut_context);
 	ClassDB::bind_method(D_METHOD("get_shortcut_context"), &Control::get_shortcut_context);
 
+	ClassDB::bind_method(D_METHOD("set_vibrate_on_long_press", "enable"), &Control::set_vibrate_on_long_press);
+	ClassDB::bind_method(D_METHOD("is_vibrate_on_long_press"), &Control::is_vibrate_on_long_press);
+
 	ClassDB::bind_method(D_METHOD("update_maximum_size"), &Control::update_maximum_size);
 	ClassDB::bind_method(D_METHOD("update_minimum_size"), &Control::update_minimum_size);
 
@@ -5073,6 +5094,7 @@ void Control::_bind_methods() {
 
 	ADD_GROUP("Input", "");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shortcut_context", PROPERTY_HINT_NODE_TYPE, "Node"), "set_shortcut_context", "get_shortcut_context");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "vibrate_on_long_press"), "set_vibrate_on_long_press", "is_vibrate_on_long_press");
 
 	ADD_GROUP("Accessibility", "accessibility_");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "accessibility_name"), "set_accessibility_name", "get_accessibility_name");

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -289,6 +289,8 @@ private:
 		bool clip_contents = false;
 		bool disable_visibility_clip = false;
 
+		bool vibrate_on_long_press = true;
+
 		CursorShape default_cursor = CURSOR_ARROW;
 
 		// Focus.
@@ -702,6 +704,9 @@ public:
 	bool is_focus_owner_in_shortcut_context() const;
 	void set_shortcut_context(const Node *p_node);
 	Node *get_shortcut_context() const;
+
+	void set_vibrate_on_long_press(bool p_enable);
+	bool is_vibrate_on_long_press() const;
 
 	// Drag and drop handling.
 


### PR DESCRIPTION
Adds a new property to `Control` node to vibrate the device on `InputEventScreenTouch` long press events.

Discussion thread: https://chat.godotengine.org/channel/gui?msg=CMwQ6QLt79HPvqKbo

Todo:
- [ ] Rework `interface/touchscreen/haptic_on_long_press` editor setting, to use this new property.
- [ ] Maybe, add an option to set `duration` and `amplitude`?


> [!NOTE]
> First two commits are from https://github.com/godotengine/godot/pull/122865 and that PR needs to be merged first. 