### PR TITLE
Add missing import settings from Texture2D to Texture2D Streamed

### DIFF
--- a/doc/classes/ResourceImporterStreamedTexture.xml
+++ b/doc/classes/ResourceImporterStreamedTexture.xml
@@ -31,6 +31,82 @@
 		<member name="compress/normal_map" type="int" setter="" getter="" default="0">
 			When using a texture as normal map, only the red and green channels are required. Given regular texture compression algorithms produce artifacts that don't look that nice in normal maps, the RGTC compression format is the best fit for this data. Forcing this option to Enable will make Godot import the image as RGTC compressed. By default, it's set to Detect. This means that if the texture is ever detected to be used as a normal map, it will be changed to Enable and reimported automatically.
 		</member>
+		<member name="mipmaps/alpha_test_threshold" type="float" setter="" getter="" default="0.5">
+			The alpha threshold used when preserving alpha test coverage across mipmap levels. The coverage is measured at mipmap 0 using the setting and the lower mipmaps are adjusted to match that coverage. Higher values preserve more detail, lower values create softer edges. Note that this threshold is independent from the [code]Alpha Scissor Threshold[/code] set on the material and they both may need to be tuned for optimal results.
+		</member>
+		<member name="mipmaps/preserve_alpha_test_coverage" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], automatically adjusts alpha values to maintain consistent coverage when alpha testing is used. This is especially useful for hair, foliage, or other alpha-tested materials, as it prevents fading or popping artifacts across mipmap levels (LODs). This option is intended for color textures and clamps the alpha channel in the 0.0 - 1.0 range.
+		</member>
+		<member name="process/channel_remap/alpha" type="int" setter="" getter="" default="3">
+			Specifies the data source of the output image's alpha channel.
+			[b]Red:[/b] Use the values from the source image's red channel.
+			[b]Green:[/b] Use the values from the source image's green channel.
+			[b]Blue:[/b] Use the values from the source image's blue channel.
+			[b]Alpha:[/b] Use the values from the source image's alpha channel.
+			[b]Red Inverted:[/b] Use inverted values from the source image's red channel ([code]1.0 - R[/code]).
+			[b]Green Inverted:[/b] Use inverted values from the source image's green channel ([code]1.0 - G[/code]).
+			[b]Blue Inverted:[/b] Use inverted values from the source image's blue channel ([code]1.0 - B[/code]).
+			[b]Alpha Inverted:[/b] Use inverted values from the source image's alpha channel ([code]1.0 - A[/code]).
+			[b]Unused:[/b] Set the color channel's value to the default ([code]1.0[/code] for alpha, [code]0.0[/code] for red, green or blue).
+			[b]Zero:[/b] Set the color channel's value to [code]0.0[/code].
+			[b]One:[/b] Set the color channel's value to [code]1.0[/code].
+		</member>
+		<member name="process/channel_remap/blue" type="int" setter="" getter="" default="2">
+			Specifies the data source of the output image's blue channel.
+			[b]Red:[/b] Use the values from the source image's red channel.
+			[b]Green:[/b] Use the values from the source image's green channel.
+			[b]Blue:[/b] Use the values from the source image's blue channel.
+			[b]Alpha:[/b] Use the values from the source image's alpha channel.
+			[b]Red Inverted:[/b] Use inverted values from the source image's red channel ([code]1.0 - R[/code]).
+			[b]Green Inverted:[/b] Use inverted values from the source image's green channel ([code]1.0 - G[/code]).
+			[b]Blue Inverted:[/b] Use inverted values from the source image's blue channel ([code]1.0 - B[/code]).
+			[b]Alpha Inverted:[/b] Use inverted values from the source image's alpha channel ([code]1.0 - A[/code]).
+			[b]Unused:[/b] Set the color channel's value to the default ([code]1.0[/code] for alpha, [code]0.0[/code] for red, green or blue).
+			[b]Zero:[/b] Set the color channel's value to [code]0.0[/code].
+			[b]One:[/b] Set the color channel's value to [code]1.0[/code].
+		</member>
+		<member name="process/channel_remap/green" type="int" setter="" getter="" default="1">
+			Specifies the data source of the output image's green channel.
+			[b]Red:[/b] Use the values from the source image's red channel.
+			[b]Green:[/b] Use the values from the source image's green channel.
+			[b]Blue:[/b] Use the values from the source image's blue channel.
+			[b]Alpha:[/b] Use the values from the source image's alpha channel.
+			[b]Red Inverted:[/b] Use inverted values from the source image's red channel ([code]1.0 - R[/code]).
+			[b]Green Inverted:[/b] Use inverted values from the source image's green channel ([code]1.0 - G[/code]).
+			[b]Blue Inverted:[/b] Use inverted values from the source image's blue channel ([code]1.0 - B[/code]).
+			[b]Alpha Inverted:[/b] Use inverted values from the source image's alpha channel ([code]1.0 - A[/code]).
+			[b]Unused:[/b] Set the color channel's value to the default ([code]1.0[/code] for alpha, [code]0.0[/code] for red, green or blue).
+			[b]Zero:[/b] Set the color channel's value to [code]0.0[/code].
+			[b]One:[/b] Set the color channel's value to [code]1.0[/code].
+		</member>
+		<member name="process/channel_remap/red" type="int" setter="" getter="" default="0">
+			Specifies the data source of the output image's red channel.
+			[b]Red:[/b] Use the values from the source image's red channel.
+			[b]Green:[/b] Use the values from the source image's green channel.
+			[b]Blue:[/b] Use the values from the source image's blue channel.
+			[b]Alpha:[/b] Use the values from the source image's alpha channel.
+			[b]Red Inverted:[/b] Use inverted values from the source image's red channel ([code]1.0 - R[/code]).
+			[b]Green Inverted:[/b] Use inverted values from the source image's green channel ([code]1.0 - G[/code]).
+			[b]Blue Inverted:[/b] Use inverted values from the source image's blue channel ([code]1.0 - B[/code]).
+			[b]Alpha Inverted:[/b] Use inverted values from the source image's alpha channel ([code]1.0 - A[/code]).
+			[b]Unused:[/b] Set the color channel's value to the default ([code]1.0[/code] for alpha, [code]0.0[/code] for red, green or blue).
+			[b]Zero:[/b] Set the color channel's value to [code]0.0[/code].
+			[b]One:[/b] Set the color channel's value to [code]1.0[/code].
+		</member>
+		<member name="process/hdr_as_srgb" type="bool" setter="" getter="" default="false">
+			Some HDR images you can find online may be broken and contain data that is encoded using the nonlinear sRGB transfer function (instead of using linear encoding). It is advised not to use those files. If you absolutely have to, enabling [member process/hdr_as_srgb] will make them look correct.
+			[b]Warning:[/b] Enabling [member process/hdr_as_srgb] on well-formatted HDR images will cause the resulting image to look too dark, so leave this on [code]false[/code] if unsure.
+		</member>
+		<member name="process/hdr_clamp_exposure" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], clamps exposure in the imported high dynamic range images using a smart clamping formula (without introducing [i]visible[/i] clipping).
+			Some HDR panorama images you can find online may contain extremely bright pixels, due to being taken from real life sources without any clipping.
+			While these HDR panorama images are accurate to real life, this can cause the radiance map generated by Godot to contain sparkles when used as a background sky. This can be seen in material reflections (even on rough materials in extreme cases). Enabling [member process/hdr_clamp_exposure] can resolve this.
+		</member>
+		<member name="process/size_limit" type="int" setter="" getter="" default="0">
+			If set to a value greater than [code]0[/code], the size of the texture is limited on import to a value smaller than or equal to the value specified here. For non-square textures, the size limit affects the longer dimension, with the shorter dimension scaled to preserve aspect ratio. Resizing is performed using cubic interpolation.
+			This can be used to reduce memory usage without affecting the source images, or avoid issues with textures not displaying on mobile/web platforms (as these usually can't display textures larger than 4096×4096).
+			[b]Note:[/b] Even if this is set to [code]0[/code], import size is limited to 32768 pixels for technical reasons (width or height, whichever is larger).
+		</member>
 		<member name="roughness/mode" type="int" setter="" getter="" default="0">
 			The color channel to consider as a roughness map in this texture. Only effective if Roughness &gt; Src Normal is not empty.
 		</member>

--- a/editor/import/resource_importer_streamed_texture.cpp
+++ b/editor/import/resource_importer_streamed_texture.cpp
@@ -66,6 +66,240 @@ void ResourceImporterStreamedTexture::_texture_reimport_normal(const Ref<Streame
 	singleton->make_flags[path].flags |= MAKE_NORMAL_FLAG;
 }
 
+void ResourceImporterStreamedTexture::_remap_channels(Ref<Image> &r_image, ChannelRemap p_options[4]) {
+	ERR_FAIL_COND(r_image->is_compressed());
+
+	// Currently HDR inverted remapping is not allowed.
+	bool attempted_hdr_inverted = false;
+	if (r_image->get_format() >= Image::FORMAT_RF && r_image->get_format() <= Image::FORMAT_RGBE9995) {
+		// Formats which can hold HDR data cannot be inverted the same way as unsigned normalized ones (1.0 - channel).
+		for (int i = 0; i < 4; i++) {
+			switch (p_options[i]) {
+				case REMAP_INV_R:
+					attempted_hdr_inverted = true;
+					p_options[i] = REMAP_R;
+					break;
+				case REMAP_INV_G:
+					attempted_hdr_inverted = true;
+					p_options[i] = REMAP_G;
+					break;
+				case REMAP_INV_B:
+					attempted_hdr_inverted = true;
+					p_options[i] = REMAP_B;
+					break;
+				case REMAP_INV_A:
+					attempted_hdr_inverted = true;
+					p_options[i] = REMAP_A;
+					break;
+				default:
+					break;
+			}
+		}
+	}
+
+	if (attempted_hdr_inverted) {
+		WARN_PRINT("Attempted to use an inverted channel remap on an HDR image. The remap has been changed to its uninverted equivalent.");
+	}
+
+	// Optimization: Set the remap from 'unused' to either 0 or 1 to avoid repeated checks in the conversion loop.
+	for (int i = 0; i < 4; i++) {
+		if (p_options[i] == REMAP_UNUSED) {
+			p_options[i] = i == 3 ? REMAP_1 : REMAP_0;
+		}
+	}
+
+	// Expand the image's channel count in the event that the current set of channels doesn't allow for the desired remap.
+	const Image::Format original_format = r_image->get_format();
+	const uint32_t channel_mask = Image::get_format_component_mask(original_format);
+
+	// Whether a channel is supported by the format itself.
+	const bool has_channel_r = channel_mask & 0x1;
+	const bool has_channel_g = channel_mask & 0x2;
+	const bool has_channel_b = channel_mask & 0x4;
+	const bool has_channel_a = channel_mask & 0x8;
+
+	// Whether a certain channel needs to be remapped.
+	const bool remap_r = p_options[0] != REMAP_R ? !(!has_channel_r && p_options[0] == REMAP_0) : false;
+	const bool remap_g = p_options[1] != REMAP_G ? !(!has_channel_g && p_options[1] == REMAP_0) : false;
+	const bool remap_b = p_options[2] != REMAP_B ? !(!has_channel_b && p_options[2] == REMAP_0) : false;
+	const bool remap_a = p_options[3] != REMAP_A ? !(!has_channel_a && p_options[3] == REMAP_1) : false;
+
+	if (!(remap_r || remap_g || remap_b || remap_a)) {
+		// Default color map, do nothing.
+		return;
+	}
+
+	// Whether a certain channel set is needed, either from the source or the remap.
+	const bool needs_rg = remap_g || has_channel_g;
+	const bool needs_rgb = remap_b || has_channel_b;
+	const bool needs_rgba = remap_a || has_channel_a;
+
+	bool could_not_expand = false;
+	switch (original_format) {
+		case Image::FORMAT_R8:
+		case Image::FORMAT_RG8:
+		case Image::FORMAT_RGB8: {
+			// Convert to either RGBA8, RGB8 or RG8.
+			if (needs_rgba) {
+				r_image->convert(Image::FORMAT_RGBA8);
+			} else if (needs_rgb) {
+				r_image->convert(Image::FORMAT_RGB8);
+			} else if (needs_rg) {
+				r_image->convert(Image::FORMAT_RG8);
+			}
+		} break;
+		case Image::FORMAT_RH:
+		case Image::FORMAT_RGH:
+		case Image::FORMAT_RGBH: {
+			// Convert to either RGBAH, RGBH or RGH.
+			if (needs_rgba) {
+				r_image->convert(Image::FORMAT_RGBAH);
+			} else if (needs_rgb) {
+				r_image->convert(Image::FORMAT_RGBH);
+			} else if (needs_rg) {
+				r_image->convert(Image::FORMAT_RGH);
+			}
+		} break;
+		case Image::FORMAT_RF:
+		case Image::FORMAT_RGF:
+		case Image::FORMAT_RGBF: {
+			// Convert to either RGBAF, RGBF or RGF.
+			if (needs_rgba) {
+				r_image->convert(Image::FORMAT_RGBAF);
+			} else if (needs_rgb) {
+				r_image->convert(Image::FORMAT_RGBF);
+			} else if (needs_rg) {
+				r_image->convert(Image::FORMAT_RGF);
+			}
+		} break;
+		case Image::FORMAT_L8: {
+			const bool uniform_rgb = (p_options[0] == p_options[1] && p_options[1] == p_options[2]) || !(remap_r || remap_g || remap_b);
+			if (uniform_rgb) {
+				// Uniform RGB.
+				if (needs_rgba) {
+					r_image->convert(Image::FORMAT_LA8);
+				}
+			} else {
+				// Non-uniform RGB.
+				if (needs_rgba) {
+					r_image->convert(Image::FORMAT_RGBA8);
+				} else {
+					r_image->convert(Image::FORMAT_RGB8);
+				}
+				could_not_expand = true;
+			}
+		} break;
+		case Image::FORMAT_LA8: {
+			const bool uniform_rgb = (p_options[0] == p_options[1] && p_options[1] == p_options[2]) || !(remap_r || remap_g || remap_b);
+			if (!uniform_rgb) {
+				// Non-uniform RGB.
+				r_image->convert(Image::FORMAT_RGBA8);
+				could_not_expand = true;
+			}
+		} break;
+		case Image::FORMAT_RGB565: {
+			if (needs_rgba) {
+				// RGB565 doesn't have an alpha expansion, convert to RGBA8.
+				r_image->convert(Image::FORMAT_RGBA8);
+				could_not_expand = true;
+			}
+		} break;
+		case Image::FORMAT_RGBE9995: {
+			if (needs_rgba) {
+				// RGB9995 doesn't have an alpha expansion, convert to RGBAH.
+				r_image->convert(Image::FORMAT_RGBAH);
+				could_not_expand = true;
+			}
+		} break;
+
+		default: {
+		} break;
+	}
+
+	if (could_not_expand) {
+		WARN_PRINT(vformat("Unable to expand image format %s's channels (the target format does not exist), converting to %s as a fallback.",
+				Image::get_format_name(original_format), Image::get_format_name(r_image->get_format())));
+	}
+
+	// Remap the channels.
+	for (int x = 0; x < r_image->get_width(); x++) {
+		for (int y = 0; y < r_image->get_height(); y++) {
+			Color src = r_image->get_pixel(x, y);
+			Color dst;
+
+			for (int i = 0; i < 4; i++) {
+				switch (p_options[i]) {
+					case REMAP_R:
+						dst[i] = src.r;
+						break;
+					case REMAP_G:
+						dst[i] = src.g;
+						break;
+					case REMAP_B:
+						dst[i] = src.b;
+						break;
+					case REMAP_A:
+						dst[i] = src.a;
+						break;
+
+					case REMAP_INV_R:
+						dst[i] = 1.0f - src.r;
+						break;
+					case REMAP_INV_G:
+						dst[i] = 1.0f - src.g;
+						break;
+					case REMAP_INV_B:
+						dst[i] = 1.0f - src.b;
+						break;
+					case REMAP_INV_A:
+						dst[i] = 1.0f - src.a;
+						break;
+
+					case REMAP_0:
+						dst[i] = 0.0f;
+						break;
+					case REMAP_1:
+						dst[i] = 1.0f;
+						break;
+
+					default:
+						break;
+				}
+			}
+
+			r_image->set_pixel(x, y, dst);
+		}
+	}
+}
+
+void ResourceImporterStreamedTexture::_clamp_hdr_exposure(Ref<Image> &r_image) {
+	// Clamp HDR exposure following Filament's tonemapping formula.
+	// This can be used to reduce fireflies in environment maps or reduce the influence
+	// of the sun from an HDRI panorama on environment lighting (when a DirectionalLight3D is used instead).
+	const int height = r_image->get_height();
+	const int width = r_image->get_width();
+
+	// These values are chosen arbitrarily and seem to produce good results with 4,096 samples.
+	const float linear = 4096.0;
+	const float compressed = 16384.0;
+
+	for (int i = 0; i < width; i++) {
+		for (int j = 0; j < height; j++) {
+			const Color color = r_image->get_pixel(i, j);
+			const float luma = color.get_luminance();
+
+			Color clamped_color;
+			if (luma <= linear) {
+				clamped_color = color;
+			} else {
+				clamped_color = (color / luma) * ((linear * linear - compressed * luma) / (2 * linear - compressed - luma));
+			}
+
+			r_image->set_pixel(i, j, clamped_color);
+		}
+	}
+}
+
 String ResourceImporterStreamedTexture::get_importer_name() const {
 	return "streamed_texture_2d";
 }
@@ -89,14 +323,28 @@ void ResourceImporterStreamedTexture::get_import_options(const String &p_path, L
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "compress/normal_map", PROPERTY_HINT_ENUM, "Detect,Enable,Disabled"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "compress/channel_pack", PROPERTY_HINT_ENUM, "sRGB Friendly,Optimized"), 0));
 
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "mipmaps/preserve_alpha_test_coverage", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), false));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "mipmaps/alpha_test_threshold", PROPERTY_HINT_RANGE, "0.01,0.99,0.01"), 0.5));
+
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "roughness/mode", PROPERTY_HINT_ENUM, "Detect,Disabled,Red,Green,Blue,Alpha,Gray"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "roughness/src_normal", PROPERTY_HINT_FILE, "*.bmp,*.exr,*.jpeg,*.jpg,*.hdr,*.png,*.svg,*.tga,*.webp"), ""));
+
+	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "process/channel_remap/red", PROPERTY_HINT_ENUM, "Red,Green,Blue,Alpha,Inverted Red,Inverted Green,Inverted Blue,Inverted Alpha,Unused,Zero,One"), 0));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "process/channel_remap/green", PROPERTY_HINT_ENUM, "Red,Green,Blue,Alpha,Inverted Red,Inverted Green,Inverted Blue,Inverted Alpha,Unused,Zero,One"), 1));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "process/channel_remap/blue", PROPERTY_HINT_ENUM, "Red,Green,Blue,Alpha,Inverted Red,Inverted Green,Inverted Blue,Inverted Alpha,Unused,Zero,One"), 2));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "process/channel_remap/alpha", PROPERTY_HINT_ENUM, "Red,Green,Blue,Alpha,Inverted Red,Inverted Green,Inverted Blue,Inverted Alpha,Unused,Zero,One"), 3));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "process/hdr_as_srgb"), false));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "process/hdr_clamp_exposure"), false));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "process/size_limit", PROPERTY_HINT_RANGE, "0,32768,1"), 0));
 
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "streaming/min_lod_override", PROPERTY_HINT_ENUM, "Settings,0,1,2,3,4,5,6,7,8,9,10,11,12,13"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "streaming/max_lod_override", PROPERTY_HINT_ENUM, "Settings,0,1,2,3,4,5,6,7,8,9,10,11,12,13"), 0));
 }
 
 bool ResourceImporterStreamedTexture::get_option_visibility(const String &p_path, const String &p_option, const HashMap<StringName, Variant> &p_options) const {
+	if (p_option == "mipmaps/alpha_test_threshold") {
+		return p_options["mipmaps/preserve_alpha_test_coverage"];
+	}
 	return true;
 }
 
