### PR TITLE
Fix MSDF glyph quad anchor mismatched with its rasterized bitmap

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1022,8 +1022,9 @@ _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_msdf(
 	chr.advance = p_advance;
 
 	if (shape.validate() && shape.contours.size() > 0) {
-		int w = (bounds.r - bounds.l);
-		int h = (bounds.t - bounds.b);
+		// Round the glyph size up to whole pixels so the bitmap fully covers the shape.
+		int w = Math::ceil(bounds.r - bounds.l);
+		int h = Math::ceil(bounds.t - bounds.b);
 
 		if (w == 0 || h == 0) {
 			chr.texture_idx = -1;
@@ -1080,8 +1081,9 @@ _FORCE_INLINE_ TextServerAdvanced::FontGlyph TextServerAdvanced::rasterize_msdf(
 		chr.texture_idx = tex_pos.index;
 
 		chr.uv_rect = Rect2(tex_pos.x + p_rect_margin, tex_pos.y + p_rect_margin, w + p_rect_margin * 2, h + p_rect_margin * 2);
-		chr.rect.position = Vector2(bounds.l - p_rect_margin, -bounds.t - p_rect_margin);
-
+		// Derive the glyph position from the same bottom-left anchor the rasterizer uses,
+		// rather than top-left, so the two agree about glyph placement.
+		chr.rect.position = Vector2(bounds.l - p_rect_margin, -(bounds.b + h) - p_rect_margin);
 		chr.rect.size = chr.uv_rect.size;
 	}
 	return chr;

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -439,8 +439,9 @@ _FORCE_INLINE_ TextServerFallback::FontGlyph TextServerFallback::rasterize_msdf(
 	chr.advance = p_advance;
 
 	if (shape.validate() && shape.contours.size() > 0) {
-		int w = (bounds.r - bounds.l);
-		int h = (bounds.t - bounds.b);
+		// Round the glyph size up to whole pixels so the bitmap fully covers the shape.
+		int w = Math::ceil(bounds.r - bounds.l);
+		int h = Math::ceil(bounds.t - bounds.b);
 
 		if (w == 0 || h == 0) {
 			chr.texture_idx = -1;
@@ -496,7 +497,9 @@ _FORCE_INLINE_ TextServerFallback::FontGlyph TextServerFallback::rasterize_msdf(
 		chr.texture_idx = tex_pos.index;
 
 		chr.uv_rect = Rect2(tex_pos.x + p_rect_margin, tex_pos.y + p_rect_margin, w + p_rect_margin * 2, h + p_rect_margin * 2);
-		chr.rect.position = Vector2(bounds.l - p_rect_margin, -bounds.t - p_rect_margin);
+		// Derive the glyph position from the same bottom-left anchor the rasterizer uses,
+		// rather than top-left, so the two agree about glyph placement.
+		chr.rect.position = Vector2(bounds.l - p_rect_margin, -(bounds.b + h) - p_rect_margin);
 		chr.rect.size = chr.uv_rect.size;
 	}
 	return chr;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes #121369.

The bitmap was rasterized bottom-anchored but the quad was placed top-anchored, with the size truncated instead of rounded. Since the bounds are fractional, this shifted each glyph off its own rasterized pixels by a per-glyph sub-pixel amount, wobbling baselines.

## Additional information

- I used some AI chat to research the issue, but designed the fix myself once I understood the problem space.
- Before coming to this solution, I tried another one which worked too but required more changes: https://github.com/akien-mga/godot/commits/msdf-fix-baseline-alignment/
  * [Snapping the bounds before using them.](https://github.com/akien-mga/godot/commit/05108fe8b1016b451c0f0a01e4c08ff44a11227f) This helped reduce the baseline shifting but not fully.
  * [Force disabling hinting.](https://github.com/akien-mga/godot/commit/e50cbf6d24f8dc22df0cb67005ef858ad5109e9c) This helped resolve the remaining baseline shifting. But it's no longer needed with this new solution, and hinting does seem to have an effect on the MSDF font, so I guess we shouldn't force it off?

## Testing

Project: [font.zip](https://github.com/user-attachments/files/31811140/font.zip)

I tested on top of #123115 to have glyph sizes that match the non-MSDF reference, to be able to compare the baseline properly. In the table, MSDF 8/32 means MSDF with Pixel Range 8 and Size 32.

### MSDF 8/32

|MSDF disabled|No fix|Anchor fix (this PR)|
|---|---|---|
|<img width="1217" height="825" alt="msdf-01-master-msdf_disabled" src="https://github.com/user-attachments/assets/8b3ab4d1-d1d3-4e85-8b47-0b2e63d2d19d" />|<img width="1204" height="820" alt="msdf-03-scale_fix-msdf-enabled" src="https://github.com/user-attachments/assets/bf79421a-1736-40c6-a547-2e78060bd7d0" />|<img width="1207" height="824" alt="msdf-07-scale_anchor_fix-msdf-8-32" src="https://github.com/user-attachments/assets/617505a7-c02d-44b2-9e58-2eda6d4e69f3" />|

For comparison, my previous attempt:

|[Bounds snapping](https://github.com/akien-mga/godot/commit/05108fe8b1016b451c0f0a01e4c08ff44a11227f)|[Disabled hinting](https://github.com/akien-mga/godot/commit/e50cbf6d24f8dc22df0cb67005ef858ad5109e9c)|Both bounds snapping and disabled hinting|
|---|---|---|
|<img width="1194" height="822" alt="msdf-05-scale_snap_fix-msdf_enabled" src="https://github.com/user-attachments/assets/a1e1d4d0-df57-4f0a-ab76-4e27339e0249" />|<img width="1196" height="821" alt="msdf-04-scale_hinting_fix-msdf_enabled" src="https://github.com/user-attachments/assets/2469c3a9-fcbd-4f53-9096-b8127c60a530" />|<img width="1205" height="822" alt="msdf-06-scale_snap_hinting_fix-msdf_enabled" src="https://github.com/user-attachments/assets/e1cd57f1-3f2e-40ac-a0d2-883ab1cbf996" />|

I'll note that I don't see anymore on the "Bounds snapping" screenshot why it wasn't sufficient when I worked on it a couple of days ago, and had to also disable hinting. This is what I had for just the "Bounds snapping" fix on another test project 2 days ago (see the baseline of T vs h)... Provided I didn't use the wrong executable when testing (entirely possible).
<img width="339" height="180" alt="image" src="https://github.com/user-attachments/assets/61c5e63f-6a96-45e9-853f-263af15788ce" />

### MSDF 16/64

|MSDF disabled|No fix|Anchor fix (this PR)|
|---|---|---|
|<img width="1217" height="825" alt="msdf-01-master-msdf_disabled" src="https://github.com/user-attachments/assets/816c1fa5-522d-4e80-8797-f0b6d2ba381e" />|<img width="1240" height="822" alt="msdf-09-scale_fix-msdf-16-64" src="https://github.com/user-attachments/assets/07248476-73ea-4656-980e-f60735738c2d" />|<img width="1207" height="824" alt="msdf-08-scale_anchor_fix-msdf-16-64" src="https://github.com/user-attachments/assets/a3fc1588-00e5-4b55-a298-a0c21656d1ba" />|

So there's one remaining issue not addressed by #123115 nor this PR, which is that depending on the MSDF size property, the vertical position of the glyph still changes significantly. I'm not aware of a bug report for it though.