### PR TITLE
Add buttons to bake all lightmaps or geometry-dependent nodes in the currently open scene

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -157,6 +157,7 @@
 #include "main/main.h"
 #include "scene/2d/node_2d.h"
 #include "scene/3d/bone_attachment_3d.h"
+#include "scene/3d/lightmap_gi.h"
 #include "scene/animation/animation_tree.h"
 #include "scene/gui/color_picker.h"
 #include "scene/gui/control.h"
@@ -7970,6 +7971,139 @@ void EditorNode::_feature_profile_changed() {
 	editor_dock_manager->update_docks_menu();
 }
 
+EditorProgress *EditorNode::lightmap_gi_progress = nullptr;
+
+bool EditorNode::lightmap_gi_bake_func_step(float p_progress, const String &p_description, void *, bool p_refresh) {
+	if (!lightmap_gi_progress) {
+		lightmap_gi_progress = memnew(EditorProgress("bake_lightmaps", TTR("Bake Lightmaps"), 1000, true));
+		ERR_FAIL_NULL_V(lightmap_gi_progress, false);
+	}
+	return lightmap_gi_progress->step(p_description, p_progress * 1000, p_refresh);
+}
+
+void EditorNode::lightmap_gi_bake_func_end(uint64_t p_time_started) {
+	if (lightmap_gi_progress != nullptr) {
+		memdelete(lightmap_gi_progress);
+		lightmap_gi_progress = nullptr;
+	}
+
+	const int time_taken = OS::get_singleton()->get_ticks_msec() - p_time_started;
+	if (time_taken > 0) {
+		// If no time was taken, this indicates a bake error and no lightmap was baked.
+		print_line(vformat("Done baking lightmap in %02d:%02d:%02d.%02d.", time_taken / 3'600'000, (time_taken % 3'600'000) / 60'000, (time_taken % 60'000) / 1000, (time_taken % 1000) / 10));
+	}
+
+	// Request attention in case the user was doing something else.
+	// Baking lightmaps is likely the editor task that can take the most time,
+	// so only request the attention for baking lightmaps.
+	DisplayServer::get_singleton()->window_request_attention();
+}
+
+void EditorNode::lightmap_gi_bake_select_file(const String &p_file, LightmapGI *p_lightmap_gi) {
+	if (p_lightmap_gi) {
+		lightmap_to_bake = p_lightmap_gi;
+	}
+
+	if (lightmap_to_bake) {
+		// LightmapGI bakes its siblings and children. Show the parent node name as well
+		// to help disambiguate a LightmapGI node from other lightmaps in the scene.
+		String name_with_parent;
+		if (lightmap_to_bake->get_parent()) {
+			name_with_parent = vformat("%s/%s", lightmap_to_bake->get_parent()->get_name(), lightmap_to_bake->get_name());
+		} else {
+			name_with_parent = "/root/" + lightmap_to_bake->get_name();
+		}
+
+		LightmapGI::BakeError err = LightmapGI::BAKE_ERROR_OK;
+		const uint64_t time_started = OS::get_singleton()->get_ticks_msec();
+		if (get_tree()->get_edited_scene_root()) {
+			Ref<LightmapGIData> lightmap_gi_data = lightmap_to_bake->get_light_data();
+
+			if (lightmap_gi_data.is_valid()) {
+				String path = lightmap_gi_data->get_path();
+				if (!path.is_resource_file()) {
+					int srpos = path.find("::");
+					if (srpos != -1) {
+						String base = path.substr(0, srpos);
+						if (ResourceLoader::get_resource_type(base) == "PackedScene") {
+							if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
+								err = LightmapGI::BAKE_ERROR_FOREIGN_DATA;
+							}
+						} else {
+							if (FileAccess::exists(base + ".import")) {
+								err = LightmapGI::BAKE_ERROR_FOREIGN_DATA;
+							}
+						}
+					}
+				} else {
+					if (FileAccess::exists(path + ".import")) {
+						err = LightmapGI::BAKE_ERROR_FOREIGN_DATA;
+					}
+				}
+			}
+
+			if (err == LightmapGI::BAKE_ERROR_OK) {
+				print_line(vformat("Baking lightmap: %s", name_with_parent));
+
+				if (get_tree()->get_edited_scene_root() == lightmap_to_bake) {
+					err = lightmap_to_bake->bake(lightmap_to_bake, p_file, lightmap_gi_bake_func_step);
+				} else {
+					err = lightmap_to_bake->bake(lightmap_to_bake->get_parent(), p_file, lightmap_gi_bake_func_step);
+				}
+			}
+		} else {
+			err = LightmapGI::BAKE_ERROR_NO_SCENE_ROOT;
+		}
+
+		lightmap_gi_bake_func_end(time_started);
+
+		switch (err) {
+			case LightmapGI::BAKE_ERROR_NO_SAVE_PATH: {
+				String scene_path = lightmap_to_bake->get_scene_file_path();
+				if (scene_path.is_empty() && lightmap_to_bake->get_owner()) {
+					scene_path = lightmap_to_bake->get_owner()->get_scene_file_path();
+				}
+				if (scene_path.is_empty()) {
+					EditorNode::get_singleton()->show_warning(vformat(TTR("%s: Can't determine a save path for lightmap images.\nSave your scene and try again."), name_with_parent));
+					break;
+				}
+				scene_path = scene_path.get_basename() + ".lmbake";
+
+				bake_lightmaps_dialog->set_current_path(scene_path);
+				bake_lightmaps_dialog->set_title(vformat(TTR("Select lightmap bake file for %s:"), name_with_parent));
+				bake_lightmaps_dialog->popup_file_dialog();
+			} break;
+			case LightmapGI::BAKE_ERROR_NO_MESHES: {
+				EditorNode::get_singleton()->show_warning(
+						vformat(TTR("%s: No meshes with lightmapping support to bake. Make sure they contain UV2 data and their Global Illumination property is set to Static."), name_with_parent) +
+						String::utf8("\n\n•  ") + TTR("To import a scene with lightmapping support, set Meshes > Light Baking to Static Lightmaps in the Import dock.") +
+						String::utf8("\n•  ") + TTR("To enable lightmapping support on a primitive mesh, edit the PrimitiveMesh resource in the inspector and check Add UV2.") +
+						String::utf8("\n•  ") + TTR("To enable lightmapping support on a CSG mesh, select the root CSG node and choose CSG > Bake Mesh Instance at the top of the 3D editor viewport.\nSelect the generated MeshInstance3D node and choose Mesh > Unwrap UV2 for Lightmap/AO at the top of the 3D editor viewport."));
+			} break;
+			case LightmapGI::BAKE_ERROR_CANT_CREATE_IMAGE: {
+				EditorNode::get_singleton()->show_warning(vformat(TTR("%s: Failed creating lightmap images. Make sure the lightmap destination path is writable."), name_with_parent));
+			} break;
+			case LightmapGI::BAKE_ERROR_NO_SCENE_ROOT: {
+				EditorNode::get_singleton()->show_warning(vformat(TTR("%s: No editor scene root found."), name_with_parent));
+			} break;
+			case LightmapGI::BAKE_ERROR_FOREIGN_DATA: {
+				EditorNode::get_singleton()->show_warning(vformat(TTR("%s: Lightmap data is not local to the scene."), name_with_parent));
+			} break;
+			case LightmapGI::BAKE_ERROR_TEXTURE_SIZE_TOO_SMALL: {
+				EditorNode::get_singleton()->show_warning(vformat(TTR("%s: Maximum texture size is too small for the lightmap images.\nWhile this can be fixed by increasing the maximum texture size, it is recommended you split the scene into more objects instead."), name_with_parent));
+			} break;
+			case LightmapGI::BAKE_ERROR_LIGHTMAP_TOO_SMALL: {
+				EditorNode::get_singleton()->show_warning(vformat(TTR("%s: Failed creating lightmap images. Make sure all meshes to bake have the Lightmap Size Hint property set high enough, and the LightmapGI's Texel Scale value is not too low."), name_with_parent));
+			} break;
+			case LightmapGI::BAKE_ERROR_ATLAS_TOO_SMALL: {
+				EditorNode::get_singleton()->show_warning(vformat(TTR("%s: Failed fitting a lightmap image into an atlas. This should never happen and should be reported."), name_with_parent));
+			} break;
+			default: {
+			} break;
+		}
+	}
+}
+
 void EditorNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("push_item", "object", "property", "inspector_only"), &EditorNode::push_item, DEFVAL(""), DEFVAL(false));
 
