### PR TITLE
Disable line antialiasing on D3D12.

### DIFF
--- a/drivers/d3d12/rendering_device_driver_d3d12.cpp
+++ b/drivers/d3d12/rendering_device_driver_d3d12.cpp
@@ -5405,7 +5405,6 @@ RDD::PipelineID RenderingDeviceDriverD3D12::render_pipeline_create(
 	(&pipeline_desc.RasterizerState)->ForcedSampleCount = 0;
 	(&pipeline_desc.RasterizerState)->ConservativeRaster = D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF;
 	(&pipeline_desc.RasterizerState)->MultisampleEnable = TEXTURE_SAMPLES_COUNT[p_multisample_state.sample_count] != 1;
-	(&pipeline_desc.RasterizerState)->AntialiasedLineEnable = true;
 
 	// In D3D12, there's no line width.
 	ERR_FAIL_COND_V(!Math::is_equal_approx(p_rasterization_state.line_width, 1.0f), PipelineID());


### PR DESCRIPTION
## What problem(s) does this PR solve?

Addresses the gizmo rendering performance problem from #123125.

For some reason, line antialiasing is enabled for all pipelines by default on D3D12, which causes a big performance hit for all gizmos. Vulkan doesn't do this, so we disable it for parity.

## Additional information

With the MRP from the issue on upstream:

Vulkan: 9~ ms
D3D12: 145~ ms

With this PR:

D3D12: 7~ ms
