### PR TITLE
Cache terrain selection and restore it when TileMapLayer node is selected

### DIFF
--- a/modules/tilemap/editor/tile_map_layer_editor.cpp
+++ b/modules/tilemap/editor/tile_map_layer_editor.cpp
@@ -2502,9 +2502,44 @@ TileMapLayerEditorTilesPlugin::TileMapLayerEditorTilesPlugin() {
 	EditorSettings::get_singleton()->connect("_translation_changed", callable_mp(this, &TileMapLayerEditorTilesPlugin::_update_translation));
 }
 
+void TileMapLayerEditorTerrainsPlugin::_prune_last_selected_terrain_cache() {
+	LocalVector<ObjectID> stale_ids;
+	for (const KeyValue<ObjectID, Vector2i> &E : last_selected_terrain_by_layer) {
+		if (ObjectDB::get_instance(E.key) == nullptr) {
+			stale_ids.push_back(E.key);
+		}
+	}
+	for (const ObjectID &id : stale_ids) {
+		last_selected_terrain_by_layer.erase(id);
+	}
+}
+
+void TileMapLayerEditorTerrainsPlugin::_restore_terrain_selection() {
+	const Vector2i *cached = last_selected_terrain_by_layer.getptr(edited_tile_map_layer_id);
+	if (!cached) {
+		return;
+	}
+
+	// Attempt to select a cached terrain.
+	for (TreeItem *item = terrains_tree->get_root()->get_first_child(); item; item = item->get_next_in_tree()) {
+		Dictionary metadata_dict = item->get_metadata(0);
+		if (metadata_dict.has("terrain_set") && metadata_dict.has("terrain_id")) {
+			int terrain_set = metadata_dict["terrain_set"];
+			int terrain_id = metadata_dict["terrain_id"];
+			if (terrain_set == cached->x && terrain_id == cached->y) {
+				// Terrain matches the cached value, select it.
+				item->select(0);
+				break;
+			}
+		}
+	}
+}
+
 void TileMapLayerEditorTerrainsPlugin::tile_set_changed() {
 	_update_terrains_cache();
 	_update_terrains_tree();
+	_prune_last_selected_terrain_cache();
+	_restore_terrain_selection();
 	_update_tiles_list();
 }
 
@@ -3392,6 +3427,7 @@ void TileMapLayerEditorTerrainsPlugin::_update_tiles_list() {
 		Dictionary metadata_dict = selected_tree_item->get_metadata(0);
 		int sel_terrain_set = metadata_dict["terrain_set"];
 		int sel_terrain_id = metadata_dict["terrain_id"];
+		last_selected_terrain_by_layer[edited_tile_map_layer_id] = Vector2i(sel_terrain_set, sel_terrain_id);
 		ERR_FAIL_INDEX(sel_terrain_set, tile_set->get_terrain_sets_count());
 		ERR_FAIL_INDEX(sel_terrain_id, tile_set->get_terrains_count(sel_terrain_set));
 

--- a/modules/tilemap/editor/tile_map_layer_editor.h
+++ b/modules/tilemap/editor/tile_map_layer_editor.h
@@ -337,6 +337,11 @@ private:
 	TileSet::TerrainsPattern selected_terrains_pattern;
 	void _update_selection();
 
+	// Terrain selection restoration
+	HashMap<ObjectID, Vector2i> last_selected_terrain_by_layer;
+	void _prune_last_selected_terrain_cache();
+	void _restore_terrain_selection();
+
 	// Bottom panel.
 	Tree *terrains_tree = nullptr;
 	ItemList *terrains_tile_list = nullptr;


### PR DESCRIPTION

## What problem(s) does this PR solve?

The aim of this PR is to have the `TileMapLayer` node remember the last selected terrain. This came up for our dev team when making a scene with multiple `TileMapLayer` which we were switching between. Before this change, one would have to re-click the target terrain each time the `TileMapLayer` was re-selected.

I do not think this has an open issue but there is an open proposal which i found today: https://github.com/godotengine/godot-proposals/issues/12413

## Additional information

I tried to make this PR as light as possible, but there's a few things I am unsure of in terms of having followed best practices...

1. To make this feature work I have added a `HashMap` to the header file along with a helper function `_restore_terrain_selection()` to `TileMapLayerEditorTerrainsPlugin`. I wasn't sure if there was a convention to how to order things within the header file itself.
2. The addition of `_restore_terrain_selection()` to `tile_set_changed()` was found with a bit of trial and error. This seems to work, but I'm not convinced I've placed this call in the absolute best place? The whole flow of function calls confused me a little (originally i was trying to call this in `edit()` for example, but the change here was overwritten
3. I'm not sure I have the optimal solution for grabbing the correct data from the `terrains_tree`. At the moment I just iterate through the children but this feels like maybe I'm missing a useful helper function.

Sorry for having three questions on such a small PR, I hope that I learn about this all quickly so I can help more efficiently in the future.

Video of the working feature:

https://github.com/user-attachments/assets/1bde150a-8082-49ae-ac6e-9ed1a09cae7f

- Bugsquad edit: Resolves godotengine/godot-proposals#12413