### PR TITLE
Fix awaited coroutines during embedded game suspension

### DIFF
--- a/scene/debugger/runtime_node_select.cpp
+++ b/scene/debugger/runtime_node_select.cpp
@@ -270,7 +270,7 @@ void RuntimeNodeSelect::_setup(const Dictionary &p_settings) {
 	sbox_mesh_xray = st_xray->commit();
 #endif // _3D_DISABLED
 
-	SceneTree::get_singleton()->connect("process_frame", callable_mp(this, &RuntimeNodeSelect::_process_frame));
+	SceneTree::get_singleton()->connect("_internal_process_frame", callable_mp(this, &RuntimeNodeSelect::_process_frame));
 	SceneTree::get_singleton()->connect("physics_frame", callable_mp(this, &RuntimeNodeSelect::_physics_frame));
 
 	// This function will be called before the root enters the tree at first when the Game view is passing its settings to

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -710,7 +710,10 @@ bool SceneTree::process(double p_time) {
 		}
 	}
 
-	emit_signal(SNAME("process_frame"));
+	emit_signal(SNAME("_internal_process_frame"));
+	if (!suspended) {
+		emit_signal(SNAME("process_frame"));
+	}
 
 	MessageQueue::get_singleton()->flush(); //small little hack
 
@@ -1989,6 +1992,9 @@ void SceneTree::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("process_frame"));
 	ADD_SIGNAL(MethodInfo("physics_frame"));
+	// Internal signal used by debugger-side features such as RuntimeNodeSelect. Emitted every frame, including while the scene tree is suspended,
+	// so the editor can continue updating debugger UI. This is not intended for user code and is subject to change without notice.
+	ADD_SIGNAL(MethodInfo("_internal_process_frame"));
 
 	BIND_ENUM_CONSTANT(GROUP_CALL_DEFAULT);
 	BIND_ENUM_CONSTANT(GROUP_CALL_REVERSE);

--- a/tests/scene/test_scene_tree.cpp
+++ b/tests/scene/test_scene_tree.cpp
@@ -1,0 +1,54 @@
+/**************************************************************************/
+/*  test_scene_tree.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "scene/main/scene_tree.h"
+#include "tests/signal_watcher.h"
+#include "tests/test_macros.h"
+
+TEST_FORCE_LINK(test_scene_tree)
+
+namespace TestSceneTree {
+
+TEST_CASE("[SceneTree] Suspended process_frame signal") {
+	SceneTree *tree = SceneTree::get_singleton();
+	REQUIRE(tree != nullptr);
+
+	SIGNAL_WATCH(tree, SNAME("process_frame"));
+	tree->set_suspend(true);
+	tree->process(0.1);
+	SIGNAL_CHECK_FALSE(SNAME("process_frame"));
+
+	tree->set_suspend(false);
+	tree->process(0.1);
+	SIGNAL_CHECK(SNAME("process_frame"), Array({ {} }));
+	SIGNAL_UNWATCH(tree, SNAME("process_frame"));
+}
+
+} // namespace TestSceneTree


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.
Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors
Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

* Closes #116443

When an embedded game is suspended, `SceneTree` continues processing so the editor and debugger stay responsive. However, `process_frame` was still being emitted, so GDScript code waiting on `get_tree().process_frame` could continue running while the game was suspended.
This PR stops emitting `process_frame` while the `SceneTree` is suspended.
`RuntimeNodeSelect` still needs to receive idle updates while suspended, so it now uses a separate internal process-frame signal.
Physics frame, timers, and tweens are left unchanged.

## Additional information

Added a test to check that `process_frame` is not emitted while suspended and starts emitting again after resuming.

## Before:

https://github.com/user-attachments/assets/4f35a270-2c04-4a0d-b6b8-87a6ee77b933

## After:

https://github.com/user-attachments/assets/7cdc9d5f-5c30-4e23-8116-5a8cbe8b76cb

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
