### PR TITLE
[macOS] Add architecture specific `.plist`s to editor template.

### DIFF
--- a/misc/dist/macos_tools.app/Contents/Info_arm64.plist
+++ b/misc/dist/macos_tools.app/Contents/Info_arm64.plist
@@ -42,20 +42,8 @@
 	<string>NSApplication</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
-	<key>LSArchitecturePriority</key>
-	<array>
-		<string>arm64</string>
-		<string>x86_64</string>
-	</array>
 	<key>LSMinimumSystemVersion</key>
-	<string>11.0</string>
-	<key>LSMinimumSystemVersionByArchitecture</key>
-	<dict>
-		<key>arm64</key>
-		<string>13.0</string>
-		<key>x86_64</key>
-		<string>11.0</string>
-	</dict>
+	<string>13.0</string>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>CFBundleDocumentTypes</key>

--- a/misc/dist/macos_tools.app/Contents/Info_x86_64.plist
+++ b/misc/dist/macos_tools.app/Contents/Info_x86_64.plist
@@ -42,20 +42,8 @@
 	<string>NSApplication</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.developer-tools</string>
-	<key>LSArchitecturePriority</key>
-	<array>
-		<string>arm64</string>
-		<string>x86_64</string>
-	</array>
 	<key>LSMinimumSystemVersion</key>
 	<string>11.0</string>
-	<key>LSMinimumSystemVersionByArchitecture</key>
-	<dict>
-		<key>arm64</key>
-		<string>13.0</string>
-		<key>x86_64</key>
-		<string>11.0</string>
-	</dict>
 	<key>NSHighResolutionCapable</key>
 	<true/>
 	<key>CFBundleDocumentTypes</key>


### PR DESCRIPTION
## What problem(s) does this PR solve?

Adds template files for single architecture editor build.