### PR TITLE
Add support for calling C++ implementations of virtual methods from GDScript 

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1815,6 +1815,90 @@ void ClassDB::add_extension_class_virtual_method(const StringName &p_class, cons
 #endif // DEBUG_ENABLED
 }
 
+void ClassDB::add_virtual_method_answer(MethodBind *p_answer, const StringName &p_method_name) {
+	ERR_FAIL_NULL(p_answer);
+
+	Locker::Lock lock(Locker::STATE_WRITE);
+
+	p_answer->set_name(p_method_name);
+
+	const StringName instance_type = p_answer->get_instance_class();
+	ClassInfo *answer_type = classes.getptr(instance_type);
+	if (!answer_type) {
+		memdelete(p_answer);
+		ERR_FAIL_MSG(vformat("Couldn't bind virtual method answer '%s' for instance '%s'.", p_method_name, instance_type));
+	}
+
+#ifdef DEBUG_ENABLED
+	ClassInfo *type = answer_type;
+	MethodInfo *virtual_method = nullptr;
+	while (type) {
+		if (type->virtual_methods_map.has(p_method_name)) {
+			virtual_method = type->virtual_methods_map.getptr(p_method_name);
+			break;
+		}
+		type = type->inherits_ptr;
+	}
+
+	if (!virtual_method || !(virtual_method->flags & METHOD_FLAG_VIRTUAL)) {
+		memdelete(p_answer);
+		ERR_FAIL_MSG(vformat("Virtual method answer '%s' for instance '%s' doesn't have a corresponding virtual method.", p_method_name, instance_type));
+	}
+
+	if (virtual_method->arguments.size() != p_answer->get_argument_count()) {
+		memdelete(p_answer);
+		ERR_FAIL_MSG(vformat("Virtual method answer '%s' for instance '%s' has a different argument count than the corresponding virtual method.", p_method_name, instance_type));
+	}
+
+	if (virtual_method->return_val.type != p_answer->get_argument_type(-1)) {
+		memdelete(p_answer);
+		ERR_FAIL_MSG(vformat("Virtual method answer '%s' for instance '%s' has a different return type than the corresponding virtual method.", p_method_name, instance_type));
+	}
+
+	for (int i = 0; i < virtual_method->arguments.size(); i++) {
+		if (virtual_method->arguments[i].type != p_answer->get_argument_type(i)) {
+			memdelete(p_answer);
+			ERR_FAIL_MSG(vformat("Virtual method answer '%s' for instance '%s' has a different argument type for argument %d than the corresponding virtual method.", p_method_name, instance_type, i));
+		}
+	}
+#endif // DEBUG_ENABLED
+
+	if (answer_type->virtual_methods_answers.has(p_method_name)) {
+		memdelete(p_answer);
+		ERR_FAIL_MSG(vformat("Virtual method answer '%s' for instance '%s' already exists.", p_method_name, instance_type));
+	}
+
+	answer_type->virtual_methods_answers[p_method_name] = p_answer;
+}
+
+bool ClassDB::has_virtual_method_answer(const StringName &p_class, const StringName &p_method) {
+	Locker::Lock lock(Locker::STATE_READ);
+
+	ClassInfo *type = classes.getptr(p_class);
+	while (type) {
+		if (type->virtual_methods_answers.has(p_method)) {
+			return true;
+		}
+		type = type->inherits_ptr;
+	}
+
+	return false;
+}
+
+const MethodBind *ClassDB::get_virtual_method_answer(const StringName &p_class, const StringName &p_method) {
+	Locker::Lock lock(Locker::STATE_READ);
+
+	ClassInfo *type = classes.getptr(p_class);
+	while (type) {
+		if (type->virtual_methods_answers.has(p_method)) {
+			return type->virtual_methods_answers[p_method];
+		}
+		type = type->inherits_ptr;
+	}
+
+	return nullptr;
+}
+
 void ClassDB::set_class_enabled(const StringName &p_class, bool p_enable) {
 	Locker::Lock lock(Locker::STATE_WRITE);
 
@@ -2042,6 +2126,9 @@ static LocalVector<GDType *> gdtype_leaked_autorelease_pool;
 void ClassDB::unregister_extension_class(const StringName &p_class) {
 	ClassInfo *c = classes.getptr(p_class);
 	ERR_FAIL_NULL_MSG(c, vformat("Class '%s' does not exist.", String(p_class)));
+	for (const KeyValue<StringName, MethodBind *> &E : c->virtual_methods_answers) {
+		memdelete(E.value);
+	}
 	// Leak the GDType until exit so potential consumers don't have dangling pointers.
 	gdtype_leaked_autorelease_pool.push_back(c->gdtype);
 	classes.erase(p_class);
@@ -2090,6 +2177,10 @@ void ClassDB::cleanup() {
 	//OBJTYPE_LOCK; hah not here
 
 	for (KeyValue<StringName, ClassInfo> &E : classes) {
+		for (const KeyValue<StringName, MethodBind *> &F : E.value.virtual_methods_answers) {
+			memdelete(F.value);
+		}
+
 		if (E.value.gdextension) {
 			WARN_PRINT(vformat("Extension class '%s' is still registered at exit; its GDExtension did not unregister it.", E.key));
 			gdtype_leaked_autorelease_pool.push_back(E.value.gdtype); // We created it; we need to clear it.

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -127,6 +127,7 @@ public:
 		List<StringName> dependency_list;
 #endif
 
+		HashMap<StringName, MethodBind *> virtual_methods_answers;
 		HashMap<StringName, Vector<uint32_t>> virtual_methods_compat;
 
 		bool disabled = false;
@@ -477,6 +478,17 @@ public:
 	static void get_virtual_methods(const StringName &p_class, List<MethodInfo> *p_methods, bool p_no_inheritance = false);
 	static void add_extension_class_virtual_method(const StringName &p_class, const GDExtensionClassVirtualMethodInfo *p_method_info);
 	static Vector<uint32_t> get_virtual_method_compatibility_hashes(const StringName &p_class, const StringName &p_name);
+
+	template <typename M>
+	static void bind_virtual_method_answer(const StringName &p_method_name, M p_method) {
+		MethodBind *bind = create_method_bind(p_method);
+		ERR_FAIL_NULL(bind);
+		add_virtual_method_answer(bind, p_method_name);
+	}
+
+	static void add_virtual_method_answer(MethodBind *p_answer, const StringName &p_method_name);
+	static bool has_virtual_method_answer(const StringName &p_class, const StringName &p_method);
+	static const MethodBind *get_virtual_method_answer(const StringName &p_class, const StringName &p_method);
 
 	static void bind_integer_constant(const StringName &p_class, const StringName &p_enum, const StringName &p_name, int64_t p_constant, bool p_is_bitfield = false);
 	static void get_integer_constant_list(const StringName &p_class, List<String> *p_constants, bool p_no_inheritance = false);

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3707,7 +3707,7 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 		// If the method is implemented in the class hierarchy, the virtual/abstract flag will not be set for that `MethodInfo` and the search stops there.
 		// Virtual/abstract check only possible for super calls because class hierarchy is known. Objects may have scripts attached we don't know of at compile-time.
 		if (p_call->is_super) {
-			if (method_flags.has_flag(METHOD_FLAG_VIRTUAL)) {
+			if (method_flags.has_flag(METHOD_FLAG_VIRTUAL) && !ClassDB::has_virtual_method_answer(base_type.native_type, p_call->function_name)) {
 				push_error(vformat(R"*(Cannot call the parent class' virtual function "%s()" because it hasn't been defined.)*", p_call->function_name), p_call);
 			} else if (method_flags.has_flag(METHOD_FLAG_VIRTUAL_REQUIRED)) {
 				push_error(vformat(R"*(Cannot call the parent class' abstract function "%s()" because it hasn't been defined.)*", p_call->function_name), p_call);

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -2542,6 +2542,9 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					if (*methodname != GDScriptLanguage::get_singleton()->strings._init) {
 						const MethodBind *mb = ClassDB::get_method(gds->native->get_name(), *methodname);
 						if (!mb) {
+							mb = ClassDB::get_virtual_method_answer(gds->native->get_name(), *methodname);
+						}
+						if (!mb) {
 							err.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
 						} else {
 							*dst = mb->call(p_instance->owner, (const Variant **)argptrs, argc, err);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1981,7 +1981,9 @@ void Control::set_block_minimum_size_adjust(bool p_block) {
 Size2 Control::get_minimum_size() const {
 	ERR_READ_THREAD_GUARD_V(Size2());
 	Vector2 ms;
-	GDVIRTUAL_CALL(_get_minimum_size, ms);
+	if (!GDVIRTUAL_CALL(_get_minimum_size, ms)) {
+		ms = __get_minimum_size();
+	}
 	return ms;
 }
 
@@ -5309,6 +5311,8 @@ void Control::_bind_methods() {
 	GDVIRTUAL_BIND(_get_accessibility_container_name, "node");
 
 	GDVIRTUAL_BIND(_gui_input, "event");
+
+	ClassDB::bind_virtual_method_answer("_get_minimum_size", &Control::__get_minimum_size);
 }
 
 Control::Control() {

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -498,6 +498,8 @@ protected:
 
 	GDVIRTUAL1(_gui_input, RequiredParam<InputEvent>)
 
+	virtual Size2 __get_minimum_size() const { return Size2(); }
+
 public:
 	enum {
 		NOTIFICATION_RESIZED = 40,

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -47,7 +47,7 @@ static inline Color _select_color(const Color &p_override_color, const Color &p_
 	return p_override_color.a > 0 ? p_override_color : p_default_color;
 }
 
-Size2 TabBar::get_minimum_size() const {
+Size2 TabBar::__get_minimum_size() const {
 	Size2 ms;
 	Size2 combined_max = get_combined_maximum_size();
 

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -227,6 +227,8 @@ protected:
 	void drop_data(const Point2 &p_point, const Variant &p_data) override;
 	void _move_tab_from(TabBar *p_from_tabbar, int p_from_index, int p_to_index);
 
+	virtual Size2 __get_minimum_size() const override;
+
 public:
 	RID get_tab_accessibility_element(int p_tab) const;
 	virtual RID get_focused_accessibility_element() const override;
@@ -345,7 +347,6 @@ public:
 	void set_switch_on_release(bool p_switch) { switch_on_release = p_switch; }
 
 	Rect2 get_tab_rect(int p_tab) const;
-	Size2 get_minimum_size() const override;
 	Size2 get_desired_size() const override;
 
 	TabBar();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/15474

Currently, it is not possible to traverse virtual implementation chains upwards from GDScript into C++:
```cpp
class BaseClass : public Object {
  virtual void _cpp_virtual_method(); // Can be named _virtual_method, keeping it separate for clarity.
  GDVIRTUAL0(_virtual_method);
  void virtual_caller() {
    if (!GDVIRTUAL_CALL(_virtual_method) {
      _cpp_virtual_method();
    }
  };
}
```
```cpp
class DerivedClass : public BaseClass {
  virtual void _cpp_virtual_method() override { // do something };
}
```
```gdscript
class_name MyClass extends DerivedClass

func _virtual_method() -> void:
  super() # This call is not possible
```

This prevents users from using the parent class's implementation inside their custom implementations, which would be possible in C++. 
This has led to several related bug reports in the past: #82233, #38342, #86559, #83624.
<sub> Note that some of these would still not be possible as they aren't meant to be, like calling `super._notification()` </sub>

This PR adds a way for C++ methods to be registered as the C++ virtual chain entry point through
`ClassDB::bind_virtual_method_answer("name", &Class::method)`.

In our example case above, this would be achieved in `BaseClass::_bind_methods()` as `ClassDB::bind_virtual_method_answer("_virtual_method", &BaseClass::_cpp_virtual_method)`.
This new binding is used only to fetch `super()` calls in GDScript and does not register it as a standard exposed method. This may be extended to GDExtension in the future (I don't know how it would work there, so I didn't add it in this PR). 

With the new binding in place, the GDScript `super()` call in the example becomes possible. 

## Additional information

This new functionality is applied to `Control::get_minimum_size()` in the example second commit (which will be removed before merge), and can be tested with this associated test project:
[test-virtuals.zip](https://github.com/user-attachments/files/31789295/test-virtuals.zip)
<sub> This required changing `Control` to use the standard mixed virtual implementation instead of custom implementations overriding the virtual caller method. The name contains two underscores because `_get_minimum_size` is used internally by some `Container` subtypes. In cases where the standard implementation is already in use, like the `BaseClass` in the example above, it would just work out of the box.</sub>