### PR TITLE
Make direction_to() consistent for all vector classes

### DIFF
--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -148,7 +148,8 @@
 			<return type="Vector3" />
 			<param index="0" name="to" type="Vector3" />
 			<description>
-				Returns the normalized vector pointing from this vector to [param to]. This is equivalent to using [code](b - a).normalized()[/code].
+				Returns the normalized vector pointing from this vector to [param to].
+				[code]a.direction_to(b)[/code] is equivalent to [code](b - a).normalized()[/code]. See also [method normalized].
 			</description>
 		</method>
 		<method name="distance_squared_to" qualifiers="const">

--- a/doc/classes/Vector4.xml
+++ b/doc/classes/Vector4.xml
@@ -100,7 +100,8 @@
 			<return type="Vector4" />
 			<param index="0" name="to" type="Vector4" />
 			<description>
-				Returns the normalized vector pointing from this vector to [param to]. This is equivalent to using [code](b - a).normalized()[/code].
+				Returns the normalized vector pointing from this vector to [param to].
+				[code]a.direction_to(b)[/code] is equivalent to [code](b - a).normalized()[/code]. See also [method normalized].
 			</description>
 		</method>
 		<method name="distance_squared_to" qualifiers="const">


### PR DESCRIPTION
This commit makes the documentation for direction_to() for Vector3 and Vector4 consistent with Vector2. This also fixes the confusing references to the (undefined) vectors 'a' and 'b' in the previous documentation.

## What problem(s) does this PR solve?

Fixes issues with the documentation for the `direction_to()` method in the `Vector3` and `Vector4` classes.

## Additional information

Please make sure I made the changes in the right files and that it's the only files that need changing as this is my first documentation PR.