### PR TITLE
Replace indentation spaces with tabs in codeblocks

### DIFF
--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -320,9 +320,9 @@
 				[codeblocks]
 				[gdscript]
 				var my_basis = Basis(
-				    Vector3(1, 1, 1),
-				    Vector3(2, 2, 2),
-				    Vector3(3, 3, 3)
+					Vector3(1, 1, 1),
+					Vector3(2, 2, 2),
+					Vector3(3, 3, 3)
 				)
 				my_basis = my_basis.scaled_local(Vector3(0, 2, -2))
 
@@ -332,9 +332,9 @@
 				[/gdscript]
 				[csharp]
 				var myBasis = new Basis(
-				    new Vector3(1.0f, 1.0f, 1.0f),
-				    new Vector3(2.0f, 2.0f, 2.0f),
-				    new Vector3(3.0f, 3.0f, 3.0f)
+					new Vector3(1.0f, 1.0f, 1.0f),
+					new Vector3(2.0f, 2.0f, 2.0f),
+					new Vector3(3.0f, 3.0f, 3.0f)
 				);
 				myBasis = myBasis.ScaledLocal(new Vector3(0.0f, 2.0f, -2.0f));
 

--- a/doc/classes/EditorContextMenuPlugin.xml
+++ b/doc/classes/EditorContextMenuPlugin.xml
@@ -105,10 +105,10 @@
 			[code]&amp;"needs_prefix": bool[/code] - Whether the option needs a "New" prefix (for consistency with native options).
 			[codeblock]
 			func _get_menu_options(data):
-			    if data["needs_prefix"]:
-			        add_context_menu_item("New Image File...", create_image)
-			    else:
-			        add_context_menu_item("Image File...", create_image)
+				if data["needs_prefix"]:
+					add_context_menu_item("New Image File...", create_image)
+				else:
+					add_context_menu_item("Image File...", create_image)
 			[/codeblock]
 		</constant>
 		<constant name="CONTEXT_SLOT_SCRIPT_EDITOR_CODE" value="4" enum="ContextMenuSlot">

--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -2374,7 +2374,7 @@
 			rd = RenderingServer.get_rendering_device()
 
 			if rd.has_feature(RenderingDevice.SUPPORTS_RAYTRACING_PIPELINE):
-			    storage_buffer = rd.storage_buffer_create(bytes.size(), bytes, RenderingDevice.BUFFER_CREATION_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT)
+				storage_buffer = rd.storage_buffer_create(bytes.size(), bytes, RenderingDevice.BUFFER_CREATION_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT)
 			[/gdscript]
 			[/codeblocks]
 		</constant>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -2430,11 +2430,11 @@
 				[codeblock]
 				{
 					# Required:
-				    "primitive": RenderingServer.PrimitiveType,
-				    "format": RenderingServer.ArrayFormat,
-				    "vertex_data": PackedByteArray,
-				    "vertex_count": int,
-				    "aabb": AABB,
+					"primitive": RenderingServer.PrimitiveType,
+					"format": RenderingServer.ArrayFormat,
+					"vertex_data": PackedByteArray,
+					"vertex_count": int,
+					"aabb": AABB,
 
 					# Optional:
 					"attribute_data": PackedByteArray,

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -127,15 +127,15 @@
 				[codeblocks]
 				[gdscript]
 				func _ready():
-				    await RenderingServer.frame_post_draw
-				    $Viewport.get_texture().get_image().save_png("user://Screenshot.png")
+					await RenderingServer.frame_post_draw
+					$Viewport.get_texture().get_image().save_png("user://Screenshot.png")
 				[/gdscript]
 				[csharp]
 				public async override void _Ready()
 				{
-				    await ToSignal(RenderingServer.Singleton, RenderingServer.SignalName.FramePostDraw);
-				    var viewport = GetNode&lt;Viewport&gt;("Viewport");
-				    viewport.GetTexture().GetImage().SavePng("user://Screenshot.png");
+					await ToSignal(RenderingServer.Singleton, RenderingServer.SignalName.FramePostDraw);
+					var viewport = GetNode&lt;Viewport&gt;("Viewport");
+					viewport.GetTexture().GetImage().SavePng("user://Screenshot.png");
 				}
 				[/csharp]
 				[/codeblocks]

--- a/modules/openxr/doc_classes/OpenXRSpatialCapabilityConfigurationAprilTag.xml
+++ b/modules/openxr/doc_classes/OpenXRSpatialCapabilityConfigurationAprilTag.xml
@@ -31,7 +31,7 @@
 			5 by 5 bits, minimum Hamming distance between any two codes = 9, 35 codes.
 		</constant>
 		<constant name="APRIL_TAG_DICT_36H10" value="3" enum="AprilTagDict">
-			 6 by 6 bits, minimum Hamming distance between any two codes = 10, 2320 codes.
+			6 by 6 bits, minimum Hamming distance between any two codes = 10, 2320 codes.
 		</constant>
 		<constant name="APRIL_TAG_DICT_36H11" value="4" enum="AprilTagDict">
 			6 by 6 bits, minimum Hamming distance between any two codes = 11, 587 codes.


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Some `[codeblock]` examples in the documentation are still using spaces for indentation instead of tabs, this PR replaces all instances (manually picked from a grep with `^\t* +(?! )`) with tabs for consistency.

Also fixes one instance of a leading space in a description paragraph.