### PR TITLE
Fix "Depth Draw Mode" having no effect when "No Depth Test" is ticked

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -361,6 +361,10 @@ void SceneShaderForwardClustered::ShaderData::_create_pipeline(PipelineKey p_pip
 		if (depth_test == DEPTH_TEST_ENABLED_INVERTED) {
 			depth_stencil_state.depth_compare_operator = RD::COMPARE_OP_LESS;
 		}
+	} else if (depth_draw != DEPTH_DRAW_DISABLED) {
+		depth_stencil_state.enable_depth_test = true;
+		depth_stencil_state.enable_depth_write = true;
+		depth_stencil_state.depth_compare_operator = RD::COMPARE_OP_ALWAYS;
 	}
 
 	bool use_stencil = stencil_enabled && p_pipeline_key.version == PIPELINE_VERSION_COLOR_PASS;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -319,6 +319,10 @@ void SceneShaderForwardMobile::ShaderData::_create_pipeline(PipelineKey p_pipeli
 		if (depth_test == DEPTH_TEST_ENABLED_INVERTED) {
 			depth_stencil_state.depth_compare_operator = RD::COMPARE_OP_LESS;
 		}
+	} else if (depth_draw != DEPTH_DRAW_DISABLED) {
+		depth_stencil_state.enable_depth_test = true;
+		depth_stencil_state.enable_depth_write = true;
+		depth_stencil_state.depth_compare_operator = RD::COMPARE_OP_ALWAYS;
 	}
 
 	RD::RenderPrimitive primitive_rd_table[RSE::PRIMITIVE_MAX] = {


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

At present, the "Depth Draw Mode" drop-down in a material is only effective as long as "No Depth Test" is unchecked.  The reason for this is that all existing rendering APIs I've tested against only write to the depth buffer when depth testing is enabled.

This adds a special case wherein turning depth draw ON but depth test OFF actually enables depth testing, but with an "always" comparison function, preserving the depth write while ignoring the depth read.

An example of why you might want this combination is cel outlines; a common trick is to turn the model inside out, push the faces out, then disable depth write so that it never draws in front of the "fill".

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

Originally part of #122501.  I've spun it off as it's a separate problem.  I don't expect this to get merged, but hopefully other people might benefit from finding it as a draft.  