### PR TITLE
Hide RefCounted category in the inspector on editable (sub)resources

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -4612,16 +4612,23 @@ void EditorInspector::update_tree() {
 			}
 
 			// Create an EditorInspectorCategory and add it to the inspector.
-			EditorInspectorCategory *category = memnew(EditorInspectorCategory);
-			category->set_property_info(p);
-			category->set_color_level(category_color_level);
-			main_vbox->add_child(category);
-			category_vbox = nullptr; // Reset.
+			//
+			// Do not create a category for RefCounted to avoid cluttering the inspector
+			// with a category that is present on every resource, especially in subresources.
+			// The Resource category is already always present in this case to distinguish
+			// "generic" properties from those specific to certain resource types.
+			if (p.name != "RefCounted") {
+				EditorInspectorCategory *category = memnew(EditorInspectorCategory);
+				category->set_property_info(p);
+				category->set_color_level(category_color_level);
+				main_vbox->add_child(category);
+				category_vbox = nullptr; // Reset.
 
-			// Set the category info.
-			category->set_tooltip_text(category_tooltip);
-			if (!is_custom_category) {
-				category->set_doc_class_name(doc_name);
+				// Set the category info.
+				category->set_tooltip_text(category_tooltip);
+				if (!is_custom_category) {
+					category->set_doc_class_name(doc_name);
+				}
 			}
 
 			// Add editors at the start of a category.


### PR DESCRIPTION
- Follow-up to https://github.com/godotengine/godot/pull/122849.

This reduces clutter in the inspector, especially when editing subresources, as this category is present on every Resource in the inspector.

This category generally has no editable properties anyway, as the Script property and metadata below it are actually handled separately.

- This closes https://github.com/godotengine/godot-proposals/issues/15319.
  - Compared to the proposal, I ended up hiding the category in the main inspector as well to further reduce clutter, and avoid confusion as to why the RefCounted category would be present in one but not the other.

## Preview

`master` | This PR
-|-
<img width="392" height="418" alt="Image" src="https://github.com/user-attachments/assets/42f4fd64-ab9a-48d9-8648-fd9e168b03f5" /> | <img width="392" height="383" alt="image" src="https://github.com/user-attachments/assets/6fff9b16-2f69-442d-ae78-4afe59d67310" />

`master` | This PR
-|-
<img width="392" height="412" alt="Image" src="https://github.com/user-attachments/assets/d9948b56-a6e5-4f44-9989-ee0271623294" /> | <img width="392" height="383" alt="image" src="https://github.com/user-attachments/assets/40d4c08b-36dc-482b-9cb3-473690f346a1" />