### PR TITLE
Make UI drag previews match their source

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1101,6 +1101,12 @@ Variant LineEdit::get_drag_data(const Point2 &p_point) {
 		l->set_text(t);
 		l->set_focus_mode(FOCUS_ACCESSIBILITY);
 		l->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED); // Don't translate user input.
+		l->add_theme_font_override(SceneStringName(font), theme_cache.font);
+		l->add_theme_font_size_override(SceneStringName(font_size), theme_cache.font_size);
+		l->add_theme_constant_override(SNAME("outline_size"), theme_cache.font_outline_size);
+		l->add_theme_color_override(SceneStringName(font_color), theme_cache.font_color);
+		l->add_theme_color_override(SNAME("font_outline_color"), theme_cache.font_outline_color);
+		l->add_theme_style_override(CoreStringName(normal), memnew(StyleBoxEmpty())); // Ensure that the label has no margins inherited from the theme.
 		set_drag_preview(l);
 		return t;
 	}

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -7083,6 +7083,12 @@ Variant RichTextLabel::get_drag_data(const Point2 &p_point) {
 		l->set_text(t);
 		l->set_focus_mode(FOCUS_ACCESSIBILITY);
 		l->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED); // Text is already translated.
+		l->add_theme_font_override(SceneStringName(font), theme_cache.normal_font);
+		l->add_theme_font_size_override(SceneStringName(font_size), theme_cache.normal_font_size);
+		l->add_theme_constant_override(SNAME("outline_size"), theme_cache.outline_size);
+		l->add_theme_color_override(SceneStringName(font_color), theme_cache.default_color);
+		l->add_theme_color_override(SNAME("font_outline_color"), theme_cache.font_outline_color);
+		l->add_theme_style_override(CoreStringName(normal), memnew(StyleBoxEmpty())); // Ensure that the label has no margins inherited from the theme.
 		set_drag_preview(l);
 		return t;
 	}

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -1664,22 +1664,30 @@ Variant TabBar::_handle_get_drag_data(const String &p_type, const Point2 &p_poin
 	}
 
 	HBoxContainer *drag_preview = memnew(HBoxContainer);
+	drag_preview->add_theme_constant_override(SNAME("separation"), theme_cache.h_separation);
 
 	if (tabs[tab_over].icon.is_valid()) {
-		const Size2 icon_size = _get_tab_icon_size(tab_over);
-
 		TextureRect *tf = memnew(TextureRect);
 		tf->set_texture(tabs[tab_over].icon);
 		tf->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
 		tf->set_expand_mode(TextureRect::EXPAND_IGNORE_SIZE);
-		tf->set_custom_minimum_size(icon_size);
-
+		tf->set_custom_minimum_size(_get_tab_icon_size(tab_over));
+		tf->set_modulate(theme_cache.icon_selected_color);
 		drag_preview->add_child(tf);
 	}
 
-	Label *label = memnew(Label(get_tab_title(tab_over)));
-	label->set_auto_translate_mode(get_auto_translate_mode()); // Reflect how the title is displayed.
-	drag_preview->add_child(label);
+	String text = get_tab_title(tab_over);
+	if (!text.is_empty()) {
+		Label *label = memnew(Label(text));
+		label->set_auto_translate_mode(get_auto_translate_mode()); // Reflect how the title is displayed.
+		label->add_theme_font_override(SceneStringName(font), theme_cache.font);
+		label->add_theme_font_size_override(SceneStringName(font_size), theme_cache.font_size);
+		label->add_theme_constant_override(SNAME("outline_size"), theme_cache.outline_size);
+		label->add_theme_color_override(SceneStringName(font_color), theme_cache.font_selected_color);
+		label->add_theme_color_override(SNAME("font_outline_color"), theme_cache.font_outline_color);
+		label->add_theme_style_override(CoreStringName(normal), memnew(StyleBoxEmpty())); // Ensure that the label has no margins inherited from the theme.
+		drag_preview->add_child(label);
+	}
 
 	set_drag_preview(drag_preview);
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4024,6 +4024,12 @@ Variant TextEdit::get_drag_data(const Point2 &p_point) {
 		l->set_auto_translate_mode(AUTO_TRANSLATE_MODE_DISABLED); // Don't translate user input.
 		l->set_focus_mode(FOCUS_ACCESSIBILITY);
 		l->set_text(t);
+		l->add_theme_font_override(SceneStringName(font), theme_cache.font);
+		l->add_theme_font_size_override(SceneStringName(font_size), theme_cache.font_size);
+		l->add_theme_constant_override(SNAME("outline_size"), theme_cache.outline_size);
+		l->add_theme_color_override(SceneStringName(font_color), theme_cache.font_color);
+		l->add_theme_color_override(SNAME("font_outline_color"), theme_cache.outline_color);
+		l->add_theme_style_override(CoreStringName(normal), memnew(StyleBoxEmpty())); // Ensure that the label has no margins inherited from the theme.
 		set_drag_preview(l);
 		return t;
 	}


### PR DESCRIPTION
## What problem(s) does this PR solve?

This makes so that the drag previews of the following `Control` nodes have the same styling as their source:
- `LineEdit`
- `TextEdit`
- `RichTextLabel`
- `TabBar`

|PR|`master`|
|-|-|
|<img width="154" height="71" alt="Screenshot_20260901_192455" src="https://github.com/user-attachments/assets/9196cc31-7419-4a92-b38e-6c46f3ddde35" />|<img width="154" height="71" alt="image" src="https://github.com/user-attachments/assets/7668a202-63e6-45d9-9919-669d5b2efb0a" />|