### PR TITLE
[Editor] Fix `AnimationStateMachineEditor` pans

### DIFF
--- a/editor/animation/animation_state_machine_editor.cpp
+++ b/editor/animation/animation_state_machine_editor.cpp
@@ -561,8 +561,9 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 
 	// Pan window
 	if (mm.is_valid() && mm->get_button_mask().has_flag(MouseButtonMask::MIDDLE)) {
-		h_scroll->set_value(h_scroll->get_value() - mm->get_relative().x);
-		v_scroll->set_value(v_scroll->get_value() - mm->get_relative().y);
+		Vector2 relative = mm->get_relative() / EDSCALE;
+		h_scroll->set_value(h_scroll->get_value() - relative.x);
+		v_scroll->set_value(v_scroll->get_value() - relative.y);
 	}
 
 	// Move mouse while connecting
@@ -768,8 +769,9 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 
 	Ref<InputEventPanGesture> pan_gesture = p_event;
 	if (pan_gesture.is_valid()) {
-		h_scroll->set_value(h_scroll->get_value() + h_scroll->get_page() * pan_gesture->get_delta().x / 8);
-		v_scroll->set_value(v_scroll->get_value() + v_scroll->get_page() * pan_gesture->get_delta().y / 8);
+		Vector2 delta = pan_gesture->get_delta() / EDSCALE;
+		h_scroll->set_value(h_scroll->get_value() + delta.x);
+		v_scroll->set_value(v_scroll->get_value() + delta.y);
 	}
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #123154

## Additional information

It fixes the pan using the mouse and using a pan gesture (with a trackpad).

### Mouse fix
It's now fixed for screens with > 100% scale. The mouse cursor now follow the contents that pan.

| Before | After |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/275eafd3-2256-4984-8fb7-c7999e48f2f9"> | <video src="https://github.com/user-attachments/assets/be941ae0-5b90-4f89-b014-9bc364b5ea6c"> |

### Pan gesture fix
It now uses the real difference in pixels instead of relying on a weird formula. 

| Before | After |
| :---: | :---: |
| <video src="https://github.com/user-attachments/assets/34857692-ae50-4e90-8692-3315afe53c58"> | <video src="https://github.com/user-attachments/assets/af3e0841-cd0c-4acf-a184-3eb045734586"> |