### PR TITLE
AudioStreamPreview: Optimize `get_min()` and `get_max()`

### DIFF
--- a/editor/audio/audio_stream_preview.cpp
+++ b/editor/audio/audio_stream_preview.cpp
@@ -57,11 +57,11 @@ float AudioStreamPreview::get_max(float p_time, float p_time_next) const {
 		time_to = time_from + 1;
 	}
 
-	uint8_t vmax = 0;
+	uint8_t vmax = preview[time_from * 2 + 1];
 
-	for (int i = time_from; i < time_to; i++) {
+	for (int i = time_from + 1; i < time_to; i++) {
 		uint8_t v = preview[i * 2 + 1];
-		if (i == 0 || v > vmax) {
+		if (v > vmax) {
 			vmax = v;
 		}
 	}
@@ -88,11 +88,11 @@ float AudioStreamPreview::get_min(float p_time, float p_time_next) const {
 		time_to = time_from + 1;
 	}
 
-	uint8_t vmin = 255;
+	uint8_t vmin = preview[time_from * 2];
 
-	for (int i = time_from; i < time_to; i++) {
+	for (int i = time_from + 1; i < time_to; i++) {
 		uint8_t v = preview[i * 2];
-		if (i == 0 || v < vmin) {
+		if (v < vmin) {
 			vmin = v;
 		}
 	}


### PR DESCRIPTION
## What problem(s) does this PR solve?

In this part of code:

https://github.com/godotengine/godot/blob/5ec4857b340b6284a18b49b2eda462bd250f219a/editor/audio/audio_stream_preview.cpp#L56-L67

the loop is guaranteed to run at least one iteration, thanks to the condition above. In the loop, we check if it's the first iteration, and if it is, we set the max value to the current value.

By simply setting the variable to the first value outside of that loop, we get a `19%` speed increase. (the compiler probably can optimize it better now)

Note that the draw call of the preview in `AudioStreamImportSettingsDialog` spends like 99% of it's time in these functions. Using the example audio from https://github.com/godotengine/godot/pull/123012, the `_draw_preview` time drops from `8.6 ms` to `7.0 ms`. 

<img width="690" height="503" alt="image" src="https://github.com/user-attachments/assets/bdf97bdc-67ea-4676-b49f-694892db4207" />

## Additional information

Compiler arguments: `scons platform=windows target=editor arch=x86_64` with MSVC. Different compilers or flags may reduce these benefits. Ran about 50 iterations for each tested version.

No AI was used.
