### PR TITLE
RenderingDevice: only require an instance hit-SBT range where raytracing pipelines exist

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -590,7 +590,11 @@ Error RenderingDevice::tlas_build(RID p_tlas, Span<AccelerationStructureInstance
 		rdd_instance.flags = rd_instance.flags;
 
 		if (rd_instance.blas.is_valid()) {
-			ERR_FAIL_COND_V_MSG(!rd_instance.hit_sbt_range, ERR_INVALID_PARAMETER, "Instance " + itos(i) + " has an invalid hit shader binding table range.");
+			// A hit shader binding table only exists where raytracing PIPELINES do. On a device that
+			// supports ray queries but not pipelines, rayQueryEXT never dispatches a hit shader and
+			// there is no SBT to index, so demanding a valid range here makes TLAS builds impossible
+			// on such a device. Only require it when pipelines are actually available.
+			ERR_FAIL_COND_V_MSG(has_feature(SUPPORTS_RAYTRACING_PIPELINE) && !rd_instance.hit_sbt_range, ERR_INVALID_PARAMETER, "Instance " + itos(i) + " has an invalid hit shader binding table range.");
 
 			AccelerationStructure *blas = acceleration_structure_owner.get_or_null(rd_instance.blas);
 			ERR_FAIL_NULL_V(blas, ERR_INVALID_PARAMETER);


### PR DESCRIPTION
`tlas_build()` rejects any instance whose `hit_sbt_range` is zero ("Instance N has an invalid hit shader binding table range"). A hit shader binding table only exists where raytracing *pipelines* do; on a device that supports ray queries but not pipelines, `rayQueryEXT` never dispatches a hit shader and there is no SBT to index, so the check makes every TLAS build fail on such a device.

Until #122051 no backend could report `SUPPORTS_RAY_QUERY` without also reporting `SUPPORTS_RAYTRACING_PIPELINE`, so the path was unreachable. With ray query now wired on Vulkan, devices exposing `VK_KHR_ray_query` without `VK_KHR_ray_tracing_pipeline` (e.g. Qualcomm Adreno 7xx) hit it on stock builds — a TLAS becomes impossible to build even though ray queries work.

This gates the requirement on `has_feature(SUPPORTS_RAYTRACING_PIPELINE)`; pipeline-capable devices are validated exactly as before.

Found while bringing up a ray-query-only `RenderingDeviceDriver` on Metal, out of tree ([`metal-ray-query`](https://github.com/iamGeoWat/godot/tree/metal-ray-query)), where a TLAS with a valid BLAS and no SBT is the normal case rather than an error.

**Tested:** a TLAS with a valid BLAS and `hit_sbt_range = 0` builds and traces correctly on the ray-query-only device (compute shader with `GL_EXT_ray_query`, editor and `template_release` builds). The pipeline-capable path — where the check must still reject `hit_sbt_range = 0` — is unchanged by this patch but was not exercised: no such device here.

Since #122051 is labelled `cherrypick:4.7`, this check becomes reachable in 4.7.x; it would make sense for this one-liner to ride along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8MztQ5duDKNHEHXtrgkDx
