### PR TITLE
Fix font in Project Manager tabs not being bold

### DIFF
--- a/editor/themes/editor_fonts.cpp
+++ b/editor/themes/editor_fonts.cpp
@@ -507,6 +507,10 @@ void editor_register_fonts(const Ref<Theme> &p_theme) {
 	p_theme->set_font(SceneStringName(font), "MainScreenContainer", bold_fc);
 	p_theme->set_font_size(SceneStringName(font_size), "MainScreenContainer", default_font_size + 2 * EDSCALE);
 
+	p_theme->set_type_variation("MainScreenButton", "Button");
+	p_theme->set_font(SceneStringName(font), "MainScreenButton", bold_fc);
+	p_theme->set_font_size(SceneStringName(font_size), "MainScreenButton", default_font_size + 2 * EDSCALE);
+
 	// Labels.
 
 	p_theme->set_font(SceneStringName(font), "Label", default_fc);


### PR DESCRIPTION
## What problem(s) does this PR solve?

|PR|`master`|
|-|-|
|<img width="240" height="39" alt="image" src="https://github.com/user-attachments/assets/4ec02659-516d-4dc5-b2ab-addb98a4e825" />|<img width="240" height="39" alt="image" src="https://github.com/user-attachments/assets/b98ddc01-4b3a-4c15-b3bb-51ceaacbed0f" />