### PR TITLE
Work around empty class errors resulting from `get_global_class_name` limitation

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5853,6 +5853,11 @@ Ref<Texture2D> EditorNode::_get_class_or_script_icon(const String &p_class, cons
 			String base_type;
 			if (ScriptServer::is_global_class(p_class)) {
 				base_type = ScriptServer::get_global_class_native_base(p_class);
+
+				// HACK: Due to a design flaw in `ScriptLanguage::get_global_class_name`, it is not always possible to determine the base class. See GH-122220.
+				if (base_type.is_empty()) {
+					base_type = Object::get_class_static();
+				}
 			} else {
 				Ref<Script> scr = ResourceLoader::load(p_script_path, "Script");
 				if (scr.is_valid()) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/122220 (the other parts of the report are intended)

## Additional information

It is not feasible to correctly implement `get_global_class_name`, since it is requesting inheritance info at a point in time when global classes are not fully indexed yet. Since inheritance info can depend on global classes, sometimes an empty base can occur in the `ScriptServer`.

This PR silences a user facing error around this, the root cause still persists and a fix would require a bit of restructuring and changes to the `get_global_class_name` API, which is not reasonable to attempt for 4.8.