### PR TITLE
Fix Auto Orthogonal mode being lost when switching editors

### DIFF
--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -3271,7 +3271,10 @@ void Node3DEditorViewport::_notification(int p_what) {
 			set_physics_process(vp_visible);
 
 			if (vp_visible) {
-				view_3d_controller->set_orthogonal(view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_ORTHOGONAL)));
+				bool orthogonal_checked = view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_ORTHOGONAL));
+				if (view_3d_controller->is_orthogonal() != orthogonal_checked) {
+					view_3d_controller->set_orthogonal(orthogonal_checked);
+				}
 				view_3d_controller->update_camera();
 				_update_name();
 			} else {
@@ -7203,6 +7206,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	viewport->add_child(ruler_label_z);
 
 	view_3d_controller.instantiate();
+	view_3d_controller->set_auto_orthogonal_allowed(view_display_menu->get_popup()->is_item_checked(view_display_menu->get_popup()->get_item_index(VIEW_AUTO_ORTHOGONAL)));
 	view_3d_controller->connect("view_state_changed", callable_mp(this, &Node3DEditorViewport::_view_state_changed));
 	view_3d_controller->connect("fov_scaled", callable_mp((CanvasItem *)surface, &CanvasItem::queue_redraw));
 	view_3d_controller->connect("freelook_changed", callable_mp(this, &Node3DEditorViewport::_freelook_changed));


### PR DESCRIPTION
## What problem(s) does this PR solve?

Closes #122689

## Additional information
1. The `Node3DEditorViewport` constructor has `set_item_checked` for the `VIEW_AUTO_ORTHOGONAL` menu item, but auto orthogonal wasn't actually enabled on the controller for a new project, so users had to turn it off and on again to make it work. Now the controller's state matches the menu correctly on a new project.
2. In `Node3DEditorViewport::_notification()`, `set_orthogonal()` was called based only on `VIEW_ORTHOGONAL`, which overwrote `ORTHOGONAL_AUTO` as well. As a result, leaving the 3D editor with auto orthogonal mode on and coming back to the 3D editor turned it into plain orthogonal mode. An extra guard is added before `set_orthogonal`, and it now behaves consistently.

_Claude Opus 5 was used to navigate the codebase._