### PR TITLE
Use copy_from to overwrite resources in cache

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -689,6 +689,10 @@ Error ResourceLoaderBinary::load() {
 		Ref<Resource> res;
 		Resource *r = nullptr;
 
+		// In CACHE_MODE_REPLACE, this is the instance registered in the cache for `path`,
+		// which will be overwritten by the new resource.
+		Ref<Resource> cached;
+
 		Ref<MissingResource> missing_resource;
 
 		if (main) {
@@ -697,56 +701,53 @@ Error ResourceLoaderBinary::load() {
 		}
 		if (!r) {
 			if (cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE && ResourceCache::has(path)) {
-				//use the existing one
-				Ref<Resource> cached = ResourceCache::get_ref(path);
-				if (cached->get_class() == t) {
-					cached->reset_state();
-					res = cached;
+				cached = ResourceCache::get_ref(path);
+				if (cached->get_class() != t) {
+					// Type does not match, load into a new instance instead of replacing.
+					cached = Ref<Resource>();
 				}
 			}
 
-			if (res.is_null()) {
-				//did not replace
-
-				Object *obj = ClassDB::instantiate(t);
-				if (!obj) {
-					if (ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {
-						//create a missing resource
-						missing_resource = memnew(MissingResource);
-						missing_resource->set_original_class(t);
-						missing_resource->set_recording_properties(true);
-						obj = missing_resource.ptr();
-					} else {
-						error = ERR_FILE_CORRUPT;
-						ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, vformat("'%s': Resource of unrecognized type in file: '%s'.", local_path, t));
-					}
-				}
-
-				r = Object::cast_to<Resource>(obj);
-				if (!r) {
-					String obj_class = obj->get_class();
+			Object *obj = ClassDB::instantiate(t);
+			if (!obj) {
+				if (ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {
+					//create a missing resource
+					missing_resource = memnew(MissingResource);
+					missing_resource->set_original_class(t);
+					missing_resource->set_recording_properties(true);
+					obj = missing_resource.ptr();
+				} else {
 					error = ERR_FILE_CORRUPT;
-					memdelete(obj); //bye
-					ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, vformat("'%s': Resource type in resource field not a resource, type is: %s.", local_path, obj_class));
+					ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, vformat("'%s': Resource of unrecognized type in file: '%s'.", local_path, t));
 				}
-
-				res = Ref<Resource>(r);
 			}
+
+			r = Object::cast_to<Resource>(obj);
+			if (!r) {
+				String obj_class = obj->get_class();
+				error = ERR_FILE_CORRUPT;
+				memdelete(obj); //bye
+				ERR_FAIL_V_MSG(ERR_FILE_CORRUPT, vformat("'%s': Resource type in resource field not a resource, type is: %s.", local_path, obj_class));
+			}
+
+			res = Ref<Resource>(r);
 		}
 
 		if (r) {
 			if (!path.is_empty()) {
-				if (cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
-					r->set_path(path, cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE); // If got here because the resource with same path has different type, replace it.
-				} else {
+				if (cache_mode == ResourceFormatLoader::CACHE_MODE_IGNORE || cached.is_valid()) {
+					// If `cached` is valid or cache is ignored, do not cache the new resource.
 					r->set_path_cache(path);
+				} else {
+					r->set_path(path, cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE); // If got here because the resource with same path has different type, replace it.
 				}
 			}
 			r->set_scene_unique_id(id);
 		}
 
 		if (!main) {
-			internal_index_cache[path] = res;
+			// Reference the instance that will ultimately live in the cache.
+			internal_index_cache[path] = cached.is_valid() ? cached : res;
 		}
 
 		int pc = f->get_32();
@@ -819,6 +820,12 @@ Error ResourceLoaderBinary::load() {
 
 		if (!missing_resource_properties.is_empty()) {
 			res->set_meta(META_MISSING_RESOURCES, missing_resource_properties);
+		}
+
+		if (cached.is_valid()) {
+			// Copy loaded state into cached, so all existing references update in place.
+			cached->copy_from(res);
+			res = cached;
 		}
 
 #ifdef TOOLS_ENABLED

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -552,52 +552,52 @@ Error ResourceLoaderText::load() {
 		Ref<Resource> res;
 		bool do_assign = false;
 
+		// In CACHE_MODE_REPLACE, this is the instance registered in the cache for `path`,
+		// which will be overwritten by the new resource.
+		Ref<Resource> cached;
 		if (cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE && ResourceCache::has(path)) {
-			//reuse existing
-			Ref<Resource> cache = ResourceCache::get_ref(path);
-			if (cache.is_valid() && cache->get_class() == type) {
-				res = cache;
-				res->reset_state();
-				do_assign = true;
+			cached = ResourceCache::get_ref(path);
+			if (cached->get_class() != type) {
+				// Type does not match, load into a new instance instead of replacing.
+				cached = Ref<Resource>();
 			}
 		}
 
 		Ref<MissingResource> missing_resource;
 
-		if (res.is_null()) { //not reuse
-			Ref<Resource> cache = ResourceCache::get_ref(path);
-			if (cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE && cache.is_valid()) { //only if it doesn't exist
-				//cached, do not assign
-				res = cache;
-			} else {
-				//create
+		if (cache_mode == ResourceFormatLoader::CACHE_MODE_REUSE) {
+			// Reuse the cached instance as-is
+			res = ResourceCache::get_ref(path);
+		}
 
-				Object *obj = ClassDB::instantiate(type);
-				if (!obj) {
-					if (ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {
-						missing_resource = memnew(MissingResource);
-						missing_resource->set_original_class(type);
-						missing_resource->set_recording_properties(true);
-						obj = missing_resource.ptr();
-					} else {
-						error_text = vformat("Can't create sub resource of type '%s'", type);
-						ERR_PRINT(_get_error_string());
-						error = ERR_FILE_CORRUPT;
-						return error;
-					}
-				}
+		if (res.is_null()) {
+			//create
 
-				Resource *r = Object::cast_to<Resource>(obj);
-				if (!r) {
-					error_text = vformat("Can't create sub resource of type '%s' as it's not a resource type", type);
+			Object *obj = ClassDB::instantiate(type);
+			if (!obj) {
+				if (ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {
+					missing_resource = memnew(MissingResource);
+					missing_resource->set_original_class(type);
+					missing_resource->set_recording_properties(true);
+					obj = missing_resource.ptr();
+				} else {
+					error_text = vformat("Can't create sub resource of type '%s'", type);
 					ERR_PRINT(_get_error_string());
 					error = ERR_FILE_CORRUPT;
 					return error;
 				}
-
-				res = Ref<Resource>(r);
-				do_assign = true;
 			}
+
+			Resource *r = Object::cast_to<Resource>(obj);
+			if (!r) {
+				error_text = vformat("Can't create sub resource of type '%s' as it's not a resource type", type);
+				ERR_PRINT(_get_error_string());
+				error = ERR_FILE_CORRUPT;
+				return error;
+			}
+
+			res = Ref<Resource>(r);
+			do_assign = true;
 		}
 
 		resource_current++;
@@ -606,12 +606,14 @@ Error ResourceLoaderText::load() {
 			*progress = resource_current / float(resources_total);
 		}
 
-		int_resources[id] = res; // Always assign int resources.
+		// Always assign int resources, reference the instance that is in cache.
+		int_resources[id] = cached.is_valid() ? cached : res;
 		if (do_assign) {
-			if (cache_mode != ResourceFormatLoader::CACHE_MODE_IGNORE) {
-				res->set_path(path, cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE);
-			} else {
+			if (cache_mode == ResourceFormatLoader::CACHE_MODE_IGNORE || cached.is_valid()) {
+				// If `cached` is valid or cache is ignored, do not cache the new resource.
 				res->set_path_cache(path);
+			} else {
+				res->set_path(path, cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE);
 			}
 			res->set_scene_unique_id(id);
 		}
@@ -693,6 +695,12 @@ Error ResourceLoaderText::load() {
 		if (!missing_resource_properties.is_empty()) {
 			res->set_meta(META_MISSING_RESOURCES, missing_resource_properties);
 		}
+
+		if (cached.is_valid()) {
+			// Copy loaded state into cached, so all existing references update in place.
+			cached->copy_from(res);
+			res = cached;
+		}
 	}
 
 	if (is_scene) {
@@ -711,38 +719,30 @@ Error ResourceLoaderText::load() {
 		if (!is_scene) {
 			resource = ResourceLoader::get_resource_ref_override(local_path);
 			if (resource.is_null()) {
-				Ref<Resource> cache = ResourceCache::get_ref(local_path);
-				if (cache_mode == ResourceFormatLoader::CACHE_MODE_REPLACE && cache.is_valid() && cache->get_class() == res_type) {
-					cache->reset_state();
-					resource = cache;
-				}
-
-				if (resource.is_null()) {
-					Object *obj = ClassDB::instantiate(res_type);
-					if (!obj) {
-						if (ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {
-							missing_resource = memnew(MissingResource);
-							missing_resource->set_original_class(res_type);
-							missing_resource->set_recording_properties(true);
-							obj = missing_resource.ptr();
-						} else {
-							error_text = vformat("Can't create sub resource of type '%s'", res_type);
-							ERR_PRINT(_get_error_string());
-							error = ERR_FILE_CORRUPT;
-							return error;
-						}
-					}
-
-					Resource *r = Object::cast_to<Resource>(obj);
-					if (!r) {
-						error_text = vformat("Can't create sub resource of type '%s' as it's not a resource type", res_type);
+				Object *obj = ClassDB::instantiate(res_type);
+				if (!obj) {
+					if (ResourceLoader::is_creating_missing_resources_if_class_unavailable_enabled()) {
+						missing_resource = memnew(MissingResource);
+						missing_resource->set_original_class(res_type);
+						missing_resource->set_recording_properties(true);
+						obj = missing_resource.ptr();
+					} else {
+						error_text = vformat("Can't create sub resource of type '%s'", res_type);
 						ERR_PRINT(_get_error_string());
 						error = ERR_FILE_CORRUPT;
 						return error;
 					}
-
-					resource = Ref<Resource>(r);
 				}
+
+				Resource *r = Object::cast_to<Resource>(obj);
+				if (!r) {
+					error_text = vformat("Can't create sub resource of type '%s' as it's not a resource type", res_type);
+					ERR_PRINT(_get_error_string());
+					error = ERR_FILE_CORRUPT;
+					return error;
+				}
+
+				resource = Ref<Resource>(r);
 			}
 		}
 

--- a/tests/scene/test_material.cpp
+++ b/tests/scene/test_material.cpp
@@ -1,0 +1,187 @@
+/**************************************************************************/
+/*  test_material.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_material)
+
+#ifndef _3D_DISABLED
+
+#include "core/io/resource_loader.h"
+#include "core/io/resource_saver.h"
+#include "scene/resources/image_texture.h"
+#include "scene/resources/material.h"
+#include "tests/test_utils.h"
+
+namespace TestMaterial {
+
+// Properties that copy_from() is not expected to transfer.
+static bool _is_ignored_property(const String &p_name) {
+	return p_name == "resource_local_to_scene" ||
+			p_name == "resource_name" ||
+			p_name == "resource_path" ||
+			p_name == "resource_scene_unique_id" ||
+			p_name == "script" ||
+			p_name.begins_with("metadata/");
+}
+
+// Produce a value different from the property's default
+static bool _perturb_value(const PropertyInfo &p_prop, const Variant &p_default, const Ref<Texture2D> &p_texture, Variant &r_out) {
+	switch (p_prop.type) {
+		case Variant::BOOL:
+			r_out = !bool(p_default);
+			return true;
+		case Variant::INT:
+			r_out = int64_t(p_default) + 1;
+			return true;
+		case Variant::FLOAT:
+			r_out = double(p_default) + 1.0;
+			return true;
+		case Variant::COLOR:
+			r_out = Color(0.12, 0.34, 0.56, 0.78);
+			return true;
+		case Variant::VECTOR3:
+			r_out = Vector3(p_default) + Vector3(1.5, 2.5, 3.5);
+			return true;
+		case Variant::OBJECT:
+			// Only texture slots can take our dummy texture; other object
+			// properties (e.g. next_pass) expect different types.
+			if (p_prop.hint_string.containsn("Texture")) {
+				r_out = p_texture;
+				return true;
+			}
+			return false;
+		default:
+			return false;
+	}
+}
+
+// The resource loaders reload a cached CACHE_MODE_REPLACE resource by loading a
+// fresh instance and transplanting it with Resource::copy_from(). This checks the
+// mechanism directly: a heavily-modified material must end up matching a
+// freshly-constructed one after copy_from(), so no stale value survives a reload.
+TEST_CASE("[SceneTree][Material] copy_from restores all storage properties to defaults") {
+	Ref<StandardMaterial3D> fresh;
+	fresh.instantiate();
+
+	Ref<StandardMaterial3D> mat;
+	mat.instantiate();
+
+	// Texture to assign to every texture slot.
+	Ref<Image> image = Image::create_empty(2, 2, false, Image::FORMAT_RGBA8);
+	image->fill(Color(1, 1, 1, 1));
+	Ref<ImageTexture> texture = ImageTexture::create_from_image(image);
+
+	List<PropertyInfo> props;
+	mat->get_property_list(&props);
+
+	for (const PropertyInfo &E : props) {
+		if (!(E.usage & PROPERTY_USAGE_STORAGE) || _is_ignored_property(E.name)) {
+			continue;
+		}
+		Variant perturbed;
+		if (!_perturb_value(E, mat->get(E.name), texture, perturbed)) {
+			continue;
+		}
+		mat->set(E.name, perturbed);
+	}
+
+	// At least confirm the perturbation took effect for a representative property.
+	CHECK(mat->get_texture(BaseMaterial3D::TEXTURE_ALBEDO).is_valid());
+	CHECK(mat->get_metallic() != fresh->get_metallic());
+
+	// This is what the loaders do to a cached resource on reload.
+	mat->copy_from(fresh);
+
+	// Every storage property must now match a freshly-constructed material.
+	for (const PropertyInfo &E : props) {
+		if (!(E.usage & PROPERTY_USAGE_STORAGE) || _is_ignored_property(E.name)) {
+			continue;
+		}
+		const Variant expected = fresh->get(E.name);
+		const Variant actual = mat->get(E.name);
+		CHECK_MESSAGE(actual == expected,
+				vformat("Property '%s' was not reset (expected %s, got %s).", E.name, expected, actual).get_data());
+	}
+
+	CHECK(mat->get_texture(BaseMaterial3D::TEXTURE_ALBEDO).is_null());
+}
+
+static void _test_replace_resets_stale_subresource(const String &p_extension) {
+	const String path = TestUtils::get_temp_path("material_reimport." + p_extension);
+
+	// "Imported" file: a parent material whose next_pass has a non-default culling mode.
+	{
+		Ref<StandardMaterial3D> child;
+		child.instantiate();
+		child->set_cull_mode(BaseMaterial3D::CULL_DISABLED);
+		Ref<StandardMaterial3D> parent;
+		parent.instantiate();
+		parent->set_next_pass(child);
+		REQUIRE(ResourceSaver::save(parent, path) == OK);
+	}
+
+	// First load caches the parent and its sub-resource.
+	Ref<StandardMaterial3D> first = ResourceLoader::load(path, "", ResourceFormatLoader::CACHE_MODE_REUSE);
+	REQUIRE(first.is_valid());
+	Ref<StandardMaterial3D> first_child = first->get_next_pass();
+	REQUIRE(first_child.is_valid());
+	CHECK(first_child->get_cull_mode() == BaseMaterial3D::CULL_DISABLED);
+
+	Ref<StandardMaterial3D> child;
+	child.instantiate();
+	REQUIRE(child->get_cull_mode() == BaseMaterial3D::CULL_BACK);
+	Ref<StandardMaterial3D> parent;
+	parent.instantiate();
+	parent->set_next_pass(child);
+	REQUIRE(ResourceSaver::save(parent, path) == OK);
+
+	Ref<StandardMaterial3D> second = ResourceLoader::load(path, "", ResourceFormatLoader::CACHE_MODE_REPLACE);
+	REQUIRE(second.is_valid());
+	Ref<StandardMaterial3D> second_child = second->get_next_pass();
+	REQUIRE(second_child.is_valid());
+
+	CHECK_MESSAGE(second_child == first_child,
+			"CACHE_MODE_REPLACE must reuse the cached sub-resource in place so existing references see the update.");
+	CHECK_MESSAGE(second_child->get_cull_mode() == BaseMaterial3D::CULL_BACK,
+			"A sub-resource property that reverted to its default on reimport must be reset, not kept stale.");
+}
+
+TEST_CASE("[SceneTree][Material] CACHE_MODE_REPLACE resets stale sub-resource properties (text)") {
+	_test_replace_resets_stale_subresource("tres");
+}
+
+TEST_CASE("[SceneTree][Material] CACHE_MODE_REPLACE resets stale sub-resource properties (binary)") {
+	_test_replace_resets_stale_subresource("res");
+}
+
+} // namespace TestMaterial
+
+#endif // _3D_DISABLED


### PR DESCRIPTION
When editing resources externally, reimport will run, process them and then ResourceBinaryLoader will be called with CACHE_MODE_REPLACE. It will take the existing resource from cache, perform reset_state, then load the stored properties from the file.

The problem is that this does not handle well properties which are no longer defined by the new resource. They do not get overwritten and stay around.

I think this was introduced by https://github.com/godotengine/godot/pull/97362 / https://github.com/godotengine/godot/commit/abf9d245208542ccf883f6b61f0d3be486dc9447. Previously we would get new ids for resources on re-import, so the caching would not find them and they would not get re-used. But once the hashing became deterministic, we find the resource and not clear all of it's properties.

I first had an attempt to fix it [here](https://github.com/godotengine/godot/pull/120380), but that was not the right approach. I think doing it the same way as https://github.com/godotengine/godot/blob/2c089e9bf0b8712d0bc444c2ceaf9c543ed9c777/core/io/resource_loader.cpp#L591 is probably the way to go.

AI disclosure - I used it to help me write the test. I wrote the original test for a material property and then AI came up with the perturb idea to test all the properties, which I though was neat. I would say it's like 50:50.

## What problem(s) does this PR solve?

- Closes #104937
- Closes #119131
- Closes #105474

## Additional information

Before and after video

https://github.com/user-attachments/assets/681c70ff-a0c7-45a7-a180-43d335088272

[project](https://github.com/user-attachments/files/29065482/material.zip)