### PR TITLE
 [GDScript] Fix hot reload leaving new members as Nil 

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2043,16 +2043,31 @@ void GDScriptInstance::reload_members() {
 	new_members.resize(script->member_indices.size());
 
 	// Transfer the old members into their new position.
-	for (KeyValue<StringName, GDScript::MemberInfo> &E : script->member_indices) {
-		const GDScript::MemberInfo *old = script->old_member_indices.getptr(E.key);
+	for (KeyValue<StringName, GDScript::MemberInfo> &current_member_index : script->member_indices) {
+		// Try to find the member in the existing list
+		const GDScript::MemberInfo *old = script->old_member_indices.getptr(current_member_index.key);
 		if (old != nullptr) {
+			// If found, transfer it
 			Variant value = members[old->index];
-			new_members[E.value.index] = value;
+			new_members[current_member_index.value.index] = value;
+		} else {
+			// If not found, attempt to set the default value
+			new_members[current_member_index.value.index] = _get_default_value_for_member(current_member_index);
 		}
 	}
 	members = std::move(new_members);
 
 #endif
+}
+
+Variant GDScriptInstance::_get_default_value_for_member(const KeyValue<StringName, GDScript::MemberInfo> &p_member_index) {
+#ifdef TOOLS_ENABLED
+	if (script->member_default_values.has(p_member_index.key)) {
+		return script->member_default_values.get(p_member_index.key);
+	}
+#endif
+
+	return GDScriptFunction::get_default_variant_for_data_type(p_member_index.value.data_type);
 }
 
 GDScriptInstance::~GDScriptInstance() {

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -389,6 +389,7 @@ public:
 	void set_path(const String &p_path);
 
 	void reload_members();
+	Variant _get_default_value_for_member(const KeyValue<StringName, GDScript::MemberInfo> &p_member_index);
 
 	virtual const Variant get_rpc_config() const;
 

--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -453,10 +453,10 @@ private:
 	String _get_callable_call_error(const String &p_where, const Callable &p_callable, const Variant **p_argptrs, int p_argcount, const Variant &p_ret, const Callable::CallError &p_err) const;
 #endif
 
-	Variant _get_default_variant_for_data_type(const GDScriptDataType &p_data_type);
-
 public:
 	static constexpr int MAX_CALL_DEPTH = 2048; // Limit to try to avoid crash because of a stack overflow.
+
+	static Variant get_default_variant_for_data_type(const GDScriptDataType &p_data_type);
 
 	struct CallState {
 		Signal completed;

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -117,7 +117,7 @@ void GDScriptFunction::_profile_native_call(uint64_t p_t_taken, const String &p_
 
 #endif // DEBUG_ENABLED
 
-Variant GDScriptFunction::_get_default_variant_for_data_type(const GDScriptDataType &p_data_type) {
+Variant GDScriptFunction::get_default_variant_for_data_type(const GDScriptDataType &p_data_type) {
 	if (p_data_type.kind == GDScriptDataType::BUILTIN) {
 		if (p_data_type.builtin_type == Variant::ARRAY) {
 			Array array;
@@ -502,7 +502,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 	OPCODES_TABLE;
 
 	if (!_code_ptr) {
-		return _get_default_variant_for_data_type(return_type);
+		return get_default_variant_for_data_type(return_type);
 	}
 
 	r_err.error = Callable::CallError::CALL_OK;
@@ -524,7 +524,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		_err_print_error(err_func.utf8().get_data(), err_file.utf8().get_data(), err_line, err_text, false, ERR_HANDLER_SCRIPT);
 		GDScriptLanguage::get_singleton()->debug_break(err_text, false);
 #endif
-		return _get_default_variant_for_data_type(return_type);
+		return get_default_variant_for_data_type(return_type);
 	}
 
 	Variant retvalue;
@@ -560,13 +560,13 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					r_err.error = Callable::CallError::CALL_ERROR_TOO_MANY_ARGUMENTS;
 					r_err.expected = _argument_count;
 					call_depth--;
-					return _get_default_variant_for_data_type(return_type);
+					return get_default_variant_for_data_type(return_type);
 				}
 			} else if (p_argcount < _argument_count - _default_arg_count) {
 				r_err.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
 				r_err.expected = _argument_count - _default_arg_count;
 				call_depth--;
-				return _get_default_variant_for_data_type(return_type);
+				return get_default_variant_for_data_type(return_type);
 			} else {
 				defarg = _argument_count - p_argcount;
 			}
@@ -594,7 +594,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				r_err.argument = i;
 				r_err.expected = argument_types[i].builtin_type;
 				call_depth--;
-				return _get_default_variant_for_data_type(return_type);
+				return get_default_variant_for_data_type(return_type);
 			}
 			if (argument_types[i].kind == GDScriptDataType::BUILTIN) {
 				if (argument_types[i].builtin_type == Variant::DICTIONARY && argument_types[i].has_container_element_types()) {
@@ -614,7 +614,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 						r_err.argument = i;
 						r_err.expected = argument_types[i].builtin_type;
 						call_depth--;
-						return _get_default_variant_for_data_type(return_type);
+						return get_default_variant_for_data_type(return_type);
 					}
 					memnew_placement(&stack[i + FIXED_ADDRESSES_MAX], Variant(variant));
 				}
@@ -3989,7 +3989,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 		GDScriptLanguage::get_singleton()->debug_break(err_text, false);
 
 		// Get a default return type in case of failure
-		retvalue = _get_default_variant_for_data_type(return_type);
+		retvalue = get_default_variant_for_data_type(return_type);
 #endif
 
 		OPCODE_OUT;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #119057

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

In the hot reload's `reload_members()` function, if the member did not previously exist in the script (which means it has been added during this hot reload iteration), it tries to initialize a value for the new member.

If the script declares a default value for the member, use the declared default value, if not, get the default value for the type. This is done by calling the existing method to get default values for GDScript types.

I have made the `_get_default_value_for_member()` method of `GDScriptFunction` static and public as it does not access any of the members of the class. However, I am not sure this is the correct approach.

I am not sure what the `GDScriptFunction` class represents exactly, but I assume the method was made private and non-static as this was not supposed to be needed anywhere else at the time of originally writing the code. It is needed to fix this issue, though.

Please do tell me if it would make sense to move this method another class, or if there is any reason to keep it private and non-static, and which approach should I take in that case.

I did personally not use AI to make this PR, but I did look at the previous PR that attempted to fix this issue (#119058), which did tell me where this fix should be done, and was later closed per the AI guidelines. I have made sure to understand why the fix needs to be in `reload_members()` and the code is mine.

## Testing and result

I have tested this myself by adding new members of different types, both with and without default values. Right now it does not support custom default values for dictionaries and arrays (couldnt find where it is located in the script instance).

### Master branch (5ec4857b340b6284a18b49b2eda462bd250f219a)

https://github.com/user-attachments/assets/f8b1934d-6e3f-4d91-a421-6654b467756a

### After

https://github.com/user-attachments/assets/7f61b81e-db25-4baf-bcf6-c5614fdf1d34



