### PR TITLE
Add support for partial 2D texture updates, use it to update font atlases in place.

### DIFF
--- a/doc/classes/RenderingDevice.xml
+++ b/doc/classes/RenderingDevice.xml
@@ -1288,6 +1288,20 @@
 				[b]Note:[/b] The existing [param texture] requires the [constant TEXTURE_USAGE_CAN_UPDATE_BIT] to be updatable.
 			</description>
 		</method>
+		<method name="texture_update_partial">
+			<return type="int" enum="Error" />
+			<param index="0" name="texture" type="RID" />
+			<param index="1" name="layer" type="int" />
+			<param index="2" name="offset" type="Vector2i" />
+			<param index="3" name="size" type="Vector2i" />
+			<param index="4" name="data" type="PackedByteArray" />
+			<description>
+				Updates part of the texture data with new data, replacing the previous data in place. The updated texture data must have the same format. For 2D textures (which only have one layer), [param layer] must be [code]0[/code]. Returns [constant @GlobalScope.OK] if the update was successful, [constant @GlobalScope.ERR_INVALID_PARAMETER] otherwise.
+				[b]Note:[/b] Updating textures is forbidden during creation of a draw or compute list.
+				[b]Note:[/b] The existing [param texture] can't be updated while a draw list that uses it as part of a framebuffer is being created. Ensure the draw list is finalized (and that the color/depth texture using it is not set to [constant FINAL_ACTION_CONTINUE]) to update this texture.
+				[b]Note:[/b] The existing [param texture] requires the [constant TEXTURE_USAGE_CAN_UPDATE_BIT] to be updatable.
+			</description>
+		</method>
 		<method name="tlas_build" experimental="">
 			<return type="int" enum="Error" />
 			<param index="0" name="tlas" type="RID" />

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3910,6 +3910,17 @@
 				[b]Note:[/b] The [param image] must have the same width, height and format as the current [param texture] data. Otherwise, an error will be printed and the original texture won't be modified. If you need to use different width, height or format, use [method texture_replace] instead.
 			</description>
 		</method>
+		<method name="texture_2d_update_partial">
+			<return type="void" />
+			<param index="0" name="texture" type="RID" />
+			<param index="1" name="offset" type="Vector2i" />
+			<param index="2" name="image" type="Image" />
+			<param index="3" name="layer" type="int" />
+			<description>
+				Updates part of the texture specified by the [param texture] [RID] with the data in [param image]. A [param layer] must also be specified, which should be [code]0[/code] when updating a single-layer texture ([Texture2D]).
+				[b]Note:[/b] The [param image] must have the same format as the current [param texture] data. Otherwise, an error will be printed and the original texture won't be modified. If you need to use different format, use [method texture_replace] instead.
+			</description>
+		</method>
 		<method name="texture_3d_create">
 			<return type="RID" />
 			<param index="0" name="format" type="int" enum="Image.Format" />

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -1315,6 +1315,18 @@ void TextureStorage::texture_2d_update(RID p_texture, const Ref<Image> &p_image,
 #endif
 }
 
