### PR TITLE
Correct hardware reference luminance on iOS.

### DIFF
--- a/platform/ios/display_server_ios.mm
+++ b/platform/ios/display_server_ios.mm
@@ -41,8 +41,6 @@ DisplayServerIOS *DisplayServerIOS::get_singleton() {
 
 DisplayServerIOS::DisplayServerIOS(const String &p_rendering_driver, DisplayServerEnums::WindowMode p_mode, DisplayServerEnums::VSyncMode p_vsync_mode, uint32_t p_flags, const Vector2i *p_position, const Vector2i &p_resolution, int p_screen, DisplayServerEnums::Context p_context, int64_t p_parent_window, Error &r_error) :
 		DisplayServerAppleEmbedded(p_rendering_driver, p_mode, p_vsync_mode, p_flags, p_position, p_resolution, p_screen, p_context, p_parent_window, r_error) {
-	// See: https://github.com/godotengine/godot/pull/106814#discussion_r2854262156 for why this was set to 203 nits.
-	hardware_reference_luminance_nits = 203.0f;
 }
 
 DisplayServerIOS::~DisplayServerIOS() {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- The hardware reference luminance for iOS is incorrectly set to 203.0 nits. This was a mistake that I made during initial HDR dev for iOS.

## Additional information

In my initial "research"/trial and error, I found the following:

> changing these constants to 203 nits makes Godot's iOS HDR report luminance values that appear to be in the right ballpark. It's possible that 203 nits is not exactly correct, but it's definitely a lot closer than 100 nits for iOS.

At the time that I [wrote this comment](https://github.com/godotengine/godot/pull/106814#discussion_r2854262156), I was not aware that this hardware reference luminance was actually changing based on ambient light conditions. So I was comparing the behaviour on my iPhone with my MacBook in a room with bright lighting, which produces entirely different behaviour when the lights are off.

Since then, I've obtained an LS-100 luminance metre and discovered that the hardware reference white luminance changes dynamically based on ambient lighting, independent of the device's automatic brightness setting. This behaviour cannot be disabled and there is no API to access the current hardware reference luminance, but in a pitch-black room it is 100.0 nits on an iPhone 13 Pro:

Room lighting | Measured luminance | Godot 4.7 reported luminance | This PR reported luminance (calculated as `/ 203 * 100`)
-- | -- | -- | --
Dark | 147.9 | 296.8 | 146.21
Dark | 100.7 | 203.44 | 100.22
Dark | 269.4 | 541.59 | 266.79
Dark | 815.6 | 1621.82 | 798.93
Bright | 149.5 | 210.24 | 103.57
Bright | 147.2 | 207.19 | 102.06
Bright | 275.5 | 383.63 | 188.98
Bright | 822.5 | 1148.79 | 565.91

So the reported luminance will be incorrect when the device detects a bright environment, but that's entirely outside of our control. The docs [already mention](https://docs.godotengine.org/en/stable/classes/class_displayserver.html#class-displayserver-method-window-get-hdr-output-current-reference-luminance) that this value might not match the physical behaviour of the screen.

## Compatibility considerations

I expect that nobody should be using raw luminance values on iOS, so I don't see this as a breaking change. This should **not** be cherry-picked because the bug is benign for old Godot versions.

## Code style
I could change `DisplayServerAppleEmbedded::hardware_reference_luminance_nits` to be a `constexpr static CGFloat` like macOS if preferred.