### PR TITLE
Fix misalignment of inline BlendSpace name edit

### DIFF
--- a/editor/animation/animation_blend_space_1d_editor.cpp
+++ b/editor/animation/animation_blend_space_1d_editor.cpp
@@ -909,8 +909,8 @@ void AnimationNodeBlendSpace1DEditor::_inline_editor_text_changed(const String &
 		return;
 	}
 
-	Vector2 editor_size = inline_editor->get_size();
-	inline_editor->set_size(Vector2(0, editor_size.y));
+	inline_editor->set_size(Vector2(0, inline_editor->get_size().y));
+	Vector2 editor_size = inline_editor->get_minimum_size();
 
 	const float pm = POINT_MARGIN * EDSCALE;
 	const Size2 s = blend_space_draw->get_size() - Vector2(pm * 2, pm * 2);

--- a/editor/animation/animation_blend_space_2d_editor.cpp
+++ b/editor/animation/animation_blend_space_2d_editor.cpp
@@ -1177,8 +1177,8 @@ void AnimationNodeBlendSpace2DEditor::_inline_editor_text_changed(const String &
 		return;
 	}
 
-	Vector2 editor_size = inline_editor->get_size();
-	inline_editor->set_size(Vector2(0, editor_size.y));
+	inline_editor->set_size(Vector2(0, inline_editor->get_size().y));
+	Vector2 editor_size = inline_editor->get_minimum_size();
 
 	const float pm = POINT_MARGIN * EDSCALE;
 	const Size2 s = blend_space_draw->get_size() - Vector2(pm * 2, pm * 2);


### PR DESCRIPTION
There is a visual bug in the inline name editor for BlendSpace points, that misaligns its text.
It is caused by a stale width calculation in `_inline_editor_text_changed`, which this PR fixes.

### Before

<img width="274" height="162" alt="inline-edit-before" src="https://github.com/user-attachments/assets/50108aa3-0106-46cb-88d8-412e8d53df6b" />

### After

<img width="274" height="162" alt="inline-edit-after" src="https://github.com/user-attachments/assets/303081c7-b398-4c14-b826-f08cfce00c37" />
