### PR TITLE
GDScript: Make errors on unexpected items in property declaration more specific

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1353,8 +1353,13 @@ GDScriptParser::VariableNode *GDScriptParser::parse_property(VariableNode *p_var
 				getter_used = true;
 			}
 		} else {
-			// TODO: Update message to only have the missing one if it's the case.
-			push_error(R"(Expected "get" or "set" for property declaration.)");
+			if (!setter_used && getter_used) {
+				push_error(R"(Expected "set" for property declaration.)");
+			} else if (setter_used && !getter_used) {
+				push_error(R"(Expected "get" for property declaration.)");
+			} else {
+				push_error(R"(Expected "get" or "set" for property declaration.)");
+			}
 		}
 
 		if (i == 0 && p_variable->property == VariableNode::PROP_SETGET) {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Takes care of a TODO item in the GDScript parser 🙂

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

While working on some other things, I noticed this TODO item sitting in the code, and realized it should be pretty easy to quickly fix. With it, if a user has defined either `set` or `get` for a property, and they use an invalid name afterwards, the error message will account for the fact that the parser is no longer expecting to see a definition of the setter or getter.