### PR TITLE
LSP: Add support for inline color previews

### DIFF
--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -35,6 +35,8 @@
 #include "gdscript_language_protocol.h"
 #include "gdscript_workspace.h"
 
+#include "core/math/color_names.inc"
+
 LSP::Position GodotPosition::to_lsp() const {
 	LSP::Position res;
 	res.line = line - 1;
@@ -143,6 +145,253 @@ void ExtendGDScriptParser::update_document_links(const String &p_code) {
 					document_links.push_back(link);
 				}
 			}
+		}
+	}
+}
+
+void ExtendGDScriptParser::update_colors() {
+	colors.clear();
+
+	const GDScriptParser::ClassNode *gdclass = get_tree();
+	parse_class_for_colors(gdclass);
+}
+
+void ExtendGDScriptParser::parse_expression_for_colors(const GDScriptParser::ExpressionNode *p_node) {
+	if (!p_node) {
+		return;
+	}
+	if (p_node->type == GDScriptParser::Node::SUBSCRIPT) {
+		// Case of Color constant, such as `Color.RED`.
+		const GDScriptParser::SubscriptNode *subscript = static_cast<const GDScriptParser::SubscriptNode *>(p_node);
+		if (subscript->base->type == GDScriptParser::Node::IDENTIFIER) {
+			const GDScriptParser::IdentifierNode *base_id = static_cast<GDScriptParser::IdentifierNode *>(subscript->base);
+			if (base_id->reduced && base_id->reduced_value.get_type() == Variant::COLOR) {
+				LSP::ColorInformation color_info;
+				color_info.range = range_of_node(subscript);
+				color_info.color = Color(base_id->reduced_value);
+				colors.append(color_info);
+			}
+			if (base_id->name == "Color" && subscript->is_attribute && Color::find_named_color(subscript->attribute->name) != -1) {
+				LSP::ColorInformation color_info;
+				color_info.range = range_of_node(subscript);
+				color_info.color = Color::named(subscript->attribute->name);
+				colors.append(color_info);
+			}
+		}
+	} else if (p_node->type == GDScriptParser::Node::CALL) {
+		// Case of Color constructor, such as `Color(1.0, 0.5, 0.25)`.
+		const GDScriptParser::CallNode *call = static_cast<const GDScriptParser::CallNode *>(p_node);
+		if (call->function_name == "Color") {
+			LSP::ColorInformation color_info;
+			color_info.range = range_of_node(call);
+
+			int num_args = call->arguments.size();
+
+			if (num_args == 0) {
+				// Color()
+				color_info.color = Color();
+				colors.append(color_info);
+			} else if (num_args == 1) {
+				// Color(Color)
+				// Color(String)
+				if (call->arguments[0]->reduced) {
+					color_info.color = Color(call->arguments[0]->reduced_value);
+					colors.append(color_info);
+				}
+			} else if (num_args == 2) {
+				// Color(Color, float)
+				// Color(String, float)
+				GDScriptParser::ExpressionNode *arg0 = call->arguments[0];
+				GDScriptParser::ExpressionNode *arg1 = call->arguments[1];
+
+				if (arg0->reduced && arg1->reduced) {
+					if (arg0->reduced_value.get_type() == Variant::COLOR) {
+						color_info.color = Color(Color(arg0->reduced_value), arg1->reduced_value);
+					} else {
+						color_info.color = Color(String(arg0->reduced_value), arg1->reduced_value);
+					}
+					colors.append(color_info);
+				}
+			} else if (num_args == 3 || num_args == 4) {
+				// Color(float, float, float)
+				// Color(float, float, float, float)
+				GDScriptParser::ExpressionNode *arg0 = call->arguments[0];
+				GDScriptParser::ExpressionNode *arg1 = call->arguments[1];
+				GDScriptParser::ExpressionNode *arg2 = call->arguments[2];
+				GDScriptParser::ExpressionNode *arg3 = num_args == 4 ? call->arguments[3] : nullptr;
+
+				if (arg0->reduced && arg1->reduced && arg2->reduced && (!arg3 || arg3->reduced)) {
+					Variant r = arg0->reduced_value;
+					Variant g = arg1->reduced_value;
+					Variant b = arg2->reduced_value;
+					Variant a = arg3 ? arg3->reduced_value : Variant(1.0);
+					color_info.color = Color(r, g, b, a);
+					colors.append(color_info);
+				}
+			}
+		}
+	} else if (p_node->type == GDScriptParser::Node::ARRAY) {
+		const GDScriptParser::ArrayNode *arr = static_cast<const GDScriptParser::ArrayNode *>(p_node);
+		for (const GDScriptParser::ExpressionNode *element : arr->elements) {
+			parse_expression_for_colors(element);
+		}
+	} else if (p_node->type == GDScriptParser::Node::DICTIONARY) {
+		const GDScriptParser::DictionaryNode *dict = static_cast<const GDScriptParser::DictionaryNode *>(p_node);
+		for (GDScriptParser::DictionaryNode::Pair pair : dict->elements) {
+			parse_expression_for_colors(pair.key);
+			parse_expression_for_colors(pair.value);
+		}
+	} else if (p_node->type == GDScriptParser::Node::BINARY_OPERATOR) {
+		const GDScriptParser::BinaryOpNode *bin_op = static_cast<const GDScriptParser::BinaryOpNode *>(p_node);
+		parse_expression_for_colors(bin_op->left_operand);
+		parse_expression_for_colors(bin_op->right_operand);
+	} else if (p_node->type == GDScriptParser::Node::LAMBDA) {
+		const GDScriptParser::LambdaNode *lambda = static_cast<const GDScriptParser::LambdaNode *>(p_node);
+		if (!lambda->function) {
+			return;
+		}
+		for (const GDScriptParser::ParameterNode *parameter : lambda->function->parameters) {
+			if (parameter->initializer) {
+				parse_expression_for_colors(parameter->initializer);
+			}
+		}
+		parse_suite_for_colors(lambda->function->body);
+	} else if (p_node->type == GDScriptParser::Node::TERNARY_OPERATOR) {
+		const GDScriptParser::TernaryOpNode *ter_op = static_cast<const GDScriptParser::TernaryOpNode *>(p_node);
+		parse_expression_for_colors(ter_op->condition);
+		parse_expression_for_colors(ter_op->true_expr);
+		parse_expression_for_colors(ter_op->false_expr);
+	}
+}
+
+void ExtendGDScriptParser::parse_class_for_colors(const GDScriptParser::ClassNode *p_class) {
+	for (const GDScriptParser::ClassNode::Member &m : p_class->members) {
+		if (m.type == GDScriptParser::ClassNode::Member::VARIABLE) {
+			if (m.variable->initializer) {
+				parse_expression_for_colors(m.variable->initializer);
+			}
+			if (m.variable->property == GDScriptParser::VariableNode::PROP_INLINE) {
+				if (m.variable->setter != nullptr) {
+					parse_suite_for_colors(m.variable->setter->body);
+				}
+
+				if (m.variable->getter != nullptr) {
+					parse_suite_for_colors(m.variable->getter->body);
+				}
+			}
+		} else if (m.type == GDScriptParser::ClassNode::Member::CONSTANT) {
+			if (m.constant->initializer) {
+				parse_expression_for_colors(m.constant->initializer);
+			}
+		} else if (m.type == GDScriptParser::ClassNode::Member::FUNCTION) {
+			// Look for colors in parameters.
+			for (const GDScriptParser::ParameterNode *parameter : m.function->parameters) {
+				if (parameter->initializer) {
+					parse_expression_for_colors(parameter->initializer);
+				}
+			}
+
+			// Look for colors in suite.
+			parse_suite_for_colors(m.function->body);
+		} else if (m.type == GDScriptParser::ClassNode::Member::CLASS) {
+			parse_class_for_colors(m.m_class);
+		}
+	}
+}
+
+void ExtendGDScriptParser::parse_suite_for_colors(const GDScriptParser::SuiteNode *p_suite) {
+	for (const Node *statement : p_suite->statements) {
+		switch (statement->type) {
+			case GDScriptParser::Node::ASSERT: {
+				const GDScriptParser::AssertNode *assert = static_cast<const GDScriptParser::AssertNode *>(statement);
+				parse_expression_for_colors(assert->condition);
+				break;
+			}
+			case GDScriptParser::Node::VARIABLE: {
+				const GDScriptParser::VariableNode *variable = static_cast<const GDScriptParser::VariableNode *>(statement);
+				parse_expression_for_colors(variable->initializer);
+				break;
+			}
+			case GDScriptParser::Node::CONSTANT: {
+				const GDScriptParser::ConstantNode *constant = static_cast<const GDScriptParser::ConstantNode *>(statement);
+				parse_expression_for_colors(constant->initializer);
+				break;
+			}
+			case GDScriptParser::Node::IF: {
+				const GDScriptParser::IfNode *if_node = static_cast<const GDScriptParser::IfNode *>(statement);
+				parse_expression_for_colors(if_node->condition);
+				parse_suite_for_colors(if_node->true_block);
+				break;
+			}
+			case GDScriptParser::Node::FOR: {
+				const GDScriptParser::ForNode *for_node = static_cast<const GDScriptParser::ForNode *>(statement);
+				if (for_node->list) {
+					parse_expression_for_colors(for_node->list);
+				}
+				parse_suite_for_colors(for_node->loop);
+				break;
+			}
+			case GDScriptParser::Node::WHILE: {
+				const GDScriptParser::WhileNode *while_node = static_cast<const GDScriptParser::WhileNode *>(statement);
+				parse_expression_for_colors(while_node->condition);
+				parse_suite_for_colors(while_node->loop);
+				break;
+			}
+			case GDScriptParser::Node::MATCH: {
+				const GDScriptParser::MatchNode *match = static_cast<const GDScriptParser::MatchNode *>(statement);
+				parse_expression_for_colors(match->test);
+				for (const GDScriptParser::MatchBranchNode *branch : match->branches) {
+					for (const GDScriptParser::PatternNode *pattern : branch->patterns) {
+						parse_pattern_for_colors(pattern);
+					}
+
+					if (branch->block) {
+						parse_suite_for_colors(branch->block);
+					}
+
+					if (branch->guard_body) {
+						parse_suite_for_colors(branch->guard_body);
+					}
+				}
+				break;
+			}
+			case GDScriptParser::Node::RETURN: {
+				const GDScriptParser::ReturnNode *ret = static_cast<const GDScriptParser::ReturnNode *>(statement);
+				parse_expression_for_colors(ret->return_value);
+				break;
+			}
+			case GDScriptParser::Node::BREAK:
+			case GDScriptParser::Node::CONTINUE:
+			case GDScriptParser::Node::PASS:
+			case GDScriptParser::Node::BREAKPOINT:
+				break;
+			case GDScriptParser::Node::ASSIGNMENT: {
+				const GDScriptParser::AssignmentNode *assignment = static_cast<const GDScriptParser::AssignmentNode *>(statement);
+				parse_expression_for_colors(assignment->assigned_value);
+				break;
+			}
+			default: {
+				if (statement->is_expression()) {
+					const GDScriptParser::ExpressionNode *expression = static_cast<const GDScriptParser::ExpressionNode *>(statement);
+					parse_expression_for_colors(expression);
+				}
+				break;
+			}
+		}
+	}
+}
+
+void ExtendGDScriptParser::parse_pattern_for_colors(const GDScriptParser::PatternNode *p_pattern) {
+	if (p_pattern->pattern_type == GDScriptParser::PatternNode::PT_EXPRESSION) {
+		parse_expression_for_colors(p_pattern->expression);
+	} else if (p_pattern->pattern_type == GDScriptParser::PatternNode::PT_ARRAY) {
+		for (const GDScriptParser::PatternNode *nested_pattern : p_pattern->array) {
+			parse_pattern_for_colors(nested_pattern);
+		}
+	} else if (p_pattern->pattern_type == GDScriptParser::PatternNode::PT_DICTIONARY) {
+		for (const GDScriptParser::PatternNode::Pair pair : p_pattern->dictionary) {
+			parse_expression_for_colors(pair.key);
+			parse_pattern_for_colors(pair.value_pattern);
 		}
 	}
 }
