### PR TITLE
Hide textures menu button when texture streaming is disabled.

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -2336,7 +2336,8 @@ void Node3DEditor::_textures_button_pressed() {
 
 void Node3DEditor::_textures_button_update_state() {
 	const bool texture_streaming_enabled = GLOBAL_GET("rendering/textures/streaming/enabled");
-	textures_button->set_disabled(!texture_streaming_enabled);
+	textures_button->set_visible(texture_streaming_enabled);
+	textures_separator->set_visible(texture_streaming_enabled);
 
 	if (!texture_streaming_enabled) {
 		textures_popup->hide();
@@ -3707,7 +3708,9 @@ Node3DEditor::Node3DEditor() {
 	textures_button->connect(SceneStringName(pressed), callable_mp(this, &Node3DEditor::_textures_button_pressed));
 
 	main_flow->add_child(textures_button);
-	main_flow->add_child(memnew(VSeparator));
+
+	textures_separator = memnew(VSeparator);
+	main_flow->add_child(textures_separator);
 #endif
 
 	context_toolbar_panel = memnew(PanelContainer);

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -224,10 +224,6 @@ private:
 	PopupMenu *gizmos_menu = nullptr;
 	MenuButton *view_layout_menu = nullptr;
 
-#ifdef MODULE_TEXTURE_STREAMING_ENABLED
-	MenuButton *textures_layout_menu = nullptr;
-#endif
-
 	AcceptDialog *accept = nullptr;
 
 	ConfirmationDialog *snap_dialog = nullptr;
@@ -360,6 +356,7 @@ private:
 
 #ifdef MODULE_TEXTURE_STREAMING_ENABLED
 	Button *textures_button = nullptr;
+	VSeparator *textures_separator = nullptr;
 	PopupPanel *textures_popup = nullptr;
 	Button *textures_very_low = nullptr;
 	Button *textures_low = nullptr;


### PR DESCRIPTION
This PR hides the "Textures" button for adjusting texture quality in the editor when texture streaming is disabled.  This was request on the PR shortly after it was merged.   

The changes do not connect to the project settings change single since changing the setting already prompts to restart in order to force shader changes.  Connecting to the signal made it hide when it was really still active which seemed worse.

Setting Disabled:
<img width="745" height="152" alt="Screenshot From 2026-09-02 07-50-39" src="https://github.com/user-attachments/assets/fd58794b-3ba9-4dc5-91e5-802ee7d6fe6c" />

Setting Enabled:
<img width="745" height="152" alt="Screenshot From 2026-09-02 07-51-30" src="https://github.com/user-attachments/assets/9ae0f437-ecc2-4f6e-a173-4d71b8b02333" />
