### PR TITLE
Prioritize filename length in fuzzy search

### DIFF
--- a/core/string/fuzzy_search.cpp
+++ b/core/string/fuzzy_search.cpp
@@ -308,12 +308,15 @@ void FuzzySearch::_sort_and_filter(Vector<Ref<FuzzySearchMatch>> &p_results) con
 
 	struct FuzzySearchResultComparator {
 		bool operator()(const Ref<FuzzySearchMatch> &p_lhs, const Ref<FuzzySearchMatch> &p_rhs) const {
-			// Sort on (score, length, alphanumeric) to ensure consistent ordering.
+			// Sort on (score, filename length, path length, alphanumeric) to ensure consistent ordering.
 			if (p_lhs->score == p_rhs->score) {
-				if (p_lhs->target.length() == p_rhs->target.length()) {
-					return p_lhs->target < p_rhs->target;
+				if (p_lhs->target.length() - p_lhs->dir_index == p_rhs->target.length() - p_rhs->dir_index) {
+					if (p_lhs->target.length() == p_rhs->target.length()) {
+						return p_lhs->target < p_rhs->target;
+					}
+					return p_lhs->target.length() < p_rhs->target.length();
 				}
-				return p_lhs->target.length() < p_rhs->target.length();
+				return p_lhs->target.length() - p_lhs->dir_index < p_rhs->target.length() - p_rhs->dir_index;
 			}
 			return p_lhs->score > p_rhs->score;
 		}


### PR DESCRIPTION
Followup to https://github.com/godotengine/godot/pull/117983
as mentioned in [this comment](https://github.com/godotengine/godot/pull/117983#issuecomment-4249859600) and the suggestion to make a followup in [this comment](https://github.com/godotengine/godot/pull/117983#issuecomment-4253980400)

This is a minor change to `FuzzySearchResultComparator` that prioritizes filename length before file path length, which better matches expectations from the UI putting larger emphasis on the filename vs. the file path.

| Before | After |
| :---: | :---: |
| <img width="782" height="682" alt="image" src="https://github.com/user-attachments/assets/838d5257-d651-4340-9e4b-911be70afa84" /> | <img width="782" height="682" alt="image" src="https://github.com/user-attachments/assets/62968c08-19cf-4405-ab14-08be5d81bfea" /> |

No AI was used anywhere.