### PR TITLE
Fix invalid character in `X509Certificate.save_to_string()`

### DIFF
--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -308,7 +308,7 @@ String X509CertificateMbedTLS::save_to_string() {
 		ERR_FAIL_COND_V_MSG(ret != 0 || wrote == 0, String(), "Error saving the certificate.");
 
 		// PEM is base64, aka ascii
-		buffer += String::ascii(Span((char *)w, wrote));
+		buffer += String::ascii(Span((char *)w, wrote - 1));
 		crt = crt->next;
 	}
 	if (buffer.length() <= PEM_MIN_SIZE) {


### PR DESCRIPTION
This PR removes the '\0' returned by mbedtls_pem_write_buffer() (pem.c) to prevent error when calling String::ascii() in X509Certificate.save_to_string() (crypto_mbedtls.cpp).



`mbedtls_pem_write_buffer()` returns a buffer ending with '\0':
https://github.com/godotengine/godot/blob/5ec4857b340b6284a18b49b2eda462bd250f219a/thirdparty/mbedtls/tf-psa-crypto/utilities/pem.c#L448-L452

So X509Certificate.save_to_string() was always writing one extra character to the string buffer:
https://github.com/godotengine/godot/blob/5ec4857b340b6284a18b49b2eda462bd250f219a/modules/mbedtls/crypto_mbedtls.cpp#L305-L311

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #123013

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
No AI was used.
