### PR TITLE
Disable auto-selection of remote objects on debugger break

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -444,10 +444,11 @@ void EditorDebuggerInspector::add_stack_variable(const Array &p_array, int p_off
 		h = PROPERTY_HINT_OBJECT_ID;
 		hs = var.type_hint;
 
-		// Makes the call stack select the node in the remote tree. See https://github.com/godotengine/godot/issues/79477
-		if (n == "self") {
-			_object_selected(v);
-		}
+		// Makes the call stack select the node in the remote tree.
+		// FIXME: Disabled until the feedback loop with breakpoints inside getters is fixed. See GH-122339.
+		//if (n == "self") {
+		//	_object_selected(v);
+		//}
 	}
 
 	String type;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #123042.
- Reverts #94096.
- Reopens #79477.

The code that triggers the automatic opening of remote objects on debugger break has been commented out, with an explanation right above it. For it to be enabled again, #122339 will need to be tackled somehow.

While the feature itself is very useful, one can still just click the object in the debugger panel.