### PR TITLE
[4.4] Fix more MSVC warnings for potential mod by 0 (C4724)

### DIFF
--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -440,7 +440,7 @@ void GenericTilePolygonEditor::_grab_polygon_segment_point(Vector2 p_pos, const 
 		const Vector<Vector2> &polygon = polygons[i];
 		const int polygon_size = polygon.size();
 		for (int j = 0; j < polygon_size; j++) {
-			Vector2 segment[2] = { polygon[j], polygon[(j + 1) % polygon.size()] };
+			Vector2 segment[2] = { polygon[j], polygon[(j + 1) % polygon_size] };
 			Vector2 closest_point = Geometry2D::get_closest_point_to_segment(point, segment);
 			float distance = closest_point.distance_to(point);
 			if (distance < grab_threshold / editor_zoom_widget->get_zoom() && distance < closest_distance) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

Somehow part of PR #121746 was missed when it was backported to 4.4. `const int polygon_size = polygon.size();` is defined, but not actually used after the `%` where it matters.

This is downright trivial of a fix, should be easy to approve.

## Additional information

No AI was used.