@@ -9641,6 +9775,12 @@ EditorNode::EditorNode() {
 
 	quick_open_color_palette = memnew(EditorQuickOpenDialog);
 	gui_base->add_child(quick_open_color_palette);
+
+	bake_lightmaps_dialog = memnew(EditorFileDialog);
+	bake_lightmaps_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
+	bake_lightmaps_dialog->add_filter("*.lmbake", TTR("LightMap Bake"));
+	bake_lightmaps_dialog->connect("file_selected", callable_mp(this, &EditorNode::lightmap_gi_bake_select_file).bind(Variant()));
+	gui_base->add_child(bake_lightmaps_dialog);
 
 	_update_recent_scenes();
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -53,6 +53,7 @@ class Control;
 class FileDialog;
 class HBoxContainer;
 class ImageTexture;
+class LightmapGI;
 class MenuBar;
 class MenuButton;
 class OptionButton;
@@ -743,6 +744,13 @@ private:
 
 	void _bottom_panel_resized();
 
+	EditorFileDialog *bake_lightmaps_dialog = nullptr;
+	LightmapGI *lightmap_to_bake = nullptr;
+
+	static EditorProgress *lightmap_gi_progress;
+	static bool lightmap_gi_bake_func_step(float p_progress, const String &p_description, void *, bool p_refresh);
+	static void lightmap_gi_bake_func_end(uint64_t p_time_started);
+
 protected:
 	friend class FileSystemDock;
 
@@ -754,6 +762,8 @@ public:
 	void _on_plugin_ready(Object *p_script, const String &p_activate_name);
 
 	void init_plugins();
+
+	void lightmap_gi_bake_select_file(const String &p_file, LightmapGI *p_lightmap_gi);
 
 	bool call_build();
 	void call_run_scene(const String &p_scene, Vector<String> &r_args);

--- a/editor/scene/3d/lightmap_gi_editor_plugin.cpp
+++ b/editor/scene/3d/lightmap_gi_editor_plugin.cpp
@@ -44,97 +44,8 @@
 
 #include "modules/modules_enabled.gen.h" // For lightmapper_rd.
 
-void LightmapGIEditorPlugin::_bake_select_file(const String &p_file) {
-	if (lightmap) {
-		LightmapGI::BakeError err = LightmapGI::BAKE_ERROR_OK;
-		const uint64_t time_started = OS::get_singleton()->get_ticks_msec();
-		if (get_tree()->get_edited_scene_root()) {
-			Ref<LightmapGIData> lightmapGIData = lightmap->get_light_data();
-
-			if (lightmapGIData.is_valid()) {
-				String path = lightmapGIData->get_path();
-				if (!path.is_resource_file()) {
-					int srpos = path.find("::");
-					if (srpos != -1) {
-						String base = path.substr(0, srpos);
-						if (ResourceLoader::get_resource_type(base) == "PackedScene") {
-							if (!get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->get_scene_file_path() != base) {
-								err = LightmapGI::BAKE_ERROR_FOREIGN_DATA;
-							}
-						} else {
-							if (FileAccess::exists(base + ".import")) {
-								err = LightmapGI::BAKE_ERROR_FOREIGN_DATA;
-							}
-						}
-					}
-				} else {
-					if (FileAccess::exists(path + ".import")) {
-						err = LightmapGI::BAKE_ERROR_FOREIGN_DATA;
-					}
-				}
-			}
-
-			if (err == LightmapGI::BAKE_ERROR_OK) {
-				if (get_tree()->get_edited_scene_root() == lightmap) {
-					err = lightmap->bake(lightmap, p_file, bake_func_step);
-				} else {
-					err = lightmap->bake(lightmap->get_parent(), p_file, bake_func_step);
-				}
-			}
-		} else {
-			err = LightmapGI::BAKE_ERROR_NO_SCENE_ROOT;
-		}
-
-		bake_func_end(time_started);
-
-		switch (err) {
-			case LightmapGI::BAKE_ERROR_NO_SAVE_PATH: {
-				String scene_path = lightmap->get_scene_file_path();
-				if (scene_path.is_empty() && lightmap->get_owner()) {
-					scene_path = lightmap->get_owner()->get_scene_file_path();
-				}
-				if (scene_path.is_empty()) {
-					EditorNode::get_singleton()->show_warning(TTR("Can't determine a save path for lightmap images.\nSave your scene and try again."));
-					break;
-				}
-				scene_path = scene_path.get_basename() + ".lmbake";
-
-				file_dialog->set_current_path(scene_path);
-				file_dialog->popup_file_dialog();
-			} break;
-			case LightmapGI::BAKE_ERROR_NO_MESHES: {
-				EditorNode::get_singleton()->show_warning(
-						TTR("No meshes with lightmapping support to bake. Make sure they contain UV2 data and their Global Illumination property is set to Static.") +
-						String::utf8("\n\n•  ") + TTR("To import a scene with lightmapping support, set Meshes > Light Baking to Static Lightmaps in the Import dock.") +
-						String::utf8("\n•  ") + TTR("To enable lightmapping support on a primitive mesh, edit the PrimitiveMesh resource in the inspector and check Add UV2.") +
-						String::utf8("\n•  ") + TTR("To enable lightmapping support on a CSG mesh, select the root CSG node and choose CSG > Bake Mesh Instance at the top of the 3D editor viewport.\nSelect the generated MeshInstance3D node and choose Mesh > Unwrap UV2 for Lightmap/AO at the top of the 3D editor viewport."));
-			} break;
-			case LightmapGI::BAKE_ERROR_CANT_CREATE_IMAGE: {
-				EditorNode::get_singleton()->show_warning(TTR("Failed creating lightmap images. Make sure the lightmap destination path is writable."));
-			} break;
-			case LightmapGI::BAKE_ERROR_NO_SCENE_ROOT: {
-				EditorNode::get_singleton()->show_warning(TTR("No editor scene root found."));
-			} break;
-			case LightmapGI::BAKE_ERROR_FOREIGN_DATA: {
-				EditorNode::get_singleton()->show_warning(TTR("Lightmap data is not local to the scene."));
-			} break;
-			case LightmapGI::BAKE_ERROR_TEXTURE_SIZE_TOO_SMALL: {
-				EditorNode::get_singleton()->show_warning(TTR("Maximum texture size is too small for the lightmap images.\nWhile this can be fixed by increasing the maximum texture size, it is recommended you split the scene into more objects instead."));
-			} break;
-			case LightmapGI::BAKE_ERROR_LIGHTMAP_TOO_SMALL: {
-				EditorNode::get_singleton()->show_warning(TTR("Failed creating lightmap images. Make sure all meshes to bake have the Lightmap Size Hint property set high enough, and the LightmapGI's Texel Scale value is not too low."));
-			} break;
-			case LightmapGI::BAKE_ERROR_ATLAS_TOO_SMALL: {
-				EditorNode::get_singleton()->show_warning(TTR("Failed fitting a lightmap image into an atlas. This should never happen and should be reported."));
-			} break;
-			default: {
-			} break;
-		}
-	}
-}
-
 void LightmapGIEditorPlugin::_bake() {
-	_bake_select_file("");
+	EditorNode::get_singleton()->lightmap_gi_bake_select_file("", lightmap);
 }
 
 void LightmapGIEditorPlugin::edit(Object *p_object) {
@@ -156,30 +67,6 @@ void LightmapGIEditorPlugin::make_visible(bool p_visible) {
 	} else {
 		bake->hide();
 	}
-}
-
-EditorProgress *LightmapGIEditorPlugin::tmp_progress = nullptr;
-
-bool LightmapGIEditorPlugin::bake_func_step(float p_progress, const String &p_description, void *, bool p_refresh) {
-	if (!tmp_progress) {
-		tmp_progress = memnew(EditorProgress("bake_lightmaps", TTR("Bake Lightmaps"), 1000, true));
-		ERR_FAIL_NULL_V(tmp_progress, false);
-	}
-	return tmp_progress->step(p_description, p_progress * 1000, p_refresh);
-}
-
-void LightmapGIEditorPlugin::bake_func_end(uint64_t p_time_started) {
-	if (tmp_progress != nullptr) {
-		memdelete(tmp_progress);
-		tmp_progress = nullptr;
-	}
-
-	const int time_taken = OS::get_singleton()->get_ticks_msec() - p_time_started;
-	print_line(vformat("Done baking lightmaps in %02d:%02d:%02d.%02d.", time_taken / 3'600'000, (time_taken % 3'600'000) / 60'000, (time_taken % 60'000) / 1000, (time_taken % 1000) / 10));
-	// Request attention in case the user was doing something else.
-	// Baking lightmaps is likely the editor task that can take the most time,
-	// so only request the attention for baking lightmaps.
-	DisplayServer::get_singleton()->window_request_attention();
 }
 
 void LightmapGIEditorPlugin::_bind_methods() {
@@ -214,11 +101,4 @@ LightmapGIEditorPlugin::LightmapGIEditorPlugin() {
 	bake->connect(SceneStringName(pressed), Callable(this, "_bake"));
 	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, bake);
 	lightmap = nullptr;
-
-	file_dialog = memnew(EditorFileDialog);
-	file_dialog->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
-	file_dialog->add_filter("*.lmbake", TTR("LightMap Bake"));
-	file_dialog->set_title(TTR("Select lightmap bake file:"));
-	file_dialog->connect("file_selected", callable_mp(this, &LightmapGIEditorPlugin::_bake_select_file));
-	bake->add_child(file_dialog);
 }

