### PR TITLE
Fix bookmark and breakpoint issues when navigating through history

### DIFF
--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -573,14 +573,14 @@ void TextEditorBase::_saved_update() {
 }
 
 void TextEditorBase::_emit_request_save_new_history() {
-	Dictionary state = get_edit_state();
+	Dictionary state = get_navigation_state();
 	state["ensure_caret_visible"] = true;
 	previous_history_line = state["row"];
 	emit_signal(SNAME("_request_save_new_history"), state);
 }
 
 void TextEditorBase::_emit_request_save_previous_state() {
-	Dictionary state = get_edit_state();
+	Dictionary state = get_navigation_state();
 	state["ensure_caret_visible"] = true;
 	previous_history_line = state["row"];
 	emit_signal(SNAME("_request_save_previous_state"), state);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #123143 

## Additional information

- Use `get_navigation_state` instead of `get_edit_state` when saving state to history.
- No AI was used.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
