### PR TITLE
Show the indicator even at the end of audio in `AudioStreamImportSettingsDialog`

### DIFF
--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -322,7 +322,7 @@ void AudioStreamImportSettingsDialog::_draw_indicator() {
 	_current_label->set_text(String::num(_current, 2).pad_decimals(2) + " /");
 
 	float ofs_x = (_current - zoom_bar->get_value()) * rect.size.width / zoom_bar->get_page();
-	if (ofs_x < 0 || ofs_x >= rect.size.width) {
+	if (ofs_x < 0 || ofs_x > rect.size.width) {
 		return;
 	}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

If the indicator was at the end of the audio, it would not draw. This makes it draw even at the end. 

The solution is as simple as replacing a `>=` with `>`. Does not cause any crashes.

## Before

https://github.com/user-attachments/assets/f9c0c061-af03-4239-87c2-f3a0c9c354ed

## After

https://github.com/user-attachments/assets/ed57cb7b-4b6a-408b-ab5f-5cae1c0aeedf

## Additional information

No AI was used.