### PR TITLE
Fix `is_ancestor_of` returning `true` when called on self.

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2170,6 +2170,9 @@ bool Node::is_ancestor_of(RequiredParam<const Node> p_node) const {
 	EXTRACT_PARAM_OR_FAIL_V(node, p_node, false);
 
 	const Node *n = node;
+	if (n == this) {
+		return false;
+	}
 
 	if (is_inside_tree() && node->data.tree == data.tree) {
 		const int depth = data.depth;

--- a/tests/scene/test_node.cpp
+++ b/tests/scene/test_node.cpp
@@ -234,15 +234,24 @@ TEST_CASE("[SceneTree][Node] Testing node operations with a more complex simple 
 	Node *node1 = memnew(Node);
 	Node *node2 = memnew(Node);
 	Node *node1_1 = memnew(Node);
+	Node *root = SceneTree::get_singleton()->get_root();
 
-	SceneTree::get_singleton()->get_root()->add_child(node1);
-	SceneTree::get_singleton()->get_root()->add_child(node2);
+	root->add_child(node1);
+	root->add_child(node2);
 
 	node1->add_child(node1_1);
 
 	CHECK(node1_1->is_inside_tree());
 	CHECK_EQ(node1_1->get_parent(), node1);
 	CHECK_EQ(node1->get_child_count(), 1);
+
+	CHECK_EQ(root->is_ancestor_of(node1), true);
+	CHECK_EQ(root->is_ancestor_of(node2), true);
+	CHECK_EQ(root->is_ancestor_of(node1_1), true);
+	CHECK_EQ(node1->is_ancestor_of(node1), false);
+	CHECK_EQ(node1->is_ancestor_of(node1_1), true);
+	CHECK_EQ(node2->is_ancestor_of(node1_1), false);
+	CHECK_EQ(node2->is_ancestor_of(node1), false);
 
 	CHECK_EQ(SceneTree::get_singleton()->get_root()->get_child_count(), 2);
 	CHECK_EQ(SceneTree::get_singleton()->get_node_count(), 4);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/122909
- Closes https://github.com/godotengine/godot/issues/122925
- Supersede https://github.com/godotengine/godot/pull/122929
