### PR TITLE
[Expression] Add argument to limit allowed built-in function scope.

### DIFF
--- a/core/math/expression.compat.inc
+++ b/core/math/expression.compat.inc
@@ -1,0 +1,45 @@
+/**************************************************************************/
+/*  expression.compat.inc                                                 */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef DISABLE_DEPRECATED
+
+#include "expression.h"
+
+#include "core/object/class_db.h"
+
+Error Expression::_parse_bind_compat_123130(const String &p_expression, const Vector<String> &p_input_names) {
+	return parse(p_expression, p_input_names, FUNC_TYPE_MATH | FUNC_TYPE_RANDOM | FUNC_TYPE_GENERAL);
+}
+
+void Expression::_bind_compatibility_methods() {
+	ClassDB::bind_compatibility_method(D_METHOD("parse", "expression", "input_names"), &Expression::_parse_bind_compat_123130, DEFVAL(Vector<String>()));
+}
+
+#endif // DISABLE_DEPRECATED

--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -29,6 +29,7 @@
 /**************************************************************************/
 
 #include "expression.h"
+#include "expression.compat.inc"
 
 #include "core/object/class_db.h"
 
@@ -483,6 +484,12 @@ Error Expression::_get_token(Token &r_token) {
 						}
 
 						if (Variant::has_utility_function(id)) {
+							Variant::UtilityFunctionType ftype = Variant::get_utility_function_type(id);
+							if (!allowed_scope.has_flag(1 << ftype)) {
+								_set_error(vformat("Unexpected function '%s'", id));
+								r_token.type = TK_ERROR;
+								return ERR_PARSE_ERROR;
+							}
 							r_token.type = TK_BUILTIN_FUNC;
 							r_token.value = id;
 							return OK;
@@ -500,7 +507,7 @@ Error Expression::_get_token(Token &r_token) {
 					return OK;
 
 				} else {
-					_set_error("Unexpected character.");
+					_set_error("Unexpected character");
 					r_token.type = TK_ERROR;
 					return ERR_PARSE_ERROR;
 				}
@@ -1395,6 +1402,12 @@ bool Expression::_execute(const Array &p_inputs, Object *p_instance, Expression:
 		case Expression::ENode::TYPE_BUILTIN_FUNC: {
 			const Expression::BuiltinFuncNode *bifunc = static_cast<const Expression::BuiltinFuncNode *>(p_node);
 
+			Variant::UtilityFunctionType ftype = Variant::get_utility_function_type(bifunc->func);
+			if (!allowed_scope.has_flag(1 << ftype)) {
+				r_error_str = vformat("Unexpected function '%s'", bifunc->func);
+				return false;
+			}
+
 			Vector<Variant> arr;
 			Vector<const Variant *> argp;
 			arr.resize(bifunc->arguments.size());
@@ -1462,7 +1475,7 @@ bool Expression::_execute(const Array &p_inputs, Object *p_instance, Expression:
 	return false;
 }
 
-Error Expression::parse(const String &p_expression, const Vector<String> &p_input_names) {
+Error Expression::parse(const String &p_expression, const Vector<String> &p_input_names, BitField<UtilityFunctionTypeFlags> p_allowed_scope) {
 	if (nodes) {
 		memdelete(nodes);
 		nodes = nullptr;
@@ -1473,6 +1486,7 @@ Error Expression::parse(const String &p_expression, const Vector<String> &p_inpu
 	error_set = false;
 	str_ofs = 0;
 	input_names = p_input_names;
+	allowed_scope = p_allowed_scope;
 
 	expression = p_expression;
 	root = _parse_expression();
@@ -1512,10 +1526,14 @@ String Expression::get_error_text() const {
 }
 
 void Expression::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("parse", "expression", "input_names"), &Expression::parse, DEFVAL(Vector<String>()));
+	ClassDB::bind_method(D_METHOD("parse", "expression", "input_names", "allowed_scope"), &Expression::parse, DEFVAL(Vector<String>()), DEFVAL(FUNC_TYPE_MATH | FUNC_TYPE_RANDOM | FUNC_TYPE_GENERAL));
 	ClassDB::bind_method(D_METHOD("execute", "inputs", "base_instance", "show_error", "const_calls_only"), &Expression::execute, DEFVAL(Array()), DEFVAL(Variant()), DEFVAL(true), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("has_execute_failed"), &Expression::has_execute_failed);
 	ClassDB::bind_method(D_METHOD("get_error_text"), &Expression::get_error_text);
+
+	BIND_BITFIELD_FLAG(FUNC_TYPE_MATH);
+	BIND_BITFIELD_FLAG(FUNC_TYPE_RANDOM);
+	BIND_BITFIELD_FLAG(FUNC_TYPE_GENERAL);
 }
 
 Expression::~Expression() {

--- a/core/math/expression.h
+++ b/core/math/expression.h
@@ -31,9 +31,17 @@
 #pragma once
 
 #include "core/object/ref_counted.h"
+#include "core/variant/type_info.h"
 
 class Expression : public RefCounted {
 	GDCLASS(Expression, RefCounted);
+
+public:
+	enum UtilityFunctionTypeFlags : uint64_t {
+		FUNC_TYPE_MATH = 1 << Variant::UTILITY_FUNC_TYPE_MATH,
+		FUNC_TYPE_RANDOM = 1 << Variant::UTILITY_FUNC_TYPE_RANDOM,
+		FUNC_TYPE_GENERAL = 1 << Variant::UTILITY_FUNC_TYPE_GENERAL,
+	};
 
 protected:
 	String expression;
@@ -240,6 +248,7 @@ protected:
 	ENode *nodes = nullptr;
 
 	Vector<String> input_names;
+	BitField<UtilityFunctionTypeFlags> allowed_scope = FUNC_TYPE_MATH | FUNC_TYPE_RANDOM | FUNC_TYPE_GENERAL;
 
 	bool execution_error = false;
 	bool _execute(const Array &p_inputs, Object *p_instance, Expression::ENode *p_node, Variant &r_ret, bool p_const_calls_only, String &r_error_str);
@@ -247,11 +256,18 @@ protected:
 protected:
 	static void _bind_methods();
 
+#ifndef DISABLE_DEPRECATED
+	Error _parse_bind_compat_123130(const String &p_expression, const Vector<String> &p_input_names);
+	static void _bind_compatibility_methods();
+#endif
+
 public:
-	Error parse(const String &p_expression, const Vector<String> &p_input_names = Vector<String>());
+	Error parse(const String &p_expression, const Vector<String> &p_input_names = Vector<String>(), BitField<UtilityFunctionTypeFlags> p_allowed_scope = FUNC_TYPE_MATH | FUNC_TYPE_RANDOM | FUNC_TYPE_GENERAL);
 	Variant execute(const Array &p_inputs = Array(), Object *p_base = nullptr, bool p_show_error = true, bool p_const_calls_only = false);
 	bool has_execute_failed() const;
 	String get_error_text() const;
 
 	~Expression();
 };
+
+VARIANT_BITFIELD_CAST(Expression::UtilityFunctionTypeFlags);

--- a/core/string/plural_rules.cpp
+++ b/core/string/plural_rules.cpp
@@ -39,7 +39,7 @@ int PluralRules::_eq_test(const Array &p_input_val, const Ref<EQNode> &p_node, c
 
 	static const Vector<String> input_name = { "n" };
 
-	Error err = expr->parse(p_node->regex, input_name);
+	Error err = expr->parse(p_node->regex, input_name, Expression::FUNC_TYPE_MATH | Expression::FUNC_TYPE_RANDOM);
 	ERR_FAIL_COND_V_MSG(err != OK, 0, vformat("Cannot parse expression \"%s\". Error: %s", p_node->regex, expr->get_error_text()));
 
 	Variant result = expr->execute(p_input_val);

--- a/doc/classes/Expression.xml
+++ b/doc/classes/Expression.xml
@@ -79,10 +79,22 @@
 			<return type="int" enum="Error" />
 			<param index="0" name="expression" type="String" />
 			<param index="1" name="input_names" type="PackedStringArray" default="PackedStringArray()" />
+			<param index="2" name="allowed_scope" type="int" enum="Expression.UtilityFunctionTypeFlags" is_bitfield="true" default="7" />
 			<description>
 				Parses the expression and returns an [enum Error] code.
-				You can optionally specify names of variables that may appear in the expression with [param input_names], so that you can bind them when it gets executed.
+				You can optionally specify names of variables that may appear in the expression with [param input_names], so that you can bind them when it gets executed. Use [param allowed_scope] to limit the set of functions available in the expression.
 			</description>
 		</method>
 	</methods>
+	<constants>
+		<constant name="FUNC_TYPE_MATH" value="1" enum="UtilityFunctionTypeFlags" is_bitfield="true">
+			If set, allows using mathematical functions from [@GlobalScope] (for example [method @GlobalScope.round], [method @GlobalScope.cos], or [method @GlobalScope.pow]).
+		</constant>
+		<constant name="FUNC_TYPE_RANDOM" value="2" enum="UtilityFunctionTypeFlags" is_bitfield="true">
+			If set, allows using RNG functions from [@GlobalScope] (for example [method @GlobalScope.randomize], [method @GlobalScope.randi], or [method @GlobalScope.randf]).
+		</constant>
+		<constant name="FUNC_TYPE_GENERAL" value="4" enum="UtilityFunctionTypeFlags" is_bitfield="true">
+			If set, allows using utility functions from [@GlobalScope] (for example [method @GlobalScope.print], [method @GlobalScope.str_to_var], or [method @GlobalScope.instance_from_id]).
+		</constant>
+	</constants>
 </class>

--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -612,13 +612,13 @@ void EditorSpinSlider::_evaluate_input_text() {
 	text = text.replace_char(';', ',');
 	text = TranslationServer::get_singleton()->parse_number(text, lang);
 
-	Error err = expr->parse(text);
+	Error err = expr->parse(text, Vector<String>(), Expression::FUNC_TYPE_MATH | Expression::FUNC_TYPE_RANDOM);
 	if (err != OK) {
 		// If the expression failed try without converting commas to dots - they might have been for parameter separation.
 		text = value_input->get_text();
 		text = TranslationServer::get_singleton()->parse_number(text, lang);
 
-		err = expr->parse(text);
+		err = expr->parse(text, Vector<String>(), Expression::FUNC_TYPE_MATH | Expression::FUNC_TYPE_RANDOM);
 		if (err != OK) {
 			return;
 		}

--- a/misc/extension_api_validation/4.7-stable/GH-123130.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-123130.txt
@@ -1,0 +1,7 @@
+GH-123130
+---------
+
+Validate extension JSON: Error: Field 'classes/Expression/methods/parse/arguments': size changed value in new API, from 2 to 3.
+
+Added optional "allowed_scope" argument.
+Compatibility method registered.

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -675,7 +675,7 @@ void ColorPicker::_html_submitted(const String &p_html) {
 	if (text_is_constructor || !is_color_valid_hex(color)) {
 		Ref<Expression> expr;
 		expr.instantiate();
-		Error err = expr->parse(p_html);
+		Error err = expr->parse(p_html, Vector<String>(), Expression::FUNC_TYPE_MATH | Expression::FUNC_TYPE_RANDOM);
 		if (err == OK) {
 			Variant result = expr->execute(Array(), nullptr, false, true);
 			// This is basically the same as Variant::operator Color(), but remains original color if Color::from_string() fails

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -177,14 +177,14 @@ void SpinBox::_text_submitted(const String &p_string) {
 	text = text.replace_char(';', ',');
 	text = TranslationServer::get_singleton()->parse_number(text, lang);
 
-	Error err = expr->parse(text);
+	Error err = expr->parse(text, Vector<String>(), Expression::FUNC_TYPE_MATH | Expression::FUNC_TYPE_RANDOM);
 
 	if (err != OK) {
 		// If the expression failed try without converting commas to dots - they might have been for parameter separation.
 		text = p_string;
 		text = TranslationServer::get_singleton()->parse_number(text, lang);
 
-		err = expr->parse(text);
+		err = expr->parse(text, Vector<String>(), Expression::FUNC_TYPE_MATH | Expression::FUNC_TYPE_RANDOM);
 		if (err != OK) {
 			_update_text();
 			return;


### PR DESCRIPTION
Adds argument to the `Expression.parse` to limit usable function set, and uses it for default controls.

## What problem(s) does this PR solve?

Prevents user accessible controls spin box and color picker from using unsafe utility functions.
