### PR TITLE
Fix AtlasTexture nesting for 2D particles

### DIFF
--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -198,20 +198,29 @@ void CPUParticles2D::_update_mesh_texture() {
 		-tex_size * 0.5 + Vector2(0, tex_size.y)
 	};
 
-	Vector<Vector2> uvs;
-	AtlasTexture *atlas_texture = Object::cast_to<AtlasTexture>(*texture);
-	if (atlas_texture && atlas_texture->get_atlas().is_valid()) {
-		Rect2 region_rect = atlas_texture->get_region();
-		Size2 atlas_size = atlas_texture->get_atlas()->get_size();
-		uvs.push_back(Vector2(region_rect.position.x / atlas_size.x, region_rect.position.y / atlas_size.y));
-		uvs.push_back(Vector2((region_rect.position.x + region_rect.size.x) / atlas_size.x, region_rect.position.y / atlas_size.y));
-		uvs.push_back(Vector2((region_rect.position.x + region_rect.size.x) / atlas_size.x, (region_rect.position.y + region_rect.size.y) / atlas_size.y));
-		uvs.push_back(Vector2(region_rect.position.x / atlas_size.x, (region_rect.position.y + region_rect.size.y) / atlas_size.y));
-	} else {
-		uvs.push_back(Vector2(0, 0));
-		uvs.push_back(Vector2(1, 0));
-		uvs.push_back(Vector2(1, 1));
-		uvs.push_back(Vector2(0, 1));
+	Vector<Vector2> uvs = {
+		Vector2(0, 0),
+		Vector2(1, 0),
+		Vector2(1, 1),
+		Vector2(0, 1)
+	};
+	
+	Ref<AtlasTexture> atlas_texture = texture;
+	if (atlas_texture.is_valid()) {
+		Rect2 region;
+		Ref<Texture2D> base_texture =
+				atlas_texture->get_base_texture_and_region(region);
+
+		if (base_texture.is_valid()) {
+			Size2 base_size = base_texture->get_size();
+			Vector2 region_end = region.get_end();
+
+			Vector2 *uvs_write = uvs.ptrw();
+			uvs_write[0] = region.position / base_size;
+			uvs_write[1] = Vector2(region_end.x, region.position.y) / base_size;
+			uvs_write[2] = region_end / base_size;
+			uvs_write[3] = Vector2(region.position.x, region_end.y) / base_size;
+		}
 	}
 
 	Vector<Color> colors = {

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -680,6 +680,23 @@ void GPUParticles2D::_notification(int p_what) {
 					}
 				}
 
+				Ref<AtlasTexture> atlas_texture = texture;
+				if (atlas_texture.is_valid()) {
+					Rect2 region;
+					Ref<Texture2D> base_texture =
+							atlas_texture->get_base_texture_and_region(region);
+
+					if (base_texture.is_valid()) {
+						Size2 base_size = base_texture->get_size();
+						Vector2 region_min = region.position / base_size;
+						Vector2 region_size = region.size / base_size;
+
+						Vector2 *uvs_write = uvs.ptrw();
+						for (int i = 0; i < uvs.size(); i++) {
+							uvs_write[i] = region_min + uvs_write[i] * region_size;
+						}
+					}
+				}
 				Array arr;
 				arr.resize(RSE::ARRAY_MAX);
 				arr[RSE::ARRAY_VERTEX] = points;
@@ -711,20 +728,28 @@ void GPUParticles2D::_notification(int p_what) {
 					Vector2(-size.x / 2.0, size.y / 2.0)
 				};
 
-				Vector<Vector2> uvs;
-				AtlasTexture *atlas_texture = Object::cast_to<AtlasTexture>(*texture);
-				if (atlas_texture && atlas_texture->get_atlas().is_valid()) {
-					Rect2 region_rect = atlas_texture->get_region();
-					Size2 atlas_size = atlas_texture->get_atlas()->get_size();
-					uvs.push_back(Vector2(region_rect.position.x / atlas_size.x, region_rect.position.y / atlas_size.y));
-					uvs.push_back(Vector2((region_rect.position.x + region_rect.size.x) / atlas_size.x, region_rect.position.y / atlas_size.y));
-					uvs.push_back(Vector2((region_rect.position.x + region_rect.size.x) / atlas_size.x, (region_rect.position.y + region_rect.size.y) / atlas_size.y));
-					uvs.push_back(Vector2(region_rect.position.x / atlas_size.x, (region_rect.position.y + region_rect.size.y) / atlas_size.y));
-				} else {
-					uvs.push_back(Vector2(0, 0));
-					uvs.push_back(Vector2(1, 0));
-					uvs.push_back(Vector2(1, 1));
-					uvs.push_back(Vector2(0, 1));
+				Vector<Vector2> uvs = {
+					Vector2(0, 0),
+					Vector2(1, 0),
+					Vector2(1, 1),
+					Vector2(0, 1)
+				};
+				Ref<AtlasTexture> atlas_texture = texture;
+				if (atlas_texture.is_valid()) {
+					Rect2 region;
+					Ref<Texture2D> base_texture =
+							atlas_texture->get_base_texture_and_region(region);
+
+					if (base_texture.is_valid()) {
+						Size2 base_size = base_texture->get_size();
+						Vector2 region_end = region.get_end();
+
+						Vector2 *uvs_write = uvs.ptrw();
+						uvs_write[0] = region.position / base_size;
+						uvs_write[1] = Vector2(region_end.x, region.position.y) / base_size;
+						uvs_write[2] = region_end / base_size;
+						uvs_write[3] = Vector2(region.position.x, region_end.y) / base_size;
+					}
 				}
 
 				Vector<int> indices = { 0, 1, 2, 0, 2, 3 };

--- a/scene/resources/atlas_texture.cpp
+++ b/scene/resources/atlas_texture.cpp
@@ -139,6 +139,22 @@ Rect2 AtlasTexture::_get_region_rect() const {
 	return rc;
 }
 
+Ref<Texture2D> AtlasTexture::get_base_texture_and_region(Rect2 &r_region) const {
+	r_region = _get_region_rect();
+
+	Ref<Texture2D> current = atlas;
+	Ref<AtlasTexture> parent = current;
+	while (parent.is_valid()) {
+		Rect2 parent_region = parent->_get_region_rect();
+		r_region.position += parent_region.position - parent->margin.position;
+
+		current = parent->atlas;
+		parent = current;
+	}
+
+	return current;
+}
+
 void AtlasTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_atlas", "atlas"), &AtlasTexture::set_atlas);
 	ClassDB::bind_method(D_METHOD("get_atlas"), &AtlasTexture::get_atlas);

--- a/scene/resources/atlas_texture.h
+++ b/scene/resources/atlas_texture.h
@@ -59,6 +59,7 @@ public:
 
 	void set_region(const Rect2 &p_region);
 	Rect2 get_region() const;
+	Ref<Texture2D> get_base_texture_and_region(Rect2 &r_region) const;
 
 	void set_margin(const Rect2 &p_margin);
 	Rect2 get_margin() const;


### PR DESCRIPTION
Adjusted the atlas texture processing such that it gets the proper segment of the texture from the Atlas if it is a nested AtlasTexture (the atlas of the texture is ANOTHER atlas texture) For particle2d nodes

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->
Location of the relevant functions to this specific issue

## What problem(s) does this PR solve?
Nested Atlas Textures not working for Particle2D Nodes (CPU and GPU)

- Closes #33855

## Additional information
This doesn't fully close the problem, considering I haven't figured out how to fix the materials (especially 3D ones) not being compatible with AtlasTextures, but for Particle2D Nodes it works. 



<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
