### PR TITLE
Implemented type/group filtering in debugger's scene tree

### DIFF
--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -195,6 +195,83 @@ void EditorDebuggerTree::_scene_tree_rmb_selected(const Vector2 &p_position, Mou
 	item_menu->popup();
 }
 
+bool EditorDebuggerTree::_type_matches_class_term(TreeItem *p_item, const String &p_term) {
+	if (p_term.is_empty()) {
+		// Defend against https://github.com/godotengine/godot/issues/82473
+		return true;
+	}
+
+	const PackedStringArray script_class_chain = p_item->get_meta("_script_class_chain", PackedStringArray());
+	for (const String &global_name : script_class_chain) {
+		if (global_name.to_lower().contains(p_term)) {
+			return true;
+		}
+	}
+
+	String type = p_item->get_meta("_native_class_name", String());
+	while (type != "Node") {
+		if (type.to_lower().contains(p_term)) {
+			return true;
+		}
+
+		type = ClassDB::get_parent_class(type);
+	}
+
+	return false;
+}
+
+bool EditorDebuggerTree::_item_matches_all_terms(TreeItem *p_item, const PackedStringArray &p_terms) {
+	if (p_terms.is_empty()) {
+		return true;
+	}
+
+	const PackedStringArray groups = p_item->get_meta("_groups", PackedStringArray());
+
+	for (int i = 0; i < p_terms.size(); i++) {
+		const String &term = p_terms[i];
+
+		// Recognize special filter.
+		if (term.contains_char(':') && !term.get_slicec(':', 0).is_empty()) {
+			String parameter = term.get_slicec(':', 0);
+			String argument = term.get_slicec(':', 1);
+
+			if (parameter == "type" || parameter == "t") {
+				// Filter by Type.
+				if (!_type_matches_class_term(p_item, argument)) {
+					return false;
+				}
+			} else if (parameter == "group" || parameter == "g") {
+				// Filter by Group.
+				if (argument.is_empty()) {
+					// When argument is empty, match all Nodes belonging to any exposed group.
+					if (groups.is_empty()) {
+						return false;
+					}
+				} else {
+					bool term_in_groups = false;
+					for (const String &group : groups) {
+						if (group.to_lower().contains(argument)) {
+							term_in_groups = true;
+							break;
+						}
+					}
+					if (!term_in_groups) {
+						return false;
+					}
+				}
+			}
+			// SceneTreeEditor will set filter_term_warning if the filter is unrecognized.
+		} else {
+			// Default.
+			if (!p_item->get_text(0).to_lower().contains(term)) {
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
 /// Populates inspect_scene_tree given data in nodes as a flat list, encoded depth first.
 ///
 /// Given a nodes array like [R,A,B,C,D,E] the following Tree will be generated, assuming
@@ -214,6 +291,7 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 
 	updating_scene_tree = true;
 	const String filter = SceneTreeDock::get_singleton()->get_filter();
+	PackedStringArray terms = filter.to_lower().split_spaces();
 	LocalVector<TreeItem *> select_items;
 	bool hide_filtered_out_parents = EDITOR_GET("docks/scene_tree/hide_filtered_out_parents");
 	debugger_id = p_debugger; // Needed by hook, could be avoided if every debugger had its own tree.
@@ -234,7 +312,7 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 			if (!(--p.child_count)) { // If no child left, remove it.
 				parents.pop_front();
 
-				if (hide_filtered_out_parents && !filter.is_subsequence_ofn(parent->get_text(0))) {
+				if (hide_filtered_out_parents && !_item_matches_all_terms(parent, terms)) {
 					if (parent == get_root()) {
 						set_hide_root(true);
 					} else {
@@ -280,6 +358,9 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 			}
 		}
 		item->set_meta("node_path", current_path + "/" + item->get_text(0));
+		item->set_meta("_script_class_chain", PackedStringArray(node.script_class_chain));
+		item->set_meta("_native_class_name", node.native_class_name);
+		item->set_meta("_groups", PackedStringArray(node.groups));
 
 		// Select previously selected nodes.
 		if (inspected_object_ids.has(uint64_t(node.id))) {
@@ -326,12 +407,12 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 
 		// Add in front of the parents stack if children are expected.
 		if (node.child_count) {
-			parents.push_front(ParentItem(item, node.child_count, filter.is_subsequence_ofn(item->get_text(0))));
+			parents.push_front(ParentItem(item, node.child_count, _item_matches_all_terms(item, terms)));
 		} else {
 			// Apply filters.
 			while (parent) {
 				const bool had_siblings = item->get_prev() || item->get_next();
-				if (filter.is_subsequence_ofn(item->get_text(0))) {
+				if (_item_matches_all_terms(item, terms)) {
 					break; // Filter matches, must survive.
 				}
 

--- a/editor/debugger/editor_debugger_tree.h
+++ b/editor/debugger/editor_debugger_tree.h
@@ -81,6 +81,9 @@ private:
 	void _item_menu_id_pressed(int p_option);
 	void _file_selected(const String &p_file);
 
+	static bool _type_matches_class_term(TreeItem *p_item, const String &p_term);
+	static bool _item_matches_all_terms(TreeItem *p_item, const PackedStringArray &p_terms);
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);

--- a/scene/debugger/scene_debugger_object.cpp
+++ b/scene/debugger/scene_debugger_object.cpp
@@ -338,7 +338,27 @@ SceneDebuggerTree::SceneDebuggerTree(Node *p_root) {
 				}
 			}
 		}
-		nodes.push_back(RemoteNode(count, n->get_name(), class_name.is_empty() ? n->get_class() : class_name, n->get_instance_id(), n->get_scene_file_path(), view_flags));
+
+		Vector<String> script_class_chain;
+		Ref<Script> item_script = n->get_script();
+		while (item_script.is_valid()) {
+			String global_name = item_script->get_global_name();
+			if (!global_name.is_empty()) {
+				script_class_chain.push_back(global_name);
+			}
+			item_script = item_script->get_base_script();
+		}
+
+		Vector<String> groups;
+		List<Node::GroupInfo> group_info_list;
+		n->get_groups(&group_info_list);
+		for (const Node::GroupInfo &group_info : group_info_list) {
+			if (group_info.persistent) {
+				groups.push_back(group_info.name);
+			}
+		}
+
+		nodes.push_back(RemoteNode(count, n->get_name(), class_name.is_empty() ? n->get_class() : class_name, n->get_instance_id(), n->get_scene_file_path(), view_flags, script_class_chain, n->get_class(), groups));
 	}
 }
 
@@ -350,21 +370,27 @@ void SceneDebuggerTree::serialize(Array &p_arr) {
 		p_arr.push_back(n.id);
 		p_arr.push_back(n.scene_file_path);
 		p_arr.push_back(n.view_flags);
+		p_arr.push_back(n.script_class_chain);
+		p_arr.push_back(n.native_class_name);
+		p_arr.push_back(n.groups);
 	}
 }
 
 void SceneDebuggerTree::deserialize(const Array &p_arr) {
 	int idx = 0;
 	while (p_arr.size() > idx) {
-		ERR_FAIL_COND(p_arr.size() < 6);
+		ERR_FAIL_COND(p_arr.size() < 9);
 		CHECK_TYPE(p_arr[idx], INT); // child_count.
 		CHECK_TYPE(p_arr[idx + 1], STRING); // name.
 		CHECK_TYPE(p_arr[idx + 2], STRING); // type_name.
 		CHECK_TYPE(p_arr[idx + 3], INT); // id.
 		CHECK_TYPE(p_arr[idx + 4], STRING); // scene_file_path.
 		CHECK_TYPE(p_arr[idx + 5], INT); // view_flags.
-		nodes.push_back(RemoteNode(p_arr[idx], p_arr[idx + 1], p_arr[idx + 2], p_arr[idx + 3], p_arr[idx + 4], p_arr[idx + 5]));
-		idx += 6;
+		CHECK_TYPE(p_arr[idx + 6], PACKED_STRING_ARRAY); // script_class_chain.
+		CHECK_TYPE(p_arr[idx + 7], STRING); // native_class_name.
+		CHECK_TYPE(p_arr[idx + 8], PACKED_STRING_ARRAY); // groups.
+		nodes.push_back(RemoteNode(p_arr[idx], p_arr[idx + 1], p_arr[idx + 2], p_arr[idx + 3], p_arr[idx + 4], p_arr[idx + 5], p_arr[idx + 6], p_arr[idx + 7], p_arr[idx + 8]));
+		idx += 9;
 	}
 }
 

--- a/scene/debugger/scene_debugger_object.h
+++ b/scene/debugger/scene_debugger_object.h
@@ -68,6 +68,9 @@ public:
 		ObjectID id;
 		String scene_file_path;
 		uint8_t view_flags = 0;
+		Vector<String> script_class_chain;
+		String native_class_name;
+		Vector<String> groups;
 
 		enum ViewFlags {
 			VIEW_HAS_VISIBLE_METHOD = 1 << 1,
@@ -75,7 +78,7 @@ public:
 			VIEW_VISIBLE_IN_TREE = 1 << 3,
 		};
 
-		RemoteNode(int p_child, const String &p_name, const String &p_type, ObjectID p_id, const String p_scene_file_path, int p_view_flags) {
+		RemoteNode(int p_child, const String &p_name, const String &p_type, ObjectID p_id, const String p_scene_file_path, int p_view_flags, const Vector<String> &p_script_class_chain, const String &p_native_class_name, const Vector<String> &p_groups) {
 			child_count = p_child;
 			name = p_name;
 			type_name = p_type;
@@ -83,6 +86,9 @@ public:
 
 			scene_file_path = p_scene_file_path;
 			view_flags = p_view_flags;
+			script_class_chain = p_script_class_chain;
+			native_class_name = p_native_class_name;
+			groups = p_groups;
 		}
 
 		RemoteNode() {}


### PR DESCRIPTION
## What problem(s) does this PR solve?

Implements filtering nodes in the Remote tab of the SceneTreeDock using "type:", "t:", "group:", and "g", with functionality mimicked from how SceneTreeEditor does it, so that the Local and Remote tabs in SceneTreeDock are consistent.

- Closes #79035

## Additional information

I expanded `RemoteNode` to carry the information needed for Group and Type filtering, including both native types and custom types. Just like SceneTreeEditor, only persistent groups are shown.

If I was reviewing this I'd be concerned about slowdown since `RemoteNode` was expanded and now carries a bunch of strings with it. However I tested this fairly thoroughly with a lot of stress tests including 10,000+ nodes at once, with lots of groups, and experienced no difference or issues with filtering while the project was running.

This also uses `.to_lower().contains()` instead of `is_subsequence_ofn` so that Remote and Local both use the same method of filtering, which wasn't the case before and was always odd to me.