--- a/editor/scene/3d/lightmap_gi_editor_plugin.h
+++ b/editor/scene/3d/lightmap_gi_editor_plugin.h
@@ -43,12 +43,6 @@ class LightmapGIEditorPlugin : public EditorPlugin {
 
 	Button *bake = nullptr;
 
-	EditorFileDialog *file_dialog = nullptr;
-	static EditorProgress *tmp_progress;
-	static bool bake_func_step(float p_progress, const String &p_description, void *, bool p_refresh);
-	static void bake_func_end(uint64_t p_time_started);
-
-	void _bake_select_file(const String &p_file);
 	void _bake();
 
 protected:

--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -83,6 +83,7 @@
 #include "editor/scene/3d/gizmos/two_bone_ik_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/visible_on_screen_notifier_3d_gizmo_plugin.h"
 #include "editor/scene/3d/gizmos/voxel_gi_gizmo_plugin.h"
+#include "editor/scene/3d/lightmap_gi_editor_plugin.h"
 #include "editor/scene/3d/node_3d_editor_constants.h"
 #include "editor/scene/3d/node_3d_editor_gizmos.h"
 #include "editor/scene/3d/node_3d_editor_viewport.h"
@@ -90,6 +91,7 @@
 #include "editor/translations/editor_translation_preview_menu.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/light_3d.h"
+#include "scene/3d/lightmap_gi.h"
 #include "scene/3d/physics/collision_shape_3d.h"
 #include "scene/3d/physics/physics_body_3d.h"
 #include "scene/3d/world_environment.h"
@@ -110,6 +112,7 @@
 #include "scene/resources/3d/sky_material.h"
 #include "scene/resources/sky.h"
 #include "scene/resources/surface_tool.h"
+#include "servers/display/display_server.h"
 #include "servers/physics_3d/physics_server_3d_types.h"
 #include "servers/rendering/rendering_server.h"
 
@@ -2321,6 +2324,41 @@ void Node3DEditor::_sun_environ_settings_pressed() {
 	sun_environ_popup->grab_focus();
 }
 
+void Node3DEditor::_bake_lightmaps_button_pressed() {
+	TypedArray<Node> lightmaps = EditorNode::get_singleton()->get_edited_scene()->find_children("*", LightmapGI::get_class_static());
+	for (int i = 0; i < lightmaps.size(); i++) {
+		LightmapGI *lightmap = Object::cast_to<LightmapGI>(lightmaps[i]);
+		if (!lightmap) {
+			continue;
+		}
+
+		Ref<LightmapGIData> lightmap_gi_data = lightmap->get_light_data();
+		bool is_read_only = false;
+		if (lightmap_gi_data.is_valid()) {
+			is_read_only = EditorNode::get_singleton()->is_resource_read_only(lightmap_gi_data);
+		}
+
+		bool is_instance = false;
+		Node *node = lightmap;
+		while (node && !is_instance) {
+			if (node->is_instance() && node != EditorNode::get_singleton()->get_edited_scene()) {
+				is_instance = true;
+			}
+			node = node->get_parent();
+		}
+
+		if (!is_read_only && !is_instance) {
+			// Do not bake LightmapGI nodes that are part of instantiated subscenes,
+			// as changes would be lost when disabling Editable Children.
+			EditorNode::get_singleton()->lightmap_gi_bake_select_file("", lightmap);
+		}
+	}
+}
+
+void Node3DEditor::_bake_geometry_button_pressed() {
+	print_line("Bake geometry button pressed");
+}
+
 #ifdef MODULE_TEXTURE_STREAMING_ENABLED
 void Node3DEditor::_textures_button_pressed() {
 	if (textures_button->is_disabled()) {
@@ -2569,6 +2607,8 @@ void Node3DEditor::_update_theme() {
 
 	sun_button->set_button_icon(get_editor_theme_icon(SNAME("PreviewSun")));
 	environ_button->set_button_icon(get_editor_theme_icon(SNAME("PreviewEnvironment")));
+	bake_lightmaps_button->set_button_icon(get_editor_theme_icon(SNAME("Bake")));
+	bake_geometry_button->set_button_icon(get_editor_theme_icon(SNAME("MeshItem"))); // TODO: Design icon for geometry baking.
 	sun_environ_settings->set_button_icon(get_editor_theme_icon(SNAME("GuiTabMenuHl")));
 
 	sun_title->add_theme_font_override(SceneStringName(font), get_theme_font(SNAME("title_font"), SNAME("Window")));
@@ -3698,6 +3738,25 @@ Node3DEditor::Node3DEditor() {
 	view_layout_menu->set_shortcut_context(this);
 	transform_view_hbox->add_child(view_layout_menu);
 	transform_view_hbox->add_child(memnew(VSeparator));
+
+	HBoxContainer *bake_hbox = memnew(HBoxContainer);
+	main_flow->add_child(bake_hbox);
+
+	bake_lightmaps_button = memnew(Button);
+	bake_lightmaps_button->set_shortcut(ED_SHORTCUT("spatial_editor/bake_lightmaps", TTRC("Bake Lightmaps"), KeyModifierMask::ALT | Key::B, true));
+	bake_lightmaps_button->set_tooltip_text(TTRC("Bake all LightmapGI nodes in the currently open scene (excluding instantiated subscenes)."));
+	bake_lightmaps_button->set_theme_type_variation(SceneStringName(FlatButton));
+	bake_lightmaps_button->connect(SceneStringName(pressed), callable_mp(this, &Node3DEditor::_bake_lightmaps_button_pressed));
+	bake_hbox->add_child(bake_lightmaps_button);
+
+	bake_geometry_button = memnew(Button);
+	bake_geometry_button->set_shortcut(ED_SHORTCUT("spatial_editor/bake_geometry_dependent_nodes", TTRC("Bake Geometry-Dependent Nodes"), KeyModifierMask::ALT | KeyModifierMask::SHIFT | Key::B, true));
+	bake_geometry_button->set_tooltip_text(TTRC("Bake all geometry-dependent nodes in the currently open scene (excluding instantiated subscenes), such as VoxelGI, OccluderInstance3D, and GPUParticlesCollisionSDF3D."));
+	bake_geometry_button->set_theme_type_variation(SceneStringName(FlatButton));
+	bake_geometry_button->connect(SceneStringName(pressed), callable_mp(this, &Node3DEditor::_bake_geometry_button_pressed));
+	bake_hbox->add_child(bake_geometry_button);
+
+	bake_hbox->add_child(memnew(VSeparator));
 
 #ifdef MODULE_TEXTURE_STREAMING_ENABLED
 	textures_button = memnew(Button);

--- a/editor/scene/3d/node_3d_editor_plugin.h
+++ b/editor/scene/3d/node_3d_editor_plugin.h
@@ -358,6 +358,12 @@ private:
 
 	Button *sun_environ_settings = nullptr;
 
+	Button *bake_lightmaps_button = nullptr;
+	Button *bake_geometry_button = nullptr;
+
+	void _bake_lightmaps_button_pressed();
+	void _bake_geometry_button_pressed();
+
 #ifdef MODULE_TEXTURE_STREAMING_ENABLED
 	Button *textures_button = nullptr;
 	PopupPanel *textures_popup = nullptr;


### PR DESCRIPTION
> [!NOTE]
>
> This PR is marked as draft since the current code is quite hacky, but the core functionality **for lightmaps** is working and can be tested for usability.

This greatly speeds up the level design workflow by no longer requiring you to select a LightmapGI node before baking. Once complete, this feature will also be available for nodes that require a rebake when the *geometry* (and not the lighting) changes, such as VoxelGI, OccluderInstance3D and GPUParticlesCollisionSDF3D. The actions are kept separate, as lightmaps need to be rebaked both when the geometry or lighting changes.

This action can also be done on lightmaps with the <kbd>Alt + B</kbd> keyboard shortcut, and <kbd>Alt + Shift + B</kbd> to bake geometry-dependent nodes.

LightmapGI nodes that are part of instantiated subscenes are ignored, as well as read-only resources.

Compared to the proposal, I didn't implement a dropdown to select a specific LightmapGI node to bake, but this can be done with relative ease (with an additional first item in the dropdown to bake all lightmaps). I would prefer keeping this one-button workflow personally, so you can bake lightmaps in one click instead of two.

- This closes https://github.com/godotengine/godot-proposals/issues/10323.

cc @passivestar 

## Preview

*At first, I use the button to bake all lightmaps (without needing to select each LightmapGI node), then I use the keyboard shortcut.*

*If a LightmapGI node hasn't been baked yet, you'll see a file dialog prompting you to choose a location for it. To help disambiguate multiple LightmapGI nodes, the dialog's title displays the node name as well as it's parent. This also helps communicate the fact that LightmapGI nodes bake both their children and siblings.*

https://github.com/user-attachments/assets/562f1cd6-2d06-4a12-a7a2-c8f9e503ae74

## TODO

- [ ] Find a cleaner way to access LightmapGI baking globally, without having to move its code to EditorNode.
  - @KoBeWi @YeldhamDev Any ideas?
  - This will be especially important for geometry-dependent node baking, as we'd have much more code to migrate.
- [ ] Implement geometry-dependent baking (VoxelGI, OccluderInstance3D, GPUParticlesCollisionSDF3D).
- [ ] Design dedicated icons for the "bake all lightmaps" and "bake all geometry-dependent nodes" actions.
