### PR TITLE
Script Editor: Make override indicators for inner class methods be relative to their parent class

### DIFF
--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1610,16 +1610,36 @@ void ScriptTextEditor::_update_connected_methods() {
 			continue;
 		}
 
+		StringName base_class = script->get_instance_base_type();
+		Ref<Script> inherited_script = script->get_base_script();
+
 		// Account for inner classes by stripping the class names from the method,
 		// starting from the right since our inner class might be inside of another inner class.
+		// We then iterate down the inner class "path" to ensure we're checking the correct
+		// base class for methods to mark as overridden.
+		String found_base_class;
 		int pos = raw_name.rfind_char('.');
 		if (pos != -1) {
 			name = raw_name.substr(pos + 1);
+
+			// We start with the main script class, and work through inner classes
+			// until we get to the inner class that is extending a type including
+			// overriding methods.
+			Ref<Script> current_inner_class_script = script;
+			for (const String &current_inner_class_name : raw_name.substr(0, pos).split(".")) {
+				HashMap<StringName, Variant> consts;
+				current_inner_class_script->get_constants(&consts);
+
+				if (consts.has(current_inner_class_name)) {
+					current_inner_class_script = consts.get(current_inner_class_name);
+				} else {
+					break;
+				}
+			}
+			base_class = current_inner_class_script->get_instance_base_type();
+			inherited_script = current_inner_class_script->get_base_script();
 		}
 
-		String found_base_class;
-		StringName base_class = script->get_instance_base_type();
-		Ref<Script> inherited_script = script->get_base_script();
 		while (inherited_script.is_valid()) {
 			if (inherited_script->has_method(name)) {
 				found_base_class = "script:" + inherited_script->get_path();


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #122975

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

Previously, `ScriptTextEditor::_update_connected_methods()` would always look to the class that the script _as a whole_ extended for potential override candidates. This is fine for "top-level" methods that belong to the script's class. However, inner classes are capable of extending classes independently of their "outer class"; as such, the methods they should have marked as being overrides are independent of their "outer class's" ancestry.

With this PR, if we detect that a method belongs to an inner class, we traverse the inner class path so that we can find the class that the relevant inner class extends, and search _it_ for methods the inner class may be overriding.

Here is a comparison of behavior without and with the PR applied, using a modified version of the MRP provided in #122975:

| Without PR | With PR |
| ----------- | -------- |
| <img width="572" height="829" alt="CleanShot 2026-08-31 at 08 56 26@2x" src="https://github.com/user-attachments/assets/dc9932ef-c05e-4649-9a44-9a33f89d837a" /> | <img width="591" height="824" alt="CleanShot 2026-08-31 at 08 53 40@2x" src="https://github.com/user-attachments/assets/693f83f2-1f25-4c49-8764-254d589f47d3" /> |

- `Inner.SuperInner` extends `Node`, so `Inner.SuperInner._ready()` is a valid override.
- `Inner` extends `Object`, _not_ `Node`, so `Inner._ready()` and `Inner._process()` are _not_ valid overrides.
- `Inner2` extends `Abstract` which in turn extends `Object`, so `Inner2._ready()` is _not_ a valid override, and `Inner2.abstract_method()` is a valid override.
- `ExtendingClass` extends `Script2.AnotherInner` which has the method `override_me()` (not pictured), so `ExtendingClass.override_me()` is a valid override.
- The main class of the script extends `Node`, so `_ready()` is a valid override.