### PR TITLE
[3.x] Fix crash and incorrect behavior when using `CanvasItem` / `CanvasItemMaterial` casts

### DIFF
--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -48,8 +48,6 @@ class CanvasItemMaterial : public Material {
 	GDCLASS(CanvasItemMaterial, Material);
 
 public:
-	static constexpr AncestralClass static_ancestral_class = AncestralClass::CANVAS_ITEM;
-
 	enum BlendMode {
 		BLEND_MODE_MIX,
 		BLEND_MODE_ADD,
@@ -167,6 +165,8 @@ class CanvasItem : public Node {
 	friend class CanvasLayer;
 
 public:
+	static constexpr AncestralClass static_ancestral_class = AncestralClass::CANVAS_ITEM;
+
 	enum BlendMode {
 
 		BLEND_MODE_MIX, //default


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Should fix https://github.com/godotengine/godot/issues/122923

## Additional information

Untested, but trivially correct.
