### PR TITLE
 Have the editor maintain scene resource information (scene type, properties, metadata, etc) on scene save.

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -721,6 +721,13 @@ void EditorData::set_scene_root(int p_idx, Node *p_root) {
 	}
 }
 
+void EditorData::set_scene_resource(int p_idx, const Ref<PackedScene> &p_scene) {
+	ERR_FAIL_INDEX(p_idx, edited_scene.size());
+	EditedScene &scene_info = edited_scene.write[p_idx];
+
+	scene_info.scene = p_scene;
+}
+
 bool EditorData::_find_updated_instances(Node *p_root, Node *p_node, HashSet<String> &checked_paths) {
 	Ref<SceneState> ss;
 

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -38,6 +38,7 @@ class ConfigFile;
 class EditorPlugin;
 class EditorUndoRedoManager;
 class PopupMenu;
+class PackedScene;
 
 /**
  * Stores the history of objects which have been selected for editing in the Editor & the Inspector.
@@ -112,6 +113,7 @@ public:
 
 	struct EditedScene {
 		Node *root = nullptr;
+		Ref<PackedScene> scene;
 		String path;
 		uint64_t file_modified_time = 0;
 		Dictionary editor_states;
@@ -201,6 +203,7 @@ public:
 	int add_edited_scene(int p_at_pos);
 	void remove_scene(int p_idx);
 	void set_scene_root(int p_idx, Node *p_root);
+	void set_scene_resource(int p_idx, const Ref<PackedScene> &p_scene);
 	void set_edited_scene(int p_idx);
 	void set_edited_scene_root(Node *p_root);
 	int get_edited_scene() const;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5032,6 +5032,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 		idx = editor_data.add_edited_scene(-1);
 	}
 	editor_data.set_scene_root(idx, new_scene);
+	editor_data.set_scene_resource(idx, sdata);
 
 	const Ref<ConfigFile> editor_state_cf = _load_scene_config(lpath);
 	if (editor_state_cf->has_section("editor_states")) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #122231

## Additional information
This is the less bad way that I could think in fixing the issue, the alternative would be to load the scene just before saving, but I think it may cause further issues and slow downs when saving big scenes since you would need to load it all again.

And since, I believe, when you load a scene in the editor, all other resources are loaded in the scene anyway, the only thing to keep in ram in addition to the dependencies would be the scene resource itself.