### PR TITLE
Strip trailing path separators in `OS::get_safe_dir_name`

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -283,7 +283,8 @@ String OS::get_safe_dir_name(const String &p_dir_name, bool p_allow_paths) const
 
 	// Trim trailing periods from the returned value as it's not valid for folder names on Windows.
 	// This check is still applied on non-Windows platforms so the returned value is consistent across platforms.
-	return safe_dir_name.rstrip(".");
+	// Trailing path separators are trimmed too, otherwise joining a file name to the result yields "//".
+	return safe_dir_name.rstrip("./");
 }
 
 // Path to data, config, cache, etc. OS-specific folders

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -327,7 +327,7 @@
 		<member name="application/config/custom_user_dir_name" type="String" setter="" getter="" default="&quot;&quot;">
 			This user directory is used for storing persistent data ([code]user://[/code] filesystem). If a custom directory name is defined, this name will be appended to the system-specific user data directory (same parent folder as the Godot configuration folder documented in [method OS.get_user_data_dir]).
 			The [member application/config/use_custom_user_dir] setting must be enabled for this to take effect.
-			[b]Note:[/b] If [member application/config/custom_user_dir_name] contains trailing periods, they will be stripped as folder names ending with a period are not allowed on Windows.
+			[b]Note:[/b] If [member application/config/custom_user_dir_name] contains trailing periods, they will be stripped as folder names ending with a period are not allowed on Windows. Trailing path separators are stripped as well.
 		</member>
 		<member name="application/config/description" type="String" setter="" getter="" default="&quot;&quot;">
 			The project's description, displayed as a tooltip in the Project Manager when hovering the project.

--- a/tests/core/os/test_os.cpp
+++ b/tests/core/os/test_os.cpp
@@ -200,4 +200,18 @@ TEST_CASE("[OS] Execute") {
 #endif
 }
 
+TEST_CASE("[OS] Safe directory names") {
+	const OS *os = OS::get_singleton();
+
+	CHECK(os->get_safe_dir_name("a/b\\c") == "a-b-c");
+	CHECK(os->get_safe_dir_name("name...") == "name");
+
+	CHECK(os->get_safe_dir_name("Studio/Game", true) == "Studio/Game");
+	CHECK(os->get_safe_dir_name("Studio/Game/", true) == "Studio/Game");
+	CHECK(os->get_safe_dir_name("Studio\\Game\\", true) == "Studio/Game");
+	CHECK(os->get_safe_dir_name("Game./", true) == "Game");
+	CHECK(os->get_safe_dir_name("Game/.", true) == "Game");
+	CHECK(os->get_safe_dir_name("/", true) == "");
+}
+
 } // namespace TestOS


### PR DESCRIPTION
## What problem(s) does this PR solve?

When `application/config/custom_user_dir_name` ends with a slash, `OS::get_safe_dir_name()` keeps it, so every path built from `user://` carries a double slash. `ProjectSettings.globalize_path("user://")` returns `…/MyGame//`, and at startup the renderer cannot create its shader cache folder.

- Fixes #110029
- Fixes #106062

## Additional information

Trailing separators are now trimmed in `get_safe_dir_name()` next to the existing trailing-period trim. Both callers that pass `p_allow_paths` are covered (`OS::get_user_data_dir()` and the project manager's user dir lookup). In the default mode separators are already replaced with `-`, so nothing changes there.

Before/after with `custom_user_dir_name = "MyGame/"` on macOS, current master:

| | before | after |
|---|---|---|
| `OS.get_user_data_dir()` | `…/MyGame/` | `…/MyGame` |
| `ProjectSettings.globalize_path("user://")` | `…/MyGame//` | `…/MyGame/` |
| `Can't create shader cache folder` at startup | printed | gone |
| `FileAccess.open("user://shader_cache/x", WRITE)` | fails | works |

Nested names such as `Studio/Game/` behave the same. A leading slash is harmless because `path_join()` already handles it.

Not covered: a name ending in `" /"` now yields a trailing space. That is a pre-existing limitation of the period trim as well (`"name ."` → `"name "`), and changing it would relocate existing user directories on Linux, so it is left for a separate discussion.

AI disclosure: this PR was prepared with Claude Code's assistance under my direction; I reviewed every line and verified the before/after behavior locally.
