### PR TITLE
Fix spawn packet size check overflow allowing OOB read

### DIFF
--- a/modules/multiplayer/scene_replication_interface.cpp
+++ b/modules/multiplayer/scene_replication_interface.cpp
@@ -583,7 +583,10 @@ Error SceneReplicationInterface::on_spawn_receive(int p_from, const uint8_t *p_b
 	ofs += 4;
 	uint32_t name_len = decode_uint32(&p_buffer[ofs]);
 	ofs += 4;
-	ERR_FAIL_COND_V_MSG(name_len + (sync_len * 4) > uint32_t(p_buffer_len - ofs), ERR_INVALID_DATA, vformat("Invalid spawn packet size: %d, wants: %d", p_buffer_len, ofs + name_len + (sync_len * 4)));
+	// sync_len * 4 wraps in 32-bit math (e.g. 0x40000001 * 4 == 4), passing the check below.
+	const int64_t remaining = int64_t(p_buffer_len) - int64_t(ofs);
+	const int64_t wanted = int64_t(name_len) + int64_t(sync_len) * 4;
+	ERR_FAIL_COND_V_MSG(wanted > remaining, ERR_INVALID_DATA, vformat("Invalid spawn packet size: %d, wants: %d", p_buffer_len, ofs + wanted));
 	List<uint32_t> sync_ids;
 	for (uint32_t i = 0; i < sync_len; i++) {
 		sync_ids.push_back(decode_uint32(&p_buffer[ofs]));


### PR DESCRIPTION


`SceneReplicationInterface::on_spawn_receive()` validated the spawn packet length with `name_len + (sync_len * 4)` evaluated in 32-bit math. Because `sync_len` is an attacker-controlled `uint32_t` read straight from the packet, the product wraps: `0x40000001 * 4 == 4`. The bounds check then passes for a minimally sized packet, and the following loop iterates `sync_len` times reading 4 bytes per iteration, walking far past the end of the buffer.

The comparison is now done in signed 64-bit, where the operands cannot overflow across their full input range. This also bounds the number of sync ids to the packet size, so a single 4-byte field can no longer drive unbounded `List<uint32_t>` allocation.

Reachable by any connected peer that is the authority of a `MultiplayerSpawner`, and by a malicious server against clients.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
