### PR TITLE
[String/SpinBox] Allow custom format strings to localize numbers.

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -5209,6 +5209,8 @@ String String::sprintf(const Span<Variant> &p_values, bool *r_error) const {
 	int min_chars = 0;
 	int min_decimals = 0;
 	bool in_decimals = false;
+	bool localize = false;
+	String locale;
 	bool pad_with_zeros = false;
 	bool left_justified = false;
 	bool show_sign = false;
@@ -5225,6 +5227,28 @@ String String::sprintf(const Span<Variant> &p_values, bool *r_error) const {
 			switch (c) {
 				case '%': { // Replace %% with %
 					formatted += c;
+					in_format = false;
+					break;
+				}
+				case 'l': {
+					uint64_t index = (selected_index >= 0 ? selected_index : value_index);
+					if (index >= p_values.size()) {
+						return "not enough arguments for format string";
+					}
+
+					if (!p_values[index].is_string()) {
+						return "a string is required";
+					}
+
+					locale = p_values[index];
+					if (TranslationServer::get_singleton()) {
+						localize = true;
+					}
+
+					if (selected_index == -1) {
+						++value_index;
+					}
+					used_args[index] = true;
 					in_format = false;
 					break;
 				}
@@ -5296,12 +5320,17 @@ String String::sprintf(const Span<Variant> &p_values, bool *r_error) const {
 						}
 					}
 
+					if (localize && !locale.is_empty()) {
+						str = TranslationServer::get_singleton()->format_number(str, locale);
+					}
+
 					formatted += str;
 					if (selected_index == -1) {
 						++value_index;
 					}
 					used_args[index] = true;
 					in_format = false;
+					localize = false;
 
 					break;
 				}
@@ -5346,12 +5375,17 @@ String String::sprintf(const Span<Variant> &p_values, bool *r_error) const {
 						}
 					}
 
+					if (localize && !locale.is_empty()) {
+						str = TranslationServer::get_singleton()->format_number(str, locale);
+					}
+
 					formatted += str;
 					if (selected_index == -1) {
 						++value_index;
 					}
 					used_args[index] = true;
 					in_format = false;
+					localize = false;
 					break;
 				}
 				case 'v': { // Vector2/3/4/2i/3i/4i
@@ -5420,12 +5454,17 @@ String String::sprintf(const Span<Variant> &p_values, bool *r_error) const {
 					}
 					str += ")";
 
+					if (localize && !locale.is_empty()) {
+						str = TranslationServer::get_singleton()->format_number(str, locale);
+					}
+
 					formatted += str;
 					if (selected_index == -1) {
 						++value_index;
 					}
 					used_args[index] = true;
 					in_format = false;
+					localize = false;
 					break;
 				}
 				case 's': { // String
@@ -5448,6 +5487,7 @@ String String::sprintf(const Span<Variant> &p_values, bool *r_error) const {
 					}
 					used_args[index] = true;
 					in_format = false;
+					localize = false;
 					break;
 				}
 				case 'c': {
@@ -5490,6 +5530,7 @@ String String::sprintf(const Span<Variant> &p_values, bool *r_error) const {
 					}
 					used_args[index] = true;
 					in_format = false;
+					localize = false;
 					break;
 				}
 				case '-': { // Left justify

--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -269,7 +269,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 										placeholder_end = from + 1;
 									} else {
 										const String allowed_chars = "+.-*0123456789";
-										const String placeholder_types = "cdfosvxX";
+										const String placeholder_types = "lcdfosvxX";
 										for (int i = 0; i < line_length - from; i++) {
 											if (allowed_chars.contains_char(str[from + i]) &&
 													!placeholder_types.contains_char(str[from + i]) &&

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -100,7 +100,13 @@ void SpinBox::_update_text(bool p_only_update_if_value_changed) {
 	if (!line_edit->is_editing() && !format.is_empty() && !use_default_format) {
 		const Variant current_value = get_value();
 		bool error = false;
-		const String text = format.sprintf(Span(&current_value, 1), &error);
+		Array values;
+		if (is_localizing_numeral_system() && format.contains("%l")) {
+			values = { _get_locale(), current_value };
+		} else {
+			values = { current_value };
+		}
+		const String text = format.sprintf(values, &error);
 		if (error) {
 			line_edit->set_text_with_selection(RTR("<Invalid>"));
 			return;


### PR DESCRIPTION
## What problem(s) does this PR solve?

Follow up to https://github.com/godotengine/godot/pull/103998

Allows custom format to localize numbers (which is already supported in case of default `%s` format, and was supported before).

<img width="153" height="129" alt="Screenshot 2026-09-02 at 12 20 29" src="https://github.com/user-attachments/assets/5eea77c3-5093-4e6d-ba1f-97378d2b1c28" />

## Additional information

I do not like adding something to `String`, but the other option would be to duplicate format string parsing in the `SpinBox`, and it might be useful for other formatted string cases.

Currently implemented as a separate `%l` value, which changes locale for next value to avoid changing existing formats, but I'm not sure if this is the best way.