### PR TITLE
Add `ObjectGDType` to hold `Object` specific type info.

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -793,7 +793,7 @@ ObjectGDExtension *ClassDB::get_placeholder_extension(const StringName &p_class)
 }
 #endif
 
-const GDType *ClassDB::get_gdtype(const StringName &p_class) {
+const ObjectGDType *ClassDB::get_gdtype(const StringName &p_class) {
 	Locker::Lock lock(Locker::STATE_READ);
 	ClassInfo *type = classes.getptr(p_class);
 	ERR_FAIL_NULL_V(type, nullptr);
@@ -921,7 +921,7 @@ bool ClassDB::is_gdextension(const StringName &p_class) {
 	return false;
 }
 
-void ClassDB::_add_class(GDType &p_class, const GDType *p_inherits) {
+void ClassDB::_add_class(ObjectGDType &p_class, const ObjectGDType *p_inherits) {
 	Locker::Lock lock(Locker::STATE_WRITE);
 
 	const StringName &name = p_class.get_name();
@@ -1396,19 +1396,7 @@ void ClassDB::add_linked_property(const StringName &p_class, const String &p_pro
 	ClassInfo *type = classes.getptr(p_class);
 	ERR_FAIL_NO_CLASS(type, p_class);
 
-	const GDType::Member *member = type->gdtype->members(true).getptr(p_property);
-	ERR_FAIL_NULL(member);
-	ERR_FAIL_COND(member->type != GDType::Member::Type::PROPERTY);
-
-	const GDType::Member *linked_property = type->gdtype->members(true).getptr(p_linked_property);
-	ERR_FAIL_NULL(linked_property);
-	ERR_FAIL_COND(linked_property->type != GDType::Member::Type::PROPERTY);
-
-	if (!type->linked_properties.has(p_property)) {
-		type->linked_properties.insert(p_property, List<StringName>());
-	}
-	type->linked_properties[p_property].push_back(p_linked_property);
-
+	type->gdtype->link_properties(p_property, p_linked_property);
 #endif
 }
 
@@ -1436,10 +1424,10 @@ void ClassDB::get_linked_properties_info(const StringName &p_class, const String
 #ifdef TOOLS_ENABLED
 	ClassInfo *check = classes.getptr(p_class);
 	while (check) {
-		if (!check->linked_properties.has(p_property)) {
+		if (!check->gdtype->get_self_linked_properties().has(p_property)) {
 			return;
 		}
-		for (const StringName &E : check->linked_properties[p_property]) {
+		for (const StringName &E : check->gdtype->get_self_linked_properties()[p_property]) {
 			r_properties->push_back(E);
 		}
 
@@ -2030,7 +2018,7 @@ void ClassDB::register_extension_class(ObjectGDExtension *p_extension) {
 	c.is_runtime = p_extension->is_runtime;
 #endif
 
-	c.gdtype = memnew(GDType(c.inherits_ptr->gdtype, p_extension->class_name));
+	c.gdtype = memnew(ObjectGDType(c.inherits_ptr->gdtype, p_extension->class_name));
 	c.gdtype->initialize();
 	p_extension->gdtype = c.gdtype;
 
@@ -2085,7 +2073,7 @@ void ClassDB::cleanup_defaults() {
 	default_values_cached.clear();
 }
 
-LocalVector<GDType **> ClassDB::gdtype_autorelease_pool;
+LocalVector<ObjectGDType **> ClassDB::gdtype_autorelease_pool;
 void ClassDB::cleanup() {
 	//OBJTYPE_LOCK; hah not here
 
@@ -2101,7 +2089,7 @@ void ClassDB::cleanup() {
 	compat_classes.clear();
 	native_structs.clear();
 
-	for (GDType **type : gdtype_autorelease_pool) {
+	for (ObjectGDType **type : gdtype_autorelease_pool) {
 		if (!*type) {
 			WARN_PRINT("GDType in autorelease pool was cleaned up before being auto-released. Ignoring.");
 			continue;

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -96,7 +96,6 @@ MethodDefinition D_METHOD(const char *p_name, const VarArgs... p_args) {
 
 class ClassDB {
 	friend class Object;
-	friend class GDType;
 
 public:
 	enum APIType {
@@ -112,7 +111,7 @@ public:
 		APIType api = API_NONE;
 		ClassInfo *inherits_ptr = nullptr;
 		void *class_ptr = nullptr;
-		GDType *gdtype = nullptr;
+		ObjectGDType *gdtype = nullptr;
 
 		ObjectGDExtension *gdextension = nullptr;
 
@@ -120,7 +119,6 @@ public:
 		List<MethodInfo> virtual_methods;
 		HashMap<StringName, MethodInfo> virtual_methods_map;
 		HashMap<StringName, Vector<Error>> method_error_values;
-		HashMap<StringName, List<StringName>> linked_properties;
 #endif // DEBUG_ENABLED
 
 #ifdef TOOLS_ENABLED
@@ -190,7 +188,7 @@ public:
 	static APIType current_api;
 	static HashMap<APIType, uint32_t> api_hashes_cache;
 
-	static void _add_class(GDType &p_class, const GDType *p_inherits);
+	static void _add_class(ObjectGDType &p_class, const ObjectGDType *p_inherits);
 
 	static HashMap<StringName, HashMap<StringName, Variant>> default_values;
 	static HashSet<StringName> default_values_cached;
@@ -207,7 +205,7 @@ public:
 
 	// Types added here will be automatically cleaned up on engine shutdown.
 	// Only add types that aren't cleaned up in another way.
-	static LocalVector<GDType **> gdtype_autorelease_pool;
+	static LocalVector<ObjectGDType **> gdtype_autorelease_pool;
 
 private:
 	// Non-locking variants of get_parent_class and is_parent_class.
@@ -310,7 +308,7 @@ public:
 	static void get_extension_class_list(const Ref<GDExtension> &p_extension, List<StringName> *p_classes);
 	static ObjectGDExtension *get_placeholder_extension(const StringName &p_class);
 #endif
-	static const GDType *get_gdtype(const StringName &p_class);
+	static const ObjectGDType *get_gdtype(const StringName &p_class);
 	static void get_inheriters_from_class(const StringName &p_class, LocalVector<StringName> &p_classes);
 	static void get_direct_inheriters_from_class(const StringName &p_class, List<StringName> *p_classes);
 	static StringName get_parent_class_nocheck(const StringName &p_class);

--- a/core/object/gdtype.h
+++ b/core/object/gdtype.h
@@ -142,7 +142,7 @@ protected:
 
 public:
 	GDType(const GDType *p_super_type, StringName p_name);
-	~GDType();
+	virtual ~GDType();
 
 	InitState get_init_state() const { return init_state; }
 	void initialize();

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1412,7 +1412,7 @@ void Object::_reset_gdtype() const {
 	}
 }
 
-void Object::autorelease_gdtype(GDType **r_type) {
+void Object::autorelease_gdtype(ObjectGDType **r_type) {
 	ClassDB::gdtype_autorelease_pool.push_back(r_type);
 }
 
@@ -1858,7 +1858,7 @@ void Object::_clear_internal_resource_paths(const Variant &p_var) {
 	}
 }
 
-void Object::_add_class_to_classdb(GDType &p_type, const GDType *p_inherits) {
+void Object::_add_class_to_classdb(ObjectGDType &p_type, const ObjectGDType *p_inherits) {
 	ClassDB::_add_class(p_type, p_inherits);
 }
 
@@ -2170,7 +2170,7 @@ uint32_t Object::get_edited_version() const {
 }
 #endif
 
-const GDType &Object::get_gdtype() const {
+const ObjectGDType &Object::get_gdtype() const {
 	if (unlikely(!_gdtype_ptr)) {
 		// While class is initializing / deinitializing, constructors and destructors
 		// need access to the proper type at the proper stage.

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -31,8 +31,8 @@
 #pragma once
 
 #include "core/extension/gdextension_interface.gen.h"
-#include "core/object/gdtype.h"
 #include "core/object/method_info.h"
+#include "core/object/object_gdtype.h"
 #include "core/object/object_id.h"
 #include "core/object/property_info.h"
 #include "core/os/mutex.h"
@@ -132,7 +132,7 @@ struct ObjectGDExtension {
 	/// A type for this Object extension.
 	/// This is not exposed through the GDExtension API (yet) so it is inferred from above parameters.
 	/// The GDType's lifetime is (usually) owned by ClassDB.
-	const GDType *gdtype = nullptr;
+	const ObjectGDType *gdtype = nullptr;
 };
 
 #define GDVIRTUAL_CALL(m_name, ...) _gdvirtual_##m_name##_call(__VA_ARGS__)
@@ -248,8 +248,8 @@ private: \
 	void operator=(const m_class &p_rval) = delete; \
 	friend class ::ClassDB; \
 \
-	static GDType &get_gdtype_static_mutable() { \
-		static GDType *gdtype = nullptr; \
+	static ObjectGDType &get_gdtype_static_mutable() { \
+		static ObjectGDType *gdtype = nullptr; \
 		static bool initialized = false; \
 		if (likely(initialized)) { \
 			return *gdtype; \
@@ -260,17 +260,17 @@ private: \
 		if (initialized) { \
 			return *gdtype; \
 		} \
-		gdtype = memnew(GDType(&super_type::get_gdtype_static(), StringName(#m_class))); \
+		gdtype = memnew(ObjectGDType(&super_type::get_gdtype_static(), StringName(#m_class))); \
 		m_class::autorelease_gdtype(&gdtype); \
 		initialized = true; \
 		return *gdtype; \
 	} \
 \
 public: \
-	virtual const GDType &_get_typev() const override { \
+	virtual const ObjectGDType &_get_typev() const override { \
 		return get_gdtype_static(); \
 	} \
-	static const GDType &get_gdtype_static() { \
+	static const ObjectGDType &get_gdtype_static() { \
 		return get_gdtype_static_mutable(); \
 	} \
 	static const StringName &get_class_static() { \
@@ -451,11 +451,11 @@ private:
 #endif
 	ScriptInstance *script_instance = nullptr;
 	HashMap<StringName, Variant> metadata;
-	mutable const GDType *_gdtype_ptr = nullptr;
+	mutable const ObjectGDType *_gdtype_ptr = nullptr;
 	void _reset_gdtype() const;
 
-	static GDType &get_gdtype_static_mutable() {
-		static GDType *gdtype = nullptr;
+	static ObjectGDType &get_gdtype_static_mutable() {
+		static ObjectGDType *gdtype = nullptr;
 		static bool initialized = false;
 		if (likely(initialized)) {
 			return *gdtype;
@@ -466,7 +466,7 @@ private:
 		if (initialized) {
 			return *gdtype;
 		}
-		gdtype = memnew(GDType(nullptr, StringName("Object")));
+		gdtype = memnew(ObjectGDType(nullptr, StringName("Object")));
 		autorelease_gdtype(&gdtype);
 		initialized = true;
 		return *gdtype;
@@ -580,9 +580,9 @@ protected:
 	Variant _call_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 	Variant _call_deferred_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 
-	static void autorelease_gdtype(GDType **r_type);
+	static void autorelease_gdtype(ObjectGDType **r_type);
 
-	virtual const GDType &_get_typev() const { return get_gdtype_static(); }
+	virtual const ObjectGDType &_get_typev() const { return get_gdtype_static(); }
 
 	TypedArray<StringName> _get_meta_list_bind() const;
 	TypedArray<Dictionary> _get_property_list_bind() const;
@@ -593,7 +593,7 @@ protected:
 	friend class ::ClassDB;
 	friend class PlaceholderExtensionInstance;
 
-	static void _add_class_to_classdb(GDType &p_class, const GDType *p_inherits);
+	static void _add_class_to_classdb(ObjectGDType &p_class, const ObjectGDType *p_inherits);
 	static void _get_property_list_from_classdb(const StringName &p_class, List<PropertyInfo> *p_list, bool p_no_inheritance, const Object *p_validator);
 
 	bool _disconnect(const StringName &p_signal, const Callable &p_callable, bool p_force = false);
@@ -666,9 +666,9 @@ public:
 	};
 
 	/* TYPE API */
-	static const GDType &get_gdtype_static() { return get_gdtype_static_mutable(); }
+	static const ObjectGDType &get_gdtype_static() { return get_gdtype_static_mutable(); }
 
-	const GDType &get_gdtype() const;
+	const ObjectGDType &get_gdtype() const;
 
 	static const StringName &get_class_static() { return get_gdtype_static().get_name(); }
 

--- a/core/object/object_gdtype.cpp
+++ b/core/object/object_gdtype.cpp
@@ -1,0 +1,53 @@
+/**************************************************************************/
+/*  object_gdtype.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "core/object/object_gdtype.h"
+
+#include "core/os/thread.h"
+
+#ifdef TOOLS_ENABLED
+void ObjectGDType::link_properties(const StringName &p_property, const StringName &p_linked_property) {
+	ERR_FAIL_COND(Thread::get_caller_id() != owning_thread_id);
+	ERR_FAIL_COND(init_state != InitState::MUTABLE);
+
+	const Member *member = _self_members.getptr(p_property);
+	ERR_FAIL_NULL(member);
+	ERR_FAIL_COND(member->type != GDType::Member::Type::PROPERTY);
+
+	const Member *linked_property = _self_members.getptr(p_linked_property);
+	ERR_FAIL_NULL(linked_property);
+	ERR_FAIL_COND(linked_property->type != GDType::Member::Type::PROPERTY);
+
+	if (!self_linked_properties.has(p_property)) {
+		self_linked_properties.insert(p_property, LocalVector<StringName>());
+	}
+	self_linked_properties[p_property].push_back(p_linked_property);
+}
+#endif

--- a/core/object/object_gdtype.h
+++ b/core/object/object_gdtype.h
@@ -1,0 +1,47 @@
+/**************************************************************************/
+/*  object_gdtype.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#include "core/object/gdtype.h"
+
+class ObjectGDType : public GDType {
+protected:
+#ifdef TOOLS_ENABLED
+	AHashMap<StringName, LocalVector<StringName>> self_linked_properties;
+#endif
+public:
+	ObjectGDType(const GDType *p_super_type, StringName p_name) : GDType(p_super_type, p_name) {}
+
+#ifdef TOOLS_ENABLED
+	void link_properties(const StringName &p_property, const StringName &p_linked_property);
+	const AHashMap<StringName, LocalVector<StringName>> &get_self_linked_properties() const { return self_linked_properties; }
+#endif
+};


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Continues / relates to https://github.com/godotengine/godot-proposals/issues/12323

`Object` has some type information that does not generalise to `Variant`.
The most obvious case is inheritance, and concepts like virtual methods - supported by `Object` but not by `Variant`.

Currently this information lives in `ClassDB`, but if we intend to migrate other APIs, the stringly lookup `ClassDB` always requires is awkward.

To avoid inventing a "third place", `GDType` is subclassed to put object-specific type information.

This has strong precedent via LLVM (`Type` inherited by `StructType` and `FunctionType`) and Clang (`Decl` tree).
It also conceptually maps to how types work in most languages: Virtual pointer tables for example can be understood as the subtype's table inheriting the supertype's table. Quite literally, it just means "Object inherits the base type" which is obviously true.

## Additional information

As an example, `linked_properties` is moved from `ClassDB::ClassInfo` to `ObjectGDType`. The concept of `linked_properties` is conceptually compatible with `Variant` types, but they do not currently support it. If support is added, the `linked_properties` can be moved to `GDType`.
