### PR TITLE
Fix incorrect tab title in translation template generation

### DIFF
--- a/editor/translations/packed_scene_translation_parser_plugin.cpp
+++ b/editor/translations/packed_scene_translation_parser_plugin.cpp
@@ -149,7 +149,14 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 
 			if (auto_translating && !tabcontainer_paths.is_empty() && ClassDB::is_parent_class(node_type, "Control") &&
 					parent_path == tabcontainer_paths[tabcontainer_paths.size() - 1]) {
-				r_translations->push_back({ state->get_node_name(i) });
+				String tab_title = state->get_node_name(i);	// default is node name
+				for (int j = 0; j < state->get_node_property_count(i); j++) { // could iterate backward to find faster
+					if (state->get_node_property_name(i, j) == "metadata/_tab_name") {
+						tab_title = (String)state->get_node_property_value(i, j);
+						break;
+					}
+				}
+				r_translations->push_back({ tab_title });
 			}
 		}
 		if (!auto_translating) {

--- a/editor/translations/packed_scene_translation_parser_plugin.cpp
+++ b/editor/translations/packed_scene_translation_parser_plugin.cpp
@@ -149,10 +149,15 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 
 			if (auto_translating && !tabcontainer_paths.is_empty() && ClassDB::is_parent_class(node_type, "Control") &&
 					parent_path == tabcontainer_paths[tabcontainer_paths.size() - 1]) {
-				String tab_title = state->get_node_name(i);	// default is node name
-				for (int j = 0; j < state->get_node_property_count(i); j++) { // could iterate backward to find faster
-					if (state->get_node_property_name(i, j) == "metadata/_tab_name") {
+				String tab_title = state->get_node_name(i); // default is node name
+				for (int j = state->get_node_property_count(i) - 1; j >= 0; j--) {
+					// backward iteration because the metadata is always at the end
+					String property = state->get_node_property_name(i, j);
+					if (property == "metadata/_tab_name") {
 						tab_title = (String)state->get_node_property_value(i, j);
+						break;
+					}
+					if (!property.begins_with("metadata/")) {
 						break;
 					}
 				}


### PR DESCRIPTION
`PackedSceneEditorTranslationParserPlugin::parse_file` now uses metadata/_tab_name instead of node name when available if a node is a child of a `TabContainer`

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #123002
(tested on the provided MRP)

## Additional information

I'm pretty sure this change doesn't need to be more complicated, it keeps the previous behavior as a fallback. If the tab title wasn't modified in the inspector, the node's `metadata/_tab_name` will be the same as the node's `name` anyway.

I noticed that the `metadata/_tab_name` was always at the end of the property list, but reverse iteration seems like premature optimisation.
