### PR TITLE
Replace `p_*` param names with `r_*` names in `script_language.h`

### DIFF
--- a/core/object/script_instance.h
+++ b/core/object/script_instance.h
@@ -39,7 +39,7 @@ class ScriptInstance {
 public:
 	virtual bool set(const StringName &p_name, const Variant &p_value) = 0;
 	virtual bool get(const StringName &p_name, Variant &r_ret) const = 0;
-	virtual void get_property_list(List<PropertyInfo> *p_properties) const = 0;
+	virtual void get_property_list(List<PropertyInfo> *r_properties) const = 0;
 	virtual Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid = nullptr) const = 0;
 	virtual void validate_property(PropertyInfo &p_property) const = 0;
 
@@ -49,7 +49,7 @@ public:
 	virtual Object *get_owner() { return nullptr; }
 	virtual void get_property_state(List<Pair<StringName, Variant>> &r_state);
 
-	virtual void get_method_list(List<MethodInfo> *p_list) const = 0;
+	virtual void get_method_list(List<MethodInfo> *r_list) const = 0;
 	virtual bool has_method(const StringName &p_method) const = 0;
 
 	virtual int get_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const;

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -691,15 +691,15 @@ bool PlaceHolderScriptInstance::get(const StringName &p_name, Variant &r_ret) co
 	return false;
 }
 
-void PlaceHolderScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const {
+void PlaceHolderScriptInstance::get_property_list(List<PropertyInfo> *r_properties) const {
 	if (script->is_placeholder_fallback_enabled()) {
 		for (const PropertyInfo &E : properties) {
-			p_properties->push_back(E);
+			r_properties->push_back(E);
 		}
 	} else {
 		for (const PropertyInfo &E : properties) {
 			PropertyInfo pinfo = E;
-			p_properties->push_back(E);
+			r_properties->push_back(E);
 		}
 	}
 }
@@ -726,13 +726,13 @@ Variant::Type PlaceHolderScriptInstance::get_property_type(const StringName &p_n
 	return Variant::NIL;
 }
 
-void PlaceHolderScriptInstance::get_method_list(List<MethodInfo> *p_list) const {
+void PlaceHolderScriptInstance::get_method_list(List<MethodInfo> *r_list) const {
 	if (script->is_placeholder_fallback_enabled()) {
 		return;
 	}
 
 	if (script.is_valid()) {
-		script->get_script_method_list(p_list);
+		script->get_script_method_list(r_list);
 	}
 }
 

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -188,13 +188,13 @@ public:
 	virtual bool get_property_default_value(const StringName &p_property, Variant &r_value) const = 0;
 
 	virtual void update_exports() {} //editor tool
-	virtual void get_script_method_list(List<MethodInfo> *p_list) const = 0;
-	virtual void get_script_property_list(List<PropertyInfo> *p_list) const = 0;
+	virtual void get_script_method_list(List<MethodInfo> *r_list) const = 0;
+	virtual void get_script_property_list(List<PropertyInfo> *r_list) const = 0;
 
 	virtual int get_member_line(const StringName &p_member) const { return -1; }
 
-	virtual void get_constants(HashMap<StringName, Variant> *p_constants) {}
-	virtual void get_members(HashSet<StringName> *p_members) {}
+	virtual void get_constants(HashMap<StringName, Variant> *r_constants) {}
+	virtual void get_members(HashSet<StringName> *r_members) {}
 
 	virtual bool is_placeholder_fallback_enabled() const { return false; }
 
@@ -369,10 +369,10 @@ public:
 	virtual int debug_get_stack_level_line(int p_level) const = 0;
 	virtual String debug_get_stack_level_function(int p_level) const = 0;
 	virtual String debug_get_stack_level_source(int p_level) const = 0;
-	virtual void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) = 0;
-	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) = 0;
+	virtual void debug_get_stack_level_locals(int p_level, List<String> *r_locals, List<Variant> *r_values, int p_max_subitems = -1, int p_max_depth = -1) = 0;
+	virtual void debug_get_stack_level_members(int p_level, List<String> *r_members, List<Variant> *r_values, int p_max_subitems = -1, int p_max_depth = -1) = 0;
 	virtual ScriptInstance *debug_get_stack_level_instance(int p_level) { return nullptr; }
-	virtual void debug_get_globals(List<String> *p_globals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) = 0;
+	virtual void debug_get_globals(List<String> *r_globals, List<Variant> *r_values, int p_max_subitems = -1, int p_max_depth = -1) = 0;
 	virtual String debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems = -1, int p_max_depth = -1) = 0;
 
 	virtual Vector<StackInfo> debug_get_current_stack_info() { return Vector<StackInfo>(); }
@@ -382,9 +382,9 @@ public:
 	virtual void reload_tool_script(const Ref<Script> &p_script) = 0;
 	/* LOADER FUNCTIONS */
 
