### PR TITLE
Fix `EDSCALE_RND` macro

### DIFF
--- a/editor/themes/editor_scale.h
+++ b/editor/themes/editor_scale.h
@@ -40,4 +40,4 @@ public:
 
 #define EDSCALE (EditorScale::get_scale())
 
-#define EDSCALE_RND(m_value) (Math::round(m_value * EDSCALE))
+#define EDSCALE_RND(m_value) (Math::round((m_value) * EDSCALE))


### PR DESCRIPTION
## What problem(s) does this PR solve?

Regression from #115070 

Fixes order of operations.

Take this line for exmaple:

https://github.com/godotengine/godot/blob/20a52a8988b1170a53e0e04a7d71a0cb26f71656/editor/themes/theme_modern.cpp#L286

`EDSCALE_RND(p_config.increased_margin + 2)` evaluates to `p_config.increased_margin + 2 * EDSCALE`, which is different from the correct behavior before #115070 - which would be `(p_config.increased_margin + 2) * EDSCALE` 

## Additional information

No AI was used.