### PR TITLE
[BaseButton] Check visible viewport rect when handling touch events.

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -74,7 +74,7 @@ void BaseButton::gui_input(const Ref<InputEvent> &p_event) {
 			if (touch->is_pressed()) {
 				status.touch_index = touch->get_index();
 				status.press_attempt = true;
-				status.pressing_inside = has_point(touch->get_position());
+				status.pressing_inside = has_point(touch->get_position()) && get_viewport_transform().xform(get_viewport_rect()).has_point(touch->get_position());
 				on_action_event(p_event);
 			}
 		} else if (touch->get_index() == status.touch_index) {
@@ -88,7 +88,7 @@ void BaseButton::gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventScreenDrag> drag = p_event;
 	if (drag.is_valid() && drag->get_index() == status.touch_index && status.press_attempt) {
 		bool last_press_inside = status.pressing_inside;
-		status.pressing_inside = has_point(drag->get_position());
+		status.pressing_inside = has_point(drag->get_position()) && get_viewport_transform().xform(get_viewport_rect()).has_point(drag->get_position());
 
 		if (last_press_inside != status.pressing_inside) {
 			queue_redraw();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/121492

## Additional information

- For mouse events, it is handed by `hover` state check (mouse enter/exit notifications).
