### PR TITLE
Remove `GDScript::get_native`

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -248,7 +248,6 @@ public:
 		CRASH_COND(!member_indices.has(p_member));
 		return member_indices[p_member].data_type;
 	}
-	const Ref<GDScriptNativeClass> &get_native() const { return native; }
 
 	_FORCE_INLINE_ const HashMap<StringName, GDScriptFunction *> &get_member_functions() const { return member_functions; }
 	_FORCE_INLINE_ const HashMap<GDScriptFunction *, LambdaInfo> &get_lambda_info() const { return lambda_info; }

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -671,7 +671,7 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 	}
 
 	// Create object instance for test.
-	Object *obj = ClassDB::instantiate(script->get_native()->get_name());
+	Object *obj = ClassDB::instantiate(script->get_instance_base_type());
 	Ref<RefCounted> obj_ref;
 	if (obj->is_ref_counted()) {
 		obj_ref = Ref<RefCounted>(Object::cast_to<RefCounted>(obj));


### PR DESCRIPTION
## What problem(s) does this PR solve?

- The method is only used from the test runner and can easily be substituted by `get_instance_base_type`. By getting rid of trivial getters like this, it gets easier to work with the code using IDE functions like "find all references".
