### PR TITLE
Only require a hit SBT range where raytracing pipelines exist

### DIFF
--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -590,7 +590,7 @@ Error RenderingDevice::tlas_build(RID p_tlas, Span<AccelerationStructureInstance
 		rdd_instance.flags = rd_instance.flags;
 
 		if (rd_instance.blas.is_valid()) {
-			ERR_FAIL_COND_V_MSG(!rd_instance.hit_sbt_range, ERR_INVALID_PARAMETER, "Instance " + itos(i) + " has an invalid hit shader binding table range.");
+			ERR_FAIL_COND_V_MSG(has_feature(SUPPORTS_RAYTRACING_PIPELINE) && !rd_instance.hit_sbt_range, ERR_INVALID_PARAMETER, "Instance " + itos(i) + " has an invalid hit shader binding table range.");
 
 			AccelerationStructure *blas = acceleration_structure_owner.get_or_null(rd_instance.blas);
 			ERR_FAIL_NULL_V(blas, ERR_INVALID_PARAMETER);


### PR DESCRIPTION
I am developing my game on M5 Pro Macbook Pro. A hit shader binding table only exists where raytracing PIPELINES do: on a device (like mine) that supports ray queries but not pipelines, `rayQueryEXT `never dispatches a hit shader and there is no SBT to index. The check therefore makes TLAS builds impossible on such a device, which no backend has hit before because none has reported `SUPPORTS_RAY_QUERY` without also reporting `SUPPORTS_RAYTRACING_PIPELINE`.

Gate the requirement on `has_feature(SUPPORTS_RAYTRACING_PIPELINE)`. Pipeline-capable devices are validated exactly as before.

Found while bringing up ray query on the Metal driver, where a TLAS with a valid BLAS and no SBT is the normal case rather than an error.