-	virtual void get_public_functions(List<MethodInfo> *p_functions) const = 0;
-	virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const = 0;
-	virtual void get_public_annotations(List<MethodInfo> *p_annotations) const = 0;
+	virtual void get_public_functions(List<MethodInfo> *r_functions) const = 0;
+	virtual void get_public_constants(List<Pair<String, Variant>> *r_constants) const = 0;
+	virtual void get_public_annotations(List<MethodInfo> *r_annotations) const = 0;
 
 	struct ProfilingInfo {
 		StringName signature;
@@ -398,8 +398,8 @@ public:
 	virtual void profiling_stop() = 0;
 	virtual void profiling_set_save_native_calls(bool p_enable) = 0;
 
-	virtual int profiling_get_accumulated_data(ProfilingInfo *p_info_arr, int p_info_max) = 0;
-	virtual int profiling_get_frame_data(ProfilingInfo *p_info_arr, int p_info_max) = 0;
+	virtual int profiling_get_accumulated_data(ProfilingInfo *r_info_arr, int p_info_max) = 0;
+	virtual int profiling_get_frame_data(ProfilingInfo *r_info_arr, int p_info_max) = 0;
 
 	virtual void frame();
 
@@ -424,14 +424,14 @@ class PlaceHolderScriptInstance : public ScriptInstance {
 public:
 	virtual bool set(const StringName &p_name, const Variant &p_value) override;
 	virtual bool get(const StringName &p_name, Variant &r_ret) const override;
-	virtual void get_property_list(List<PropertyInfo> *p_properties) const override;
+	virtual void get_property_list(List<PropertyInfo> *r_properties) const override;
 	virtual Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid = nullptr) const override;
-	virtual void validate_property(PropertyInfo &p_property) const override {}
+	virtual void validate_property(PropertyInfo &p_property) const override {} // TODO: Should this be `r_property`?
 
 	virtual bool property_can_revert(const StringName &p_name) const override { return false; }
 	virtual bool property_get_revert(const StringName &p_name, Variant &r_ret) const override { return false; }
 
-	virtual void get_method_list(List<MethodInfo> *p_list) const override;
+	virtual void get_method_list(List<MethodInfo> *r_list) const override;
 	virtual bool has_method(const StringName &p_method) const override;
 
 	virtual int get_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const override {
@@ -450,6 +450,7 @@ public:
 
 	Object *get_owner() override { return owner; }
 
+	// TODO: Should these be `r_properties` and `r_values`?
 	void update(const List<PropertyInfo> &p_properties, const HashMap<StringName, Variant> &p_values); //likely changed in editor
 
 	virtual bool is_placeholder() const override { return true; }

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -199,19 +199,19 @@ public:
 
 	GDVIRTUAL0RC_REQUIRED(Dictionary, _get_constants)
 
-	virtual void get_constants(HashMap<StringName, Variant> *p_constants) override {
+	virtual void get_constants(HashMap<StringName, Variant> *r_constants) override {
 		Dictionary constants;
 		GDVIRTUAL_CALL(_get_constants, constants);
 		for (const KeyValue<Variant, Variant> &kv : constants) {
-			p_constants->insert(kv.key, kv.value);
+			r_constants->insert(kv.key, kv.value);
 		}
 	}
 	GDVIRTUAL0RC_REQUIRED(TypedArray<StringName>, _get_members)
-	virtual void get_members(HashSet<StringName> *p_members) override {
+	virtual void get_members(HashSet<StringName> *r_members) override {
 		TypedArray<StringName> members;
 		GDVIRTUAL_CALL(_get_members, members);
 		for (int i = 0; i < members.size(); i++) {
-			p_members->insert(members[i]);
+			r_members->insert(members[i]);
 		}
 	}
 
@@ -602,22 +602,22 @@ public:
 		}
 	}
 	GDVIRTUAL3R_REQUIRED(Dictionary, _debug_get_stack_level_members, int, int, int)
-	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override {
+	virtual void debug_get_stack_level_members(int p_level, List<String> *r_members, List<Variant> *r_values, int p_max_subitems = -1, int p_max_depth = -1) override {
 		Dictionary ret;
 		GDVIRTUAL_CALL(_debug_get_stack_level_members, p_level, p_max_subitems, p_max_depth, ret);
 		if (ret.is_empty()) {
 			return;
 		}
-		if (p_members != nullptr && ret.has("members")) {
+		if (r_members != nullptr && ret.has("members")) {
 			PackedStringArray strings = ret["members"];
 			for (int i = 0; i < strings.size(); i++) {
-				p_members->push_back(strings[i]);
+				r_members->push_back(strings[i]);
 			}
 		}
-		if (p_values != nullptr && ret.has("values")) {
+		if (r_values != nullptr && ret.has("values")) {
 			Array values = ret["values"];
 			for (const Variant &value : values) {
-				p_values->push_back(value);
+				r_values->push_back(value);
 			}
 		}
 	}
@@ -629,22 +629,22 @@ public:
 		return reinterpret_cast<ScriptInstance *>(ret.operator void *());
 	}
 	GDVIRTUAL2R_REQUIRED(Dictionary, _debug_get_globals, int, int)
-	virtual void debug_get_globals(List<String> *p_globals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override {
+	virtual void debug_get_globals(List<String> *r_globals, List<Variant> *r_values, int p_max_subitems = -1, int p_max_depth = -1) override {
 		Dictionary ret;
 		GDVIRTUAL_CALL(_debug_get_globals, p_max_subitems, p_max_depth, ret);
 		if (ret.is_empty()) {
 			return;
 		}
-		if (p_globals != nullptr && ret.has("globals")) {
+		if (r_globals != nullptr && ret.has("globals")) {
 			PackedStringArray strings = ret["globals"];
 			for (int i = 0; i < strings.size(); i++) {
-				p_globals->push_back(strings[i]);
+				r_globals->push_back(strings[i]);
 			}
 		}
-		if (p_values != nullptr && ret.has("values")) {
+		if (r_values != nullptr && ret.has("values")) {
 			Array values = ret["values"];
 			for (const Variant &value : values) {
-				p_values->push_back(value);
+				r_values->push_back(value);
 			}
 		}
 	}
@@ -686,32 +686,32 @@ public:
 #endif
 
 	GDVIRTUAL0RC_REQUIRED(TypedArray<Dictionary>, _get_public_functions)
-	virtual void get_public_functions(List<MethodInfo> *p_functions) const override {
+	virtual void get_public_functions(List<MethodInfo> *r_functions) const override {
 		TypedArray<Dictionary> ret;
 		GDVIRTUAL_CALL(_get_public_functions, ret);
 		for (const Variant &var : ret) {
 			MethodInfo mi = MethodInfo::from_dict(var);
-			p_functions->push_back(mi);
+			r_functions->push_back(mi);
 		}
 	}
 	GDVIRTUAL0RC_REQUIRED(Dictionary, _get_public_constants)
-	virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const override {
+	virtual void get_public_constants(List<Pair<String, Variant>> *r_constants) const override {
 		Dictionary ret;
 		GDVIRTUAL_CALL(_get_public_constants, ret);
 		for (int i = 0; i < ret.size(); i++) {
 			Dictionary d = ret[i];
 			ERR_CONTINUE(!d.has("name"));
 			ERR_CONTINUE(!d.has("value"));
-			p_constants->push_back(Pair<String, Variant>(d["name"], d["value"]));
+			r_constants->push_back(Pair<String, Variant>(d["name"], d["value"]));
 		}
 	}
 	GDVIRTUAL0RC_REQUIRED(TypedArray<Dictionary>, _get_public_annotations)
-	virtual void get_public_annotations(List<MethodInfo> *p_annotations) const override {
+	virtual void get_public_annotations(List<MethodInfo> *r_annotations) const override {
 		TypedArray<Dictionary> ret;
 		GDVIRTUAL_CALL(_get_public_annotations, ret);
 		for (const Variant &var : ret) {
 			MethodInfo mi = MethodInfo::from_dict(var);
-			p_annotations->push_back(mi);
+			r_annotations->push_back(mi);
 		}
 	}
 
@@ -721,17 +721,17 @@ public:
 
 	GDVIRTUAL2R_REQUIRED(int, _profiling_get_accumulated_data, GDExtensionPtr<ScriptLanguageExtensionProfilingInfo>, int)
 
-	virtual int profiling_get_accumulated_data(ProfilingInfo *p_info_arr, int p_info_max) override {
+	virtual int profiling_get_accumulated_data(ProfilingInfo *r_info_arr, int p_info_max) override {
 		int ret = 0;
-		GDVIRTUAL_CALL(_profiling_get_accumulated_data, p_info_arr, p_info_max, ret);
+		GDVIRTUAL_CALL(_profiling_get_accumulated_data, r_info_arr, p_info_max, ret);
 		return ret;
 	}
 
 	GDVIRTUAL2R_REQUIRED(int, _profiling_get_frame_data, GDExtensionPtr<ScriptLanguageExtensionProfilingInfo>, int)
 
-	virtual int profiling_get_frame_data(ProfilingInfo *p_info_arr, int p_info_max) override {
+	virtual int profiling_get_frame_data(ProfilingInfo *r_info_arr, int p_info_max) override {
 		int ret = 0;
-		GDVIRTUAL_CALL(_profiling_get_frame_data, p_info_arr, p_info_max, ret);
+		GDVIRTUAL_CALL(_profiling_get_frame_data, r_info_arr, p_info_max, ret);
 		return ret;
 	}
 
@@ -800,7 +800,7 @@ public:
 		}
 		return false;
 	}
-	virtual void get_property_list(List<PropertyInfo> *p_list) const override {
+	virtual void get_property_list(List<PropertyInfo> *r_list) const override {
 		if (native_info->get_property_list_func) {
 			uint32_t pcount;
 			const GDExtensionPropertyInfo *pinfo = native_info->get_property_list_func(instance, &pcount);
@@ -810,19 +810,19 @@ public:
 				if (native_info->get_class_category_func) {
 					GDExtensionPropertyInfo gdext_class_category;
 					if (native_info->get_class_category_func(instance, &gdext_class_category)) {
-						p_list->push_back(PropertyInfo(gdext_class_category));
+						r_list->push_back(PropertyInfo(gdext_class_category));
 					}
 				} else {
 					Ref<Script> script = get_script();
 					if (script.is_valid()) {
-						p_list->push_back(script->get_class_category());
+						r_list->push_back(script->get_class_category());
 					}
 				}
 			}
 #endif // TOOLS_ENABLED
 
 			for (uint32_t i = 0; i < pcount; i++) {
-				p_list->push_back(PropertyInfo(pinfo[i]));
+				r_list->push_back(PropertyInfo(pinfo[i]));
 			}
 			if (native_info->free_property_list_func) {
 				native_info->free_property_list_func(instance, pinfo, pcount);
@@ -898,12 +898,12 @@ public:
 		ScriptInstance::get_property_state(r_state);
 	}
 
-	virtual void get_method_list(List<MethodInfo> *p_list) const override {
+	virtual void get_method_list(List<MethodInfo> *r_list) const override {
 		if (native_info->get_method_list_func) {
 			uint32_t mcount;
 			const GDExtensionMethodInfo *minfo = native_info->get_method_list_func(instance, &mcount);
 			for (uint32_t i = 0; i < mcount; i++) {
-				p_list->push_back(MethodInfo(minfo[i]));
+				r_list->push_back(MethodInfo(minfo[i]));
 			}
 			if (native_info->free_method_list_func) {
 				native_info->free_method_list_func(instance, minfo, mcount);

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -908,18 +908,18 @@ ScriptLanguage *GDScript::get_language() const {
 	return GDScriptLanguage::get_singleton();
 }
 
-void GDScript::get_constants(HashMap<StringName, Variant> *p_constants) {
-	if (p_constants) {
+void GDScript::get_constants(HashMap<StringName, Variant> *r_constants) {
+	if (r_constants) {
 		for (const KeyValue<StringName, Variant> &E : constants) {
-			(*p_constants)[E.key] = E.value;
+			(*r_constants)[E.key] = E.value;
 		}
 	}
 }
 
-void GDScript::get_members(HashSet<StringName> *p_members) {
-	if (p_members) {
+void GDScript::get_members(HashSet<StringName> *r_members) {
+	if (r_members) {
 		for (const StringName &E : members) {
-			p_members->insert(E);
+			r_members->insert(E);
 		}
 	}
 }
@@ -1729,7 +1729,7 @@ void GDScriptInstance::validate_property(PropertyInfo &p_property) const {
 	}
 }
 
-void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const {
+void GDScriptInstance::get_property_list(List<PropertyInfo> *r_properties) const {
 	// exported members, not done yet!
 
 	const GDScript *sptr = script.ptr();
@@ -1834,12 +1834,12 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 		}
 
 #ifdef TOOLS_ENABLED
-		p_properties->push_back(sptr->get_class_category());
+		r_properties->push_back(sptr->get_class_category());
 #endif // TOOLS_ENABLED
 
 		for (PropertyInfo &prop : props) {
 			validate_property(prop);
-			p_properties->push_back(prop);
+			r_properties->push_back(prop);
 		}
 
 		props.clear();
@@ -1893,11 +1893,11 @@ bool GDScriptInstance::property_get_revert(const StringName &p_name, Variant &r_
 	return false;
 }
 
-void GDScriptInstance::get_method_list(List<MethodInfo> *p_list) const {
+void GDScriptInstance::get_method_list(List<MethodInfo> *r_list) const {
 	const GDScript *sptr = script.ptr();
 	while (sptr) {
 		for (const KeyValue<StringName, GDScriptFunction *> &E : sptr->member_functions) {
-			p_list->push_back(E.value->get_method_info());
+			r_list->push_back(E.value->get_method_info());
 		}
 		sptr = sptr->base.ptr();
 	}
@@ -2330,7 +2330,7 @@ void GDScriptLanguage::profiling_stop() {
 #endif
 }
 
-int GDScriptLanguage::profiling_get_accumulated_data(ProfilingInfo *p_info_arr, int p_info_max) {
+int GDScriptLanguage::profiling_get_accumulated_data(ProfilingInfo *r_info_arr, int p_info_max) {
 	int current = 0;
 #ifdef DEBUG_ENABLED
 
@@ -2343,24 +2343,24 @@ int GDScriptLanguage::profiling_get_accumulated_data(ProfilingInfo *p_info_arr, 
 			break;
 		}
 		int last_non_internal = current;
-		p_info_arr[current].call_count = elem->self()->profile.call_count.get();
-		p_info_arr[current].self_time = elem->self()->profile.self_time.get();
-		p_info_arr[current].total_time = elem->self()->profile.total_time.get();
-		p_info_arr[current].signature = elem->self()->profile.signature;
+		r_info_arr[current].call_count = elem->self()->profile.call_count.get();
+		r_info_arr[current].self_time = elem->self()->profile.self_time.get();
+		r_info_arr[current].total_time = elem->self()->profile.total_time.get();
+		r_info_arr[current].signature = elem->self()->profile.signature;
 		current++;
 
 		int nat_time = 0;
 		HashMap<String, GDScriptFunction::Profile::NativeProfile>::ConstIterator nat_calls = elem->self()->profile.native_calls.begin();
 		while (nat_calls) {
-			p_info_arr[current].call_count = nat_calls->value.call_count;
-			p_info_arr[current].total_time = nat_calls->value.total_time;
-			p_info_arr[current].self_time = nat_calls->value.total_time;
-			p_info_arr[current].signature = nat_calls->value.signature;
+			r_info_arr[current].call_count = nat_calls->value.call_count;
+			r_info_arr[current].total_time = nat_calls->value.total_time;
+			r_info_arr[current].self_time = nat_calls->value.total_time;
+			r_info_arr[current].signature = nat_calls->value.signature;
 			nat_time += nat_calls->value.total_time;
 			current++;
 			++nat_calls;
 		}
-		p_info_arr[last_non_internal].internal_time = nat_time;
+		r_info_arr[last_non_internal].internal_time = nat_time;
 		elem = elem->next();
 	}
 #endif
@@ -2368,7 +2368,7 @@ int GDScriptLanguage::profiling_get_accumulated_data(ProfilingInfo *p_info_arr, 
 	return current;
 }
 
-int GDScriptLanguage::profiling_get_frame_data(ProfilingInfo *p_info_arr, int p_info_max) {
+int GDScriptLanguage::profiling_get_frame_data(ProfilingInfo *r_info_arr, int p_info_max) {
 	int current = 0;
 
 #ifdef DEBUG_ENABLED
@@ -2382,25 +2382,25 @@ int GDScriptLanguage::profiling_get_frame_data(ProfilingInfo *p_info_arr, int p_
 		}
 		if (elem->self()->profile.last_frame_call_count > 0) {
 			int last_non_internal = current;
-			p_info_arr[current].call_count = elem->self()->profile.last_frame_call_count;
-			p_info_arr[current].self_time = elem->self()->profile.last_frame_self_time;
-			p_info_arr[current].total_time = elem->self()->profile.last_frame_total_time;
-			p_info_arr[current].signature = elem->self()->profile.signature;
+			r_info_arr[current].call_count = elem->self()->profile.last_frame_call_count;
+			r_info_arr[current].self_time = elem->self()->profile.last_frame_self_time;
+			r_info_arr[current].total_time = elem->self()->profile.last_frame_total_time;
+			r_info_arr[current].signature = elem->self()->profile.signature;
 			current++;
 
 			int nat_time = 0;
 			HashMap<String, GDScriptFunction::Profile::NativeProfile>::ConstIterator nat_calls = elem->self()->profile.last_native_calls.begin();
 			while (nat_calls) {
-				p_info_arr[current].call_count = nat_calls->value.call_count;
-				p_info_arr[current].total_time = nat_calls->value.total_time;
-				p_info_arr[current].self_time = nat_calls->value.total_time;
-				p_info_arr[current].internal_time = nat_calls->value.total_time;
-				p_info_arr[current].signature = nat_calls->value.signature;
+				r_info_arr[current].call_count = nat_calls->value.call_count;
+				r_info_arr[current].total_time = nat_calls->value.total_time;
+				r_info_arr[current].self_time = nat_calls->value.total_time;
+				r_info_arr[current].internal_time = nat_calls->value.total_time;
+				r_info_arr[current].signature = nat_calls->value.signature;
 				nat_time += nat_calls->value.total_time;
 				current++;
 				++nat_calls;
 			}
-			p_info_arr[last_non_internal].internal_time = nat_time;
+			r_info_arr[last_non_internal].internal_time = nat_time;
 		}
 		elem = elem->next();
 	}

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -324,8 +324,8 @@ public:
 		return -1;
 	}
 
-	virtual void get_constants(HashMap<StringName, Variant> *p_constants) override;
-	virtual void get_members(HashSet<StringName> *p_members) override;
+	virtual void get_constants(HashMap<StringName, Variant> *r_constants) override;
+	virtual void get_members(HashSet<StringName> *r_members) override;
 
 	virtual const Variant get_rpc_config() const override;
 
@@ -363,14 +363,14 @@ public:
 
 	virtual bool set(const StringName &p_name, const Variant &p_value);
 	virtual bool get(const StringName &p_name, Variant &r_ret) const;
-	virtual void get_property_list(List<PropertyInfo> *p_properties) const;
+	virtual void get_property_list(List<PropertyInfo> *r_properties) const;
 	virtual Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid = nullptr) const;
 	virtual void validate_property(PropertyInfo &p_property) const;
 
 	virtual bool property_can_revert(const StringName &p_name) const;
 	virtual bool property_get_revert(const StringName &p_name, Variant &r_ret) const;
 
-	virtual void get_method_list(List<MethodInfo> *p_list) const;
+	virtual void get_method_list(List<MethodInfo> *r_list) const;
 	virtual bool has_method(const StringName &p_method) const;
 
 	virtual int get_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const;
@@ -611,10 +611,10 @@ public:
 	virtual int debug_get_stack_level_line(int p_level) const override;
 	virtual String debug_get_stack_level_function(int p_level) const override;
 	virtual String debug_get_stack_level_source(int p_level) const override;
-	virtual void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override;
-	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override;
+	virtual void debug_get_stack_level_locals(int p_level, List<String> *r_locals, List<Variant> *r_values, int p_max_subitems = -1, int p_max_depth = -1) override;
+	virtual void debug_get_stack_level_members(int p_level, List<String> *r_members, List<Variant> *r_values, int p_max_subitems = -1, int p_max_depth = -1) override;
 	virtual ScriptInstance *debug_get_stack_level_instance(int p_level) override;
-	virtual void debug_get_globals(List<String> *p_globals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) override;
+	virtual void debug_get_globals(List<String> *r_globals, List<Variant> *r_values, int p_max_subitems = -1, int p_max_depth = -1) override;
 	virtual String debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems = -1, int p_max_depth = -1) override;
 
 	virtual void reload_all_scripts() override;
@@ -623,17 +623,17 @@ public:
 
 	virtual void frame() override;
 
-	virtual void get_public_functions(List<MethodInfo> *p_functions) const override;
-	virtual void get_public_constants(List<Pair<String, Variant>> *p_constants) const override;
-	virtual void get_public_annotations(List<MethodInfo> *p_annotations) const override;
+	virtual void get_public_functions(List<MethodInfo> *r_functions) const override;
+	virtual void get_public_constants(List<Pair<String, Variant>> *r_constants) const override;
+	virtual void get_public_annotations(List<MethodInfo> *r_annotations) const override;
 
 	virtual void profiling_start() override;
 	virtual void profiling_stop() override;
 	virtual void profiling_set_save_native_calls(bool p_enable) override;
 	void profiling_collate_native_call_data(bool p_accumulated);
 
-	virtual int profiling_get_accumulated_data(ProfilingInfo *p_info_arr, int p_info_max) override;
-	virtual int profiling_get_frame_data(ProfilingInfo *p_info_arr, int p_info_max) override;
+	virtual int profiling_get_accumulated_data(ProfilingInfo *r_info_arr, int p_info_max) override;
+	virtual int profiling_get_frame_data(ProfilingInfo *r_info_arr, int p_info_max) override;
 
 	/* GLOBAL CLASSES */
 

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -361,7 +361,7 @@ String GDScriptLanguage::debug_get_stack_level_source(int p_level) const {
 	return _get_stack_level(p_level)->function->get_source();
 }
 
-void GDScriptLanguage::debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems, int p_max_depth) {
+void GDScriptLanguage::debug_get_stack_level_locals(int p_level, List<String> *r_locals, List<Variant> *r_values, int p_max_subitems, int p_max_depth) {
 	if (_debug_parse_err_line >= 0) {
 		return;
 	}
@@ -375,17 +375,17 @@ void GDScriptLanguage::debug_get_stack_level_locals(int p_level, List<String> *p
 
 	f->debug_get_stack_member_state(*cl->line, &locals);
 	for (const Pair<StringName, int> &E : locals) {
-		p_locals->push_back(E.first);
+		r_locals->push_back(E.first);
 
 		if (f->constant_map.has(E.first)) {
-			p_values->push_back(f->constant_map[E.first]);
+			r_values->push_back(f->constant_map[E.first]);
 		} else {
-			p_values->push_back(cl->stack[E.second]);
+			r_values->push_back(cl->stack[E.second]);
 		}
 	}
 }
 
-void GDScriptLanguage::debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems, int p_max_depth) {
+void GDScriptLanguage::debug_get_stack_level_members(int p_level, List<String> *r_members, List<Variant> *r_values, int p_max_subitems, int p_max_depth) {
 	if (_debug_parse_err_line >= 0) {
 		return;
 	}
@@ -405,8 +405,8 @@ void GDScriptLanguage::debug_get_stack_level_members(int p_level, List<String> *
 	const HashMap<StringName, GDScript::MemberInfo> &mi = scr->debug_get_member_indices();
 
 	for (const KeyValue<StringName, GDScript::MemberInfo> &E : mi) {
-		p_members->push_back(E.key);
-		p_values->push_back(instance->debug_get_member_by_index(E.value.index));
+		r_members->push_back(E.key);
+		r_values->push_back(instance->debug_get_member_by_index(E.value.index));
 	}
 }
 
@@ -420,7 +420,7 @@ ScriptInstance *GDScriptLanguage::debug_get_stack_level_instance(int p_level) {
 	return _get_stack_level(p_level)->instance;
 }
 
-void GDScriptLanguage::debug_get_globals(List<String> *p_globals, List<Variant> *p_values, int p_max_subitems, int p_max_depth) {
+void GDScriptLanguage::debug_get_globals(List<String> *r_globals, List<Variant> *r_values, int p_max_subitems, int p_max_depth) {
 	const HashMap<StringName, int> &name_idx = GDScriptLanguage::get_singleton()->get_global_map();
 	const Variant *gl_array = GDScriptLanguage::get_singleton()->get_global_array();
 
@@ -463,8 +463,8 @@ void GDScriptLanguage::debug_get_globals(List<String> *p_globals, List<Variant> 
 			continue;
 		}
 
-		p_globals->push_back(E.key);
-		p_values->push_back(var);
+		r_globals->push_back(E.key);
+		r_values->push_back(var);
 	}
 }
 
@@ -495,12 +495,12 @@ String GDScriptLanguage::debug_parse_stack_level_expression(int p_level, const S
 	return String();
 }
 
-void GDScriptLanguage::get_public_functions(List<MethodInfo> *p_functions) const {
+void GDScriptLanguage::get_public_functions(List<MethodInfo> *r_functions) const {
 	List<StringName> functions;
 	GDScriptUtilityFunctions::get_function_list(&functions);
 
 	for (const StringName &E : functions) {
-		p_functions->push_back(GDScriptUtilityFunctions::get_function_info(E));
+		r_functions->push_back(GDScriptUtilityFunctions::get_function_info(E));
 	}
 
 	// Not really "functions", but show in documentation.
@@ -509,7 +509,7 @@ void GDScriptLanguage::get_public_functions(List<MethodInfo> *p_functions) const
 		mi.name = "preload";
 		mi.arguments.push_back(PropertyInfo(Variant::STRING, "path"));
 		mi.return_val = PropertyInfo(Variant::OBJECT, "", PROPERTY_HINT_RESOURCE_TYPE, Resource::get_class_static());
-		p_functions->push_back(mi);
+		r_functions->push_back(mi);
 	}
 	{
 		MethodInfo mi;
@@ -518,39 +518,39 @@ void GDScriptLanguage::get_public_functions(List<MethodInfo> *p_functions) const
 		mi.arguments.push_back(PropertyInfo(Variant::BOOL, "condition"));
 		mi.arguments.push_back(PropertyInfo(Variant::STRING, "message"));
 		mi.default_arguments.push_back(String());
-		p_functions->push_back(mi);
+		r_functions->push_back(mi);
 	}
 }
 
-void GDScriptLanguage::get_public_constants(List<Pair<String, Variant>> *p_constants) const {
+void GDScriptLanguage::get_public_constants(List<Pair<String, Variant>> *r_constants) const {
 	Pair<String, Variant> pi;
 	pi.first = "PI";
 	pi.second = Math::PI;
-	p_constants->push_back(pi);
+	r_constants->push_back(pi);
 
 	Pair<String, Variant> tau;
 	tau.first = "TAU";
 	tau.second = Math::TAU;
-	p_constants->push_back(tau);
+	r_constants->push_back(tau);
 
 	Pair<String, Variant> infinity;
 	infinity.first = "INF";
 	infinity.second = Math::INF;
-	p_constants->push_back(infinity);
+	r_constants->push_back(infinity);
 
 	Pair<String, Variant> nan;
 	nan.first = "NAN";
 	nan.second = Math::NaN;
-	p_constants->push_back(nan);
+	r_constants->push_back(nan);
 }
 
-void GDScriptLanguage::get_public_annotations(List<MethodInfo> *p_annotations) const {
+void GDScriptLanguage::get_public_annotations(List<MethodInfo> *r_annotations) const {
 	GDScriptParser parser;
 	List<MethodInfo> annotations;
 	parser.get_annotation_list(&annotations);
 
 	for (const MethodInfo &E : annotations) {
-		p_annotations->push_back(E);
+		r_annotations->push_back(E);
 	}
 }
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1509,7 +1509,7 @@ bool CSharpInstance::get(const StringName &p_name, Variant &r_ret) const {
 	return false;
 }
 
-void CSharpInstance::get_property_list(List<PropertyInfo> *p_properties) const {
+void CSharpInstance::get_property_list(List<PropertyInfo> *r_properties) const {
 	List<PropertyInfo> props;
 	ERR_FAIL_COND(script.is_null());
 #ifdef TOOLS_ENABLED
@@ -1524,7 +1524,7 @@ void CSharpInstance::get_property_list(List<PropertyInfo> *p_properties) const {
 
 	for (PropertyInfo &prop : props) {
 		validate_property(prop);
-		p_properties->push_back(prop);
+		r_properties->push_back(prop);
 	}
 
 	// Call _get_property_list
@@ -1545,7 +1545,7 @@ void CSharpInstance::get_property_list(List<PropertyInfo> *p_properties) const {
 		} else {
 			Array array = ret;
 			for (int i = 0, size = array.size(); i < size; i++) {
-				p_properties->push_back(PropertyInfo::from_dict(array.get(i)));
+				r_properties->push_back(PropertyInfo::from_dict(array.get(i)));
 			}
 		}
 	}
@@ -1565,7 +1565,7 @@ void CSharpInstance::get_property_list(List<PropertyInfo> *p_properties) const {
 
 		for (PropertyInfo &prop : props) {
 			validate_property(prop);
-			p_properties->push_back(prop);
+			r_properties->push_back(prop);
 		}
 
 		top = top->base_script.ptr();
@@ -1642,12 +1642,12 @@ bool CSharpInstance::property_get_revert(const StringName &p_name, Variant &r_re
 	return true;
 }
 
-void CSharpInstance::get_method_list(List<MethodInfo> *p_list) const {
+void CSharpInstance::get_method_list(List<MethodInfo> *r_list) const {
 	if (!script->is_script_valid() || !script->valid) {
 		return;
 	}
 
-	script->get_script_method_list(p_list);
+	script->get_script_method_list(r_list);
 }
 
 bool CSharpInstance::has_method(const StringName &p_method) const {
@@ -2801,11 +2801,11 @@ CSharpScript::~CSharpScript() {
 	}
 }
 
-void CSharpScript::get_members(HashSet<StringName> *p_members) {
+void CSharpScript::get_members(HashSet<StringName> *r_members) {
 #ifdef DEBUG_ENABLED
-	if (p_members) {
+	if (r_members) {
 		for (const StringName &member_name : exported_members_names) {
-			p_members->insert(member_name);
+			r_members->insert(member_name);
 		}
 	}
 #endif // DEBUG_ENABLED

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -261,7 +261,7 @@ public:
 	void get_script_property_list(List<PropertyInfo> *r_list) const override;
 	void update_exports() override;
 
-	void get_members(HashSet<StringName> *p_members) override;
+	void get_members(HashSet<StringName> *r_members) override;
 
 	bool is_tool() const override {
 		return type_info.is_tool;
@@ -342,14 +342,14 @@ public:
 
 	bool set(const StringName &p_name, const Variant &p_value) override;
 	bool get(const StringName &p_name, Variant &r_ret) const override;
-	void get_property_list(List<PropertyInfo> *p_properties) const override;
+	void get_property_list(List<PropertyInfo> *r_properties) const override;
 	Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid) const override;
 	virtual void validate_property(PropertyInfo &p_property) const override;
 
 	bool property_can_revert(const StringName &p_name) const override;
 	bool property_get_revert(const StringName &p_name, Variant &r_ret) const override;
 
-	void get_method_list(List<MethodInfo> *p_list) const override;
+	void get_method_list(List<MethodInfo> *r_list) const override;
 	bool has_method(const StringName &p_method) const override;
 	virtual int get_method_argument_count(const StringName &p_method, bool *r_is_valid = nullptr) const override;
 	Variant callp(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) override;
@@ -529,9 +529,9 @@ public:
 	int debug_get_stack_level_line(int p_level) const override;
 	String debug_get_stack_level_function(int p_level) const override;
 	String debug_get_stack_level_source(int p_level) const override;
-	/* TODO */ void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems, int p_max_depth) override {}
-	/* TODO */ void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems, int p_max_depth) override {}
-	/* TODO */ void debug_get_globals(List<String> *p_locals, List<Variant> *p_values, int p_max_subitems, int p_max_depth) override {}
+	/* TODO */ void debug_get_stack_level_locals(int p_level, List<String> *r_locals, List<Variant> *r_values, int p_max_subitems, int p_max_depth) override {}
+	/* TODO */ void debug_get_stack_level_members(int p_level, List<String> *r_members, List<Variant> *r_values, int p_max_subitems, int p_max_depth) override {}
+	/* TODO */ void debug_get_globals(List<String> *r_locals, List<Variant> *r_values, int p_max_subitems, int p_max_depth) override {}
 	/* TODO */ String debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems, int p_max_depth) override {
 		return "";
 	}
@@ -541,18 +541,18 @@ public:
 	/* TODO */ void profiling_start() override {}
 	/* TODO */ void profiling_stop() override {}
 	/* TODO */ void profiling_set_save_native_calls(bool p_enable) override {}
-	/* TODO */ int profiling_get_accumulated_data(ProfilingInfo *p_info_arr, int p_info_max) override {
+	/* TODO */ int profiling_get_accumulated_data(ProfilingInfo *r_info_arr, int p_info_max) override {
 		return 0;
 	}
-	/* TODO */ int profiling_get_frame_data(ProfilingInfo *p_info_arr, int p_info_max) override {
+	/* TODO */ int profiling_get_frame_data(ProfilingInfo *r_info_arr, int p_info_max) override {
 		return 0;
 	}
 
 	void frame() override;
 
-	/* TODO? */ void get_public_functions(List<MethodInfo> *p_functions) const override {}
-	/* TODO? */ void get_public_constants(List<Pair<String, Variant>> *p_constants) const override {}
-	/* TODO? */ void get_public_annotations(List<MethodInfo> *p_annotations) const override {}
+	/* TODO? */ void get_public_functions(List<MethodInfo> *r_functions) const override {}
+	/* TODO? */ void get_public_constants(List<Pair<String, Variant>> *r_constants) const override {}
+	/* TODO? */ void get_public_annotations(List<MethodInfo> *r_annotations) const override {}
 
 	void reload_all_scripts() override;
 	void reload_scripts(const Array &p_scripts) override;

--- a/tests/core/object/test_object.cpp
+++ b/tests/core/object/test_object.cpp
@@ -74,7 +74,7 @@ public:
 		}
 		return false;
 	}
-	void get_property_list(List<PropertyInfo> *p_properties) const override {
+	void get_property_list(List<PropertyInfo> *r_properties) const override {
 	}
 	Variant::Type get_property_type(const StringName &p_name, bool *r_is_valid) const override {
 		return Variant::PACKED_FLOAT32_ARRAY;
@@ -87,7 +87,7 @@ public:
 	bool property_get_revert(const StringName &p_name, Variant &r_ret) const override {
 		return false;
 	}
-	void get_method_list(List<MethodInfo> *p_list) const override {
+	void get_method_list(List<MethodInfo> *r_list) const override {
 	}
 	bool has_method(const StringName &p_method) const override {
 		return false;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Makes some methods' functionality clearer 

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

To my understanding, the `p_` prefix for parameters is to be used when a parameter informs the behavior of a method; the `r_` prefix should be used when the parameter is a pointer/reference, and the method populates its fields/data so that it can be used elsewhere.

While working on another PR, I needed to use `get_constants(HashMap<StringName, Variant> *p_constants)`. I realized that, according to the naming rules this should instead be `r_constants` since I am meant to pass in an empty HashMap and have it be populated by the method. For the PR fixing this, I ended up going through the rest of the `script_language.h` file to fix all of the instances I could find. Of course, the implementations and subclass override declarations of these methods in other files have also been updated.