### PR TITLE
Keep copy of UID cache for lookup during scan

### DIFF
--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -191,6 +191,13 @@ String ResourceUID::get_id_path(ID p_id) const {
 	const ResourceUID::Cache *cache = unique_ids.getptr(p_id);
 
 #if TOOLS_ENABLED
+	if (!cache) {
+		const ResourceUID::Cache *copy_cache = unique_ids_copy.getptr(p_id);
+		if (copy_cache) {
+			return String::utf8(copy_cache->cs.ptr());
+		}
+	}
+
 	// On startup, the scan_for_uid_on_startup callback should be set and will
 	// execute EditorFileSystem::scan_for_uid, which scans all project files
 	// to reload the UID cache before the first scan.
@@ -398,6 +405,7 @@ String ResourceUID::get_path_from_cache(Ref<FileAccess> &p_cache_file, const Str
 }
 
 void ResourceUID::clear() {
+	MutexLock l(mutex);
 	cache_entries = 0;
 	if (use_reverse_cache) {
 		reverse_cache.clear();
@@ -405,6 +413,20 @@ void ResourceUID::clear() {
 	unique_ids.clear();
 	changed = false;
 }
+
+#ifdef TOOLS_ENABLED
+void ResourceUID::copy_and_clear_cache() {
+	MutexLock l(mutex);
+	cache_entries = 0;
+	unique_ids_copy = std::move(unique_ids);
+	changed = false;
+}
+
+void ResourceUID::clear_copy() {
+	MutexLock l(mutex);
+	unique_ids_copy.clear();
+}
+#endif
 
 void ResourceUID::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("id_to_text", "id"), &ResourceUID::id_to_text);

--- a/core/io/resource_uid.h
+++ b/core/io/resource_uid.h
@@ -54,6 +54,9 @@ private:
 	};
 
 	HashMap<ID, Cache> unique_ids; // Unique IDs and utf8 paths (less memory used).
+#ifdef TOOLS_ENABLED
+	HashMap<ID, Cache> unique_ids_copy; // Copy of the cache during filesystem scan.
+#endif
 	bool use_reverse_cache = false;
 	HashMap<CharString, ID> reverse_cache; // Used at runtime.
 	static ResourceUID *singleton;
@@ -92,6 +95,10 @@ public:
 
 	void enable_reverse_cache() { use_reverse_cache = true; }
 	void clear();
+#ifdef TOOLS_ENABLED
+	void copy_and_clear_cache();
+	void clear_copy();
+#endif
 
 	static ResourceUID *get_singleton() { return singleton; }
 

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -510,8 +510,7 @@ void EditorFileSystem::_scan_filesystem() {
 	// On the first scan, the first_scan_root_dir is created in _first_scan_filesystem.
 	if (first_scan) {
 		sd = first_scan_root_dir;
-		// Will be updated on scan.
-		ResourceUID::get_singleton()->clear();
+		ResourceUID::get_singleton()->copy_and_clear_cache();
 		ResourceUID::scan_for_uid_on_startup = nullptr;
 		processed_files = memnew(HashSet<String>());
 	} else {
@@ -1115,6 +1114,7 @@ void EditorFileSystem::scan() {
 		scanning = true;
 		scan_total = 0;
 		_scan_filesystem();
+		ResourceUID::get_singleton()->clear_copy();
 		memdelete(filesystem);
 		//file_type_cache.clear();
 		filesystem = new_filesystem;
@@ -1793,6 +1793,7 @@ void EditorFileSystem::_notification(int p_what) {
 					}
 				} else if (!scanning && thread.is_started()) {
 					set_process(false);
+					ResourceUID::get_singleton()->clear_copy();
 
 					memdelete(filesystem);
 					filesystem = new_filesystem;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #117362

## Additional information

Inspired by https://github.com/godotengine/godot/pull/122640#issuecomment-5357106375
The editor does have access to UIDs at startup, but they were cleared on the first scan. With this PR, the editor will make a copy of the cache, which ResourceUID can use for path lookup during scan, and clears it after scanning. Note that the copied cache may contain outdated paths.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
