### PR TITLE
Compatibility: Fix meshes not rendering in viewports with a zero shadow atlas

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1364,7 +1364,7 @@ void RasterizerSceneGLES3::_fill_render_list(RenderListType p_render_list, const
 					RID light = light_storage->light_instance_get_base_light(light_instance);
 					int32_t shadow_id = light_storage->light_instance_get_shadow_id(light_instance);
 
-					if (light_storage->light_has_shadow(light) && shadow_id >= 0) {
+					if (light_storage->light_has_shadow(light) && shadow_id >= 0 && light_storage->light_instance_has_shadow_atlas(light_instance, p_render_data->shadow_atlas)) {
 						GeometryInstanceGLES3::LightPass pass;
 						pass.light_id = light_storage->light_instance_get_gl_id(light_instance);
 						pass.shadow_id = shadow_id;
@@ -1372,7 +1372,9 @@ void RasterizerSceneGLES3::_fill_render_list(RenderListType p_render_list, const
 						pass.is_omni = true;
 						inst->light_passes.push_back(pass);
 					} else {
-						// Lights without shadow can all go in base pass.
+						// Lights without a shadow, or without a slot in this render's
+						// shadow atlas (e.g. on a viewport with a zero-size atlas),
+						// can all go in the base pass.
 						inst->omni_light_gl_cache.push_back((uint32_t)light_storage->light_instance_get_gl_id(light_instance));
 					}
 				}
@@ -1387,14 +1389,16 @@ void RasterizerSceneGLES3::_fill_render_list(RenderListType p_render_list, const
 					RID light = light_storage->light_instance_get_base_light(light_instance);
 					int32_t shadow_id = light_storage->light_instance_get_shadow_id(light_instance);
 
-					if (light_storage->light_has_shadow(light) && shadow_id >= 0) {
+					if (light_storage->light_has_shadow(light) && shadow_id >= 0 && light_storage->light_instance_has_shadow_atlas(light_instance, p_render_data->shadow_atlas)) {
 						GeometryInstanceGLES3::LightPass pass;
 						pass.light_id = light_storage->light_instance_get_gl_id(light_instance);
 						pass.shadow_id = shadow_id;
 						pass.light_instance_rid = light_instance;
 						inst->light_passes.push_back(pass);
 					} else {
-						// Lights without shadow can all go in base pass.
+						// Lights without a shadow, or without a slot in this render's
+						// shadow atlas (e.g. on a viewport with a zero-size atlas),
+						// can all go in the base pass.
 						inst->spot_light_gl_cache.push_back((uint32_t)light_storage->light_instance_get_gl_id(light_instance));
 					}
 				}


### PR DESCRIPTION
Fixes #123050

### Bug:
A viewport with `positional_shadow_atlas_size = 0` does not draw any mesh lit by a shadow-casting positional light, whenever another viewport in the same frame has granted that light a shadow atlas slot.

---

### Cause:
`_fill_render_list()` decides a light is "shadowed" from `light_has_shadow()` and the cached `shadow_id`. 

Both are global light state, written when any viewport grants the light a slot. The atlas-less viewport inherits that verdict and files the light into `light_passes`. 

Pass 0 of the color loop then checks the light against this render's own atlas with `light_instance_has_shadow_atlas()`. 

The check fails, and a `continue` meant to skip one shadow skips the mesh's base draw instead. The mesh never renders.

---

### Fix:
Treat a light as shadowed only when it also holds a slot in the rendering viewport's own shadow atlas. 

Otherwise it goes into the base-pass light cache, and the mesh renders lit, without positional shadows, which is what a zero-size atlas is documented to do. 

Viewports with a real atlas grant slots as before, and the additive shadow path is unchanged.

---

### Testing: 
Reproduced with the MRP from #123050 on 4.6.2-stable (desktop macOS and web export) and on current master. 

With this change applied to master, the same scene renders correctly. A non-zero atlas renders identically before and after.