### PR TITLE
[macOS] Fix precise scrolling

### DIFF
--- a/platform/macos/godot_content_view.mm
+++ b/platform/macos/godot_content_view.mm
@@ -896,12 +896,12 @@
 	DisplayServerMacOS::WindowData &wd = ds->get_window(window_id);
 	ds->update_mouse_pos(wd, [event locationInWindow]);
 
-	double delta_x = [event scrollingDeltaX];
-	double delta_y = [event scrollingDeltaY];
+	double delta_x = [event deltaX];
+	double delta_y = [event deltaY];
 
 	if ([event hasPreciseScrollingDeltas]) {
-		delta_x *= 0.03;
-		delta_y *= 0.03;
+		delta_x = [event scrollingDeltaX];
+		delta_y = [event scrollingDeltaY];
 	}
 
 	if ([event momentumPhase] != NSEventPhaseNone) {
@@ -915,11 +915,14 @@
 	if ([event phase] != NSEventPhaseNone || [event momentumPhase] != NSEventPhaseNone) {
 		[self processPanEvent:event dx:delta_x dy:delta_y];
 	} else {
-		if (std::abs(delta_x)) {
-			[self processScrollEvent:event button:(0 > delta_x ? MouseButton::WHEEL_RIGHT : MouseButton::WHEEL_LEFT) factor:std::abs(delta_x * 0.3)];
+		double delta_x_abs = Math::abs(delta_x);
+		double delta_y_abs = Math::abs(delta_y);
+
+		if (!Math::is_zero_approx(delta_x_abs)) {
+			[self processScrollEvent:event button:(0 > delta_x ? MouseButton::WHEEL_RIGHT : MouseButton::WHEEL_LEFT) factor:delta_x_abs];
 		}
-		if (std::abs(delta_y)) {
-			[self processScrollEvent:event button:(0 < delta_y ? MouseButton::WHEEL_UP : MouseButton::WHEEL_DOWN) factor:std::abs(delta_y * 0.3)];
+		if (!Math::is_zero_approx(delta_y_abs)) {
+			[self processScrollEvent:event button:(0 < delta_y ? MouseButton::WHEEL_UP : MouseButton::WHEEL_DOWN) factor:delta_y_abs];
 		}
 	}
 }

--- a/scene/gui/view_panner.cpp
+++ b/scene/gui/view_panner.cpp
@@ -160,7 +160,7 @@ bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) 
 			zoom_callback.call(zoom, pan_gesture->get_position(), p_event);
 			return true;
 		}
-		pan_callback.call(-pan_gesture->get_delta() * scroll_speed, p_event);
+		pan_callback.call(-pan_gesture->get_delta(), p_event);
 	}
 
 	Ref<InputEventScreenDrag> screen_drag = p_event;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #107358
- Closes #75855

## Additional information

[According to the documentation](https://developer.apple.com/documentation/appkit/nsevent/hasprecisescrollingdeltas?language=objc), `hasPreciseScrollingData` tells if `[event scrollingDeltaX]` and `[event scrollingDeltaY]` are available (i.e. for Apple trackpads and mice). Otherwise, `[event deltaX]` and `[event deltaY]` are OK to use.

The current code on `master` works for non precise scrolling input devices because macOS makes sure to put the delta values on the scrolling delta values in that case.

The result on `master` for precise Apple trackpads and mice was #107358. Multipling `[event scrollingDeltaX]` and `[event scrollingDeltaX]` by `0.03` made the scrolling... `0.03`× less efficient.

I tested my PR with my Logitech MX Master 4 Wireless Mouse mouse that doesn't have "precise scrolling data", and nothing changed for it as expected.