### PR TITLE
Dont reload builtin live scripts when connecting signals

### DIFF
--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -401,7 +401,7 @@ void ConnectDialog::_update_method_tree() {
 	ScriptInstance *si = target->get_script_instance();
 	if (si) {
 		if (si->get_script()->is_built_in()) {
-			si->get_script()->reload();
+			si->get_script()->reload(true);
 		}
 		List<MethodInfo> methods;
 		si->get_method_list(&methods);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #123083

## Additional information

The signal connection dialog tried to reload builtin target scripts, but since they inherently always are in the active scene, reload on the live script always fails. Instead we can just keep the last state since the scripts are always loaded.

<details>
<summary>Verification</summary>

https://github.com/user-attachments/assets/3319b610-07e9-412e-9191-80600de261f3

</details>
