### PR TITLE
RenderingDevice: Fix the optional second argument in `_shader_create_from_spirv()` not being passed to `shader_create_from_spirv()`

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -10281,7 +10281,7 @@ RID RenderingDevice::_shader_create_from_spirv(const Ref<RDShaderSPIRV> &p_spirv
 		}
 		stage_data.push_back(sd);
 	}
-	return shader_create_from_spirv(stage_data);
+	return shader_create_from_spirv(stage_data, p_shader_name);
 }
 
 RID RenderingDevice::_uniform_set_create(const TypedArray<RDUniform> &p_uniforms, RID p_shader, uint32_t p_shader_set) {


### PR DESCRIPTION
…

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- [shader_create_from_spirv()](https://docs.godotengine.org/en/stable/classes/class_renderingdevice.html#class-renderingdevice-method-shader-create-from-spirv) method in RenderingDevice accepts the optional second argument to set the shader name. Internally it wasn't passed further so the name was never set.

## Additional information
```gdscript
@export shader_file: RDShaderFile 

func _ready():
  var spirv: RDShaderSPIRV = shader_file.get_spirv()
  var rd: RenderingDevice = RenderingServer.get_rendering_device()
  var shader_name = "TestShaderName"
  var shader_rid = rd.shader_create_from_spirv(spirv, shader_name)
```
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
