### PR TITLE
Android editor: Show the StatusBar when in portrait mode

### DIFF
--- a/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
+++ b/platform/android/java/lib/src/main/java/org/godotengine/godot/Godot.kt
@@ -448,11 +448,15 @@ class Godot private constructor(val context: Context) {
 			controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
 		} else {
 			val fullScreenThemeValue = TypedValue()
-			val hasStatusBar = if (activity.theme.resolveAttribute(android.R.attr.windowFullscreen, fullScreenThemeValue, true) && fullScreenThemeValue.type == TypedValue.TYPE_INT_BOOLEAN) {
+			var hasStatusBar = if (activity.theme.resolveAttribute(android.R.attr.windowFullscreen, fullScreenThemeValue, true) && fullScreenThemeValue.type == TypedValue.TYPE_INT_BOOLEAN) {
 				fullScreenThemeValue.data == 0
 			} else {
 				// Fallback to checking the editor build
 				!isEditorBuild()
+			}
+
+			if (isEditorBuild() && orientation == Configuration.ORIENTATION_PORTRAIT) {
+				hasStatusBar = true
 			}
 
 			val types = if (hasStatusBar) {
@@ -786,6 +790,18 @@ class Godot private constructor(val context: Context) {
 			orientation = newConfig.orientation
 			runOnRenderThread {
 				GodotLib.onOrientationChange(orientation)
+			}
+
+			if (isEditorBuild() && !isInImmersiveMode()) {
+				val window = getActivity()?.window
+				if (window != null) {
+					val controller = WindowInsetsControllerCompat(window, window.decorView)
+					if (orientation == Configuration.ORIENTATION_PORTRAIT) {
+						controller.show(WindowInsetsCompat.Type.statusBars())
+					} else {
+						controller.hide(WindowInsetsCompat.Type.statusBars())
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This PR enables the status bar in portrait mode (if not in immersive), while keeping it hidden in landscape.


https://github.com/user-attachments/assets/35ffeef1-f4ac-4c11-9541-2f60b5d5b3e3

