### PR TITLE
Make path `CSGPolygon3D` dirty when entering tree

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -2683,6 +2683,13 @@ void CSGPolygon3D::_notification(int p_what) {
 			path->disconnect("curve_changed", callable_mp(this, &CSGPolygon3D::_path_changed));
 			path = nullptr;
 		}
+	} else if (p_what == NOTIFICATION_ENTER_TREE) {
+		if (mode == MODE_PATH && !is_using_collision()) {
+			// Force an update when the CSGPolygon3D re-enters the tree to make sure it still follows the Path3D's current state.
+			// This is not needed when collision is enabled, as having collision
+			// enabled will automatically trigger an update.
+			_make_dirty();
+		}
 	}
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes #76514

If a `CSGPolygon3D` set to `MODE_PATH` gets removed from tree, it also gets disconnected from its path to stop updating.

When it is re-added, however, it's never told to re-connect, unless collisions are enabled (in which case `CSGShape3D::_notification()` will handle it), or we do something to manually make it dirty (like setting it to `MODE_PATH` again immediately after it re-enters the tree).

The simplest fix I found was to call `_make_dirty()` when re-entering the tree, specifically for `CSGPolygon3D` when it's `MODE_PATH`. The check for collision usage is just to ensure it won't mark it as dirty twice.

## Additional information

### Reproduction project
Same as the issue, but modified for demonstration: [csg_polygon_exit_enter_bug.zip](https://github.com/user-attachments/files/31802891/csg_polygon_exit_enter_bug.zip)

### Before fix
https://github.com/user-attachments/assets/11891602-ffb1-4e02-a5fc-9b26fddc617c

One still works because, as mentioned, it's set to `MODE_PATH` again which marks it as dirty.

### After fix
https://github.com/user-attachments/assets/7e2daeae-073e-4cb5-9c2d-38ab9d71a7db