### PR TITLE
Allow to pick categories in the Asset Store's template mode

### DIFF
--- a/editor/asset_library/asset_library_editor_plugin.cpp
+++ b/editor/asset_library/asset_library_editor_plugin.cpp
@@ -1757,9 +1757,7 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 
 	switch (requested) {
 		case REQUESTING_CHECK: {
-			if (!templates_only) {
-				_api_request("tags/?featured_only=true", REQUESTING_TAGS, true);
-			}
+			_api_request("tags/?featured_only=true", REQUESTING_TAGS, true);
 			_api_request("licenses/", REQUESTING_LICENSES, true);
 
 			filter->set_editable(true);
@@ -1771,12 +1769,8 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 		case REQUESTING_TAGS: {
 			categories->clear();
 
-			if (templates_only) {
-				categories->add_item(TTRC("Template"));
-			} else {
-				categories->add_item(TTRC("All"));
-				categories->set_disabled(false);
-			}
+			categories->add_item(TTRC("All"));
+			categories->set_disabled(false);
 
 			Array arr = dt;
 			for (int i = arr.size() - 1; i >= 0; i--) {
@@ -2205,7 +2199,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	filter->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	filter->connect(SceneStringName(text_changed), callable_mp(filter_debounce_timer, &Timer::start).bind(-1).unbind(1));
 
-	if (!p_templates_only) {
+	if (!templates_only) {
 		search_hb->add_child(memnew(VSeparator));
 	}
 
@@ -2219,7 +2213,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	search_hb->add_child(plugins);
 	plugins->connect(SceneStringName(pressed), callable_mp(this, &EditorAssetLibrary::_manage_plugins));
 
-	if (p_templates_only) {
+	if (templates_only) {
 		open_asset->hide();
 		plugins->hide();
 	}
@@ -2245,11 +2239,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
 	search_hb2->add_child(memnew(Label(TTRC("Category:"))));
 	categories = memnew(OptionButton);
-	if (p_templates_only) {
-		categories->add_item(TTRC("Template"));
-	} else {
-		categories->add_item(TTRC("All"));
-	}
+	categories->add_item(TTRC("All"));
 	categories->set_disabled(true);
 	categories->set_clip_text(true);
 	categories->set_fit_to_longest_item(false);


### PR DESCRIPTION
## What problem(s) does this PR solve?

After #119608, I forgot to also remove the behavior that disables category picking for templates, as the new `type` argument in the store API now allows for them.