### PR TITLE
Don't freeze window until Preview is generated in `AudioStreamImportSettingsDialog`

### DIFF
--- a/editor/audio/audio_stream_preview.cpp
+++ b/editor/audio/audio_stream_preview.cpp
@@ -32,6 +32,7 @@
 
 #include "core/object/callable_mp.h"
 #include "core/object/class_db.h"
+#include "core/os/os.h"
 #include "servers/audio/audio_server.h"
 
 float AudioStreamPreview::get_length() const {
@@ -125,6 +126,10 @@ void AudioStreamPreviewGenerator::_preview_thread(void *p_preview) {
 	int frames_total = AudioServer::get_singleton()->get_mix_rate() * preview->preview->length;
 	int frames_todo = frames_total;
 
+	const uint64_t update_interval_usec = 16000; // Roughly 60 Hz.
+	uint64_t time_accum_usec = 0;
+	uint64_t last_time_usec = OS::get_singleton()->get_ticks_usec();
+
 	preview->playback->start();
 
 	while (frames_todo) {
@@ -162,8 +167,17 @@ void AudioStreamPreviewGenerator::_preview_thread(void *p_preview) {
 		}
 
 		frames_todo -= to_read;
-		callable_mp(singleton, &AudioStreamPreviewGenerator::_update_emit).call_deferred(preview->id);
+
+		uint64_t new_time_usec = OS::get_singleton()->get_ticks_usec();
+		time_accum_usec += new_time_usec - last_time_usec;
+		last_time_usec = new_time_usec;
+		if (time_accum_usec >= update_interval_usec) {
+			time_accum_usec = 0;
+			callable_mp(singleton, &AudioStreamPreviewGenerator::_update_emit).call_deferred(preview->id);
+		}
 	}
+
+	callable_mp(singleton, &AudioStreamPreviewGenerator::_update_emit).call_deferred(preview->id);
 
 	preview->preview->version++;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

When editing a large audio file, the window takes a while to open. It seems to freeze the editor until the preview is generated, which doesn't lead to a nice user experience. 

The actual reason for this happening is that it's constantly being redrawn, without time to escape to the next frame. It happens because `AudioStreamPreviewGenerator` emits a deferred signal that calls `queue_redraw` many times per milisecond, so when the preview finishes drawing, it draws again, until `AudioStreamPreviewGenerator` stops emiting the signal that calls `queue_redraw()`.

My proposed solution is to add a timer (not a `Timer` Node, but a manual one using `OS::get_ticks_usec()`), so the signal is emitted at a rate of (currently) 60 FPS, not after every loop iteration. This makes the audio data "load" into the preview smoothly, without freezing.

Picked 60 FPS because it's smooth enough on most displays. (didn't want to add complicated logic that detects the monitor refresh rate)

## Before

https://github.com/user-attachments/assets/096d95f9-a8a9-4d8e-9d4d-a746ebccd674

## After

https://github.com/user-attachments/assets/eac62b5c-f119-44a2-912e-133f272089b6

## Additional information

Here's 30 minutes of brown noise for testing: https://drive.google.com/file/d/1oEIzhEE6uC-LjnCHpAUbLrsWvlGg6EU8/view?usp=sharing (didn't fit in the 10 MB github limit).

This doesn't have any noticable effect on audio files that load quickly (like most game audio/SFX).

I understand that this change is controversial, but to me it feels nicer to use. It also gives the user an estimate of how long it's going to take to load the file.

No AI was used.