### PR TITLE
Fix ImageLoaderHDR possibly hanging on a truncated image

### DIFF
--- a/modules/hdr/image_loader_hdr.cpp
+++ b/modules/hdr/image_loader_hdr.cpp
@@ -103,6 +103,8 @@ Error ImageLoaderHDR::load_image(Ref<Image> p_image, Ref<FileAccess> f, BitField
 					int i = 0;
 					while (i < width) {
 						int count = f->get_8();
+						ERR_FAIL_COND_V_MSG(count == 0, ERR_FILE_CORRUPT, "Invalid decoded run count, corrupt HDR.");
+
 						if (count > 128) {
 							// Run
 							int value = f->get_8();


### PR DESCRIPTION
## What problem(s) does this PR solve?
The ImageLoaderHDR can currently infinitely hang busily if the image is truncated. When reading RLE data, it is possible for it to enter a state where if the buffer runs out, it tries to read again continously

## Additional information
To fix the issue, I added a check that the decoded run count is not 0. 0 would be an invalid value anyway and is returned when the buffer runs out.  If we want to make sure the 0 is because we reached eof, I can add a check for `FileAcess::get_error`