@@ -973,4 +1222,5 @@ void ExtendGDScriptParser::parse(const String &p_code, const String &p_path) {
 	update_diagnostics();
 	update_symbols();
 	update_document_links(p_code);
+	update_colors();
 }

--- a/modules/gdscript/language_server/gdscript_extend_parser.h
+++ b/modules/gdscript/language_server/gdscript_extend_parser.h
@@ -111,6 +111,7 @@ class ExtendGDScriptParser : public GDScriptParser {
 	List<LSP::DocumentLink> document_links;
 	ClassMembers members;
 	HashMap<String, ClassMembers> inner_classes;
+	Vector<LSP::ColorInformation> colors;
 
 	LSP::Range range_of_node(const GDScriptParser::Node *p_node) const;
 
@@ -118,6 +119,11 @@ class ExtendGDScriptParser : public GDScriptParser {
 
 	void update_symbols();
 	void update_document_links(const String &p_code);
+	void update_colors();
+	void parse_expression_for_colors(const GDScriptParser::ExpressionNode *p_node);
+	void parse_class_for_colors(const GDScriptParser::ClassNode *p_class);
+	void parse_suite_for_colors(const GDScriptParser::SuiteNode *p_suite);
+	void parse_pattern_for_colors(const GDScriptParser::PatternNode *p_pattern);
 	void parse_class_symbol(const GDScriptParser::ClassNode *p_class, LSP::DocumentSymbol &r_symbol);
 	void parse_function_symbol(const GDScriptParser::FunctionNode *p_func, LSP::DocumentSymbol &r_symbol);
 
@@ -133,6 +139,7 @@ public:
 	_FORCE_INLINE_ const Vector<LSP::Diagnostic> &get_diagnostics() const { return diagnostics; }
 	_FORCE_INLINE_ const ClassMembers &get_members() const { return members; }
 	_FORCE_INLINE_ const HashMap<String, ClassMembers> &get_inner_classes() const { return inner_classes; }
+	_FORCE_INLINE_ const Vector<LSP::ColorInformation> &get_colors() const { return colors; }
 	Error parse_result;
 
 	Error get_left_function_call(const LSP::Position &p_position, LSP::Position &r_func_pos, int &r_arg_index) const;

--- a/modules/gdscript/language_server/gdscript_language_protocol.cpp
+++ b/modules/gdscript/language_server/gdscript_language_protocol.cpp
@@ -677,6 +677,8 @@ GDScriptLanguageProtocol::GDScriptLanguageProtocol() {
 	SET_DOCUMENT_METHOD(definition);
 	SET_DOCUMENT_METHOD(declaration);
 	SET_DOCUMENT_METHOD(signatureHelp);
+	SET_DOCUMENT_METHOD(documentColor);
+	SET_DOCUMENT_METHOD(colorPresentation);
 
 	SET_DOCUMENT_METHOD(nativeSymbol); // Custom method.
 

--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -368,6 +368,39 @@ Variant GDScriptTextDocument::signatureHelp(const Dictionary &p_params) {
 	return ret;
 }
 
+Array GDScriptTextDocument::documentColor(const Dictionary &p_params) {
+	Dictionary textDocument = p_params["textDocument"];
+	String uri = textDocument["uri"];
+	String path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(uri);
+
+	Array arr;
+
+	ExtendGDScriptParser *parser = GDScriptLanguageProtocol::get_singleton()->get_parse_result(path);
+	if (parser) {
+		for (const LSP::ColorInformation &color_info : parser->get_colors()) {
+			arr.push_back(color_info.to_json());
+		}
+	}
+	return arr;
+}
+
+Array GDScriptTextDocument::colorPresentation(const Dictionary &p_params) {
+	LSP::ColorPresentationParams params;
+	params.load(p_params);
+
+	LSP::ColorPresentation presentation;
+
+	if (params.color.a == 1.0) {
+		presentation.label = vformat("Color(%.2f, %.2f, %.2f)", params.color.r, params.color.g, params.color.b);
+	} else {
+		presentation.label = vformat("Color(%.2f, %.2f, %.2f, %.2f)", params.color.r, params.color.g, params.color.b, params.color.a);
+	}
+
+	Array arr;
+	arr.push_back(presentation.to_json());
+	return arr;
+}
+
 GDScriptTextDocument::GDScriptTextDocument() {
 	file_checker = FileAccess::create(FileAccess::ACCESS_RESOURCES);
 }

--- a/modules/gdscript/language_server/gdscript_text_document.h
+++ b/modules/gdscript/language_server/gdscript_text_document.h
@@ -71,6 +71,8 @@ public:
 	Array definition(const Dictionary &p_params);
 	Variant declaration(const Dictionary &p_params);
 	Variant signatureHelp(const Dictionary &p_params);
+	Array documentColor(const Dictionary &p_params);
+	Array colorPresentation(const Dictionary &p_params);
 
 	GDScriptTextDocument();
 };

--- a/modules/gdscript/language_server/godot_lsp.h
+++ b/modules/gdscript/language_server/godot_lsp.h
@@ -1575,6 +1575,76 @@ struct SignatureHelp {
 	}
 };
 
+struct ColorInformation {
+	/**
+	 * The range in the document where this color appears.
+	 */
+	Range range;
+
+	/**
+	 * The actual color value for this color range.
+	 */
+	Color color;
+
+	_FORCE_INLINE_ Dictionary to_json() const {
+		Dictionary dict;
+		dict["range"] = range.to_json();
+
+		Dictionary color_dict;
+		color_dict["red"] = color.r;
+		color_dict["green"] = color.g;
+		color_dict["blue"] = color.b;
+		color_dict["alpha"] = color.a;
+
+		dict["color"] = color_dict;
+		return dict;
+	}
+};
+
+struct ColorPresentationParams {
+	/**
+	 * The text document.
+	 */
+	TextDocumentIdentifier textDocument;
+
+	/**
+	 * The color information to request presentations for.
+	 */
+	Color color;
+
+	/**
+	 * The range where the color would be inserted. Serves as a context.
+	 */
+	Range range;
+
+	_FORCE_INLINE_ void load(const Dictionary &p_params) {
+		textDocument.load(p_params["textDocument"]);
+
+		const Dictionary c = p_params["color"];
+		color.r = c["red"];
+		color.g = c["green"];
+		color.b = c["blue"];
+		color.a = c["alpha"];
+
+		range.load(p_params["range"]);
+	}
+};
+
+struct ColorPresentation {
+	/**
+	 * The label of this color presentation. It will be shown on the color
+	 * picker header. By default this is also the text that is inserted when
+	 * selecting this color presentation.
+	 */
+	String label;
+
+	_FORCE_INLINE_ Dictionary to_json() const {
+		Dictionary dict;
+		dict["label"] = label;
+		return dict;
+	}
+};
+
 /**
  * A pattern to describe in which file operation requests or notifications
  * the server is interested in.
@@ -1749,6 +1819,13 @@ struct ServerCapabilities {
 	bool codeActionProvider = false;
 
 	/**
+	 * The server provides color provider support.
+	 *
+	 * @since 3.6.0
+	 */
+	bool colorProvider = true;
+
+	/**
 	 * The server provides document formatting.
 	 */
 	bool documentFormattingProvider = false;
@@ -1811,6 +1888,7 @@ struct ServerCapabilities {
 		dict["documentFormattingProvider"] = documentFormattingProvider;
 		dict["documentRangeFormattingProvider"] = documentRangeFormattingProvider;
 		dict["declarationProvider"] = declarationProvider;
+		dict["colorProvider"] = colorProvider;
 		return dict;
 	}
 };


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Implements https://github.com/godotengine/godot/pull/105724 and https://github.com/godotengine/godot/pull/109104 for external IDEs implementing the language server protocol

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

This PR sends information about colors in GDScript files to external editors using the LSP, allowing the editors to render inline previews of the colors. Additionally, in editors that support it (such as VS Code), hovering over the color displays a color picker, allowing the user to change or refine the color visually rather than changing numerical values.


https://github.com/user-attachments/assets/d77faede-a4d4-4963-8752-54973d6605b5

> [!note]
> While the current built-in script editor implementation appears to parse the GDScript text, this implementation instead traverses the AST generated by a GDScript parser to find the relevant references to the Color class.