### PR TITLE
[Web, 3.x] Don't focus IME div when Virtual Keyboard is available

### DIFF
--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -777,11 +777,18 @@ void OS_JavaScript::ime_callback(int p_type, const char *p_text) {
 }
 
 void OS_JavaScript::set_ime_active(const bool p_active) {
+	// IME does not work with experimental VK support.
+	if (godot_js_display_vk_available() != 0) {
+		return;
+	}
 	ime_active = p_active;
 	godot_js_set_ime_active(p_active);
 }
 
 void OS_JavaScript::set_ime_position(const Point2 &p_pos) {
+	if (godot_js_display_vk_available() != 0) {
+		return;
+	}
 	godot_js_set_ime_position(p_pos.x, p_pos.y);
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #103387

## Additional information

While the backport of IME from 4.x to 3.x is mostly identical, 3.x does not run the check for `!DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_IME)` in line_edit.cpp or text_edit.cpp before invoking either `set_ime_active` or `set_ime_position`. On `DisplayServerWeb`'s implementation of `has_feature`, this only returns true if virtual keyboard support is not available.  This has the unfortunate effect having the `<div class="ime">` take focus away from the `<input>` on Mobile Web while using a LineEdit or TextEdit, causing various levels of input being missed depending of your mobile browser.

This PR essentially bakes the FEATURE_IME check from 4.x into `OS_JavaScript::set_ime_active` and `OS_JavaScript::set_ime_position`, resulting in the same behavior as 4.x.

Tested on Android Firefox 154.0.1 and Android Chrome 151.0.7922.137 on a basic scene with only a line edit, and all inputs were able to be captured, including backspace.

Tested on Desktop Firefox 154.0.1 as working with regular keyboard input with the same scene setup. I have not tested IME with my changes, but in theory this should give equal behavior to 4.x.
