### PR TITLE
Disable pancake when angular distance is bigger than 0.

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -40,6 +40,7 @@
 #include "servers/rendering/renderer_rd/uniform_set_cache_rd.h"
 #include "servers/rendering/rendering_device.h"
 #include "servers/rendering/rendering_server_default.h"
+#include "servers/rendering/rendering_server_enums.h"
 #include "servers/rendering/storage/ltc_lut.gen.h"
 
 #include "modules/modules_enabled.gen.h"
@@ -2666,7 +2667,9 @@ void RenderForwardClustered::_render_shadow_pass(RID p_light, RID p_shadow_atlas
 			light_storage->light_instance_set_shadow_pass(p_light, get_scene_pass());
 		}
 
-		use_pancake = light_storage->light_get_param(base, RSE::LIGHT_PARAM_SHADOW_PANCAKE_SIZE) > 0;
+		// Disable pancake when DirectionalLight3D.angular_distance is bigger than 0.
+		// Pancake flattens the depth buffer and PCSS need the full depth buffer untouched to work correctly.
+		use_pancake = light_storage->light_get_param(base, RSE::LIGHT_PARAM_SHADOW_PANCAKE_SIZE) > 0 && light_storage->light_get_param(base, RSE::LIGHT_PARAM_SIZE) <= 0;
 		light_projection = light_storage->light_instance_get_shadow_camera(p_light, p_pass);
 		light_transform = light_storage->light_instance_get_shadow_transform(p_light, p_pass);
 


### PR DESCRIPTION
Pancake flattens the depth buffer and PCSS need the full depth buffer untouched to work correctly.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/63610

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

This only disables setting the `SCENE_DATA_FLAGS_USE_PANCAKE_SHADOWS` in the shader. The shadow's camera z-far offset that pancake offers is still needed to avoid culling distant objects behind the camera.

The user still needs to tweak the `DirectionalLight3D.pancake_size` to avoid culling said objects. It depends on the angle of the shadow, the light max distance,... 
