### PR TITLE
AudioStreamPreview: Use `LocalVector` instead of `Vector`

### DIFF
--- a/editor/audio/audio_stream_preview.cpp
+++ b/editor/audio/audio_stream_preview.cpp
@@ -119,7 +119,7 @@ void AudioStreamPreviewGenerator::_preview_thread(void *p_preview) {
 
 	int mixbuff_chunk_frames = AudioServer::get_singleton()->get_mix_rate() * muxbuff_chunk_s;
 
-	Vector<AudioFrame> mix_chunk;
+	LocalVector<AudioFrame> mix_chunk;
 	mix_chunk.resize(mixbuff_chunk_frames);
 
 	int frames_total = AudioServer::get_singleton()->get_mix_rate() * preview->preview->length;
@@ -131,9 +131,9 @@ void AudioStreamPreviewGenerator::_preview_thread(void *p_preview) {
 		int ofs_write = uint64_t(frames_total - frames_todo) * uint64_t(preview->preview->preview.size() / 2) / uint64_t(frames_total);
 		int to_read = MIN(frames_todo, mixbuff_chunk_frames);
 		int to_write = uint64_t(to_read) * uint64_t(preview->preview->preview.size() / 2) / uint64_t(frames_total);
-		to_write = MIN(to_write, (preview->preview->preview.size() / 2) - ofs_write);
+		to_write = MIN(to_write, int(preview->preview->preview.size() / 2) - ofs_write);
 
-		preview->playback->mix(mix_chunk.ptrw(), 1.0, to_read);
+		preview->playback->mix(mix_chunk.ptr(), 1.0, to_read);
 
 		for (int i = 0; i < to_write; i++) {
 			float max = -1000;
@@ -157,8 +157,8 @@ void AudioStreamPreviewGenerator::_preview_thread(void *p_preview) {
 			uint8_t pfrom = CLAMP((min * 0.5 + 0.5) * 255, 0, 255);
 			uint8_t pto = CLAMP((max * 0.5 + 0.5) * 255, 0, 255);
 
-			preview->preview->preview.write[(ofs_write + i) * 2 + 0] = pfrom;
-			preview->preview->preview.write[(ofs_write + i) * 2 + 1] = pto;
+			preview->preview->preview[(ofs_write + i) * 2 + 0] = pfrom;
+			preview->preview->preview[(ofs_write + i) * 2 + 1] = pto;
 		}
 
 		frames_todo -= to_read;
@@ -196,14 +196,11 @@ Ref<AudioStreamPreview> AudioStreamPreviewGenerator::generate_preview(const Ref<
 
 	int frames = AudioServer::get_singleton()->get_mix_rate() * len_s;
 
-	Vector<uint8_t> maxmin;
+	LocalVector<uint8_t> maxmin;
 	int pw = frames / 20;
 	maxmin.resize(pw * 2);
-	{
-		uint8_t *ptr = maxmin.ptrw();
-		for (int i = 0; i < pw * 2; i++) {
-			ptr[i] = 127;
-		}
+	for (int i = 0; i < pw * 2; i++) {
+		maxmin[i] = 127;
 	}
 
 	preview->preview.instantiate();

--- a/editor/audio/audio_stream_preview.h
+++ b/editor/audio/audio_stream_preview.h
@@ -38,7 +38,7 @@
 class AudioStreamPreview : public RefCounted {
 	GDCLASS(AudioStreamPreview, RefCounted);
 	friend class AudioStream;
-	Vector<uint8_t> preview;
+	LocalVector<uint8_t> preview;
 	float length;
 
 	friend class AudioStreamPreviewGenerator;


### PR DESCRIPTION
## What problem(s) does this PR solve?

The main reason was to clean up this codeblock:

https://github.com/godotengine/godot/blob/5ec4857b340b6284a18b49b2eda462bd250f219a/editor/audio/audio_stream_preview.cpp#L199-L207

but it turns out there's a real performance benefit - see below.

## `AudioStreamPreview::preview`

Doesn't need CoW.

Changing this to `LocalVector` improves the performance of `AudioStreamPreview::get_max()` / `get_min()` by 10%, together with #123033 by 27%, which makes `AudioStreamImportSettingsDialog::_draw_preview()` faster by the same amount - see the other PR for more details on that.

This change doesn't hurt thread safety, as it's only accessed from `AudioStreamPreview` and `AudioStreamPreviewGenerator`, which don't copy it anywhere. There should probably be a Mutex, but that's not in the scope of this PR, and this bug existed before this change.

## `Vector<AudioFrame> mix_chunk` in `AudioStreamPreviewGenerator::_preview_thread`

Doesn't need CoW, but changing it to `LocalVector` doesn't produce any performance impact (the overhead is very small in this case), so it's only a codestyle change.

## Additional information

No AI was used.
