### PR TITLE
Add missing @export_range hint completions

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1017,6 +1017,14 @@ static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_a
 			r_result.insert(slider3.display, slider3);
 			EditorLanguage::CompletionOption slider4 = _calculate_string_insertion(existing_argument, "hide_control");
 			r_result.insert(slider4.display, slider4);
+			EditorLanguage::CompletionOption slider5 = _calculate_string_insertion(existing_argument, "exp");
+			r_result.insert(slider5.display, slider5);
+			EditorLanguage::CompletionOption slider6 = _calculate_string_insertion(existing_argument, "radians_as_degrees");
+			r_result.insert(slider6.display, slider6);
+			EditorLanguage::CompletionOption slider7 = _calculate_string_insertion(existing_argument, "degrees");
+			r_result.insert(slider7.display, slider7);
+			EditorLanguage::CompletionOption slider8 = _calculate_string_insertion(existing_argument, "suffix:");
+			r_result.insert(slider8.display, slider8);
 		}
 	} else if (p_annotation->name == SNAME("@export_exp_easing")) {
 		if (p_argument == 0 || p_argument == 1) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1007,7 +1007,7 @@ static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_a
 		r_arghint = _make_arguments_hint(p_annotation->info->info, p_argument, true);
 	}
 	if (p_annotation->name == SNAME("@export_range")) {
-		if (p_argument == 3 || p_argument == 4 || p_argument == 5) {
+		if (p_argument >= 3 && p_argument <= 10) {
 			// Slider hint.
 			EditorLanguage::CompletionOption slider1 = _calculate_string_insertion(existing_argument, "or_greater");
 			r_result.insert(slider1.display, slider1);


### PR DESCRIPTION
## What problem does this PR solve?
`@export_range` autocomplete only showed 4 of the 8 documented hints. The other 4 (`exp`, `radians_as_degrees`, `degrees`, `suffix:`) worked fine if typed manually, they just weren't showing up in the autocomplete. This adds them.

Closes #123139