### PR TITLE
Clarify size limit for images in the Image documentation

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2517,7 +2517,7 @@ void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Forma
 	ERR_FAIL_COND_MSG(p_height > MAX_HEIGHT,
 			vformat("The Image height specified (%d pixels) cannot be greater than %d pixels.", p_height, MAX_HEIGHT));
 	ERR_FAIL_COND_MSG(p_width * p_height > MAX_PIXELS,
-			vformat("Too many pixels for Image. Maximum is %dx%d = %d pixels.", MAX_WIDTH, MAX_HEIGHT, MAX_PIXELS));
+			vformat("The Image pixel count (%dx%d = %d pixels) cannot be greater than %d pixels.", p_width, p_height, p_width * p_height, MAX_PIXELS));
 	ERR_FAIL_INDEX_MSG(p_format, FORMAT_MAX, vformat("The Image format specified (%d) is out of range. See Image's Format enum.", p_format));
 
 	int mm = 0;
@@ -2543,7 +2543,7 @@ void Image::initialize_data(int p_width, int p_height, bool p_use_mipmaps, Forma
 	ERR_FAIL_COND_MSG(p_height > MAX_HEIGHT,
 			vformat("The Image height specified (%d pixels) cannot be greater than %d pixels.", p_height, MAX_HEIGHT));
 	ERR_FAIL_COND_MSG(p_width * p_height > MAX_PIXELS,
-			vformat("Too many pixels for Image. Maximum is %dx%d = %d pixels.", MAX_WIDTH, MAX_HEIGHT, MAX_PIXELS));
+			vformat("The Image pixel count (%dx%d = %d pixels) cannot be greater than %d pixels.", p_width, p_height, p_width * p_height, MAX_PIXELS));
 	ERR_FAIL_INDEX_MSG(p_format, FORMAT_MAX, vformat("The Image format specified (%d) is out of range. See Image's Format enum.", p_format));
 
 	int mm;

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -4,10 +4,9 @@
 		Image datatype.
 	</brief_description>
 	<description>
-		Native image datatype. Contains image data which can be converted to an [ImageTexture] and provides commonly used [i]image processing[/i] methods. The maximum width and height for an [Image] are [constant MAX_WIDTH] and [constant MAX_HEIGHT].
+		Native image datatype. Contains image data which can be converted to an [ImageTexture] and provides commonly used [i]image processing[/i] methods. The maximum width and height for an [Image] are [constant MAX_WIDTH] and [constant MAX_HEIGHT], but the maximum pixel count is [code]268435456[/code] (which means that a square image can be 16384×16384 at most).
 		An [Image] cannot be assigned to a texture property of an object directly (such as [member Sprite2D.texture]), and has to be converted manually to an [ImageTexture] first.
 		[b]Note:[/b] Methods that modify the image data cannot be used on VRAM-compressed images. Use [method decompress] to convert the image to an uncompressed format first.
-		[b]Note:[/b] The maximum image size is 16384×16384 pixels due to graphics hardware limitations. Larger images may fail to import.
 	</description>
 	<tutorials>
 		<link title="Importing images">$DOCS_URL/tutorials/assets_pipeline/importing_images.html</link>


### PR DESCRIPTION
- Remove note on import size, as Image is not rendered on the GPU (it can manipulate images with dimensions larger than the current GPU can handle).

@Saalvage also wrote:

> P.S.: `MAX_PIXELS` isn't exposed either, it probably should be!

This could be worth doing, but if we expose it, it'll likely have to stay frozen in place throughout the 4.x cycle for compatibility. Should we consider increasing it first?

___

- See https://github.com/godotengine/godot-docs-user-notes/discussions/890#discussioncomment-18199578.
