### PR TITLE
GDShader: Display preprocessor errors instead of trying to compile non-preprocessed file

### DIFF
--- a/editor/shader/shader_text_editor.cpp
+++ b/editor/shader/shader_text_editor.cpp
@@ -953,7 +953,7 @@ void ShaderTextEditor::_code_complete_script(const String &p_code, List<EditorLa
 	if (!complete_from_path.ends_with("/")) {
 		complete_from_path += "/";
 	}
-	preprocessor.preprocess_for_editor(p_code, resource_path, code, nullptr, nullptr, nullptr, &pp_options, &pp_defines, _complete_include_paths);
+	preprocessor.preprocess_for_editor(p_code, resource_path, code, nullptr, nullptr, nullptr, nullptr, &pp_options, &pp_defines, _complete_include_paths);
 	complete_from_path = String();
 	if (pp_options.size()) {
 		for (const EditorLanguage::CompletionOption &E : pp_options) {

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -52,7 +52,15 @@ Shader::Mode Shader::get_mode() const {
 void Shader::_check_shader_rid() const {
 	MutexLock lock(shader_rid_mutex);
 	if (shader_rid.is_null() && !preprocessed_code.is_empty()) {
-		shader_rid = RenderingServer::get_singleton()->shader_create_from_code(preprocessed_code, get_path());
+		String shader_to_compile;
+		String path;
+		if (preprocessor_result == OK) {
+			shader_to_compile = preprocessed_code;
+			path = get_path();
+		} else {
+			_err_print_error(nullptr, get_path().utf8().get_data(), 0, preprocessor_error_string, true, ERR_HANDLER_SHADER);
+		}
+		shader_rid = RenderingServer::get_singleton()->shader_create_from_code(shader_to_compile, path);
 		preprocessed_code = String();
 	}
 }
@@ -98,8 +106,19 @@ void Shader::set_code(const String &p_code) {
 		// 2) Server does not do interaction with Resource filetypes, this is a scene level feature.
 		HashSet<Ref<ShaderInclude>> new_include_dependencies;
 		ShaderPreprocessor preprocessor;
-		Error result = preprocessor.preprocess(p_code, path, preprocessed_code, &new_include_dependencies);
-		if (result == OK) {
+#ifdef TOOLS_ENABLED
+		preprocessor_result = preprocessor.preprocess_for_editor(
+				p_code,
+				path,
+				preprocessed_code,
+				&preprocessor_error_string,
+				nullptr,
+				nullptr,
+				&new_include_dependencies);
+#else
+		preprocessor_result = preprocessor.preprocess(p_code, path, preprocessed_code, &new_include_dependencies);
+#endif // TOOLS_ENABLED
+		if (preprocessor_result == OK) {
 			// This ensures previous include resources are not freed and then re-loaded during parse (which would make compiling slower)
 			include_dependencies = new_include_dependencies;
 		}
@@ -127,8 +146,12 @@ void Shader::set_code(const String &p_code) {
 	}
 
 	if (shader_rid.is_valid()) {
-		RenderingServer::get_singleton()->shader_set_code(shader_rid, preprocessed_code);
-		preprocessed_code = String();
+		if (preprocessor_result == OK) {
+			RenderingServer::get_singleton()->shader_set_code(shader_rid, preprocessed_code);
+			preprocessed_code = String();
+		} else {
+			_err_print_error(nullptr, get_path().utf8().get_data(), 0, preprocessor_error_string, true, ERR_HANDLER_SHADER);
+		}
 	}
 
 	emit_changed();

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -61,6 +61,8 @@ private:
 	HashSet<Ref<ShaderInclude>> include_dependencies;
 	String code;
 	String include_path;
+	Error preprocessor_result;
+	String preprocessor_error_string;
 
 	HashMap<StringName, HashMap<int, Ref<Texture>>> default_textures;
 

--- a/servers/rendering/shader_preprocessor.cpp
+++ b/servers/rendering/shader_preprocessor.cpp
@@ -1377,7 +1377,7 @@ Error ShaderPreprocessor::preprocess(const String &p_code, const String &p_filen
 }
 
 #ifdef TOOLS_ENABLED
-Error ShaderPreprocessor::preprocess_for_editor(const String &p_code, const String &p_filename, String &r_result, String *r_error_text, List<FilePosition> *r_error_position, List<Region> *r_regions, List<EditorLanguage::CompletionOption> *r_completion_options, List<EditorLanguage::CompletionOption> *r_completion_defines, IncludeCompletionFunction p_include_completion_func) {
+Error ShaderPreprocessor::preprocess_for_editor(const String &p_code, const String &p_filename, String &r_result, String *r_error_text, List<FilePosition> *r_error_position, List<Region> *r_regions, HashSet<Ref<ShaderInclude>> *r_includes, List<EditorLanguage::CompletionOption> *r_completion_options, List<EditorLanguage::CompletionOption> *r_completion_defines, IncludeCompletionFunction p_include_completion_func) {
 	State pp_state;
 	_prepare_state(pp_state, p_filename, r_regions != nullptr);
 	Error err = preprocess(&pp_state, p_code, r_result);
@@ -1392,6 +1392,9 @@ Error ShaderPreprocessor::preprocess_for_editor(const String &p_code, const Stri
 	}
 	if (r_regions) {
 		*r_regions = pp_state.regions[p_filename];
+	}
+	if (r_includes) {
+		*r_includes = pp_state.shader_includes;
 	}
 
 	if (r_completion_defines) {

--- a/servers/rendering/shader_preprocessor.h
+++ b/servers/rendering/shader_preprocessor.h
@@ -227,7 +227,7 @@ public:
 #ifdef TOOLS_ENABLED
 	typedef void (*IncludeCompletionFunction)(List<EditorLanguage::CompletionOption> *);
 
-	Error preprocess_for_editor(const String &p_code, const String &p_filename, String &r_result, String *r_error_text = nullptr, List<FilePosition> *r_error_position = nullptr, List<Region> *r_regions = nullptr, List<EditorLanguage::CompletionOption> *r_completion_options = nullptr, List<EditorLanguage::CompletionOption> *r_completion_defines = nullptr, IncludeCompletionFunction p_include_completion_func = nullptr);
+	Error preprocess_for_editor(const String &p_code, const String &p_filename, String &r_result, String *r_error_text = nullptr, List<FilePosition> *r_error_position = nullptr, List<Region> *r_regions = nullptr, HashSet<Ref<ShaderInclude>> *r_includes = nullptr, List<EditorLanguage::CompletionOption> *r_completion_options = nullptr, List<EditorLanguage::CompletionOption> *r_completion_defines = nullptr, IncludeCompletionFunction p_include_completion_func = nullptr);
 #endif
 
 	static void get_keyword_list(List<String> *r_keywords, bool p_include_shader_keywords, bool p_ignore_context_keywords = false);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #123056

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

Previously, if shader preprocessing failed (such as due to an invalid path in an `#include` statement), the shader code as a whole would remain non-preprocessed before being compiled. Then, the compiler would see the `#` symbols from the preprocessor directives and fail on them. This meant that straightforward preprocessor errors would result in seemingly nonsensical error messages being displayed.

This PR saves the result of preprocessing, and checks to ensure the most recent preprocessing attempt was successful before attempting to compile the shader. If it was not successful, the error message from the preprocessor is displayed, and an empty shader is compiled in place of the broken, un-preprocessed shader supplied by the user.

Results in the output panel using a modified version of the MRP for the issue linked above:
| Without PR | With PR |
| --- | --- |
| <img width="447" height="482" alt="CleanShot 2026-09-01 at 09 40 01@2x" src="https://github.com/user-attachments/assets/b2b9cbb9-3233-4e3d-a175-e5f465d30b91" /> | <img width="452" height="232" alt="CleanShot 2026-09-01 at 09 38 43@2x" src="https://github.com/user-attachments/assets/5ef05a7a-b6a5-4f40-a1c7-2abd176549e4" /> |

Notes:
- I initially felt like I should include a similar code pattern in `ShaderInclude` (specifically, saving the result and possible error message of the preprocessor), but scanning through the codebase I didn't see anywhere that it would actually be applicable, so I left it be.
- This error checking is currently not applied to cases in the engine where shaders are constructed such as the sky materials. 