### PR TITLE
Discard outdated diagnostics in `GDScriptEditorLanguage::validate`

### DIFF
--- a/editor/gui/code_editor.cpp
+++ b/editor/gui/code_editor.cpp
@@ -1614,6 +1614,9 @@ Point2i CodeTextEditor::get_pos_for_display(Point2i p_internal_position) const {
 
 	int corrected_column = 0;
 	for (int i = 0; i < p_internal_position.y; i++) {
+		if (i >= line_text.size()) {
+			break;
+		}
 		if (line_text[i] == '\t') {
 			corrected_column += indent_size - (corrected_column % indent_size);
 		} else {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -205,6 +205,12 @@ bool GDScriptEditorLanguage::validate(const String &p_script, const String &p_pa
 			}
 
 			for (KeyValue<String, Ref<GDScriptParserRef>> E : parser.get_depended_parsers()) {
+				if (GDScript::is_canonically_equal_paths(E.key, p_path)) {
+					// HACK: A bug in the analyzer can lead to it depending on itself, which pulls an outdated parser from the cache.
+					// The errors from this parser are irrelevant and the wrong positions could lead to crashes down the line.
+					continue;
+				}
+
 				GDScriptParser *depended_parser = E.value->get_parser();
 				for (const GDScriptParser::ParserError &pe : depended_parser->get_errors()) {
 					ScriptError e;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/122821

## Additional information

This is a workaround. Fixing the root cause will be more involved, so we should merge this to get the crash addressed.

Also applied a bit more checks to the editor side of things, just in case.