### PR TITLE
GDScript: Remove outdated TODOs in parser

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -229,7 +229,6 @@ void GDScriptParser::clear() {
 }
 
 void GDScriptParser::push_error(const String &p_message, const Node *p_origin) {
-	// TODO: Improve error reporting by pointing at source code.
 	// TODO: Errors might point at more than one place at once (e.g. show previous declaration).
 	panic_mode = true;
 	ParserError err;
@@ -2246,8 +2245,6 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 		current_suite->has_unreachable_code = true;
 		if (current_function) {
 			push_warning(result, GDScriptWarning::UNREACHABLE_CODE, current_function->identifier ? current_function->identifier->name : "<anonymous lambda>");
-		} else {
-			// TODO: Properties setters and getters with unreachable code are not being warned
 		}
 	}
 #endif
@@ -2260,7 +2257,6 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 }
 
 GDScriptParser::AssertNode *GDScriptParser::parse_assert() {
-	// TODO: Add assert message.
 	AssertNode *assert = alloc_node<AssertNode>();
 
 	push_multiline(true);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Cleans up the GDScript parser a teensy bit 🙂

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

While working on some other things, I ran into a few TODO items in the GDScript parser that, to my understanding, were since addressed, but the TODO comments themselves were never removed.

- `TODO: Improve error reporting by pointing at source code.` – Comment added 6 years ago, but down below in the method, error ranges are defined with the most recent changes being 8 months ago.
- `TODO: Add assert message.` – Comment added 6 years ago, but assert message seems to be implemented down below on line 2277.

If this is too small a PR to merge at this time, I'd be happy to add more "paper-cut" fixes that I run into while working on GDScript things, until it gets substantial enough that it feels like a merge is warranted. Just hoping to improve GDScript and improve the experience of developing it along the way as I go 😄 