### PR TITLE
Fix script state not updating in the editor when global classes change

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -2193,6 +2193,7 @@ void ScriptEditor::_notification(int p_what) {
 			list_split->connect("dragged", callable_mp(this, &ScriptEditor::_split_dragged));
 
 			EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &ScriptEditor::_update_filenames));
+			EditorFileSystem::get_singleton()->connect("script_classes_updated", callable_mp(this, &ScriptEditor::_script_classes_updated));
 #ifdef ANDROID_ENABLED
 			set_process(true);
 #endif
@@ -4674,4 +4675,17 @@ ScriptEditorPlugin::ScriptEditorPlugin() {
 
 ScriptEditorPlugin::~ScriptEditorPlugin() {
 	memdelete(FindInFiles::get_singleton());
+}
+
+void ScriptEditor::_script_classes_updated() {
+	for (int i = 0; i < ScriptServer::get_language_count(); i++) {
+		ScriptServer::get_language(i)->reload_all_scripts();
+	}
+
+	for (int i = 0; i < tab_container->get_tab_count(); i++) {
+		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
+		if (se) {
+			se->validate_script();
+		}
+	}
 }

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -393,6 +393,7 @@ class ScriptEditor : public EditorDock {
 	void _update_online_doc();
 
 	void _split_dragged(float);
+	void _script_classes_updated();
 
 	virtual void input(const Ref<InputEvent> &p_event) override;
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.
Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
Use of AI must be disclosed and should include a description of how it was used.
-->
## What problem(s) does this PR solve?

- Closes #102222

## Additional information

When a script uses a `class_name` that doesn't exist yet, creating the missing class doesn't cause the script to be checked again. The script can remain in an invalid state, and its exported properties won't appear in the Inspector until the editor is restarted or the script is changed and saved again.

The same problem can leave open script tabs showing stale errors after the missing class has been created.

This PR listens for `EditorFileSystem`'s `script_classes_updated` signal. When the set of global classes changes, the loaded scripts are reloaded so they can re-evaluate their dependencies. Open script tabs are also validated so their error state is updated.

### Before

https://github.com/user-attachments/assets/0d88faa7-9636-4fc3-acc0-4ca6cc989538

### After

https://github.com/user-attachments/assets/bb6b4f06-04bf-43bf-8dce-beca8a213ea4

With this change, creating a missing global class updates the affected scripts without requiring an editor restart.