### PR TITLE
[4.4] SCons: Pass `-mcmodel=medium` on Linux x86_64 GCC sanitizers

### DIFF
--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -146,6 +146,10 @@ def configure(env: "SConsEnvironment"):
         env.extra_suffix += ".san"
         env.Append(CCFLAGS=["-DSANITIZERS_ENABLED"])
 
+        if not env["use_llvm"] and env["arch"] == "x86_64":
+            env.Append(CCFLAGS=["-mcmodel=medium"])
+            env.Append(LINKFLAGS=["-mcmodel=medium"])
+
         if env["use_ubsan"]:
             env.Append(
                 CCFLAGS=[

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -79,6 +79,7 @@ Patches:
 - `0004-remove-tinydds-qoi.patch` (GH-97582)
 - `0005-msvc-include-ctype.patch` (GH-106155)
 - `0006-clang-warning-exclude.patch` (GH-121604)
+- `0007-mcmodel-medium-section-conflict.patch` (GH-123001)
 
 
 ## brotli

--- a/thirdparty/basis_universal/encoder/basisu_astc_hdr_enc.cpp
+++ b/thirdparty/basis_universal/encoder/basisu_astc_hdr_enc.cpp
@@ -248,13 +248,11 @@ static inline half_float qlog12_to_half_slow(uint32_t qlog12)
 //half_float g_qlog12_to_half[4096];
 //float g_qlog12_to_float[4096];
 
-static half_float g_qlog16_to_half[65536];
-
 inline half_float qlog_to_half(uint32_t val, uint32_t bits)
 {
-	assert((bits >= 5) && (bits <= 16));
+	assert((bits >= 7) && (bits <= 16));
 	assert(val < (1U << bits));
-	return g_qlog16_to_half[val << (16 - bits)];
+	return qlog_to_half_slow(val, bits);
 }
 
 // nearest values given a positive half float value (only)
@@ -435,7 +433,6 @@ static void init_qlog_tables()
 	for (uint32_t i = 0; i <= 65535; i++)
 	{
 		half_float h = qlog16_to_half_slow(i);
-		g_qlog16_to_half[i] = h;
 
 		qlog16_to_float[i] = half_to_float(h);
 	}

--- a/thirdparty/basis_universal/patches/0007-mcmodel-medium-section-conflict.patch
+++ b/thirdparty/basis_universal/patches/0007-mcmodel-medium-section-conflict.patch
@@ -1,0 +1,28 @@
+diff --git a/thirdparty/basis_universal/encoder/basisu_astc_hdr_enc.cpp b/thirdparty/basis_universal/encoder/basisu_astc_hdr_enc.cpp
+index d698a7ff872..bef0b2c5f06 100644
+--- a/thirdparty/basis_universal/encoder/basisu_astc_hdr_enc.cpp
++++ b/thirdparty/basis_universal/encoder/basisu_astc_hdr_enc.cpp
+@@ -248,13 +248,11 @@ static inline half_float qlog12_to_half_slow(uint32_t qlog12)
+ //half_float g_qlog12_to_half[4096];
+ //float g_qlog12_to_float[4096];
+ 
+-static half_float g_qlog16_to_half[65536];
+-
+ inline half_float qlog_to_half(uint32_t val, uint32_t bits)
+ {
+-	assert((bits >= 5) && (bits <= 16));
++	assert((bits >= 7) && (bits <= 16));
+ 	assert(val < (1U << bits));
+-	return g_qlog16_to_half[val << (16 - bits)];
++	return qlog_to_half_slow(val, bits);
+ }
+ 
+ // nearest values given a positive half float value (only)
+@@ -435,7 +433,6 @@ static void init_qlog_tables()
+ 	for (uint32_t i = 0; i <= 65535; i++)
+ 	{
+ 		half_float h = qlog16_to_half_slow(i);
+-		g_qlog16_to_half[i] = h;
+ 
+ 		qlog16_to_float[i] = half_to_float(h);
+ 	}


### PR DESCRIPTION
This is a manual cherry-pick of PR #122804, which is itself a cherry-pick of PR #121647 and its follow-up PR #121719 to ensure that the commit is atomically correct, plus a new change only for the Godot 4.4 branch.

Why: In Basis Universal 1.50 (in Godot 4.4), this lookup table fails to compile when using `-mcmodel=medium` because of the `static half_float g_qlog16_to_half[65536];` lookup table being above the 65536-byte relocation threshold:

```
  thirdparty/basis_universal/encoder/basisu_astc_hdr_enc.cpp:261:17: error: 'basisu::g_half_to_qlog7' causes a section type conflict with 'basisu::g_qlog16_to_half'
    261 | static uint16_t g_half_to_qlog7[32768], g_half_to_qlog8[32768], g_half_to_qlog9[32768], g_half_to_qlog10[32768], g_half_to_qlog11[32768], g_half_to_qlog12[32768];
        |                 ^~~~~~~~~~~~~~~
  thirdparty/basis_universal/encoder/basisu_astc_hdr_enc.cpp:251:19: note: 'basisu::g_qlog16_to_half' was declared here
    251 | static half_float g_qlog16_to_half[65536];
        |                   ^~~~~~~~~~~~~~~~
  scons: *** [thirdparty/basis_universal/encoder/basisu_astc_hdr_enc.linuxbsd.editor.dev.double.x86_64.san.o] Error 1
```

Specifically, `[65536]` of `half_float` is 131072 bytes so it's over the threshold.

I did not check specifically which Basis Universal commit introduced the problem, but here is what I do know:

- Basis Universal fixed this by replacing the function, and therefore removing the lookup table. [The replacement](https://github.com/BinomialLLC/basis_universal/commit/ec5396c49cefbf1b09298b13845774c6cde91bf0#diff-7b0a33dd7283984111f052162bd8833b47ce775d71dd7791c8fa3a718a5c6a0cR40-R72) already exists in Basis Universal 1.50, but future Basis Universal commits replace the calls with this new code, and also future Basis Universal commits removed "slow" from the name.
- This PR fixes the problem by introducing essentially the same upstream fix: removing the lookup table, and making this function call the "slow" one (not named "slow" upstream anymore).
- The behavior is bit-for-bit identical, the only change is in the performance characteristics (which I did not benchmark) in terms of a trade-off between CPU usage and memory usage.
- The `bits >= 7` change does not alter behavior, because it is not possible for bits to be 5 or 6, and this makes the bits checks identical with upstream.
- This does not affect the 4.3 branch, which uses Basis Universal 1.16.4, which does not have this lookup table.
- This does not affect the 4.5 branch, which uses Basis Universal 1.60, which does not have this lookup table.

## Additional information

I used AI to investigate and fix the problem, then manually hunted down the corresponding upstream code, and manually verified the fix (and, of course, as always, manually wrote the PR description myself).

The "[4.4] SCons: Pass -mcmodel=medium on Linux x86_64 GCC sanitizers" commit is a clean, exact cherry-pick of PR #122804, with only the title changed. The Basis Universal commit in this PR is the new stuff.