### PR TITLE
Add option to limit loss of control focus to parent viewport

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -368,6 +368,10 @@
 			A [SubViewportContainer] will automatically set this property to [code]false[/code] for the [Viewport] contained inside of it.
 			See also [method set_input_as_handled] and [method is_input_handled].
 		</member>
+		<member name="local_focus" type="bool" setter="set_local_focus" getter="get_local_focus" default="false">
+			If [code]false[/code], all other [Control]s in the same [Window] will lose focus when a [Control] grabs focus.
+			If [code]true[/code], only other [Control]s in the same [Viewport] will lose focus when a [Control] grabs focus.
+		</member>
 		<member name="mesh_lod_threshold" type="float" setter="set_mesh_lod_threshold" getter="get_mesh_lod_threshold" default="1.0">
 			The automatic LOD bias to use for meshes rendered within the [Viewport] (this is analogous to [member ReflectionProbe.mesh_lod_threshold]). Higher values will use less detailed versions of meshes that have LOD variations generated. If set to [code]0.0[/code], automatic LOD is disabled. Increase [member mesh_lod_threshold] to improve performance at the cost of geometry detail.
 			To control this property on the root viewport, set the [member ProjectSettings.rendering/mesh_lod/lod_change/threshold_pixels] project setting.

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2724,7 +2724,7 @@ Window *Viewport::get_base_window() {
 }
 
 void Viewport::_gui_remove_focus_for_window(Node *p_window) {
-	if (get_base_window() == p_window) {
+	if (get_base_window() == p_window && !local_focus) {
 		gui_release_focus();
 	}
 }
@@ -2743,7 +2743,12 @@ void Viewport::_gui_control_grab_focus(Control *p_control, bool p_hide_focus) {
 		return;
 	}
 
-	get_tree()->call_group("_viewports", "_gui_remove_focus_for_window", get_base_window());
+	if (local_focus) {
+		gui_release_focus();
+	} else {
+		get_tree()->call_group("_viewports", "_gui_remove_focus_for_window", get_base_window());
+	}
+
 	if (p_control->is_inside_tree() && p_control->get_viewport() == this) {
 		gui.key_focus = p_control;
 		if (_can_hide_focus_state()) {
@@ -3560,6 +3565,15 @@ void Viewport::push_input(RequiredParam<InputEvent> p_event, bool p_local_coords
 	}
 
 	event_count++;
+}
+
+void Viewport::set_local_focus(bool p_local_focus) {
+	ERR_MAIN_THREAD_GUARD;
+	local_focus = p_local_focus;
+}
+
+bool Viewport::get_local_focus() const {
+	return local_focus;
 }
 
 #ifndef DISABLE_DEPRECATED
@@ -5239,6 +5253,7 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_viewport_rid"), &Viewport::get_viewport_rid);
 	ClassDB::bind_method(D_METHOD("push_text_input", "text"), &Viewport::push_text_input);
 	ClassDB::bind_method(D_METHOD("push_input", "event", "in_local_coords"), &Viewport::push_input, DEFVAL(false));
+
 #ifndef DISABLE_DEPRECATED
 	ClassDB::bind_method(D_METHOD("push_unhandled_input", "event", "in_local_coords"), &Viewport::push_unhandled_input, DEFVAL(false));
 #endif // DISABLE_DEPRECATED
@@ -5288,6 +5303,9 @@ void Viewport::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_handle_input_locally", "enable"), &Viewport::set_handle_input_locally);
 	ClassDB::bind_method(D_METHOD("is_handling_input_locally"), &Viewport::is_handling_input_locally);
+
+	ClassDB::bind_method(D_METHOD("set_local_focus", "local_focus"), &Viewport::set_local_focus);
+	ClassDB::bind_method(D_METHOD("get_local_focus"), &Viewport::get_local_focus);
 
 	ClassDB::bind_method(D_METHOD("set_default_canvas_item_texture_filter", "mode"), &Viewport::set_default_canvas_item_texture_filter);
 	ClassDB::bind_method(D_METHOD("get_default_canvas_item_texture_filter"), &Viewport::get_default_canvas_item_texture_filter);
@@ -5383,6 +5401,7 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "world_2d", PROPERTY_HINT_RESOURCE_TYPE, World2D::get_class_static(), PROPERTY_USAGE_NONE), "set_world_2d", "get_world_2d");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "transparent_bg"), "set_transparent_background", "has_transparent_background");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "handle_input_locally"), "set_handle_input_locally", "is_handling_input_locally");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "local_focus"), "set_local_focus", "get_local_focus");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "snap_2d_transforms_to_pixel"), "set_snap_2d_transforms_to_pixel", "is_snap_2d_transforms_to_pixel_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "snap_2d_vertices_to_pixel"), "set_snap_2d_vertices_to_pixel", "is_snap_2d_vertices_to_pixel_enabled");
 	ADD_GROUP("Rendering", "");

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -435,6 +435,7 @@ private:
 
 	bool disable_input = false;
 	bool disable_input_override = false;
+	bool local_focus = false;
 
 	void _gui_call_input(Control *p_control, const Ref<InputEvent> &p_input);
 	void _gui_call_notification(Control *p_control, int p_what);
@@ -631,6 +632,10 @@ public:
 	void _push_text_input(const String &p_text, bool p_emit_text_changed_signal = false);
 	void push_text_input(const String &p_text);
 	void push_input(RequiredParam<InputEvent> p_event, bool p_local_coords = false);
+
+	void set_local_focus(bool p_local_focus);
+	bool get_local_focus() const;
+
 #ifndef DISABLE_DEPRECATED
 	void push_unhandled_input(RequiredParam<InputEvent> p_event, bool p_local_coords = false);
 #endif // DISABLE_DEPRECATED


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

It is currently not possible to give each player their own UI to interact with as when one player focuses a control, all other controls in the same window lose focus.

There have been PRs in the past to try to resolve this, but they get stuck in review as they end up touching a great many files.

This, instead, just adds a single flag to change the focus behavior, which limits the clearing of focus to individual viewports.  This means that you can now treat viewports as having their own completely separate UIs which do not directly interact with one another.

### Demonstration Videos

Without this flag, each time a new instance of the UI is added, focusing a control blurs the controls in all other instances:

https://github.com/user-attachments/assets/c019c4fc-9c92-40d6-8099-b00d229c66e4

The common workaround at the moment is to build a new system on top of Control using GDScript which has its own, parallel implementation of `grab_focus`/etc.

With this flag, it is possible for each UI to be interacted with individually.  This might be used in a split-screen multiplayer game to implement player set-up (loadouts, etc.) and to give each player their own pause menu:

https://github.com/user-attachments/assets/a45ef5df-9f7f-4e88-931f-e8a6352a2c49

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

This is the project displayed in the demonstration videos: [demonstration.zip](https://github.com/user-attachments/files/31800457/demonstration.zip)

