### PR TITLE
Fix renaming popup issue when selecting multiple nodes in Scene Tree

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3324,7 +3324,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 			case TreeItem::CELL_MODE_STRING: {
 				// Nothing in particular.
 
-				if (select_mode == SELECT_MULTI && (get_viewport()->get_processed_events_count() == focus_in_id || !already_cursor)) {
+				if (select_mode == SELECT_MULTI && (get_viewport()->get_processed_events_count() == focus_in_id || !already_cursor || single_select_defer)) {
 					bring_up_editor = false;
 				}
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #122889

## Additional information

- After Shift multi-selection, the first selected item can remain the current cursor item, causing a subsequent click to both collapse the selection and start renaming.
- Added `single_select_defer` to the `CELL_MODE_STRING` multi-selection check to prevent the same click from both collapsing the selection and starting the rename editor.
- The issue is fixed, and F2 and right-click renaming still work as expected.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