@@ -116,7 +364,9 @@ Error ResourceImporterStreamedTexture::import(ResourceUID::ID p_source_id, const
 
 	Image::CompressSource comp_source = srgb_friendly_pack ? Image::COMPRESS_SOURCE_SRGB : Image::COMPRESS_SOURCE_GENERIC;
 
-	err = ImageLoader::load_image(p_source_file, image);
+	// Mipmaps
+	const bool mipmaps_preserve_alpha_test_coverage = p_options["mipmaps/preserve_alpha_test_coverage"];
+	const float mipmaps_alpha_test_threshold = p_options["mipmaps/alpha_test_threshold"];
 
 	// Roughness.
 	const int roughness = p_options["roughness/mode"];
@@ -128,6 +378,30 @@ Error ResourceImporterStreamedTexture::import(ResourceUID::ID p_source_id, const
 	const bool detect_normal = normal == 0; // Normal is set to Detect
 	const bool force_normal = normal == 1; // Normal is set to Enable
 
+	// Processing.
+	const int remap_r = p_options["process/channel_remap/red"];
+	const int remap_g = p_options["process/channel_remap/green"];
+	const int remap_b = p_options["process/channel_remap/blue"];
+	const int remap_a = p_options["process/channel_remap/alpha"];
+
+	const bool hdr_as_srgb = p_options["process/hdr_as_srgb"];
+	const bool hdr_clamp_exposure = p_options["process/hdr_clamp_exposure"];
+	int size_limit = p_options["process/size_limit"];
+
+	bool using_fallback_size_limit = false;
+	if (size_limit == 0) {
+		using_fallback_size_limit = true;
+		// If no size limit is defined, use a fallback size limit to prevent textures from looking incorrect or failing to import.
+		// As of June 2024, no GPU can correctly display a texture larger than 32768 pixels on either axis.
+		size_limit = 32768;
+	}
+
+	// Parse import options.
+	int32_t loader_flags = ImageFormatLoader::FLAG_NONE;
+	if (hdr_as_srgb) {
+		loader_flags |= ImageFormatLoader::FLAG_FORCE_LINEAR;
+	}
+
 	if (detect_normal || force_normal) {
 		save_flags |= StreamedTexture2D::FORMAT_BIT_DETECT_NORMAL;
 	}
@@ -138,6 +412,51 @@ Error ResourceImporterStreamedTexture::import(ResourceUID::ID p_source_id, const
 
 	if (force_normal) {
 		comp_source = Image::COMPRESS_SOURCE_NORMAL;
+	}
+
+	err = ImageLoader::load_image(p_source_file, image, nullptr, loader_flags);
+
+	{
+		ChannelRemap remaps[4] = {
+			(ChannelRemap)remap_r,
+			(ChannelRemap)remap_g,
+			(ChannelRemap)remap_b,
+			(ChannelRemap)remap_a,
+		};
+
+		_remap_channels(image, remaps);
+	}
+
+	// Clamp HDR exposure.
+	if (hdr_clamp_exposure) {
+		_clamp_hdr_exposure(image);
+	}
+
+	// Apply the size limit.
+	if (size_limit > 0 && (image->get_width() > size_limit || image->get_height() > size_limit)) {
+		if (image->get_width() >= image->get_height()) {
+			int new_width = size_limit;
+			int new_height = image->get_height() * new_width / image->get_width();
+
+			if (using_fallback_size_limit) {
+				// Only warn if downsizing occurred when the user did not explicitly request it.
+				WARN_PRINT(vformat("%s: Texture was downsized on import as its width (%d pixels) exceeded the importable size limit (%d pixels).", p_source_file, image->get_width(), size_limit));
+			}
+			image->resize(new_width, new_height, Image::INTERPOLATE_CUBIC);
+		} else {
+			int new_height = size_limit;
+			int new_width = image->get_width() * new_height / image->get_height();
+
+			if (using_fallback_size_limit) {
+				// Only warn if downsizing occurred when the user did not explicitly request it.
+				WARN_PRINT(vformat("%s: Texture was downsized on import as its height (%d pixels) exceeded the importable size limit (%d pixels).", p_source_file, image->get_height(), size_limit));
+			}
+			image->resize(new_width, new_height, Image::INTERPOLATE_CUBIC);
+		}
+
+		if (normal == 1) {
+			image->normalize();
+		}
 	}
 
 	// Load the normal image.
@@ -152,7 +471,7 @@ Error ResourceImporterStreamedTexture::import(ResourceUID::ID p_source_id, const
 	}
 
 	if (!image->has_mipmaps() || force_normal) {
-		image->generate_mipmaps(force_normal);
+		image->generate_mipmaps(force_normal, mipmaps_preserve_alpha_test_coverage, mipmaps_alpha_test_threshold);
 	}
 
 	// Generate roughness mipmaps from normal texture.

--- a/editor/import/resource_importer_streamed_texture.h
+++ b/editor/import/resource_importer_streamed_texture.h
@@ -30,6 +30,7 @@
 
 #pragma once
 
+#include "core/io/image.h"
 #include "core/io/resource_importer.h"
 #include "servers/rendering/rendering_server_enums.h"
 
@@ -39,6 +40,20 @@ class ResourceImporterStreamedTexture : public ResourceImporter {
 	GDCLASS(ResourceImporterStreamedTexture, ResourceImporter);
 
 	static ResourceImporterStreamedTexture *singleton;
+
+	enum ChannelRemap {
+		REMAP_R,
+		REMAP_G,
+		REMAP_B,
+		REMAP_A,
+		REMAP_INV_R,
+		REMAP_INV_G,
+		REMAP_INV_B,
+		REMAP_INV_A,
+		REMAP_UNUSED,
+		REMAP_0,
+		REMAP_1,
+	};
 
 	enum {
 		MAKE_ROUGHNESS_FLAG = 1,
@@ -56,6 +71,9 @@ class ResourceImporterStreamedTexture : public ResourceImporter {
 
 	static void _texture_reimport_roughness(const Ref<StreamedTexture2D> &p_tex, const String &p_normal_path, RSE::TextureDetectRoughnessChannel p_channel);
 	static void _texture_reimport_normal(const Ref<StreamedTexture2D> &p_tex);
+
+	static inline void _remap_channels(Ref<Image> &r_image, ChannelRemap p_options[4]);
+	static inline void _clamp_hdr_exposure(Ref<Image> &r_image);
 
 public:
 	static ResourceImporterStreamedTexture *get_singleton() { return singleton; }


### PR DESCRIPTION
## What problem(s) does this PR solve?

- See https://github.com/godotengine/godot/pull/113429#issuecomment-5443819464

## Additional information

I have added the following settings because I found them relevant:
* mipmaps/preserve_alpha_test_coverage
* mipmaps/alpha_test_threshold
* process/channel_remap/red
* process/channel_remap/green
* process/channel_remap/blue
* process/channel_remap/alpha
* process/hdr_as_srgb
* process/hdr_clamp_exposure
* process/size_limit

**If you think any of these options shouldn't be included, or if any Texture2D options are missing, please let me know.**
