### PR TITLE
[Android] Update the logic to validate the Android SDK setup

### DIFF
--- a/editor/export/android_sdk_manager.cpp
+++ b/editor/export/android_sdk_manager.cpp
@@ -54,9 +54,13 @@ static const char *ANDROID_SDK_PACKAGES[] = {
 	"platform-tools",
 	"build-tools/36.1.0", // Should match the value in 'platform/android/java/app/config.gradle#buildTools'.
 	"platforms/android-36",
+	"cmdline-tools/latest",
+	nullptr
+};
+// Android NDK packages.
+static const char *ANDROID_NDK_PACKAGES[] = {
 	"ndk/29.0.14206865", // Should match the value in 'platform/android/java/app/config.gradle#ndkVersion'.
 	"cmake/3.22.1",
-	"cmdline-tools/latest",
 	nullptr
 };
 
@@ -320,15 +324,23 @@ void AndroidSDKManager::_install_android_sdk_packages() {
 	cli_args.push_back("sdk");
 	cli_args.push_back("install");
 
-	const char **packages = ANDROID_SDK_PACKAGES;
-	while (*packages) {
-		String package = String(*packages);
+	const char **sdk_packages = ANDROID_SDK_PACKAGES;
+	while (*sdk_packages) {
+		String package = String(*sdk_packages);
 		print_verbose("Requesting Android SDK package " + package);
 		cli_args.push_back(package);
-		packages++;
+		sdk_packages++;
 	}
 
-	print_verbose("Installing Android SDK packages to " + default_android_sdk_path);
+	const char **ndk_packages = ANDROID_NDK_PACKAGES;
+	while (*ndk_packages) {
+		String package = String(*ndk_packages);
+		print_verbose("Requesting Android NDK package " + package);
+		cli_args.push_back(package);
+		ndk_packages++;
+	}
+
+	print_verbose("Installing Android SDK / NDK packages to " + default_android_sdk_path);
 	setup_process_data = OS::get_singleton()->execute_with_pipe(cli_bin, cli_args, false);
 	if (!setup_process_data.has("pid") || setup_process_data["pid"].operator int() <= 0) {
 		ERR_PRINT("Installation of Android SDK packages failed.");

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -15,7 +15,7 @@ ext.versions = [
     // Also update 'editor/export/android_sdk_manager.h#DEFAULT_JAVA_VERSION'.
     javaVersion        : JavaVersion.VERSION_17,
     // Also update:
-    // - 'editor/export/android_sdk_manager.cpp#ANDROID_SDK_PACKAGES[ndk]'
+    // - 'editor/export/android_sdk_manager.cpp#ANDROID_NDK_PACKAGES[ndk]'
     // - 'platform/android/detect.py#get_ndk_version()'
     ndkVersion         : '29.0.14206865',
     splashscreenVersion: '1.0.1',


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Follow-up to https://github.com/godotengine/godot/pull/121849; the updated logic ensures that validation for the Android SDK setup doesn't include the Android NDK packages

- Addresses reports of export failures due to more stringent checks.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
