### PR TITLE
Fix infinite layout loop caused by `desired_size` circular dependency

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2073,7 +2073,14 @@ Size2 Control::get_bound_desired_size() const {
 	}
 	Size2 desired_size = data.desired_size_cache;
 	desired_size = desired_size.max(get_combined_minimum_size());
-	Size2 max_size = get_combined_maximum_size();
+	Size2 max_size = get_maximum_size();
+	Size2 custom_max_size = get_custom_maximum_size();
+	if (custom_max_size.x >= 0) {
+		max_size.x = max_size.x >= 0 ? MIN(max_size.x, custom_max_size.x) : custom_max_size.x;
+	}
+	if (custom_max_size.y >= 0) {
+		max_size.y = max_size.y >= 0 ? MIN(max_size.y, custom_max_size.y) : custom_max_size.y;
+	}
 	if (max_size.x >= 0) {
 		desired_size.x = MIN(desired_size.x, max_size.x);
 	}
@@ -2093,7 +2100,13 @@ void Control::grow_to_desired_size() {
 		return;
 	}
 
+	LayoutMode layout_mode = _get_layout_mode();
+	if (layout_mode != LayoutMode::LAYOUT_MODE_POSITION && layout_mode != LayoutMode::LAYOUT_MODE_UNCONTROLLED) {
+		return;
+	}
+
 	Size2 desired_size = get_bound_desired_size();
+
 	if (desired_size <= get_combined_minimum_size()) {
 		return;
 	}

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -1086,7 +1086,14 @@ Size2 Label::get_minimum_size() const {
 }
 
 Size2 Label::get_desired_size() const {
-	Size2 combined_max = get_combined_maximum_size();
+	Size2 combined_max = get_maximum_size();
+	Size2 custom_max = get_custom_maximum_size();
+	if (custom_max.x >= 0) {
+		combined_max.x = combined_max.x >= 0 ? MIN(combined_max.x, custom_max.x) : custom_max.x;
+	}
+	if (custom_max.y >= 0) {
+		combined_max.y = combined_max.y >= 0 ? MIN(combined_max.y, custom_max.y) : custom_max.y;
+	}
 	if (combined_max.width < 0) {
 		return Size2();
 	}

--- a/scene/gui/margin_container.cpp
+++ b/scene/gui/margin_container.cpp
@@ -50,7 +50,7 @@ Size2 MarginContainer::get_desired_size() const {
 			continue;
 		}
 
-		Size2 s = c->get_desired_size();
+		Size2 s = c->get_bound_desired_size();
 		ds = ds.max(s);
 	}
 

--- a/scene/gui/panel_container.cpp
+++ b/scene/gui/panel_container.cpp
@@ -50,7 +50,7 @@ Size2 PanelContainer::get_desired_size() const {
 			continue;
 		}
 
-		Size2 minsize = c->get_desired_size();
+		Size2 minsize = c->get_bound_desired_size();
 		ds = ds.max(minsize);
 	}
 	if (theme_cache.panel_style.is_valid()) {


### PR DESCRIPTION
This prevents a circular dependency between a child's desired size and its parent's dynamic maximum-size cache during layout.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #122944

## Additional information

Fixes an infinite layout loop that can freeze the editor when using an autowrapped `Label` inside a `BoxContainer`.

The issue comes from a circular dependency during layout. `BoxContainer` uses `get_bound_desired_size()` when calculating the space for its children, and then updates the child's `parent_maximum_size_cache`. That cache is also used when calculating the child's combined maximum size.

For an autowrapped `Label`, its desired size can depend on the width available to it. This means the parent can change the child's maximum size, which changes the label's desired size, which then changes the size calculated by the parent again. In some configurations this repeats indefinitely.

This PR changes the relevant desired-size calculations so they don't use the parent's dynamic maximum-size cache when applying the control's own maximum-size constraints. **It does this by calculating a "local maximum" that still fully respects `get_maximum_size()` and `custom_maximum_size`, ensuring user-defined limits are preserved.**

## Before:

https://github.com/user-attachments/assets/ad758af0-82cb-48f2-ab56-12bfc355734a

## After:

https://github.com/user-attachments/assets/b527105d-f4e4-4f59-8842-d221ad1b0bac