### PR TITLE
Fix 26.6 fixed point conversion in MSDF outline decomposition

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1266,6 +1266,10 @@
 		<member name="gui/common/text_edit_undo_stack_max_size" type="int" setter="" getter="" default="1024">
 			Maximum undo/redo history size for [TextEdit] fields.
 		</member>
+		<member name="gui/fonts/compatibility/msdf_legacy_scaling" type="bool" setter="" getter="" default="false">
+			If set to [code]true[/code], multichannel signed distance field (MSDF) glyph shapes are scaled using the divisor used before Godot 4.8, which was incorrect and made MSDF text render about 6.67% larger than intended.
+			This setting is provided for compatibility with existing projects that relied on the incorrect scaling and would otherwise have their layout shifted by the fix. New projects should leave this disabled.
+		</member>
 		<member name="gui/fonts/dynamic_fonts/use_oversampling" type="bool" setter="" getter="" default="true">
 			If set to [code]true[/code] and [member display/window/stretch/mode] is set to [code]"canvas_items"[/code], font and [DPITexture] oversampling is enabled in the main window. Use [member Viewport.oversampling] to control oversampling in other viewports and windows.
 		</member>

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -907,6 +907,11 @@ _FORCE_INLINE_ TextServerAdvanced::FontTexturePosition TextServerAdvanced::find_
 
 #ifdef MODULE_MSDFGEN_ENABLED
 
+// FreeType outline coordinates are 26.6 fixed point, so one pixel is 64 units.
+// Godot versions before 4.8 used an incorrect divisor of 60, which can be
+// restored via the `gui/fonts/compatibility/msdf_legacy_scaling` project setting.
+static double ft_units_per_pixel = 64.0;
+
 struct MSContext {
 	msdfgen::Point2 position;
 	msdfgen::Shape *shape = nullptr;
@@ -935,7 +940,7 @@ struct MSDFThreadData {
 };
 
 static msdfgen::Point2 ft_point2(const FT_Vector &vector) {
-	return msdfgen::Point2(vector.x / 60.0f, vector.y / 60.0f);
+	return msdfgen::Point2(vector.x / ft_units_per_pixel, vector.y / ft_units_per_pixel);
 }
 
 static int ft_move_to(const FT_Vector *to, void *user) {
@@ -8446,6 +8451,11 @@ TextServerAdvanced::TextServerAdvanced() {
 	_bmp_create_font_funcs();
 	_update_settings();
 	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &TextServerAdvanced::_update_settings));
+#if defined(MODULE_MSDFGEN_ENABLED) && !defined(DISABLE_DEPRECATED)
+	if (GLOBAL_GET("gui/fonts/compatibility/msdf_legacy_scaling")) {
+		ft_units_per_pixel = 60.0;
+	}
+#endif
 }
 
 void TextServerAdvanced::_font_clear_system_fallback_cache() {

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -324,6 +324,11 @@ _FORCE_INLINE_ TextServerFallback::FontTexturePosition TextServerFallback::find_
 
 #ifdef MODULE_MSDFGEN_ENABLED
 
+// FreeType outline coordinates are 26.6 fixed point, so one pixel is 64 units.
+// Godot versions before 4.8 used an incorrect divisor of 60, which can be
+// restored via the `gui/fonts/compatibility/msdf_legacy_scaling` project setting.
+static double ft_units_per_pixel = 64.0;
+
 struct MSContext {
 	msdfgen::Point2 position;
 	msdfgen::Shape *shape = nullptr;
@@ -352,7 +357,7 @@ struct MSDFThreadData {
 };
 
 static msdfgen::Point2 ft_point2(const FT_Vector &vector) {
-	return msdfgen::Point2(vector.x / 60.0f, vector.y / 60.0f);
+	return msdfgen::Point2(vector.x / ft_units_per_pixel, vector.y / ft_units_per_pixel);
 }
 
 static int ft_move_to(const FT_Vector *to, void *user) {
@@ -5380,6 +5385,11 @@ void TextServerFallback::_update_settings() {
 TextServerFallback::TextServerFallback() {
 	_insert_feature_sets();
 	ProjectSettings::get_singleton()->connect("settings_changed", callable_mp(this, &TextServerFallback::_update_settings));
+#if defined(MODULE_MSDFGEN_ENABLED) && !defined(DISABLE_DEPRECATED)
+	if (GLOBAL_GET("gui/fonts/compatibility/msdf_legacy_scaling")) {
+		ft_units_per_pixel = 60.0;
+	}
+#endif
 }
 
 void TextServerFallback::_font_clear_system_fallback_cache() {

--- a/servers/text/text_server.cpp
+++ b/servers/text/text_server.cpp
@@ -2400,6 +2400,12 @@ TextServer::TextServer() {
 	GLOBAL_DEF_RST("gui/theme/default_font_generate_mipmaps", false);
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "gui/theme/lcd_subpixel_layout", PROPERTY_HINT_ENUM, "Disabled,Horizontal RGB,Horizontal BGR,Vertical RGB,Vertical BGR"), 1);
+
+#ifndef DISABLE_DEPRECATED
+	// Compatibility with Godot versions before 4.8 where MSDF glyph shapes were incorrectly scaled up.
+	GLOBAL_DEF_RST("gui/fonts/compatibility/msdf_legacy_scaling", false);
+#endif
+
 	GLOBAL_DEF_BASIC("internationalization/locale/include_text_server_data", false);
 	GLOBAL_DEF_BASIC(PropertyInfo(Variant::INT, "internationalization/locale/line_breaking_strictness", PROPERTY_HINT_ENUM, "Auto,Loose,Normal,Strict"), 0);
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

FreeType outline coordinates are encoded using the 26.6 fixed-point format, where the fractional part is encoded on 6 bits, i.e. 64 parts, not 60. Our MSDF shapes were 6.67% larger than the actual font metrics.

- Fixes #118293.

## Additional information

Fixing this bug will change the metrics for MSDF text in user projects, which may be seen as breaking as it might shuffle some glyphs or parts of UI around.

So we should consider whether this is fine to simply document, or if we should add a font import option to keep using the wrong divisor for compatibility.

*Edit:* A compatibility setting was added as `gui/fonts/compatibility/msdf_legacy_scaling` (opt-in) so that projects upgrading to 4.8 who need to ensure their MSDF fonts don't change metric can enable that.

## Testing

Project: [font.zip](https://github.com/user-attachments/files/31809690/font.zip)

|Master, MSDF disabled|Master, MSDF enabled|PR, MSDF enabled|
|---|---|---|
| <img width="1217" height="825" alt="msdf-01-master-msdf_disabled" src="https://github.com/user-attachments/assets/5d21bb6b-8dec-4314-b61c-23df37856cb8" /> | <img width="1206" height="816" alt="msdf-02-master-msdf_enabled" src="https://github.com/user-attachments/assets/a88055c3-d6fb-40fe-a9ab-733e99429b91" /> |<img width="1204" height="820" alt="msdf-03-scale_fix-msdf-enabled" src="https://github.com/user-attachments/assets/4603d03e-332b-46da-8349-4c6b5ace5120" /> |

While this PR fixes the relative glyph size, you can see from the rulers that the positioning is still a bit different in this case, and there's an inconsistent baseline (that part is #121369 which will be addressed in another PR).