### PR TITLE
Jolt: Use `PositionAndVelocity` motor state when motor and spring are both enabled

### DIFF
--- a/modules/jolt_physics/joints/jolt_generic_6dof_joint_3d.cpp
+++ b/modules/jolt_physics/joints/jolt_generic_6dof_joint_3d.cpp
@@ -111,7 +111,9 @@ void JoltGeneric6DOFJoint3D::_update_limit_spring_parameters(int p_axis) {
 
 void JoltGeneric6DOFJoint3D::_update_motor_state(int p_axis) {
 	if (JPH::SixDOFConstraint *constraint = static_cast<JPH::SixDOFConstraint *>(jolt_ref.GetPtr())) {
-		if (motor_enabled[p_axis]) {
+		if (motor_enabled[p_axis] && spring_enabled[p_axis]) {
+			constraint->SetMotorState((JoltAxis)p_axis, JPH::EMotorState::PositionAndVelocity);
+		} else if (motor_enabled[p_axis]) {
 			constraint->SetMotorState((JoltAxis)p_axis, JPH::EMotorState::Velocity);
 		} else if (spring_enabled[p_axis]) {
 			constraint->SetMotorState((JoltAxis)p_axis, JPH::EMotorState::Position);


### PR DESCRIPTION
### What
Implemnts the fix discussed in godotengine/godot-proposals#14845.

Jolt's `SixDOFConstraint` supports `EMotorState::PositionAndVelocity`:

```
force = stiffness * (target_position - current_position)
      + damping   * (target_velocity - current_velocity)
```

`_update_motor_state()` never selects it, because the state was added in Jolt 5.6.0 and the mapping predates that integration (#121260). Enabling both the motor and the spring flags on an axis therefore selects `Velocity`, and the spring settings are silently unused.

| `motor_enabled` | `spring_enabled` | before | after |
|---|---|---|---|
| yes | yes | `Velocity` (spring settings unused) | `PositionAndVelocity` |
| yes | no  | `Velocity` | `Velocity` |
| no  | yes | `Position` | `Position` |
| no  | no  | `Off` | `Off` |

Only the first row changes, so no existing configuration behaves differently unless it was already setting both flags and losing the spring.

### Why 

`Position` damps against absolute velocity, so the damping term resists all motion including the motion needed to follow a moving target. `PositionAndVelocity` damps against velocity error instead, which is what a servo tracking an animated pose needs.

### Testing

I couldn't find a place to add a test for this. So I built against 4.8-dev2  and manually testsed. A 6DOF joint with all three angular axes driven, stiffness 400, damping 40, 50° target:

| target velocity | both flags | motor only | spring only |
|---|---|---|---|
| 0 rad/s | 50° → 0.0° | 50° → 50° (no movement) | 50° → 0.0° |
| 2 rad/s | 50° → 23.3°, settles | 50° → 136.8°, still rotating | 50° → 0.0° |

The residual at a non-zero velocity target is the expected steady state, approximately `damping * target_velocity / stiffness`.

### AI Disclaimer
I used a 🤖 to 
- understand the Godot/Jolt codebase to find this bit of the code (to get my active ragdolls working)
- wrangle git for this PR 

@jrouwe verified understanding/fix on godotengine/godot-proposals#14845 and suggested I create PR. 