+void TextureStorage::texture_2d_update_partial(RID p_texture, const Vector2i &p_offset, const Ref<Image> &p_image, int p_layer) {
+	_texture_set_data_partial(p_texture, p_offset, p_image, p_layer);
+
+	Texture *tex = texture_owner.get_or_null(p_texture);
+	ERR_FAIL_NULL(tex);
+	GLES3::Utilities::get_singleton()->texture_resize_data(tex->tex_id, tex->total_data_size);
+
+#ifdef TOOLS_ENABLED
+	tex->image_cache_2d.unref();
+#endif
+}
+
 void TextureStorage::texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) {
 	Texture *tex = texture_owner.get_or_null(p_texture);
 	ERR_FAIL_NULL(tex);
@@ -2113,6 +2125,90 @@ void TextureStorage::_texture_set_data(RID p_texture, const Ref<Image> &p_image,
 		texture->total_data_size = tsize * texture->layers;
 	} else {
 		texture->total_data_size = tsize;
+	}
+
+	texture->stored_cube_sides |= (1 << p_layer);
+
+	texture->mipmaps = mipmaps;
+}
+
+void TextureStorage::_texture_set_data_partial(RID p_texture, const Vector2i &p_offset, const Ref<Image> &p_image, int p_layer) {
+	Texture *texture = texture_owner.get_or_null(p_texture);
+
+	ERR_FAIL_NULL(texture);
+	if (texture->target == GL_TEXTURE_3D) {
+		// Target is set to a 3D texture or array texture, exit early to avoid spamming errors
+		return;
+	}
+	ERR_FAIL_COND(!texture->active);
+	ERR_FAIL_COND(texture->is_render_target);
+	ERR_FAIL_COND(p_image.is_null());
+	ERR_FAIL_COND(texture->format != p_image->get_format());
+
+	ERR_FAIL_COND(!p_image->get_width());
+	ERR_FAIL_COND(!p_image->get_height());
+
+	GLenum type;
+	GLenum format;
+	GLenum internal_format;
+	bool compressed = false;
+
+	bool needs_decompress = texture->resize_to_po2;
+
+	// Support for RGTC-compressed Texture Arrays isn't mandated by GLES3/WebGL.
+	if (!RasterizerUtilGLES3::is_gles_over_gl() && texture->target == GL_TEXTURE_2D_ARRAY) {
+		if (p_image->get_format() == Image::FORMAT_RGTC_R || p_image->get_format() == Image::FORMAT_RGTC_RG) {
+			needs_decompress = true;
+		}
+	}
+
+	Image::Format real_format;
+	Ref<Image> img = _get_gl_image_and_format(p_image, p_image->get_format(), real_format, format, internal_format, type, compressed, needs_decompress);
+	ERR_FAIL_COND(img.is_null());
+
+	GLenum blit_target = (texture->target == GL_TEXTURE_CUBE_MAP) ? _cube_side_enum[p_layer] : texture->target;
+
+	Vector<uint8_t> read = img->get_data();
+
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(texture->target, texture->tex_id);
+	_texture_set_swizzle(texture, real_format);
+
+	int mipmaps = img->has_mipmaps() ? img->get_mipmap_count() + 1 : 1;
+
+	// Set filtering and repeat state to default.
+	if (mipmaps > 1) {
+		texture->gl_set_filter(RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS);
+	} else {
+		texture->gl_set_filter(RSE::CANVAS_ITEM_TEXTURE_FILTER_NEAREST);
+	}
+
+	texture->gl_set_repeat(RSE::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED);
+
+	int w = img->get_width();
+	int h = img->get_height();
+
+	for (int i = 0; i < mipmaps; i++) {
+		int64_t size, ofs;
+		img->get_mipmap_offset_and_size(i, ofs, size);
+		if (compressed) {
+			glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+			if (texture->target == GL_TEXTURE_2D_ARRAY) {
+				glCompressedTexSubImage3D(GL_TEXTURE_2D_ARRAY, i, p_offset.x, p_offset.y, p_layer, w, h, 1, internal_format, size, &read[ofs]);
+			} else {
+				glCompressedTexSubImage2D(blit_target, i, p_offset.x, p_offset.y, w, h, format, size, &read[ofs]);
+			}
+		} else {
+			glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+			if (texture->target == GL_TEXTURE_2D_ARRAY) {
+				glTexSubImage3D(GL_TEXTURE_2D_ARRAY, i, p_offset.x, p_offset.y, p_layer, w, h, 1, format, type, &read[ofs]);
+			} else {
+				glTexSubImage2D(blit_target, i, p_offset.x, p_offset.y, w, h, format, type, &read[ofs]);
+			}
+		}
+
+		w = MAX(1, w >> 1);
+		h = MAX(1, h >> 1);
 	}
 
 	texture->stored_cube_sides |= (1 << p_layer);

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -595,6 +595,7 @@ private:
 
 	void _texture_set_data(RID p_texture, const Ref<Image> &p_image, int p_layer, bool p_initialize);
 	void _texture_set_3d_data(RID p_texture, const Vector<Ref<Image>> &p_data, bool p_initialize);
+	void _texture_set_data_partial(RID p_texture, const Vector2i &p_offset, const Ref<Image> &p_image, int p_layer);
 	void _texture_set_swizzle(Texture *p_texture, Image::Format p_real_format);
 	Vector<Ref<Image>> _texture_3d_read_framebuffer(Texture *p_texture) const;
 
@@ -673,6 +674,7 @@ public:
 
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) override;
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) override;
+	virtual void texture_2d_update_partial(RID p_texture, const Vector2i &p_offset, const Ref<Image> &p_image, int p_layer = 0) override;
 	virtual void texture_external_update(RID p_texture, int p_width, int p_height, uint64_t p_external_buffer) override;
 	virtual void texture_proxy_update(RID p_proxy, RID p_base) override;
 	void texture_remap_proxies(RID p_from_texture, RID p_to_texture);

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -825,7 +825,7 @@ String TextServerAdvanced::_tag_to_name(int64_t p_tag) const {
 /* Font Glyph Rendering                                                  */
 /*************************************************************************/
 
-_FORCE_INLINE_ TextServerAdvanced::FontTexturePosition TextServerAdvanced::find_texture_pos_for_glyph(FontForSizeAdvanced *p_data, int p_color_size, Image::Format p_image_format, int p_width, int p_height, bool p_msdf) const {
+_FORCE_INLINE_ TextServerAdvanced::FontTexturePosition TextServerAdvanced::find_texture_pos_for_glyph(FontForSizeAdvanced *p_data, Image::Format p_image_format, int p_width, int p_height, bool p_mipmaps) const {
 	FontTexturePosition ret;
 
 	int mw = p_width;
@@ -833,10 +833,7 @@ _FORCE_INLINE_ TextServerAdvanced::FontTexturePosition TextServerAdvanced::find_
 
 	ShelfPackTexture *ct = p_data->textures.ptrw();
 	for (int32_t i = 0; i < p_data->textures.size(); i++) {
-		if (ct[i].image.is_null()) {
-			continue;
-		}
-		if (p_image_format != ct[i].image->get_format()) {
+		if (p_image_format != ct[i].texture->get_format()) {
 			continue;
 		}
 		if (mw > ct[i].texture_w || mh > ct[i].texture_h) { // Too big for this texture.
@@ -851,51 +848,9 @@ _FORCE_INLINE_ TextServerAdvanced::FontTexturePosition TextServerAdvanced::find_
 
 	if (ret.index == -1) {
 		// Could not find texture to fit, create one.
-		int texsize = MAX(p_data->size.x * 0.125, 256);
-
-		texsize = Math::next_power_of_2((uint32_t)texsize);
-		if (p_msdf) {
-			texsize = MIN(texsize, 2048);
-		} else {
-			texsize = MIN(texsize, 1024);
-		}
-		if (mw > texsize) { // Special case, adapt to it?
-			texsize = Math::next_power_of_2((uint32_t)mw);
-		}
-		if (mh > texsize) { // Special case, adapt to it?
-			texsize = Math::next_power_of_2((uint32_t)mh);
-		}
-
-		ShelfPackTexture tex = ShelfPackTexture(texsize, texsize);
-		tex.image = Image::create_empty(texsize, texsize, false, p_image_format);
-		{
-			// Zero texture.
-			uint8_t *w = tex.image->ptrw();
-			ERR_FAIL_COND_V(texsize * texsize * p_color_size > tex.image->get_data_size(), ret);
-			// Initialize the texture to all-white pixels to prevent artifacts when the
-			// font is displayed at a non-default scale with filtering enabled.
-			if (p_color_size == 2) {
-				for (int i = 0; i < texsize * texsize * p_color_size; i += 2) { // FORMAT_LA8, BW font.
-					w[i + 0] = 255;
-					w[i + 1] = 0;
-				}
-			} else if (p_color_size == 4) {
-				for (int i = 0; i < texsize * texsize * p_color_size; i += 4) { // FORMAT_RGBA8, Color font, Multichannel(+True) SDF.
-					if (p_msdf) {
-						w[i + 0] = 0;
-						w[i + 1] = 0;
-						w[i + 2] = 0;
-					} else {
-						w[i + 0] = 255;
-						w[i + 1] = 255;
-						w[i + 2] = 255;
-					}
-					w[i + 3] = 0;
-				}
-			} else {
-				ERR_FAIL_V(ret);
-			}
-		}
+		ShelfPackTexture tex = ShelfPackTexture(4096, 4096);
+		Ref<Image> img = Image::create_empty(4096, 4096, p_mipmaps, p_image_format);
+		tex.texture = ImageTexture::create_from_image(img);
 		p_data->textures.push_back(tex);
 
 		int32_t idx = p_data->textures.size() - 1;
@@ -935,7 +890,7 @@ struct MSDFThreadData {
 };
 
 static msdfgen::Point2 ft_point2(const FT_Vector &vector) {
-	return msdfgen::Point2(vector.x / 60.0f, vector.y / 60.0f);
+	return msdfgen::Point2(vector.x / 64.0f, vector.y / 64.0f);
 }
 
 static int ft_move_to(const FT_Vector *to, void *user) {
@@ -1038,7 +993,7 @@ _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_msdf(
 		ERR_FAIL_COND_V(mw > 4096, FontGlyph());
 		ERR_FAIL_COND_V(mh > 4096, FontGlyph());
 
-		FontTexturePosition tex_pos = find_texture_pos_for_glyph(p_data, 4, Image::FORMAT_RGBA8, mw, mh, true);
+		FontTexturePosition tex_pos = find_texture_pos_for_glyph(p_data, Image::FORMAT_RGBA8, mw, mh, p_font_data->mipmaps);
 		ERR_FAIL_COND_V(tex_pos.index < 0, FontGlyph());
 		ShelfPackTexture &tex = p_data->textures.write[tex_pos.index];
 
@@ -1060,13 +1015,14 @@ _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_msdf(
 
 		msdfgen::msdfErrorCorrection(image, shape, projection, p_pixel_range, config);
 
+		Ref<Image> img = Image::create_empty(w + p_rect_margin * 2, h + p_rect_margin * 2, p_font_data->mipmaps, Image::FORMAT_RGBA8);
 		{
-			uint8_t *wr = tex.image->ptrw();
+			uint8_t *wr = img->ptrw();
 
 			for (int i = 0; i < h; i++) {
 				for (int j = 0; j < w; j++) {
-					int ofs = ((i + tex_pos.y + p_rect_margin * 2) * tex.texture_w + j + tex_pos.x + p_rect_margin * 2) * 4;
-					ERR_FAIL_COND_V(ofs >= tex.image->get_data_size(), FontGlyph());
+					int ofs = ((i + p_rect_margin * 2) * (w + p_rect_margin * 2) + j + p_rect_margin * 2) * 4;
+					ERR_FAIL_COND_V(ofs >= img->get_data_size(), FontGlyph());
 					wr[ofs + 0] = (uint8_t)(CLAMP(image(j, i)[0] * 256.f, 0.f, 255.f));
 					wr[ofs + 1] = (uint8_t)(CLAMP(image(j, i)[1] * 256.f, 0.f, 255.f));
 					wr[ofs + 2] = (uint8_t)(CLAMP(image(j, i)[2] * 256.f, 0.f, 255.f));
@@ -1075,7 +1031,7 @@ _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_msdf(
 			}
 		}
 
-		tex.dirty = true;
+		tex.texture->update_partial(img, Vector2i(tex_pos.x, tex_pos.y));
 
 		chr.texture_idx = tex_pos.index;
 
@@ -1090,7 +1046,7 @@ _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_msdf(
 
 #ifdef MODULE_FREETYPE_ENABLED
 #if HB_VERSION_ATLEAST(13, 0, 0)
-_FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_hb_bitmap(FontForSizeAdvanced *p_data, int p_rect_margin, hb_raster_image_t *p_image, const hb_raster_extents_t &p_ext, const Vector2 &p_advance, bool p_bgra) const {
+_FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_hb_bitmap(FontAdvanced *p_font_data, FontForSizeAdvanced *p_data, int p_rect_margin, hb_raster_image_t *p_image, const hb_raster_extents_t &p_ext, const Vector2 &p_advance, bool p_bgra) const {
 	FontGlyph chr;
 	chr.advance = p_advance * p_data->scale;
 	chr.found = true;
@@ -1115,7 +1071,7 @@ _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_hb_bi
 
 	Image::Format require_format = color_size == 4 ? Image::FORMAT_RGBA8 : Image::FORMAT_LA8;
 
-	FontTexturePosition tex_pos = find_texture_pos_for_glyph(p_data, color_size, require_format, mw, mh, false);
+	FontTexturePosition tex_pos = find_texture_pos_for_glyph(p_data, require_format, mw, mh, p_font_data->mipmaps);
 	ERR_FAIL_COND_V(tex_pos.index < 0, FontGlyph());
 
 	const uint8_t *img_src = hb_raster_image_get_buffer(p_image);
@@ -1123,13 +1079,14 @@ _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_hb_bi
 	// Fit character in char texture.
 	ShelfPackTexture &tex = p_data->textures.write[tex_pos.index];
 
+	Ref<Image> img = Image::create_empty(w + p_rect_margin * 2, h + p_rect_margin * 2, p_font_data->mipmaps, require_format);
 	{
-		uint8_t *wr = tex.image->ptrw();
+		uint8_t *wr = img->ptrw();
 
 		for (int i = 0; i < h; i++) {
 			for (int j = 0; j < w; j++) {
-				int ofs = ((i + tex_pos.y + p_rect_margin * 2) * tex.texture_w + j + tex_pos.x + p_rect_margin * 2) * color_size;
-				ERR_FAIL_COND_V(ofs >= tex.image->get_data_size(), FontGlyph());
+				int ofs = ((i + +p_rect_margin * 2) * (w + p_rect_margin * 2) + j + p_rect_margin * 2) * color_size;
+				ERR_FAIL_COND_V(ofs >= img->get_data_size(), FontGlyph());
 				if (p_bgra) {
 					int ofs_color = i * p_ext.stride + (j << 2);
 					wr[ofs + 2] = img_src[ofs_color + 0];
@@ -1144,7 +1101,7 @@ _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_hb_bi
 		}
 	}
 
-	tex.dirty = true;
+	tex.texture->update_partial(img, Vector2i(tex_pos.x, tex_pos.y));
 
 	chr.texture_idx = tex_pos.index;
 
@@ -1155,7 +1112,7 @@ _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_hb_bi
 }
 #endif
 
-_FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_bitmap(FontForSizeAdvanced *p_data, int p_rect_margin, FT_Bitmap p_bitmap, int p_yofs, int p_xofs, const Vector2 &p_advance, bool p_bgra) const {
+_FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_bitmap(FontAdvanced *p_font_data, FontForSizeAdvanced *p_data, int p_rect_margin, FT_Bitmap p_bitmap, int p_yofs, int p_xofs, const Vector2 &p_advance, bool p_bgra, bool p_fix_edge) const {
 	FontGlyph chr;
 	chr.advance = p_advance * p_data->scale;
 	chr.found = true;
@@ -1198,19 +1155,20 @@ _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_bitma
 
 	Image::Format require_format = color_size == 4 ? Image::FORMAT_RGBA8 : Image::FORMAT_LA8;
 
-	FontTexturePosition tex_pos = find_texture_pos_for_glyph(p_data, color_size, require_format, mw, mh, false);
+	FontTexturePosition tex_pos = find_texture_pos_for_glyph(p_data, require_format, mw, mh, p_font_data->mipmaps);
 	ERR_FAIL_COND_V(tex_pos.index < 0, FontGlyph());
 
 	// Fit character in char texture.
 	ShelfPackTexture &tex = p_data->textures.write[tex_pos.index];
 
+	Ref<Image> img = Image::create_empty(w + p_rect_margin * 2, h + p_rect_margin * 2, p_font_data->mipmaps, require_format);
 	{
-		uint8_t *wr = tex.image->ptrw();
+		uint8_t *wr = img->ptrw();
 
 		for (int i = 0; i < h; i++) {
 			for (int j = 0; j < w; j++) {
-				int ofs = ((i + tex_pos.y + p_rect_margin * 2) * tex.texture_w + j + tex_pos.x + p_rect_margin * 2) * color_size;
-				ERR_FAIL_COND_V(ofs >= tex.image->get_data_size(), FontGlyph());
+				int ofs = ((i + p_rect_margin * 2) * (w + p_rect_margin * 2) + j + p_rect_margin * 2) * color_size;
+				ERR_FAIL_COND_V(ofs >= img->get_data_size(), FontGlyph());
 				switch (p_bitmap.pixel_mode) {
 					case FT_PIXEL_MODE_MONO: {
 						int byte = i * p_bitmap.pitch + (j >> 3);
@@ -1264,8 +1222,11 @@ _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_bitma
 			}
 		}
 	}
+	if (p_fix_edge) {
+		img->fix_alpha_edges();
+	}
 
-	tex.dirty = true;
+	tex.texture->update_partial(img, Vector2i(tex_pos.x, tex_pos.y));
 
 	chr.texture_idx = tex_pos.index;
 
@@ -1291,7 +1252,7 @@ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data, const Vector2i
 		bool tx_valid = true;
 		if (E->value.texture_idx >= 0) {
 			if (E->value.texture_idx < fd->textures.size()) {
-				tx_valid = fd->textures[E->value.texture_idx].image.is_valid();
+				tx_valid = fd->textures[E->value.texture_idx].texture.is_valid();
 			} else {
 				tx_valid = false;
 			}
@@ -1458,10 +1419,10 @@ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data, const Vector2i
 							hb_raster_extents_t ext = { 0, 0, 0, 0, 0 };
 							if (img) {
 								hb_raster_image_get_extents(img, &ext);
-								gl = rasterize_hb_bitmap(fd, rect_range, img, ext, Vector2((h + (1 << 9)) >> 10, (v + (1 << 9)) >> 10) / 64.0, true);
+								gl = rasterize_hb_bitmap(p_font_data, fd, rect_range, img, ext, Vector2((h + (1 << 9)) >> 10, (v + (1 << 9)) >> 10) / 64.0, true);
 								hb_raster_paint_recycle_image(p_font_data->hb_rdr, img);
 							} else {
-								gl = rasterize_hb_bitmap(fd, rect_range, nullptr, ext, Vector2((h + (1 << 9)) >> 10, (v + (1 << 9)) >> 10) / 64.0, true);
+								gl = rasterize_hb_bitmap(p_font_data, fd, rect_range, nullptr, ext, Vector2((h + (1 << 9)) >> 10, (v + (1 << 9)) >> 10) / 64.0, true);
 							}
 						}
 					}
@@ -1484,16 +1445,16 @@ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data, const Vector2i
 						if (img) {
 							is_rasterized = true;
 							hb_raster_image_get_extents(img, &ext);
-							gl = rasterize_hb_bitmap(fd, rect_range, img, ext, Vector2((h + (1 << 9)) >> 10, (v + (1 << 9)) >> 10) / 64.0, false);
+							gl = rasterize_hb_bitmap(p_font_data, fd, rect_range, img, ext, Vector2((h + (1 << 9)) >> 10, (v + (1 << 9)) >> 10) / 64.0, false);
 							hb_raster_draw_recycle_image(p_font_data->hb_mono, img);
 						} else {
-							gl = rasterize_hb_bitmap(fd, rect_range, nullptr, ext, Vector2((h + (1 << 9)) >> 10, (v + (1 << 9)) >> 10) / 64.0, false);
+							gl = rasterize_hb_bitmap(p_font_data, fd, rect_range, nullptr, ext, Vector2((h + (1 << 9)) >> 10, (v + (1 << 9)) >> 10) / 64.0, false);
 						}
 					}
 					if (!is_rasterized) {
 						error = FT_Render_Glyph(slot, aa_mode);
 						if (!error) {
-							gl = rasterize_bitmap(fd, rect_range, slot->bitmap, slot->bitmap_top, slot->bitmap_left, Vector2((h + (1 << 9)) >> 10, (v + (1 << 9)) >> 10) / 64.0, bgra);
+							gl = rasterize_bitmap(p_font_data, fd, rect_range, slot->bitmap, slot->bitmap_top, slot->bitmap_left, Vector2((h + (1 << 9)) >> 10, (v + (1 << 9)) >> 10) / 64.0, bgra, fix_edge);
 						}
 					}
 				} else {
@@ -1502,7 +1463,7 @@ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data, const Vector2i
 #endif
 					error = FT_Render_Glyph(slot, aa_mode);
 					if (!error) {
-						gl = rasterize_bitmap(fd, rect_range, slot->bitmap, slot->bitmap_top, slot->bitmap_left, Vector2((h + (1 << 9)) >> 10, (v + (1 << 9)) >> 10) / 64.0, bgra);
+						gl = rasterize_bitmap(p_font_data, fd, rect_range, slot->bitmap, slot->bitmap_top, slot->bitmap_left, Vector2((h + (1 << 9)) >> 10, (v + (1 << 9)) >> 10) / 64.0, bgra, fix_edge);
 					}
 				}
 			}
@@ -1527,14 +1488,13 @@ bool TextServerAdvanced::_ensure_glyph(FontAdvanced *p_font_data, const Vector2i
 				goto cleanup_glyph;
 			}
 			glyph_bitmap = (FT_BitmapGlyph)glyph;
-			gl = rasterize_bitmap(fd, rect_range, glyph_bitmap->bitmap, glyph_bitmap->top, glyph_bitmap->left, Vector2(), bgra);
+			gl = rasterize_bitmap(p_font_data, fd, rect_range, glyph_bitmap->bitmap, glyph_bitmap->top, glyph_bitmap->left, Vector2(), bgra, fix_edge);
 
 		cleanup_glyph:
 			FT_Done_Glyph(glyph);
 		cleanup_stroker:
 			FT_Stroker_Done(stroker);
 		}
-		gl.fix_edge = fix_edge;
 		E = fd->glyph_map.insert(p_glyph, gl);
 		r_glyph = E->value;
 		return gl.found;
@@ -2653,7 +2613,6 @@ void TextServerAdvanced::_font_set_generate_mipmaps(const RID &p_font_rid, bool 
 	if (fd->mipmaps != p_generate_mipmaps) {
 		for (KeyValue<Vector2i, FontForSizeAdvanced *> &E : fd->cache) {
 			for (int i = 0; i < E.value->textures.size(); i++) {
-				E.value->textures.write[i].dirty = true;
 				E.value->textures.write[i].texture = Ref<ImageTexture>();
 			}
 		}
@@ -3115,7 +3074,7 @@ TypedArray<Dictionary> TextServerAdvanced::_font_get_size_cache_info(const RID &
 		size_info["textures"] = E.value->textures.size();
 		uint64_t sz = 0;
 		for (const ShelfPackTexture &tx : E.value->textures) {
-			sz += tx.image->get_data_size() * 2;
+			sz += tx.texture->get_image()->get_data_size() * 2;
 		}
 		size_info["textures_size"] = sz;
 		ret.push_back(size_info);
@@ -3394,7 +3353,6 @@ void TextServerAdvanced::_font_set_texture_image(const RID &p_font_rid, const Ve
 
 	ShelfPackTexture &tex = ffsd->textures.write[p_texture_index];
 
-	tex.image = p_image;
 	tex.texture_w = p_image->get_width();
 	tex.texture_h = p_image->get_height();
 
@@ -3404,7 +3362,6 @@ void TextServerAdvanced::_font_set_texture_image(const RID &p_font_rid, const Ve
 		img->generate_mipmaps();
 	}
 	tex.texture = ImageTexture::create_from_image(img);
-	tex.dirty = false;
 }
 
 Ref<Image> TextServerAdvanced::_font_get_texture_image(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) const {
@@ -3418,7 +3375,7 @@ Ref<Image> TextServerAdvanced::_font_get_texture_image(const RID &p_font_rid, co
 	ERR_FAIL_INDEX_V(p_texture_index, ffsd->textures.size(), Ref<Image>());
 
 	const ShelfPackTexture &tex = ffsd->textures[p_texture_index];
-	return tex.image;
+	return tex.texture->get_image();
 }
 
 void TextServerAdvanced::_font_set_texture_offsets(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index, const PackedInt32Array &p_offsets) {
@@ -3797,24 +3754,6 @@ RID TextServerAdvanced::_font_get_glyph_texture_rid(const RID &p_font_rid, const
 	ERR_FAIL_COND_V(fgl.texture_idx < -1 || fgl.texture_idx >= ffsd->textures.size(), RID());
 
 	if (fgl.texture_idx != -1) {
-		if (ffsd->textures[fgl.texture_idx].dirty) {
-			ShelfPackTexture &tex = ffsd->textures.write[fgl.texture_idx];
-			Ref<Image> img = tex.image;
-			if (fgl.fix_edge) {
-				// Same as the "fix alpha border" process option when importing SVGs
-				img->fix_alpha_edges();
-			}
-			if (fd->mipmaps && !img->has_mipmaps()) {
-				img = tex.image->duplicate();
-				img->generate_mipmaps();
-			}
-			if (tex.texture.is_null()) {
-				tex.texture = ImageTexture::create_from_image(img);
-			} else {
-				tex.texture->update(img);
-			}
-			tex.dirty = false;
-		}
 		return ffsd->textures[fgl.texture_idx].texture->get_rid();
 	}
 
@@ -3847,24 +3786,6 @@ Size2 TextServerAdvanced::_font_get_glyph_texture_size(const RID &p_font_rid, co
 	ERR_FAIL_COND_V(fgl.texture_idx < -1 || fgl.texture_idx >= ffsd->textures.size(), Size2());
 
 	if (fgl.texture_idx != -1) {
-		if (ffsd->textures[fgl.texture_idx].dirty) {
-			ShelfPackTexture &tex = ffsd->textures.write[fgl.texture_idx];
-			Ref<Image> img = tex.image;
-			if (fgl.fix_edge) {
-				// Same as the "fix alpha border" process option when importing SVGs
-				img->fix_alpha_edges();
-			}
-			if (fd->mipmaps && !img->has_mipmaps()) {
-				img = tex.image->duplicate();
-				img->generate_mipmaps();
-			}
-			if (tex.texture.is_null()) {
-				tex.texture = ImageTexture::create_from_image(img);
-			} else {
-				tex.texture->update(img);
-			}
-			tex.dirty = false;
-		}
 		return ffsd->textures[fgl.texture_idx].texture->get_size();
 	}
 
@@ -4319,28 +4240,10 @@ void TextServerAdvanced::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 		if (fgl.texture_idx != -1) {
 			Color modulate = p_color;
 #ifdef MODULE_FREETYPE_ENABLED
-			if (!fd->modulate_color_glyphs && fd->face && ffsd->textures[fgl.texture_idx].image.is_valid() && (ffsd->textures[fgl.texture_idx].image->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
+			if (!fd->modulate_color_glyphs && fd->face && ffsd->textures[fgl.texture_idx].texture.is_valid() && (ffsd->textures[fgl.texture_idx].texture->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
 				modulate.r = modulate.g = modulate.b = 1.0;
 			}
 #endif
-			if (ffsd->textures[fgl.texture_idx].dirty) {
-				ShelfPackTexture &tex = ffsd->textures.write[fgl.texture_idx];
-				Ref<Image> img = tex.image;
-				if (fgl.fix_edge) {
-					// Same as the "fix alpha border" process option when importing SVGs
-					img->fix_alpha_edges();
-				}
-				if (fd->mipmaps && !img->has_mipmaps()) {
-					img = tex.image->duplicate();
-					img->generate_mipmaps();
-				}
-				if (tex.texture.is_null()) {
-					tex.texture = ImageTexture::create_from_image(img);
-				} else {
-					tex.texture->update(img);
-				}
-				tex.dirty = false;
-			}
 			if (fd->msdf) {
 				Point2 cpos = p_pos;
 				cpos += fgl.rect.position * (double)p_size / (double)fd->msdf_source_size;
@@ -4462,24 +4365,10 @@ void TextServerAdvanced::_font_draw_glyph_outline(const RID &p_font_rid, const R
 		if (fgl.texture_idx != -1) {
 			Color modulate = p_color;
 #ifdef MODULE_FREETYPE_ENABLED
-			if (fd->face && fd->cache[size]->textures[fgl.texture_idx].image.is_valid() && (ffsd->textures[fgl.texture_idx].image->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
+			if (fd->face && fd->cache[size]->textures[fgl.texture_idx].texture.is_valid() && (ffsd->textures[fgl.texture_idx].texture->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
 				modulate.r = modulate.g = modulate.b = 1.0;
 			}
 #endif
-			if (ffsd->textures[fgl.texture_idx].dirty) {
-				ShelfPackTexture &tex = ffsd->textures.write[fgl.texture_idx];
-				Ref<Image> img = tex.image;
-				if (fd->mipmaps && !img->has_mipmaps()) {
-					img = tex.image->duplicate();
-					img->generate_mipmaps();
-				}
-				if (tex.texture.is_null()) {
-					tex.texture = ImageTexture::create_from_image(img);
-				} else {
-					tex.texture->update(img);
-				}
-				tex.dirty = false;
-			}
 			if (fd->msdf) {
 				Point2 cpos = p_pos;
 				cpos += fgl.rect.position * (double)p_size / (double)fd->msdf_source_size;

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -176,12 +176,10 @@ class TextServerAdvanced : public TextServerExtension {
 	};
 
 	struct ShelfPackTexture {
-		int32_t texture_w = 1024;
-		int32_t texture_h = 1024;
+		int32_t texture_w = 4096;
+		int32_t texture_h = 4096;
 
-		Ref<Image> image;
 		Ref<ImageTexture> texture;
-		bool dirty = true;
 
 		List<Shelf> shelves;
 
@@ -231,7 +229,6 @@ class TextServerAdvanced : public TextServerExtension {
 		Rect2 rect;
 		Rect2 uv_rect;
 		Vector2 advance;
-		bool fix_edge = false;
 	};
 
 	struct FontAdvanced;
@@ -370,14 +367,14 @@ class TextServerAdvanced : public TextServerExtension {
 		}
 	};
 
-	_FORCE_INLINE_ FontTexturePosition find_texture_pos_for_glyph(FontForSizeAdvanced *p_data, int p_color_size, Image::Format p_image_format, int p_width, int p_height, bool p_msdf) const;
+	_FORCE_INLINE_ FontTexturePosition find_texture_pos_for_glyph(FontForSizeAdvanced *p_data, Image::Format p_image_format, int p_width, int p_height, bool p_mipmaps) const;
 #ifdef MODULE_MSDFGEN_ENABLED
 	_FORCE_INLINE_ FontGlyph rasterize_msdf(FontAdvanced *p_font_data, FontForSizeAdvanced *p_data, int p_pixel_range, int p_rect_margin, FT_Outline *p_outline, const Vector2 &p_advance) const;
 #endif
 #ifdef MODULE_FREETYPE_ENABLED
-	_FORCE_INLINE_ FontGlyph rasterize_bitmap(FontForSizeAdvanced *p_data, int p_rect_margin, FT_Bitmap p_bitmap, int p_yofs, int p_xofs, const Vector2 &p_advance, bool p_bgra) const;
+	_FORCE_INLINE_ FontGlyph rasterize_bitmap(FontAdvanced *p_font_data, FontForSizeAdvanced *p_data, int p_rect_margin, FT_Bitmap p_bitmap, int p_yofs, int p_xofs, const Vector2 &p_advance, bool p_bgra, bool p_fix_edge) const;
 #if HB_VERSION_ATLEAST(13, 0, 0)
-	_FORCE_INLINE_ FontGlyph rasterize_hb_bitmap(FontForSizeAdvanced *p_data, int p_rect_margin, hb_raster_image_t *p_image, const hb_raster_extents_t &p_ext, const Vector2 &p_advance, bool p_bgra) const;
+	_FORCE_INLINE_ FontGlyph rasterize_hb_bitmap(FontAdvanced *p_font_data, FontForSizeAdvanced *p_data, int p_rect_margin, hb_raster_image_t *p_image, const hb_raster_extents_t &p_ext, const Vector2 &p_advance, bool p_bgra) const;
 #endif
 #endif
 	bool _ensure_glyph(FontAdvanced *p_font_data, const Vector2i &p_size, int32_t p_glyph, FontGlyph &r_glyph, uint32_t p_oversampling = 0) const;

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -241,7 +241,7 @@ String TextServerFallback::_tag_to_name(int64_t p_tag) const {
 /* Font Glyph Rendering                                                  */
 /*************************************************************************/
 
-_FORCE_INLINE_ TextServerFallback::FontTexturePosition TextServerFallback::find_texture_pos_for_glyph(FontForSizeFallback *p_data, int p_color_size, Image::Format p_image_format, int p_width, int p_height, bool p_msdf) const {
+_FORCE_INLINE_ TextServerFallback::FontTexturePosition TextServerFallback::find_texture_pos_for_glyph(FontForSizeFallback *p_data, Image::Format p_image_format, int p_width, int p_height, bool p_mipmaps) const {
 	FontTexturePosition ret;
 
 	int mw = p_width;
@@ -249,10 +249,7 @@ _FORCE_INLINE_ TextServerFallback::FontTexturePosition TextServerFallback::find_
 
 	ShelfPackTexture *ct = p_data->textures.ptrw();
 	for (int32_t i = 0; i < p_data->textures.size(); i++) {
-		if (ct[i].image.is_null()) {
-			continue;
-		}
-		if (p_image_format != ct[i].image->get_format()) {
+		if (p_image_format != ct[i].texture->get_format()) {
 			continue;
 		}
 		if (mw > ct[i].texture_w || mh > ct[i].texture_h) { // Too big for this texture.
@@ -267,52 +264,9 @@ _FORCE_INLINE_ TextServerFallback::FontTexturePosition TextServerFallback::find_
 
 	if (ret.index == -1) {
 		// Could not find texture to fit, create one.
-		int texsize = MAX(p_data->size.x * 0.125, 256);
-
-		texsize = Math::next_power_of_2((uint32_t)texsize);
-
-		if (p_msdf) {
-			texsize = MIN(texsize, 2048);
-		} else {
-			texsize = MIN(texsize, 1024);
-		}
-		if (mw > texsize) { // Special case, adapt to it?
-			texsize = Math::next_power_of_2((uint32_t)mw);
-		}
-		if (mh > texsize) { // Special case, adapt to it?
-			texsize = Math::next_power_of_2((uint32_t)mh);
-		}
-
-		ShelfPackTexture tex = ShelfPackTexture(texsize, texsize);
-		tex.image = Image::create_empty(texsize, texsize, false, p_image_format);
-		{
-			// Zero texture.
-			uint8_t *w = tex.image->ptrw();
-			ERR_FAIL_COND_V(texsize * texsize * p_color_size > tex.image->get_data_size(), ret);
-			// Initialize the texture to all-white pixels to prevent artifacts when the
-			// font is displayed at a non-default scale with filtering enabled.
-			if (p_color_size == 2) {
-				for (int i = 0; i < texsize * texsize * p_color_size; i += 2) { // FORMAT_LA8, BW font.
-					w[i + 0] = 255;
-					w[i + 1] = 0;
-				}
-			} else if (p_color_size == 4) {
-				for (int i = 0; i < texsize * texsize * p_color_size; i += 4) { // FORMAT_RGBA8, Color font, Multichannel(+True) SDF.
-					if (p_msdf) {
-						w[i + 0] = 0;
-						w[i + 1] = 0;
-						w[i + 2] = 0;
-					} else {
-						w[i + 0] = 255;
-						w[i + 1] = 255;
-						w[i + 2] = 255;
-					}
-					w[i + 3] = 0;
-				}
-			} else {
-				ERR_FAIL_V(ret);
-			}
-		}
+		ShelfPackTexture tex = ShelfPackTexture(4096, 4096);
+		Ref<Image> img = Image::create_empty(4096, 4096, p_mipmaps, p_image_format);
+		tex.texture = ImageTexture::create_from_image(img);
 		p_data->textures.push_back(tex);
 
 		int32_t idx = p_data->textures.size() - 1;
@@ -352,7 +306,7 @@ struct MSDFThreadData {
 };
 
 static msdfgen::Point2 ft_point2(const FT_Vector &vector) {
-	return msdfgen::Point2(vector.x / 60.0f, vector.y / 60.0f);
+	return msdfgen::Point2(vector.x / 64.0f, vector.y / 64.0f);
 }
 
 static int ft_move_to(const FT_Vector *to, void *user) {
@@ -454,7 +408,7 @@ _FORCE_INLINE_ TextServerFallback::FontGlyph TextServerFallback::rasterize_msdf(
 		ERR_FAIL_COND_V(mw > 4096, FontGlyph());
 		ERR_FAIL_COND_V(mh > 4096, FontGlyph());
 
-		FontTexturePosition tex_pos = find_texture_pos_for_glyph(p_data, 4, Image::FORMAT_RGBA8, mw, mh, true);
+		FontTexturePosition tex_pos = find_texture_pos_for_glyph(p_data, Image::FORMAT_RGBA8, mw, mh, p_font_data->mipmaps);
 		ERR_FAIL_COND_V(tex_pos.index < 0, FontGlyph());
 		ShelfPackTexture &tex = p_data->textures.write[tex_pos.index];
 
@@ -476,13 +430,14 @@ _FORCE_INLINE_ TextServerFallback::FontGlyph TextServerFallback::rasterize_msdf(
 
 		msdfgen::msdfErrorCorrection(image, shape, projection, p_pixel_range, config);
 
+		Ref<Image> img = Image::create_empty(w + p_rect_margin * 2, h + p_rect_margin * 2, p_font_data->mipmaps, Image::FORMAT_RGBA8);
 		{
-			uint8_t *wr = tex.image->ptrw();
+			uint8_t *wr = img->ptrw();
 
 			for (int i = 0; i < h; i++) {
 				for (int j = 0; j < w; j++) {
-					int ofs = ((i + tex_pos.y + p_rect_margin * 2) * tex.texture_w + j + tex_pos.x + p_rect_margin * 2) * 4;
-					ERR_FAIL_COND_V(ofs >= tex.image->get_data_size(), FontGlyph());
+					int ofs = ((i + p_rect_margin * 2) * (w + p_rect_margin * 2) + j + p_rect_margin * 2) * 4;
+					ERR_FAIL_COND_V(ofs >= img->get_data_size(), FontGlyph());
 					wr[ofs + 0] = (uint8_t)(CLAMP(image(j, i)[0] * 256.f, 0.f, 255.f));
 					wr[ofs + 1] = (uint8_t)(CLAMP(image(j, i)[1] * 256.f, 0.f, 255.f));
 					wr[ofs + 2] = (uint8_t)(CLAMP(image(j, i)[2] * 256.f, 0.f, 255.f));
@@ -491,7 +446,7 @@ _FORCE_INLINE_ TextServerFallback::FontGlyph TextServerFallback::rasterize_msdf(
 			}
 		}
 
-		tex.dirty = true;
+		tex.texture->update_partial(img, Vector2i(tex_pos.x, tex_pos.y));
 
 		chr.texture_idx = tex_pos.index;
 
@@ -504,7 +459,7 @@ _FORCE_INLINE_ TextServerFallback::FontGlyph TextServerFallback::rasterize_msdf(
 #endif
 
 #ifdef MODULE_FREETYPE_ENABLED
-_FORCE_INLINE_ TextServerFallback::FontGlyph TextServerFallback::rasterize_bitmap(FontForSizeFallback *p_data, int p_rect_margin, FT_Bitmap p_bitmap, int p_yofs, int p_xofs, const Vector2 &p_advance, bool p_bgra) const {
+_FORCE_INLINE_ TextServerFallback::FontGlyph TextServerFallback::rasterize_bitmap(FontFallback *p_font_data, FontForSizeFallback *p_data, int p_rect_margin, FT_Bitmap p_bitmap, int p_yofs, int p_xofs, const Vector2 &p_advance, bool p_bgra, bool p_fix_edge) const {
 	FontGlyph chr;
 	chr.advance = p_advance * p_data->scale;
 	chr.found = true;
@@ -547,19 +502,20 @@ _FORCE_INLINE_ TextServerFallback::FontGlyph TextServerFallback::rasterize_bitma
 
 	Image::Format require_format = color_size == 4 ? Image::FORMAT_RGBA8 : Image::FORMAT_LA8;
 
-	FontTexturePosition tex_pos = find_texture_pos_for_glyph(p_data, color_size, require_format, mw, mh, false);
+	FontTexturePosition tex_pos = find_texture_pos_for_glyph(p_data, require_format, mw, mh, p_font_data->mipmaps);
 	ERR_FAIL_COND_V(tex_pos.index < 0, FontGlyph());
 
 	// Fit character in char texture.
 	ShelfPackTexture &tex = p_data->textures.write[tex_pos.index];
 
+	Ref<Image> img = Image::create_empty(w + p_rect_margin * 2, h + p_rect_margin * 2, p_font_data->mipmaps, require_format);
 	{
-		uint8_t *wr = tex.image->ptrw();
+		uint8_t *wr = img->ptrw();
 
 		for (int i = 0; i < h; i++) {
 			for (int j = 0; j < w; j++) {
-				int ofs = ((i + tex_pos.y + p_rect_margin * 2) * tex.texture_w + j + tex_pos.x + p_rect_margin * 2) * color_size;
-				ERR_FAIL_COND_V(ofs >= tex.image->get_data_size(), FontGlyph());
+				int ofs = ((i + p_rect_margin * 2) * (w + p_rect_margin * 2) + j + p_rect_margin * 2) * color_size;
+				ERR_FAIL_COND_V(ofs >= img->get_data_size(), FontGlyph());
 				switch (p_bitmap.pixel_mode) {
 					case FT_PIXEL_MODE_MONO: {
 						int byte = i * p_bitmap.pitch + (j >> 3);
@@ -613,8 +569,11 @@ _FORCE_INLINE_ TextServerFallback::FontGlyph TextServerFallback::rasterize_bitma
 			}
 		}
 	}
+	if (p_fix_edge) {
+		img->fix_alpha_edges();
+	}
 
-	tex.dirty = true;
+	tex.texture->update_partial(img, Vector2i(tex_pos.x, tex_pos.y));
 
 	chr.texture_idx = tex_pos.index;
 
@@ -640,7 +599,7 @@ bool TextServerFallback::_ensure_glyph(FontFallback *p_font_data, const Vector2i
 		bool tx_valid = true;
 		if (E->value.texture_idx >= 0) {
 			if (E->value.texture_idx < fd->textures.size()) {
-				tx_valid = fd->textures[E->value.texture_idx].image.is_valid();
+				tx_valid = fd->textures[E->value.texture_idx].texture.is_valid();
 			} else {
 				tx_valid = false;
 			}
@@ -756,7 +715,7 @@ bool TextServerFallback::_ensure_glyph(FontFallback *p_font_data, const Vector2i
 		}
 
 		FT_GlyphSlot slot = p_font_data->face->glyph;
-		bool from_svg = (slot->format == FT_GLYPH_FORMAT_SVG); // Need to check before FT_Render_Glyph as it will change format to bitmap.
+		bool fix_edge = (slot->format == FT_GLYPH_FORMAT_SVG); // Need to check before FT_Render_Glyph as it will change format to bitmap.
 		if (!outline) {
 			if (!p_font_data->msdf) {
 				error = FT_Render_Glyph(slot, aa_mode);
@@ -770,7 +729,7 @@ bool TextServerFallback::_ensure_glyph(FontFallback *p_font_data, const Vector2i
 					ERR_FAIL_V_MSG(false, "Compiled without MSDFGEN support!");
 #endif
 				} else {
-					gl = rasterize_bitmap(fd, rect_range, slot->bitmap, slot->bitmap_top, slot->bitmap_left, Vector2((h + (1 << 9)) >> 10, (v + (1 << 9)) >> 10) / 64.0, bgra);
+					gl = rasterize_bitmap(p_font_data, fd, rect_range, slot->bitmap, slot->bitmap_top, slot->bitmap_left, Vector2((h + (1 << 9)) >> 10, (v + (1 << 9)) >> 10) / 64.0, bgra, fix_edge);
 				}
 			}
 		} else {
@@ -794,14 +753,13 @@ bool TextServerFallback::_ensure_glyph(FontFallback *p_font_data, const Vector2i
 				goto cleanup_glyph;
 			}
 			glyph_bitmap = (FT_BitmapGlyph)glyph;
-			gl = rasterize_bitmap(fd, rect_range, glyph_bitmap->bitmap, glyph_bitmap->top, glyph_bitmap->left, Vector2(), bgra);
+			gl = rasterize_bitmap(p_font_data, fd, rect_range, glyph_bitmap->bitmap, glyph_bitmap->top, glyph_bitmap->left, Vector2(), bgra, fix_edge);
 
 		cleanup_glyph:
 			FT_Done_Glyph(glyph);
 		cleanup_stroker:
 			FT_Stroker_Done(stroker);
 		}
-		gl.from_svg = from_svg;
 		E = fd->glyph_map.insert(p_glyph, gl);
 		r_glyph = E->value;
 		return gl.found;
@@ -1395,7 +1353,6 @@ void TextServerFallback::_font_set_generate_mipmaps(const RID &p_font_rid, bool 
 	if (fd->mipmaps != p_generate_mipmaps) {
 		for (KeyValue<Vector2i, FontForSizeFallback *> &E : fd->cache) {
 			for (int i = 0; i < E.value->textures.size(); i++) {
-				E.value->textures.write[i].dirty = true;
 				E.value->textures.write[i].texture = Ref<ImageTexture>();
 			}
 		}
@@ -1819,7 +1776,7 @@ TypedArray<Dictionary> TextServerFallback::_font_get_size_cache_info(const RID &
 		size_info["textures"] = E.value->textures.size();
 		uint64_t sz = 0;
 		for (const ShelfPackTexture &tx : E.value->textures) {
-			sz += tx.image->get_data_size() * 2;
+			sz += tx.texture->get_image()->get_data_size() * 2;
 		}
 		size_info["textures_size"] = sz;
 		ret.push_back(size_info);
@@ -2097,7 +2054,6 @@ void TextServerFallback::_font_set_texture_image(const RID &p_font_rid, const Ve
 
 	ShelfPackTexture &tex = ffsd->textures.write[p_texture_index];
 
-	tex.image = p_image;
 	tex.texture_w = p_image->get_width();
 	tex.texture_h = p_image->get_height();
 
@@ -2107,7 +2063,6 @@ void TextServerFallback::_font_set_texture_image(const RID &p_font_rid, const Ve
 		img->generate_mipmaps();
 	}
 	tex.texture = ImageTexture::create_from_image(img);
-	tex.dirty = false;
 }
 
 Ref<Image> TextServerFallback::_font_get_texture_image(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index) const {
@@ -2121,7 +2076,7 @@ Ref<Image> TextServerFallback::_font_get_texture_image(const RID &p_font_rid, co
 	ERR_FAIL_INDEX_V(p_texture_index, ffsd->textures.size(), Ref<Image>());
 
 	const ShelfPackTexture &tex = ffsd->textures[p_texture_index];
-	return tex.image;
+	return tex.texture->get_image();
 }
 
 void TextServerFallback::_font_set_texture_offsets(const RID &p_font_rid, const Vector2i &p_size, int64_t p_texture_index, const PackedInt32Array &p_offsets) {
@@ -2486,24 +2441,6 @@ RID TextServerFallback::_font_get_glyph_texture_rid(const RID &p_font_rid, const
 	ERR_FAIL_COND_V(fgl.texture_idx < -1 || fgl.texture_idx >= ffsd->textures.size(), RID());
 
 	if (fgl.texture_idx != -1) {
-		if (ffsd->textures[fgl.texture_idx].dirty) {
-			ShelfPackTexture &tex = ffsd->textures.write[fgl.texture_idx];
-			Ref<Image> img = tex.image;
-			if (fgl.from_svg) {
-				// Same as the "fix alpha border" process option when importing SVGs
-				img->fix_alpha_edges();
-			}
-			if (fd->mipmaps && !img->has_mipmaps()) {
-				img = tex.image->duplicate();
-				img->generate_mipmaps();
-			}
-			if (tex.texture.is_null()) {
-				tex.texture = ImageTexture::create_from_image(img);
-			} else {
-				tex.texture->update(img);
-			}
-			tex.dirty = false;
-		}
 		return ffsd->textures[fgl.texture_idx].texture->get_rid();
 	}
 
@@ -2536,24 +2473,6 @@ Size2 TextServerFallback::_font_get_glyph_texture_size(const RID &p_font_rid, co
 	ERR_FAIL_COND_V(fgl.texture_idx < -1 || fgl.texture_idx >= ffsd->textures.size(), Size2());
 
 	if (fgl.texture_idx != -1) {
-		if (ffsd->textures[fgl.texture_idx].dirty) {
-			ShelfPackTexture &tex = ffsd->textures.write[fgl.texture_idx];
-			Ref<Image> img = tex.image;
-			if (fgl.from_svg) {
-				// Same as the "fix alpha border" process option when importing SVGs
-				img->fix_alpha_edges();
-			}
-			if (fd->mipmaps && !img->has_mipmaps()) {
-				img = tex.image->duplicate();
-				img->generate_mipmaps();
-			}
-			if (tex.texture.is_null()) {
-				tex.texture = ImageTexture::create_from_image(img);
-			} else {
-				tex.texture->update(img);
-			}
-			tex.dirty = false;
-		}
 		return ffsd->textures[fgl.texture_idx].texture->get_size();
 	}
 
@@ -2963,28 +2882,10 @@ void TextServerFallback::_font_draw_glyph(const RID &p_font_rid, const RID &p_ca
 		if (fgl.texture_idx != -1) {
 			Color modulate = p_color;
 #ifdef MODULE_FREETYPE_ENABLED
-			if (!fd->modulate_color_glyphs && fd->face && ffsd->textures[fgl.texture_idx].image.is_valid() && (ffsd->textures[fgl.texture_idx].image->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
+			if (!fd->modulate_color_glyphs && fd->face && ffsd->textures[fgl.texture_idx].texture.is_valid() && (ffsd->textures[fgl.texture_idx].texture->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
 				modulate.r = modulate.g = modulate.b = 1.0;
 			}
 #endif
-			if (ffsd->textures[fgl.texture_idx].dirty) {
-				ShelfPackTexture &tex = ffsd->textures.write[fgl.texture_idx];
-				Ref<Image> img = tex.image;
-				if (fgl.from_svg) {
-					// Same as the "fix alpha border" process option when importing SVGs
-					img->fix_alpha_edges();
-				}
-				if (fd->mipmaps && !img->has_mipmaps()) {
-					img = tex.image->duplicate();
-					img->generate_mipmaps();
-				}
-				if (tex.texture.is_null()) {
-					tex.texture = ImageTexture::create_from_image(img);
-				} else {
-					tex.texture->update(img);
-				}
-				tex.dirty = false;
-			}
 			if (fd->msdf) {
 				Point2 cpos = p_pos;
 				cpos += fgl.rect.position * (double)p_size / (double)fd->msdf_source_size;
@@ -3106,24 +3007,10 @@ void TextServerFallback::_font_draw_glyph_outline(const RID &p_font_rid, const R
 		if (fgl.texture_idx != -1) {
 			Color modulate = p_color;
 #ifdef MODULE_FREETYPE_ENABLED
-			if (fd->face && ffsd->textures[fgl.texture_idx].image.is_valid() && (ffsd->textures[fgl.texture_idx].image->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
+			if (fd->face && ffsd->textures[fgl.texture_idx].texture.is_valid() && (ffsd->textures[fgl.texture_idx].texture->get_format() == Image::FORMAT_RGBA8) && !lcd_aa && !fd->msdf) {
 				modulate.r = modulate.g = modulate.b = 1.0;
 			}
 #endif
-			if (ffsd->textures[fgl.texture_idx].dirty) {
-				ShelfPackTexture &tex = ffsd->textures.write[fgl.texture_idx];
-				Ref<Image> img = tex.image;
-				if (fd->mipmaps && !img->has_mipmaps()) {
-					img = tex.image->duplicate();
-					img->generate_mipmaps();
-				}
-				if (tex.texture.is_null()) {
-					tex.texture = ImageTexture::create_from_image(img);
-				} else {
-					tex.texture->update(img);
-				}
-				tex.dirty = false;
-			}
 			if (fd->msdf) {
 				Point2 cpos = p_pos;
 				cpos += fgl.rect.position * (double)p_size / (double)fd->msdf_source_size;

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -117,12 +117,10 @@ class TextServerFallback : public TextServerExtension {
 	};
 
 	struct ShelfPackTexture {
-		int32_t texture_w = 1024;
-		int32_t texture_h = 1024;
+		int32_t texture_w = 4096;
+		int32_t texture_h = 4096;
 
-		Ref<Image> image;
 		Ref<ImageTexture> texture;
-		bool dirty = true;
 
 		List<Shelf> shelves;
 
@@ -172,7 +170,6 @@ class TextServerFallback : public TextServerExtension {
 		Rect2 rect;
 		Rect2 uv_rect;
 		Vector2 advance;
-		bool from_svg = false;
 	};
 
 	struct FontFallback;
@@ -281,12 +278,12 @@ class TextServerFallback : public TextServerExtension {
 		}
 	};
 
-	_FORCE_INLINE_ FontTexturePosition find_texture_pos_for_glyph(FontForSizeFallback *p_data, int p_color_size, Image::Format p_image_format, int p_width, int p_height, bool p_msdf) const;
+	_FORCE_INLINE_ FontTexturePosition find_texture_pos_for_glyph(FontForSizeFallback *p_data, Image::Format p_image_format, int p_width, int p_height, bool p_mipmaps) const;
 #ifdef MODULE_MSDFGEN_ENABLED
 	_FORCE_INLINE_ FontGlyph rasterize_msdf(FontFallback *p_font_data, FontForSizeFallback *p_data, int p_pixel_range, int p_rect_margin, FT_Outline *p_outline, const Vector2 &p_advance) const;
 #endif
 #ifdef MODULE_FREETYPE_ENABLED
-	_FORCE_INLINE_ FontGlyph rasterize_bitmap(FontForSizeFallback *p_data, int p_rect_margin, FT_Bitmap p_bitmap, int p_yofs, int p_xofs, const Vector2 &p_advance, bool p_bgra) const;
+	_FORCE_INLINE_ FontGlyph rasterize_bitmap(FontFallback *p_font_data, FontForSizeFallback *p_data, int p_rect_margin, FT_Bitmap p_bitmap, int p_yofs, int p_xofs, const Vector2 &p_advance, bool p_bgra, bool p_fix_edge) const;
 #endif
 	bool _ensure_glyph(FontFallback *p_font_data, const Vector2i &p_size, int32_t p_glyph, FontGlyph &r_glyph, uint32_t p_oversampling = 0) const;
 	bool _ensure_cache_for_size(FontFallback *p_font_data, const Vector2i &p_size, FontForSizeFallback *&r_cache_for_size, bool p_silent = false, uint32_t p_oversampling = 0) const;

--- a/scene/resources/image_texture.cpp
+++ b/scene/resources/image_texture.cpp
@@ -113,6 +113,25 @@ void ImageTexture::update(const Ref<Image> &p_image) {
 	image_stored = true;
 }
 
+void ImageTexture::update_partial(const Ref<Image> &p_image, const Vector2i &p_offset) {
+	ERR_FAIL_COND_MSG(p_image.is_null(), "Invalid image");
+	ERR_FAIL_COND_MSG(texture.is_null(), "Texture is not initialized.");
+	ERR_FAIL_COND_MSG(p_image->get_width() + p_offset.x > w || p_image->get_height() + p_offset.y > h,
+			"The new image dimensions must match or be smaller than the texture size.");
+	ERR_FAIL_COND_MSG(p_image->get_format() != format,
+			"The new image format must match the texture's image format.");
+	ERR_FAIL_COND_MSG(mipmaps != p_image->has_mipmaps(),
+			"The new image mipmaps configuration must match the texture's image mipmaps configuration");
+
+	RS::get_singleton()->texture_2d_update_partial(texture, p_offset, p_image);
+
+	notify_property_list_changed();
+	emit_changed();
+
+	alpha_cache.unref();
+	image_stored = true;
+}
+
 Ref<Image> ImageTexture::get_image() const {
 	if (image_stored) {
 		return RenderingServer::get_singleton()->texture_2d_get(texture);

--- a/scene/resources/image_texture.h
+++ b/scene/resources/image_texture.h
@@ -58,6 +58,7 @@ public:
 	virtual Image::Format get_format() const override;
 
 	void update(const Ref<Image> &p_image);
+	void update_partial(const Ref<Image> &p_image, const Vector2i &p_offset);
 	Ref<Image> get_image() const override;
 
 	int get_width() const override;

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -95,6 +95,7 @@ public:
 
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) override {}
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) override {}
+	virtual void texture_2d_update_partial(RID p_texture, const Vector2i &p_offset, const Ref<Image> &p_image, int p_layer = 0) override {}
 	virtual void texture_external_update(RID p_texture, int p_width, int p_height, uint64_t p_external_buffer) override {}
 	virtual void texture_proxy_update(RID p_proxy, RID p_base) override {}
 

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -1641,6 +1641,27 @@ void TextureStorage::_texture_2d_update(RID p_texture, const Ref<Image> &p_image
 	RD::get_singleton()->texture_update(tex->rd_texture, p_layer, validated->get_data());
 }
 
+void TextureStorage::_texture_2d_update_partial(RID p_texture, const Vector2i &p_offset, const Ref<Image> &p_image, int p_layer, bool p_immediate) {
+	ERR_FAIL_COND(p_image.is_null() || p_image->is_empty());
+
+	Texture *tex = texture_owner.get_or_null(p_texture);
+	ERR_FAIL_NULL(tex);
+	ERR_FAIL_COND(tex->is_render_target);
+	ERR_FAIL_COND(p_image->get_format() != tex->format);
+
+	if (tex->type == TextureStorage::TYPE_LAYERED) {
+		ERR_FAIL_INDEX(p_layer, tex->layers);
+	}
+
+#ifdef TOOLS_ENABLED
+	tex->image_cache_2d.unref();
+#endif
+	TextureToRDFormat f;
+	Ref<Image> validated = _validate_texture_format(p_image, f);
+
+	RD::get_singleton()->texture_update_partial(tex->rd_texture, p_layer, p_offset, validated->get_size(), validated->get_data());
+}
+
 void TextureStorage::texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer) {
 	_texture_2d_update(p_texture, p_image, p_layer, false);
 }
@@ -1681,6 +1702,10 @@ void TextureStorage::texture_3d_update(RID p_texture, const Vector<Ref<Image>> &
 	}
 
 	RD::get_singleton()->texture_update(tex->rd_texture, 0, all_data);
+}
+
+void TextureStorage::texture_2d_update_partial(RID p_texture, const Vector2i &p_offset, const Ref<Image> &p_image, int p_layer) {
+	_texture_2d_update_partial(p_texture, p_offset, p_image, p_layer);
 }
 
 void TextureStorage::texture_external_update(RID p_texture, int p_width, int p_height, uint64_t p_external_buffer) {

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -230,6 +230,7 @@ private:
 
 	Ref<Image> _validate_texture_format(const Ref<Image> &p_image, TextureToRDFormat &r_format);
 	void _texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0, bool p_immediate = false);
+	void _texture_2d_update_partial(RID p_texture, const Vector2i &p_offset, const Ref<Image> &p_image, int p_layer = 0, bool p_immediate = false);
 
 	struct TextureFromRDFormat {
 		Image::Format image_format;
@@ -601,6 +602,7 @@ public:
 
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) override;
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) override;
+	virtual void texture_2d_update_partial(RID p_texture, const Vector2i &p_offset, const Ref<Image> &p_image, int p_layer = 0) override;
 	virtual void texture_external_update(RID p_texture, int p_width, int p_height, uint64_t p_external_buffer) override;
 	virtual void texture_proxy_update(RID p_proxy, RID p_base) override;
 

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -2450,6 +2450,144 @@ Error RenderingDevice::texture_update(RID p_texture, uint32_t p_layer, const Vec
 	return OK;
 }
 
+Error RenderingDevice::texture_update_partial(RID p_texture, uint32_t p_layer, const Vector2i &p_offset, const Vector2i &p_size, const Vector<uint8_t> &p_data) {
+	ERR_RENDER_THREAD_GUARD_V(ERR_UNAVAILABLE);
+
+	ERR_FAIL_COND_V_MSG(draw_list.active, ERR_INVALID_PARAMETER, "Updating textures is forbidden during creation of a draw list.");
+	ERR_FAIL_COND_V_MSG(compute_list.active, ERR_INVALID_PARAMETER, "Updating textures is forbidden during creation of a compute list.");
+	ERR_FAIL_COND_V_MSG(raytracing_list.active, ERR_INVALID_PARAMETER, "Updating textures is forbidden during creation of a raytracing list.");
+
+	Texture *texture = texture_owner.get_or_null(p_texture);
+	ERR_FAIL_NULL_V(texture, ERR_INVALID_PARAMETER);
+
+	if (texture->owner != RID()) {
+		p_texture = texture->owner;
+		texture = texture_owner.get_or_null(texture->owner);
+		ERR_FAIL_NULL_V(texture, ERR_BUG); // This is a bug.
+	}
+
+	ERR_FAIL_COND_V_MSG(texture->bound, ERR_CANT_ACQUIRE_RESOURCE,
+			"Texture can't be updated while a draw list that uses it as part of a framebuffer is being created. Ensure the draw list is finalized (and that the color/depth texture using it is not set to `RenderingDevice.FINAL_ACTION_CONTINUE`) to update this texture.");
+
+	ERR_FAIL_COND_V_MSG(!(texture->usage_flags & TEXTURE_USAGE_CAN_UPDATE_BIT), ERR_INVALID_PARAMETER, "Texture requires the `RenderingDevice.TEXTURE_USAGE_CAN_UPDATE_BIT` to be set to be updatable.");
+
+	uint32_t layer_count = _texture_layer_count(texture);
+	ERR_FAIL_COND_V(p_layer >= layer_count, ERR_INVALID_PARAMETER);
+
+	uint32_t width, height;
+	uint32_t tight_mip_size = get_image_format_required_size(texture->format, p_size.x, p_size.y, texture->depth, texture->mipmaps, &width, &height);
+	uint32_t required_size = tight_mip_size;
+	uint32_t required_align = _texture_alignment(texture);
+
+	ERR_FAIL_COND_V_MSG(required_size != (uint32_t)p_data.size(), ERR_INVALID_PARAMETER,
+			"Required size for texture update (" + itos(required_size) + ") does not match data supplied size (" + itos(p_data.size()) + ").");
+
+	// Clear the texture if the driver requires it during its first use.
+	_texture_check_pending_clear(p_texture, texture);
+
+	_check_transfer_worker_texture(texture);
+
+	uint32_t block_w, block_h;
+	get_compressed_image_format_block_dimensions(texture->format, block_w, block_h);
+
+	uint32_t pixel_size = get_image_format_pixel_size(texture->format);
+	uint32_t block_size = get_compressed_image_format_block_byte_size(texture->format);
+
+	uint32_t region_size = texture_upload_region_size_px;
+
+	const uint8_t *read_ptr = p_data.ptr();
+
+	thread_local LocalVector<RDG::RecordedBufferToTextureCopy> command_buffer_to_texture_copies_vector;
+	command_buffer_to_texture_copies_vector.clear();
+
+	// Indicate the texture will get modified for the shared texture fallback.
+	_texture_update_shared_fallback(p_texture, texture, true);
+
+	uint32_t mipmap_offset = 0;
+
+	uint32_t logic_width = p_size.x;
+	uint32_t logic_height = p_size.y;
+
+	for (uint32_t mm_i = 0; mm_i < texture->mipmaps; mm_i++) {
+		uint32_t depth = 0;
+		uint32_t image_total = get_image_format_required_size(texture->format, p_size.x, p_size.y, texture->depth, mm_i + 1, &width, &height, &depth);
+
+		const uint8_t *read_ptr_mipmap = read_ptr + mipmap_offset;
+		tight_mip_size = image_total - mipmap_offset;
+
+		for (uint32_t z = 0; z < depth; z++) {
+			const uint8_t *read_ptr_mipmap_layer = read_ptr_mipmap + (tight_mip_size / depth) * z;
+			for (uint32_t y = 0; y < height; y += region_size) {
+				for (uint32_t x = 0; x < width; x += region_size) {
+					uint32_t region_w = MIN(region_size, width - x);
+					uint32_t region_h = MIN(region_size, height - y);
+
+					uint32_t region_logic_w = MIN(region_size, logic_width - x);
+					uint32_t region_logic_h = MIN(region_size, logic_height - y);
+
+					uint32_t region_pitch = get_compressed_image_format_pixels_shifted(texture->format, region_w * pixel_size * block_w);
+					uint32_t pitch_step = driver->api_trait_get(RDD::API_TRAIT_TEXTURE_DATA_ROW_PITCH_STEP);
+					region_pitch = STEPIFY(region_pitch, pitch_step);
+					uint32_t to_allocate = region_pitch * region_h;
+					uint32_t alloc_offset = 0, alloc_size = 0;
+					StagingRequiredAction required_action;
+					Error err = _staging_buffer_allocate(upload_staging_buffers, to_allocate, required_align, alloc_offset, alloc_size, required_action, false);
+					ERR_FAIL_COND_V(err, ERR_CANT_CREATE);
+
+					if (!command_buffer_to_texture_copies_vector.is_empty() && required_action == STAGING_REQUIRED_ACTION_FLUSH_AND_STALL_ALL) {
+						if (_texture_make_mutable(texture, p_texture)) {
+							// The texture must be mutable to be used as a copy destination.
+							draw_graph.add_synchronization();
+						}
+
+						// If the staging buffer requires flushing everything, we submit the command early and clear the current vector.
+						draw_graph.add_texture_update(texture->driver_id, texture->draw_tracker, command_buffer_to_texture_copies_vector);
+						command_buffer_to_texture_copies_vector.clear();
+					}
+
+					_staging_buffer_execute_required_action(upload_staging_buffers, required_action);
+
+					uint8_t *write_ptr = upload_staging_buffers.blocks[upload_staging_buffers.current].data_ptr + alloc_offset;
+
+					ERR_FAIL_COND_V(region_w % block_w, ERR_BUG);
+					ERR_FAIL_COND_V(region_h % block_h, ERR_BUG);
+
+					_copy_region_block_or_regular(read_ptr_mipmap_layer, write_ptr, x, y, width, region_w, region_h, block_w, block_h, region_pitch, pixel_size, block_size);
+
+					RDD::BufferTextureCopyRegion copy_region;
+					copy_region.buffer_offset = alloc_offset;
+					copy_region.row_pitch = region_pitch;
+					copy_region.texture_subresource.aspect = texture->read_aspect_flags.has_flag(RDD::TEXTURE_ASPECT_DEPTH_BIT) ? RDD::TEXTURE_ASPECT_DEPTH : RDD::TEXTURE_ASPECT_COLOR;
+					copy_region.texture_subresource.mipmap = mm_i;
+					copy_region.texture_subresource.layer = p_layer;
+					copy_region.texture_offset = Vector3i(x + p_offset.x, y + p_offset.y, z);
+					copy_region.texture_region_size = Vector3i(region_logic_w, region_logic_h, 1);
+
+					RDG::RecordedBufferToTextureCopy buffer_to_texture_copy;
+					buffer_to_texture_copy.from_buffer = upload_staging_buffers.blocks[upload_staging_buffers.current].driver_id;
+					buffer_to_texture_copy.region = copy_region;
+					command_buffer_to_texture_copies_vector.push_back(buffer_to_texture_copy);
+
+					upload_staging_buffers.blocks.write[upload_staging_buffers.current].fill_amount = alloc_offset + alloc_size;
+				}
+			}
+		}
+
+		mipmap_offset = image_total;
+		logic_width = MAX(1u, logic_width >> 1);
+		logic_height = MAX(1u, logic_height >> 1);
+	}
+
+	if (_texture_make_mutable(texture, p_texture)) {
+		// The texture must be mutable to be used as a copy destination.
+		draw_graph.add_synchronization();
+	}
+
+	draw_graph.add_texture_update(texture->driver_id, texture->draw_tracker, command_buffer_to_texture_copies_vector);
+
+	return OK;
+}
+
 void RenderingDevice::_texture_check_shared_fallback(Texture *p_texture) {
 	if (p_texture->shared_fallback == nullptr) {
 		p_texture->shared_fallback = memnew(Texture::SharedFallback);
@@ -9316,6 +9454,7 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("texture_create_from_extension", "type", "format", "samples", "usage_flags", "image", "width", "height", "depth", "layers", "mipmaps"), &RenderingDevice::texture_create_from_extension, DEFVAL(1));
 
 	ClassDB::bind_method(D_METHOD("texture_update", "texture", "layer", "data"), &RenderingDevice::texture_update);
+	ClassDB::bind_method(D_METHOD("texture_update_partial", "texture", "layer", "offset", "size", "data"), &RenderingDevice::texture_update_partial);
 	ClassDB::bind_method(D_METHOD("texture_get_data", "texture", "layer"), &RenderingDevice::texture_get_data);
 	ClassDB::bind_method(D_METHOD("texture_get_data_async", "texture", "layer", "callback"), &RenderingDevice::texture_get_data_async);
 

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -471,6 +471,7 @@ public:
 	RID texture_create_from_extension(TextureType p_type, DataFormat p_format, TextureSamples p_samples, BitField<RenderingDevice::TextureUsageBits> p_usage, uint64_t p_image, uint64_t p_width, uint64_t p_height, uint64_t p_depth, uint64_t p_layers, uint64_t p_mipmaps = 1);
 	RID texture_create_shared_from_slice(const TextureView &p_view, RID p_with_texture, uint32_t p_layer, uint32_t p_mipmap, uint32_t p_mipmaps = 1, TextureSliceType p_slice_type = TEXTURE_SLICE_2D, uint32_t p_layers = 0);
 	Error texture_update(RID p_texture, uint32_t p_layer, const Vector<uint8_t> &p_data);
+	Error texture_update_partial(RID p_texture, uint32_t p_layer, const Vector2i &p_offset, const Vector2i &p_size, const Vector<uint8_t> &p_data);
 	Vector<uint8_t> texture_get_data(RID p_texture, uint32_t p_layer); // CPU textures will return immediately, while GPU textures will most likely force a flush
 	Error texture_get_data_async(RID p_texture, uint32_t p_layer, const Callable &p_callback);
 

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -2272,6 +2272,7 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("texture_2d_update", "texture", "image", "layer"), &RenderingServer::texture_2d_update);
 	ClassDB::bind_method(D_METHOD("texture_3d_update", "texture", "data"), &RenderingServer::_texture_3d_update);
+	ClassDB::bind_method(D_METHOD("texture_2d_update_partial", "texture", "offset", "image", "layer"), &RenderingServer::texture_2d_update_partial);
 	ClassDB::bind_method(D_METHOD("texture_proxy_update", "texture", "proxy_to"), &RenderingServer::texture_proxy_update);
 
 	ClassDB::bind_method(D_METHOD("texture_drawable_blit_rect", "textures", "rect", "material", "modulate", "source_textures", "to_mipmap"), &RenderingServer::texture_drawable_blit_rect, DEFVAL(0));

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -118,6 +118,7 @@ public:
 
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) = 0;
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) = 0;
+	virtual void texture_2d_update_partial(RID p_texture, const Vector2i &p_offset, const Ref<Image> &p_image, int p_layer = 0) = 0;
 	virtual void texture_external_update(RID p_texture, int p_width, int p_height, uint64_t p_external_buffer = 0) = 0;
 	virtual void texture_proxy_update(RID p_texture, RID p_proxy_to) = 0;
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -226,6 +226,7 @@ public:
 	//these go through command queue if they are in another thread
 	FUNC3(texture_2d_update, RID, const Ref<Image> &, int)
 	FUNC2(texture_3d_update, RID, const Vector<Ref<Image>> &)
+	FUNC4(texture_2d_update_partial, RID, const Vector2i &, const Ref<Image> &, int)
 	FUNC4(texture_external_update, RID, int, int, uint64_t)
 	FUNC2(texture_proxy_update, RID, RID)
 

--- a/servers/rendering/storage/texture_storage.h
+++ b/servers/rendering/storage/texture_storage.h
@@ -76,6 +76,7 @@ public:
 
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) = 0;
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) = 0;
+	virtual void texture_2d_update_partial(RID p_texture, const Vector2i &p_offset, const Ref<Image> &p_image, int p_layer = 0) = 0;
 	virtual void texture_external_update(RID p_proxy, int p_width, int p_height, uint64_t p_external_buffer) = 0;
 	virtual void texture_proxy_update(RID p_proxy, RID p_base) = 0;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Should fix some font updating bottlenecks and allow using larger atlas texture size to improve batching.