### PR TITLE
Fix main dock tabs on right-to-left layout

### DIFF
--- a/editor/gui/editor_title_bar.cpp
+++ b/editor/gui/editor_title_bar.cpp
@@ -162,7 +162,7 @@ void EditorTitleBar::_notification(int p_what) {
 				fit_child_in_rect(next, Rect2i(offset + c_size.width, 0, next->get_position().x + next->get_size().x - (offset + c_size.width), title_size.height));
 
 				int center = title_size.x / 2;
-				int width = MIN(center - prev->get_position().x, next->get_end().x - center) * 1.9;
+				int width = MIN(center - prev->get_position().x, next->get_position().x + next->get_size().x - center) * 1.9;
 				fit_child_in_rect(base, Rect2i(center - width / 2, 0, width, title_size.height));
 			}
 		} break;


### PR DESCRIPTION
## What problem(s) does this PR solve?

|PR|`master`|
|-|-|
|<img width="452" height="43" alt="Screenshot_20260831_202053" src="https://github.com/user-attachments/assets/d01612c1-47f4-42e7-9ae5-0aef4bebf60a" />|<img width="452" height="43" alt="image" src="https://github.com/user-attachments/assets/3ae876bc-1bc5-4675-b8fd-695fb14a51e8" />|