### PR TITLE
Fix crash when hovering node

### DIFF
--- a/editor/docks/scene_tree_dock.cpp
+++ b/editor/docks/scene_tree_dock.cpp
@@ -129,7 +129,7 @@ void SceneTreeDock::_handle_hover_to_inspect() {
 
 	if (item) {
 		const NodePath &np = item->get_metadata(0);
-		node_hovered_now = get_node_or_null(np);
+		node_hovered_now = edited_scene->get_node_or_null(np);
 		if (node_hovered_previously != node_hovered_now) {
 			inspect_hovered_node_delay->start();
 		}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #123025 (I think?)

This is the stack trace I manged to get:
```
[1] 7fc38ea43190 (libc.so.6+43190) - /lib64/libc.so.6(+0x43190) [0x7fc38ea43190]
[2] 5226f32 (main+5026f32) - Node::is_inside_tree() const at /home/tomek/Godot/Source/scene/main/node.h:566
[3] 7daad41 (main+7baad41) - Node::get_path() const at /home/tomek/Godot/Source/scene/main/node.cpp:2460 (discriminator 1)
[4] 70cf147 (main+6ecf147) - SceneTreeDock::_inspect_hovered_node() at /home/tomek/Godot/Source/editor/docks/scene_tree_dock.cpp:108 (discriminator 1)
[5] 7158ade (main+6f58ade) - void call_with_variant_args_helper<SceneTreeDock>(SceneTreeDock*, void (SceneTreeDock::*)(), Variant const**, Callable::CallError&, IndexSequence<>) at /home/tomek/Godot/Source/core/variant/binder_common.h:63
[6] 71534b9 (main+6f534b9) - void call_with_variant_args<SceneTreeDock>(SceneTreeDock*, void (SceneTreeDock::*)(), Variant const**, int, Callable::CallError&) at /home/tomek/Godot/Source/core/variant/binder_common.h:173
[7] 713fafb (main+6f3fafb) - CallableCustomMethodPointer<SceneTreeDock, void>::call(Variant const**, int, Variant&, Callable::CallError&) const at /home/tomek/Godot/Source/core/object/callable_mp.h:107
[8] 9fa9ead (main+9da9ead) - Callable::callp(Variant const**, int, Variant&, Callable::CallError&) const at /home/tomek/Godot/Source/core/variant/callable.cpp:58
[9] a31db82 (main+a11db82) - Object::emit_signalp(StringName const&, Variant const**, int) at /home/tomek/Godot/Source/core/object/object.cpp:1368
[10] 7dbb4a5 (main+7bbb4a5) - Node::emit_signalp(StringName const&, Variant const**, int) at /home/tomek/Godot/Source/scene/main/node.cpp:4222 (discriminator 1)
[11] 4e53361 (main+4c53361) - Error Object::emit_signal<>(StringName const&) at /home/tomek/Godot/Source/core/object/object.h:779
[12] 7dd07c5 (main+7bd07c5) - Timer::_notification(int) at /home/tomek/Godot/Source/scene/main/timer.cpp:69
[13] 7e328d8 (main+7c328d8) - Timer::_notification_forwardv(int) at /home/tomek/Godot/Source/scene/main/timer.h:36
[14] a31bd95 (main+a11bd95) - Object::_notification_forward(int) at /home/tomek/Godot/Source/core/object/object.cpp:994
[15] 4a5de4e (main+485de4e) - Object::notification(int, bool) at /home/tomek/Godot/Source/core/object/object.h:733
[16] 7dc19b4 (main+7bc19b4) - SceneTree::_process_group(SceneTree::ProcessGroup*, bool) at /home/tomek/Godot/Source/scene/main/scene_tree.cpp:1235
[17] 7dc1f4c (main+7bc1f4c) - SceneTree::_process(bool) at /home/tomek/Godot/Source/scene/main/scene_tree.cpp:1308 (discriminator 1)
[18] 7dbfb04 (main+7bbfb04) - SceneTree::process(double) at /home/tomek/Godot/Source/scene/main/scene_tree.cpp:721
[19] 4b62cd9 (main+4962cd9) - Main::iteration() at /home/tomek/Godot/Source/main/main.cpp:5029 (discriminator 3)
[20] 4a66c2f (main+4866c2f) - OS_LinuxBSD::run() at /home/tomek/Godot/Source/platform/linuxbsd/os_linuxbsd.cpp:1026 (discriminator 1)
[21] 4a7bdfd (main+487bdfd) - main at /home/tomek/Godot/Source/platform/linuxbsd/godot_linuxbsd.cpp:122
[22] 7fc38ea2b4fe (libc.so.6+2b4fe) - /lib64/libc.so.6(+0x2b4fe) [0x7fc38ea2b4fe]
[23] 7fc38ea2b62b (libc.so.6+2b62b) - /lib64/libc.so.6(__libc_start_main+0x8d) [0x7fc38ea2b62b]
[24] 4a5c5a5 (main+485c5a5) - _start at /home/abuild/rpmbuild/BUILD/glibc-2.43-build/glibc-2.43/csu/../sysdeps/x86_64/start.S:117
-- END OF C++ BACKTRACE --
```
The problem turned out to be unrelated to moving docks. The Scene dock could crash when hovering node, after the switch to scene-relative paths. After the fix I can't reproduce the dock-moving crash, so it was probably this.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
