### PR TITLE
Improve doc for ConeTwistJoint3D's twist axis

### DIFF
--- a/doc/classes/ConeTwistJoint3D.xml
+++ b/doc/classes/ConeTwistJoint3D.xml
@@ -4,7 +4,8 @@
 		A physics joint that connects two 3D physics bodies in a way that simulates a ball-and-socket joint.
 	</brief_description>
 	<description>
-		A physics joint that connects two 3D physics bodies in a way that simulates a ball-and-socket joint. The twist axis is initiated as the X axis of the [ConeTwistJoint3D]. Once the physics bodies swing, the twist axis is calculated as the middle of the X axes of the joint in the local space of the two physics bodies. Useful for limbs like shoulders and hips, lamps hanging off a ceiling, etc.
+		A physics joint that connects two 3D physics bodies in a way that simulates a ball-and-socket joint. Useful for limbs like shoulders and hips, lamps hanging off a ceiling, etc.
+		[b]Note:[/b] The twist axis is initialized as the X axis of the [ConeTwistJoint3D]. Once the physics bodies swing, the twist axis is calculated as the average of the X axes of the joint in the local space of the two physics bodies.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -41,10 +42,12 @@
 			The swing span defines, how much rotation will not get corrected along the swing axis.
 			Could be defined as looseness in the [ConeTwistJoint3D].
 			If below 0.05, this behavior is locked.
+			[b]Note:[/b] The twist axis is initialized as the X axis of the [ConeTwistJoint3D].
 		</member>
 		<member name="twist_span" type="float" setter="set_param" getter="get_param" default="3.1415927">
 			Twist is the rotation around the twist axis, this value defined how far the joint can twist.
 			Twist is locked if below 0.05.
+			[b]Note:[/b] The twist axis is initialized as the X axis of the [ConeTwistJoint3D].
 		</member>
 	</members>
 	<constants>
@@ -53,10 +56,12 @@
 			The swing span defines, how much rotation will not get corrected along the swing axis.
 			Could be defined as looseness in the [ConeTwistJoint3D].
 			If below 0.05, this behavior is locked.
+			[b]Note:[/b] The twist axis is initialized as the X axis of the [ConeTwistJoint3D].
 		</constant>
 		<constant name="PARAM_TWIST_SPAN" value="1" enum="Param">
 			Twist is the rotation around the twist axis, this value defined how far the joint can twist.
 			Twist is locked if below 0.05.
+			[b]Note:[/b] The twist axis is initialized as the X axis of the [ConeTwistJoint3D].
 		</constant>
 		<constant name="PARAM_BIAS" value="2" enum="Param">
 			The speed with which the swing or twist will take place.


### PR DESCRIPTION
## What problem(s) does this PR solve?

Closes https://github.com/godotengine/godot/issues/123048
Complements https://github.com/godotengine/godot/pull/123218

## Additional information

Changes:
- Moves the twist axis notes into a `Note:` in the description.
- Copies the twist axis notes (partially) to `swing_span` and `twist_span` in the properties/enumerations.
- Changes "the middle of the X axes" to "the average of the X axes".
  - See [godot_cone_twist_joint_3d.cpp](https://github.com/godotengine/godot/blob/20a52a8988b1170a53e0e04a7d71a0cb26f71656/modules/godot_physics_3d/joints/godot_cone_twist_joint_3d.cpp#L179).
- Changes "is initiated as" to "is initialized as".

## Author disclosure

I wrote this PR by myself.
