### PR TITLE
Core vectors: Prefer data pointer over first element addresses

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1328,14 +1328,13 @@ String Marshalls::variant_to_base64(const Variant &p_var, bool p_full_objects) {
 	Error err = encode_variant(p_var, nullptr, len, p_full_objects);
 	ERR_FAIL_COND_V_MSG(err != OK, "", "Error when trying to encode Variant.");
 
-	Vector<uint8_t> buff;
+	LocalVector<uint8_t> buff;
 	buff.resize(len);
-	uint8_t *w = buff.ptrw();
 
-	err = encode_variant(p_var, &w[0], len, p_full_objects);
+	err = encode_variant(p_var, buff.ptr(), len, p_full_objects);
 	ERR_FAIL_COND_V_MSG(err != OK, "", "Error when trying to encode Variant.");
 
-	String ret = CryptoCore::b64_encode_str(&w[0], len);
+	String ret = CryptoCore::b64_encode_str(buff.ptr(), len);
 	ERR_FAIL_COND_V(ret.is_empty(), ret);
 
 	return ret;
@@ -1345,15 +1344,14 @@ Variant Marshalls::base64_to_variant(const String &p_str, bool p_allow_objects) 
 	int strlen = p_str.length();
 	CharString cstr = p_str.ascii();
 
-	Vector<uint8_t> buf;
+	LocalVector<uint8_t> buf;
 	buf.resize(strlen / 4 * 3 + 1);
-	uint8_t *w = buf.ptrw();
 
 	size_t len = 0;
-	ERR_FAIL_COND_V(CryptoCore::b64_decode(&w[0], buf.size(), &len, (unsigned char *)cstr.get_data(), strlen) != OK, Variant());
+	ERR_FAIL_COND_V(CryptoCore::b64_decode(buf.ptr(), buf.size(), &len, (unsigned char *)cstr.get_data(), strlen) != OK, Variant());
 
 	Variant v;
-	Error err = decode_variant(v, &w[0], len, nullptr, p_allow_objects);
+	Error err = decode_variant(v, buf.ptr(), len, nullptr, p_allow_objects);
 	ERR_FAIL_COND_V_MSG(err != OK, Variant(), "Error when trying to decode Variant.");
 
 	return v;
@@ -1373,9 +1371,7 @@ Vector<uint8_t> Marshalls::base64_to_raw(const String &p_str) {
 	Vector<uint8_t> buf;
 	{
 		buf.resize(strlen / 4 * 3 + 1);
-		uint8_t *w = buf.ptrw();
-
-		ERR_FAIL_COND_V(CryptoCore::b64_decode(&w[0], buf.size(), &arr_len, (unsigned char *)cstr.get_data(), strlen) != OK, Vector<uint8_t>());
+		ERR_FAIL_COND_V(CryptoCore::b64_decode(buf.ptrw(), buf.size(), &arr_len, (unsigned char *)cstr.get_data(), strlen) != OK, Vector<uint8_t>());
 	}
 	buf.resize(arr_len);
 
@@ -1396,15 +1392,14 @@ String Marshalls::base64_to_utf8(const String &p_str) {
 	int strlen = p_str.length();
 	CharString cstr = p_str.ascii();
 
-	Vector<uint8_t> buf;
+	LocalVector<uint8_t> buf;
 	buf.resize(strlen / 4 * 3 + 1 + 1);
-	uint8_t *w = buf.ptrw();
 
 	size_t len = 0;
-	ERR_FAIL_COND_V(CryptoCore::b64_decode(&w[0], buf.size(), &len, (unsigned char *)cstr.get_data(), strlen) != OK, String());
+	ERR_FAIL_COND_V(CryptoCore::b64_decode(buf.ptr(), buf.size(), &len, (unsigned char *)cstr.get_data(), strlen) != OK, String());
 
-	w[len] = 0;
-	String ret = String::utf8((char *)&w[0]);
+	buf[len] = 0;
+	String ret = String::utf8((char *)buf.ptr());
 
 	return ret;
 }

--- a/core/crypto/crypto_core.cpp
+++ b/core/crypto/crypto_core.cpp
@@ -229,13 +229,12 @@ Error CryptoCore::generate_random(uint8_t *r_buffer, size_t p_buffer_len) {
 
 String CryptoCore::b64_encode_str(const uint8_t *p_src, size_t p_src_len) {
 	size_t b64len = p_src_len / 3 * 4 + 4 + 1;
-	Vector<uint8_t> b64buff;
+	LocalVector<uint8_t, size_t> b64buff;
 	b64buff.resize(b64len);
-	uint8_t *w64 = b64buff.ptrw();
 	size_t strlen = 0;
-	int ret = b64_encode(&w64[0], b64len, &strlen, p_src, p_src_len);
-	w64[strlen] = 0;
-	return ret ? String() : (const char *)&w64[0];
+	int ret = b64_encode(b64buff.ptr(), b64len, &strlen, p_src, p_src_len);
+	b64buff[strlen] = 0;
+	return ret ? String() : (const char *)b64buff.ptr();
 }
 
 Error CryptoCore::b64_encode(uint8_t *r_dst, size_t p_dst_len, size_t *r_len, const uint8_t *p_src, size_t p_src_len) {

--- a/core/crypto/hashing_context.cpp
+++ b/core/crypto/hashing_context.cpp
@@ -52,14 +52,13 @@ Error HashingContext::update(const PackedByteArray &p_chunk) {
 	ERR_FAIL_NULL_V(ctx, ERR_UNCONFIGURED);
 	size_t len = p_chunk.size();
 	ERR_FAIL_COND_V(len == 0, FAILED);
-	const uint8_t *r = p_chunk.ptr();
 	switch (type) {
 		case HASH_MD5:
-			return ((CryptoCore::MD5Context *)ctx)->update(&r[0], len);
+			return ((CryptoCore::MD5Context *)ctx)->update(p_chunk.ptr(), len);
 		case HASH_SHA1:
-			return ((CryptoCore::SHA1Context *)ctx)->update(&r[0], len);
+			return ((CryptoCore::SHA1Context *)ctx)->update(p_chunk.ptr(), len);
 		case HASH_SHA256:
-			return ((CryptoCore::SHA256Context *)ctx)->update(&r[0], len);
+			return ((CryptoCore::SHA256Context *)ctx)->update(p_chunk.ptr(), len);
 	}
 	return ERR_UNAVAILABLE;
 }

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -365,10 +365,8 @@ Variant FileAccess::get_var(bool p_allow_objects) const {
 	Vector<uint8_t> buff = get_buffer(len);
 	ERR_FAIL_COND_V((uint32_t)buff.size() != len, Variant());
 
-	const uint8_t *r = buff.ptr();
-
 	Variant v;
-	Error err = decode_variant(v, &r[0], len, nullptr, p_allow_objects);
+	Error err = decode_variant(v, buff.ptr(), len, nullptr, p_allow_objects);
 	ERR_FAIL_COND_V_MSG(err != OK, Variant(), "Error when trying to encode Variant.");
 
 	return v;
@@ -819,12 +817,12 @@ bool FileAccess::store_string(const String &p_string) {
 	}
 
 	CharString cs = p_string.utf8();
-	return store_buffer((uint8_t *)&cs[0], cs.length());
+	return store_buffer((uint8_t *)cs.ptrw(), cs.length());
 }
 
 bool FileAccess::store_pascal_string(const String &p_string) {
 	CharString cs = p_string.utf8();
-	return store_32(cs.length()) && store_buffer((uint8_t *)&cs[0], cs.length());
+	return store_32(cs.length()) && store_buffer((uint8_t *)cs.ptrw(), cs.length());
 }
 
 String FileAccess::get_pascal_string() {
@@ -891,8 +889,7 @@ bool FileAccess::store_var(const Variant &p_var, bool p_full_objects) {
 	Vector<uint8_t> buff;
 	buff.resize(len);
 
-	uint8_t *w = buff.ptrw();
-	err = encode_variant(p_var, &w[0], len, p_full_objects);
+	err = encode_variant(p_var, buff.ptrw(), len, p_full_objects);
 	ERR_FAIL_COND_V_MSG(err != OK, false, "Error when trying to encode Variant.");
 
 	return store_32(uint32_t(len)) && store_buffer(buff);

--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -71,8 +71,7 @@ Error PacketPeer::put_packet_buffer(const Vector<uint8_t> &p_buffer) {
 		return OK;
 	}
 
-	const uint8_t *r = p_buffer.ptr();
-	return put_packet(&r[0], len);
+	return put_packet(p_buffer.ptr(), len);
 }
 
 Error PacketPeer::get_var(Variant &r_variant, bool p_allow_objects) {
@@ -197,7 +196,7 @@ Error PacketPeerStream::_poll_buffer() const {
 		return OK;
 	}
 
-	int w = ring_buffer.write(&input_buffer[0], read);
+	int w = ring_buffer.write(input_buffer.ptr(), read);
 	ERR_FAIL_COND_V(w != read, ERR_BUG);
 
 	return OK;
@@ -244,7 +243,7 @@ Error PacketPeerStream::get_packet(const uint8_t **r_buffer, int &r_buffer_size)
 	ring_buffer.read(lbuf, 4); //get rid of first 4 bytes
 	ring_buffer.read(input_buffer.ptrw(), len); // read packet
 
-	*r_buffer = &input_buffer[0];
+	*r_buffer = input_buffer.ptr();
 	r_buffer_size = len;
 	return OK;
 }
@@ -270,7 +269,7 @@ Error PacketPeerStream::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
 		dst[i] = p_buffer[i];
 	}
 
-	return peer->put_data(&output_buffer[0], p_buffer_size + 4);
+	return peer->put_data(output_buffer.ptr(), p_buffer_size + 4);
 }
 
 int PacketPeerStream::get_max_packet_size() const {

--- a/core/io/plist.cpp
+++ b/core/io/plist.cpp
@@ -75,9 +75,7 @@ Variant PListNode::get_value() const {
 			Vector<uint8_t> buf;
 			{
 				buf.resize(strlen / 4 * 3 + 1);
-				uint8_t *w = buf.ptrw();
-
-				ERR_FAIL_COND_V(CryptoCore::b64_decode(&w[0], buf.size(), &arr_len, (unsigned char *)data_string.get_data(), strlen) != OK, Vector<uint8_t>());
+				ERR_FAIL_COND_V(CryptoCore::b64_decode(buf.ptrw(), buf.size(), &arr_len, (unsigned char *)data_string.get_data(), strlen) != OK, Vector<uint8_t>());
 			}
 			buf.resize(arr_len);
 			return buf;

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -148,8 +148,8 @@ StringName ResourceLoaderBinary::_get_string() {
 		if (len == 0) {
 			return StringName();
 		}
-		f->get_buffer((uint8_t *)&str_buf[0], len);
-		return String::utf8(&str_buf[0], len);
+		f->get_buffer((uint8_t *)str_buf.ptr(), len);
+		return String::utf8(str_buf.ptr(), len);
 	}
 
 	return string_map[id];
@@ -854,11 +854,11 @@ static void save_ustring(Ref<FileAccess> r_file, const String &p_string) {
 }
 
 static String get_ustring(Ref<FileAccess> r_file) {
-	int len = r_file->get_32();
-	Vector<char> str_buf;
+	uint32_t len = r_file->get_32();
+	LocalVector<char> str_buf;
 	str_buf.resize(len);
-	r_file->get_buffer((uint8_t *)&str_buf[0], len);
-	return String::utf8(&str_buf[0], len);
+	r_file->get_buffer((uint8_t *)str_buf.ptr(), len);
+	return String::utf8(str_buf.ptr(), len);
 }
 
 String ResourceLoaderBinary::get_unicode_string() {
@@ -869,8 +869,8 @@ String ResourceLoaderBinary::get_unicode_string() {
 	if (len == 0) {
 		return String();
 	}
-	f->get_buffer((uint8_t *)&str_buf[0], len);
-	return String::utf8(&str_buf[0], len);
+	f->get_buffer((uint8_t *)str_buf.ptrw(), len);
+	return String::utf8(str_buf.ptr(), len);
 }
 
 void ResourceLoaderBinary::get_classes_used(Ref<FileAccess> p_file, HashSet<StringName> *p_classes) {

--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -38,8 +38,7 @@ Error StreamPeer::_put_data(const Vector<uint8_t> &p_data) {
 	if (len == 0) {
 		return OK;
 	}
-	const uint8_t *r = p_data.ptr();
-	return put_data(&r[0], len);
+	return put_data(p_data.ptr(), len);
 }
 
 Array StreamPeer::_put_partial_data(const Vector<uint8_t> &p_data) {
@@ -52,9 +51,8 @@ Array StreamPeer::_put_partial_data(const Vector<uint8_t> &p_data) {
 		return ret;
 	}
 
-	const uint8_t *r = p_data.ptr();
 	int sent;
-	Error err = put_partial_data(&r[0], len, sent);
+	Error err = put_partial_data(p_data.ptr(), len, sent);
 
 	if (err != OK) {
 		sent = 0;
@@ -75,8 +73,7 @@ Array StreamPeer::_get_data(int p_bytes) {
 		return ret;
 	}
 
-	uint8_t *w = data.ptrw();
-	Error err = get_data(&w[0], p_bytes);
+	Error err = get_data(data.ptrw(), p_bytes);
 
 	ret.push_back(err);
 	ret.push_back(data);
@@ -94,9 +91,8 @@ Array StreamPeer::_get_partial_data(int p_bytes) {
 		return ret;
 	}
 
-	uint8_t *w = data.ptrw();
 	int received;
-	Error err = get_partial_data(&w[0], p_bytes, received);
+	Error err = get_partial_data(data.ptrw(), p_bytes, received);
 
 	if (err != OK) {
 		data.clear();
@@ -363,12 +359,11 @@ String StreamPeer::get_string(int p_bytes) {
 	}
 	ERR_FAIL_COND_V(p_bytes < 0, String());
 
-	Vector<char> buf;
-	Error err = buf.resize(p_bytes + 1);
+	LocalVector<char> buf;
+	buf.resize(p_bytes + 1);
+	Error err = get_data((uint8_t *)buf.ptr(), p_bytes);
 	ERR_FAIL_COND_V(err != OK, String());
-	err = get_data((uint8_t *)&buf[0], p_bytes);
-	ERR_FAIL_COND_V(err != OK, String());
-	buf.write[p_bytes] = 0;
+	buf[p_bytes] = 0;
 	return buf.ptr();
 }
 
@@ -378,10 +373,9 @@ String StreamPeer::get_utf8_string(int p_bytes) {
 	}
 	ERR_FAIL_COND_V(p_bytes < 0, String());
 
-	Vector<uint8_t> buf;
-	Error err = buf.resize(p_bytes);
-	ERR_FAIL_COND_V(err != OK, String());
-	err = get_data(buf.ptrw(), p_bytes);
+	LocalVector<uint8_t> buf;
+	buf.resize(p_bytes);
+	Error err = get_data(buf.ptr(), p_bytes);
 	ERR_FAIL_COND_V(err != OK, String());
 
 	return String::utf8((const char *)buf.ptr(), buf.size());
@@ -389,10 +383,9 @@ String StreamPeer::get_utf8_string(int p_bytes) {
 
 Variant StreamPeer::get_var(bool p_allow_objects) {
 	int len = get_32();
-	Vector<uint8_t> var;
-	Error err = var.resize(len);
-	ERR_FAIL_COND_V(err != OK, Variant());
-	err = get_data(var.ptrw(), len);
+	LocalVector<uint8_t> var;
+	var.resize(len);
+	Error err = get_data(var.ptr(), len);
 	ERR_FAIL_COND_V(err != OK, Variant());
 
 	Variant ret;

--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -409,7 +409,7 @@ public:
 			return 0;
 		}
 
-		Vector<Vector3> convex_points = Geometry3D::compute_convex_mesh_points(&p_convex[0], p_convex.size());
+		Vector<Vector3> convex_points = Geometry3D::compute_convex_mesh_points(p_convex.ptr(), p_convex.size());
 		if (convex_points.is_empty()) {
 			return 0;
 		}
@@ -422,9 +422,9 @@ public:
 		params.tester = p_tester;
 		params.tree_collision_mask = p_tree_collision_mask;
 
-		params.hull.planes = &p_convex[0];
+		params.hull.planes = p_convex.ptr();
 		params.hull.num_planes = p_convex.size();
-		params.hull.points = &convex_points[0];
+		params.hull.points = convex_points.ptr();
 		params.hull.num_points = convex_points.size();
 
 		tree.cull_convex(params);

--- a/core/math/dynamic_bvh.cpp
+++ b/core/math/dynamic_bvh.cpp
@@ -296,7 +296,7 @@ void DynamicBVH::optimize_bottom_up() {
 	if (bvh_root) {
 		LocalVector<Node *> leaves;
 		_fetch_leaves(bvh_root, leaves);
-		_bottom_up(&leaves[0], leaves.size());
+		_bottom_up(leaves.ptr(), leaves.size());
 		bvh_root = leaves[0];
 	}
 }
@@ -305,7 +305,7 @@ void DynamicBVH::optimize_top_down(int p_bu_threshold) {
 	if (bvh_root) {
 		LocalVector<Node *> leaves;
 		_fetch_leaves(bvh_root, leaves);
-		bvh_root = _top_down(&leaves[0], leaves.size(), p_bu_threshold);
+		bvh_root = _top_down(leaves.ptr(), leaves.size(), p_bu_threshold);
 	}
 }
 

--- a/core/math/triangulate.cpp
+++ b/core/math/triangulate.cpp
@@ -32,7 +32,7 @@
 
 real_t Triangulate::get_area(const Vector<Vector2> &p_contour) {
 	int n = p_contour.size();
-	const Vector2 *c = &p_contour[0];
+	const Vector2 *c = p_contour.ptr();
 
 	real_t A = 0.0;
 
@@ -75,7 +75,7 @@ bool Triangulate::is_inside_triangle(real_t p_ax, real_t p_ay, real_t p_bx, real
 bool Triangulate::snip(const Vector<Vector2> &p_contour, int p_u, int p_v, int p_w, int p_n, const Vector<int> &p_values, bool p_relaxed) {
 	int p;
 	real_t Ax, Ay, Bx, By, Cx, Cy, Px, Py;
-	const Vector2 *contour = &p_contour[0];
+	const Vector2 *contour = p_contour.ptr();
 
 	Ax = contour[p_values[p_u]].x;
 	Ay = contour[p_values[p_u]].y;

--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -602,7 +602,7 @@ TypedArray<int> ScriptLanguage::CodeCompletionOption::get_option_characteristics
 	}
 	charac.push_back(matches.size());
 	charac.push_back((matches[0].first == 0) ? 0 : 1);
-	const char32_t *target_char = &p_base[0];
+	const char32_t *target_char = p_base.ptr();
 	int bad_case = 0;
 	for (const Pair<int, int> &match_segment : matches) {
 		const char32_t *string_to_complete_char = &display[match_segment.first];

--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -156,11 +156,8 @@ bool OptimizedTranslation::generate(const Ref<Translation> &p_from) {
 	hash_table.resize(size);
 	bucket_table.resize(bucket_table_size);
 
-	int *htwb = hash_table.ptrw();
-	int *btwb = bucket_table.ptrw();
-
-	uint32_t *htw = (uint32_t *)&htwb[0];
-	uint32_t *btw = (uint32_t *)&btwb[0];
+	uint32_t *htw = (uint32_t *)hash_table.ptrw();
+	uint32_t *btw = (uint32_t *)bucket_table.ptrw();
 
 	int btindex = 0;
 
@@ -243,12 +240,9 @@ StringName OptimizedTranslation::get_message(const StringName &p_src_text, const
 	CharString str = p_src_text.string().utf8();
 	uint32_t h = hash(0, str.get_data());
 
-	const int *htr = hash_table.ptr();
-	const uint32_t *htptr = (const uint32_t *)&htr[0];
-	const int *btr = bucket_table.ptr();
-	const uint32_t *btptr = (const uint32_t *)&btr[0];
-	const uint8_t *sr = strings.ptr();
-	const char *sptr = (const char *)&sr[0];
+	const uint32_t *htptr = (const uint32_t *)hash_table.ptr();
+	const uint32_t *btptr = (const uint32_t *)bucket_table.ptr();
+	const char *sptr = (const char *)strings.ptr();
 
 	uint32_t p = htptr[h % htsize];
 
@@ -286,12 +280,9 @@ StringName OptimizedTranslation::get_message(const StringName &p_src_text, const
 Vector<String> OptimizedTranslation::get_translated_message_list() const {
 	Vector<String> msgs;
 
-	const int *htr = hash_table.ptr();
-	const uint32_t *htptr = (const uint32_t *)&htr[0];
-	const int *btr = bucket_table.ptr();
-	const uint32_t *btptr = (const uint32_t *)&btr[0];
-	const uint8_t *sr = strings.ptr();
-	const char *sptr = (const char *)&sr[0];
+	const uint32_t *htptr = (const uint32_t *)hash_table.ptr();
+	const uint32_t *btptr = (const uint32_t *)bucket_table.ptr();
+	const char *sptr = (const char *)strings.ptr();
 
 	for (int i = 0; i < hash_table.size(); i++) {
 		uint32_t p = htptr[i];

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3088,7 +3088,7 @@ int String::findmk(const Vector<String> &p_keys, int p_from, int *r_key) const {
 	}
 
 	//int str_len=p_str.length();
-	const String *keys = &p_keys[0];
+	const String *keys = p_keys.ptr();
 	int key_count = p_keys.size();
 	int len = length();
 
@@ -3453,7 +3453,7 @@ bool String::_base_is_subsequence_of(const String &p_string, bool p_case_insensi
 	}
 
 	const char32_t *src = &operator[](0);
-	const char32_t *tgt = &p_string[0];
+	const char32_t *tgt = p_string.ptr();
 
 	for (; *src && *tgt; tgt++) {
 		bool match = false;

--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -3014,8 +3014,7 @@ uint32_t Variant::recursive_hash(int p_recursion_count) const {
 			const PackedByteArray &arr = PackedArrayRef<uint8_t>::get_array(_data.packed_array);
 			int len = arr.size();
 			if (likely(len)) {
-				const uint8_t *r = arr.ptr();
-				return hash_murmur3_buffer((uint8_t *)&r[0], len);
+				return hash_murmur3_buffer(arr.ptr(), len);
 			} else {
 				return hash_murmur3_one_64(0);
 			}
@@ -3025,8 +3024,7 @@ uint32_t Variant::recursive_hash(int p_recursion_count) const {
 			const PackedInt32Array &arr = PackedArrayRef<int32_t>::get_array(_data.packed_array);
 			int len = arr.size();
 			if (likely(len)) {
-				const int32_t *r = arr.ptr();
-				return hash_murmur3_buffer((uint8_t *)&r[0], len * sizeof(int32_t));
+				return hash_murmur3_buffer((uint8_t *)arr.ptr(), len * sizeof(int32_t));
 			} else {
 				return hash_murmur3_one_64(0);
 			}
@@ -3036,8 +3034,7 @@ uint32_t Variant::recursive_hash(int p_recursion_count) const {
 			const PackedInt64Array &arr = PackedArrayRef<int64_t>::get_array(_data.packed_array);
 			int len = arr.size();
 			if (likely(len)) {
-				const int64_t *r = arr.ptr();
-				return hash_murmur3_buffer((uint8_t *)&r[0], len * sizeof(int64_t));
+				return hash_murmur3_buffer((uint8_t *)arr.ptr(), len * sizeof(int64_t));
 			} else {
 				return hash_murmur3_one_64(0);
 			}

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -848,8 +848,7 @@ struct _VariantCall {
 		if (p_instance->size() == 0) {
 			return String();
 		}
-		const uint8_t *r = p_instance->ptr();
-		String s = String::hex_encode_buffer(&r[0], p_instance->size());
+		String s = String::hex_encode_buffer(p_instance->ptr(), p_instance->size());
 		return s;
 	}
 
@@ -924,18 +923,16 @@ struct _VariantCall {
 	static bool func_PackedByteArray_has_encoded_var(PackedByteArray *p_instance, int64_t p_offset, bool p_allow_objects) {
 		uint64_t size = p_instance->size();
 		ERR_FAIL_COND_V(p_offset < 0, false);
-		const uint8_t *r = p_instance->ptr();
 		Variant ret;
-		Error err = decode_variant(ret, r + p_offset, size - p_offset, nullptr, p_allow_objects);
+		Error err = decode_variant(ret, p_instance->ptr() + p_offset, size - p_offset, nullptr, p_allow_objects);
 		return err == OK;
 	}
 
 	static Variant func_PackedByteArray_decode_var(PackedByteArray *p_instance, int64_t p_offset, bool p_allow_objects) {
 		uint64_t size = p_instance->size();
 		ERR_FAIL_COND_V(p_offset < 0, Variant());
-		const uint8_t *r = p_instance->ptr();
 		Variant ret;
-		Error err = decode_variant(ret, r + p_offset, size - p_offset, nullptr, p_allow_objects);
+		Error err = decode_variant(ret, p_instance->ptr() + p_offset, size - p_offset, nullptr, p_allow_objects);
 		if (err != OK) {
 			ret = Variant();
 		}
@@ -945,10 +942,9 @@ struct _VariantCall {
 	static int64_t func_PackedByteArray_decode_var_size(PackedByteArray *p_instance, int64_t p_offset, bool p_allow_objects) {
 		uint64_t size = p_instance->size();
 		ERR_FAIL_COND_V(p_offset < 0, 0);
-		const uint8_t *r = p_instance->ptr();
 		Variant ret;
 		int r_size;
-		Error err = decode_variant(ret, r + p_offset, size - p_offset, &r_size, p_allow_objects);
+		Error err = decode_variant(ret, p_instance->ptr() + p_offset, size - p_offset, &r_size, p_allow_objects);
 		if (err == OK) {
 			return r_size;
 		}
@@ -962,10 +958,9 @@ struct _VariantCall {
 			return dest;
 		}
 		ERR_FAIL_COND_V_MSG(size % sizeof(int32_t), dest, "PackedByteArray size must be a multiple of 4 (size of 32-bit integer) to convert to PackedInt32Array.");
-		const uint8_t *r = p_instance->ptr();
 		dest.resize(size / sizeof(int32_t));
 		ERR_FAIL_COND_V(dest.is_empty(), dest); // Avoid UB in case resize failed.
-		memcpy(dest.ptrw(), r, dest.size() * sizeof(int32_t));
+		memcpy(dest.ptrw(), p_instance->ptr(), dest.size() * sizeof(int32_t));
 		return dest;
 	}
 
@@ -976,10 +971,9 @@ struct _VariantCall {
 			return dest;
 		}
 		ERR_FAIL_COND_V_MSG(size % sizeof(int64_t), dest, "PackedByteArray size must be a multiple of 8 (size of 64-bit integer) to convert to PackedInt64Array.");
-		const uint8_t *r = p_instance->ptr();
 		dest.resize(size / sizeof(int64_t));
 		ERR_FAIL_COND_V(dest.is_empty(), dest); // Avoid UB in case resize failed.
-		memcpy(dest.ptrw(), r, dest.size() * sizeof(int64_t));
+		memcpy(dest.ptrw(), p_instance->ptr(), dest.size() * sizeof(int64_t));
 		return dest;
 	}
 
@@ -990,10 +984,9 @@ struct _VariantCall {
 			return dest;
 		}
 		ERR_FAIL_COND_V_MSG(size % sizeof(float), dest, "PackedByteArray size must be a multiple of 4 (size of 32-bit float) to convert to PackedFloat32Array.");
-		const uint8_t *r = p_instance->ptr();
 		dest.resize(size / sizeof(float));
 		ERR_FAIL_COND_V(dest.is_empty(), dest); // Avoid UB in case resize failed.
-		memcpy(dest.ptrw(), r, dest.size() * sizeof(float));
+		memcpy(dest.ptrw(), p_instance->ptr(), dest.size() * sizeof(float));
 		return dest;
 	}
 
@@ -1004,10 +997,9 @@ struct _VariantCall {
 			return dest;
 		}
 		ERR_FAIL_COND_V_MSG(size % sizeof(double), dest, "PackedByteArray size must be a multiple of 8 (size of 64-bit double) to convert to PackedFloat64Array.");
-		const uint8_t *r = p_instance->ptr();
 		dest.resize(size / sizeof(double));
 		ERR_FAIL_COND_V(dest.is_empty(), dest); // Avoid UB in case resize failed.
-		memcpy(dest.ptrw(), r, dest.size() * sizeof(double));
+		memcpy(dest.ptrw(), p_instance->ptr(), dest.size() * sizeof(double));
 		return dest;
 	}
 
@@ -1018,10 +1010,9 @@ struct _VariantCall {
 			return dest;
 		}
 		ERR_FAIL_COND_V_MSG(size % sizeof(Vector2), dest, "PackedByteArray size must be a multiple of " + itos(sizeof(Vector2)) + " (size of Vector2) to convert to PackedVector2Array.");
-		const uint8_t *r = p_instance->ptr();
 		dest.resize(size / sizeof(Vector2));
 		ERR_FAIL_COND_V(dest.is_empty(), dest); // Avoid UB in case resize failed.
-		memcpy(dest.ptrw(), r, dest.size() * sizeof(Vector2));
+		memcpy(dest.ptrw(), p_instance->ptr(), dest.size() * sizeof(Vector2));
 		return dest;
 	}
 
@@ -1032,10 +1023,9 @@ struct _VariantCall {
 			return dest;
 		}
 		ERR_FAIL_COND_V_MSG(size % sizeof(Vector3), dest, "PackedByteArray size must be a multiple of " + itos(sizeof(Vector3)) + " (size of Vector3) to convert to PackedVector3Array.");
-		const uint8_t *r = p_instance->ptr();
 		dest.resize(size / sizeof(Vector3));
 		ERR_FAIL_COND_V(dest.is_empty(), dest); // Avoid UB in case resize failed.
-		memcpy(dest.ptrw(), r, dest.size() * sizeof(Vector3));
+		memcpy(dest.ptrw(), p_instance->ptr(), dest.size() * sizeof(Vector3));
 		return dest;
 	}
 
@@ -1046,10 +1036,9 @@ struct _VariantCall {
 			return dest;
 		}
 		ERR_FAIL_COND_V_MSG(size % sizeof(Vector4), dest, "PackedByteArray size must be a multiple of " + itos(sizeof(Vector4)) + " (size of Vector4) to convert to PackedVector4Array.");
-		const uint8_t *r = p_instance->ptr();
 		dest.resize(size / sizeof(Vector4));
 		ERR_FAIL_COND_V(dest.is_empty(), dest); // Avoid UB in case resize failed.
-		memcpy(dest.ptrw(), r, dest.size() * sizeof(Vector4));
+		memcpy(dest.ptrw(), p_instance->ptr(), dest.size() * sizeof(Vector4));
 		return dest;
 	}
 
@@ -1060,24 +1049,21 @@ struct _VariantCall {
 			return dest;
 		}
 		ERR_FAIL_COND_V_MSG(size % sizeof(Color), dest, "PackedByteArray size must be a multiple of " + itos(sizeof(Color)) + " (size of Color variant) to convert to PackedColorArray.");
-		const uint8_t *r = p_instance->ptr();
 		dest.resize(size / sizeof(Color));
 		ERR_FAIL_COND_V(dest.is_empty(), dest); // Avoid UB in case resize failed.
-		memcpy(dest.ptrw(), r, dest.size() * sizeof(Color));
+		memcpy(dest.ptrw(), p_instance->ptr(), dest.size() * sizeof(Color));
 		return dest;
 	}
 
 	static void func_PackedByteArray_encode_u8(PackedByteArray *p_instance, int64_t p_offset, int64_t p_value) {
 		uint64_t size = p_instance->size();
 		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(size) - 1);
-		uint8_t *w = p_instance->ptrw();
-		*((uint8_t *)&w[p_offset]) = p_value;
+		*((uint8_t *)&p_instance->write[p_offset]) = p_value;
 	}
 	static void func_PackedByteArray_encode_s8(PackedByteArray *p_instance, int64_t p_offset, int64_t p_value) {
 		uint64_t size = p_instance->size();
 		ERR_FAIL_COND(p_offset < 0 || p_offset > int64_t(size) - 1);
-		uint8_t *w = p_instance->ptrw();
-		*((int8_t *)&w[p_offset]) = p_value;
+		*((int8_t *)&p_instance->write[p_offset]) = p_value;
 	}
 
 	static void func_PackedByteArray_encode_u16(PackedByteArray *p_instance, int64_t p_offset, int64_t p_value) {

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -615,8 +615,7 @@ Error VariantParser::_parse_byte_array(Stream *p_stream, Vector<uint8_t> &r_cons
 
 		size_t arr_len = 0;
 		r_construct.resize(strlen / 4 * 3 + 1);
-		uint8_t *w = r_construct.ptrw();
-		Error err = CryptoCore::b64_decode(&w[0], r_construct.size(), &arr_len, (unsigned char *)cstr.get_data(), strlen);
+		Error err = CryptoCore::b64_decode(r_construct.ptrw(), r_construct.size(), &arr_len, (unsigned char *)cstr.get_data(), strlen);
 		if (err) {
 			r_err_str = "Invalid base64-encoded string";
 			return ERR_PARSE_ERROR;


### PR DESCRIPTION
## What problem(s) does this PR solve?

Some vectors in core have their pointers get with `&vec[0]` instead of `ptr()` or `ptrw()`:
```cpp
const uint8_t *evptr = &existing_vector[0];
```

When it should usually be like this:

```cpp
const uint8_t *evptr = existing_vector.ptr();
```
---


Additionally, many `Vector`s in core have these weird patterns:

```cpp
Vector<uint8_t> my_vector;
my_vector.resize(my_size);
uint8_t *w = my_vector.ptrw();
do_something_with_pointer(&w[0]); // Asking a pointer for its first member address (a.k.a. itself)?
```

```cpp
int *evr = existing_vector.ptrw();
uint32_t *evptr = (uint32_t *)&evr[0]; // Again, why?
```

When they could be literally these:
```cpp
Vector<uint8_t> my_vector;
my_vector.resize(my_size);
do_something_with_pointer(my_vector.ptrw());
```

```cpp
uint32_t *evptr = (uint32_t *)existing_vector.ptrw();
```

I've looked for as many cases as these in core, and changed them to keep code less noisy. Should not affect performance (at least not in any optimization level other than `o0` where it should be insignificant).

## Additional information

On cases where a `Vector` only exists within a function body and isn't returned, I've replaced with a `LocalVector`. Vectors that are class members were kept out of scope.

These cases also happen outside core, but not only it would make the PR massive, it would also touch separate areas that are sensitive to changes.
