### PR TITLE
metal: ensure subpass N is dependent on N-1

### DIFF
--- a/drivers/metal/metal3_objects.cpp
+++ b/drivers/metal/metal3_objects.cpp
@@ -1277,6 +1277,8 @@ void MDCommandBuffer::render_next_subpass() {
 	MDSubpass *prev_subpass = render.current_subpass;
 	if (prev_subpass != nullptr) {
 		_end_render_pass();
+		// The closed encoder updated F_cur, and this subpass depends on it.
+		_fence_wait_current_level = true;
 	}
 
 	render.current_subpass = (prev_subpass == nullptr)

--- a/drivers/metal/metal_objects_shared.cpp
+++ b/drivers/metal/metal_objects_shared.cpp
@@ -441,7 +441,8 @@ MTL::Fence *MDCommandBufferBase::_fence_to_wait() {
 	if (!_fences[0]) {
 		return nullptr;
 	}
-	uint32_t i = (_fence_level + 1) & 1;
+	uint32_t i = _fence_wait_current_level ? (_fence_level & 1) : ((_fence_level + 1) & 1);
+	_fence_wait_current_level = false;
 #ifdef DEV_ENABLED
 	_fence_wait_issued = true;
 #endif

--- a/drivers/metal/metal_objects_shared.h
+++ b/drivers/metal/metal_objects_shared.h
@@ -607,6 +607,10 @@ protected:
 	// waited in the current level.
 	bool _fence_updated[2] = { false, false };
 	bool _fence_level_dirty = false;
+	// true when the next encoder continues the encoder just closed and must
+	// therefore wait F_cur rather than F_prev. Metal does not order encoders, so
+	// subpasses split across encoders require an explicit dependency.
+	bool _fence_wait_current_level = false;
 #ifdef DEV_ENABLED
 	// Set by _fence_to_wait(), consumed by _fence_to_update(): every encoder
 	// that updates F_cur must have waited F_prev, or the level chain breaks.

--- a/drivers/metal/rendering_device_driver_metal.cpp
+++ b/drivers/metal/rendering_device_driver_metal.cpp
@@ -1684,6 +1684,17 @@ RDD::RenderPassID RenderingDeviceDriverMetal::render_pass_create(VectorView<Atta
 
 	size_t subpass_count = p_subpasses.size();
 
+#ifdef DEV_ENABLED
+	// This loop validates the assumption that Godot configures subpass N is
+	// dependent on all prior subpasses (transitively).
+	for (uint32_t i = 0; i < p_subpass_dependencies.size(); i++) {
+		const SubpassDependency &dep = p_subpass_dependencies[i];
+		// If this asserts, then MDCommandBuffer::render_next_subpass will need
+		// to be updated, as it assumes subpass N must complete before N+1 starts.
+		DEV_ASSERT(dep.src_subpass < dep.dst_subpass && "unimplemented: subpass dependency not covered by the sequential subpass fence chain");
+	}
+#endif
+
 	LocalVector<MDSubpass> subpasses;
 	subpasses.resize(subpass_count);
 	for (uint32_t i = 0; i < subpass_count; i++) {


### PR DESCRIPTION
Hazard tracking is now disabled by default, so this fixes a race in the mobile renderer, which uses subpasses. Godot currently builds subpass dependencies explicitly as `N -> N+1`. I have added a `DEV_ASSERT` in `RenderingDeviceDriverMetal::render_pass_create` to validate this assumption. There is no public API to create subpasses with custom dependency chains.