### PR TITLE
[macOS] Allow `generate_bundle` to make single architecture editor bundles.

### DIFF
--- a/misc/dist/macos/editor_info_plist.template
+++ b/misc/dist/macos/editor_info_plist.template
@@ -42,10 +42,7 @@
 	<string>public.app-category.developer-tools</string>
 	<key>LSMinimumSystemVersionByArchitecture</key>
 	<dict>
-		<key>arm64</key>
-		<string>13.0</string>
-		<key>x86_64</key>
-		<string>11.0</string>
+$min_version_info
 	</dict>
 	<key>NSHighResolutionCapable</key>
 	<true/>

--- a/platform/macos/detect.py
+++ b/platform/macos/detect.py
@@ -70,6 +70,7 @@ def get_opts():
             "-",
         ),
         BoolVariable("generate_bundle", "Generate an APP bundle after building iOS/macOS binaries", False),
+        BoolVariable("generate_bundle_universal", "Generate an APP bundle with universal binaries (editor only)", True),
     ]
 
 

--- a/platform/macos/platform_macos_builders.py
+++ b/platform/macos/platform_macos_builders.py
@@ -5,7 +5,7 @@ import shutil
 import subprocess
 
 from methods import get_version_info
-from platform_methods import lipo
+from platform_methods import lipo, lipo_find_archs
 
 
 def generate_bundle(target, source, env):
@@ -20,11 +20,20 @@ def generate_bundle(target, source, env):
             prefix += ".double"
 
         # Lipo editor executable.
-        target_bin = lipo(bin_dir + "/" + prefix, env.extra_suffix + env.module_version_string)
+        if env["generate_bundle_universal"]:
+            target_archs = lipo_find_archs(bin_dir + "/" + prefix, env.extra_suffix + env.module_version_string)
+            target_bin = lipo(bin_dir + "/" + prefix, env.extra_suffix + env.module_version_string)
+            arch_suffix = ""
+        else:
+            target_archs = [env["arch"]]
+            target_bin = bin_dir + "/" + prefix + "." + env["arch"] + env.extra_suffix + env.module_version_string
+            arch_suffix = "_" + env["arch"]
+            if env.extra_suffix + env.module_version_string != "":
+                arch_suffix += "_"
 
         # Assemble .app bundle and update version info.
         app_dir = env.Dir(
-            "#bin/" + (prefix + env.extra_suffix + env.module_version_string).replace(".", "_") + ".app"
+            "#bin/" + (prefix + arch_suffix + env.extra_suffix + env.module_version_string).replace(".", "_") + ".app"
         ).abspath
         templ = env.Dir("#misc/dist/macos_tools.app").abspath
         if os.path.exists(app_dir):
@@ -48,7 +57,15 @@ def generate_bundle(target, source, env):
         version = get_version_info("", True)
         with open(env.Dir("#misc/dist/macos").abspath + "/editor_info_plist.template", "rt", encoding="utf-8") as fin:
             with open(app_dir + "/Contents/Info.plist", "wt", encoding="utf-8", newline="\n") as fout:
+                min_ver_string = ""
+                for arch in target_archs:
+                    min_ver_string += "\t\t<key>" + arch + "</key>\n"
+                    if arch == "x86_64":
+                        min_ver_string += "\t\t<string>11.0</string>\n"
+                    else:
+                        min_ver_string += "\t\t<string>13.0</string>\n"
                 for line in fin:
+                    line = line.replace("$min_version_info", min_ver_string)
                     line = line.replace("$version", "{major}.{minor}.{patch}.{status}.{build}".format(**version))
                     line = line.replace("$short_version", "{major}.{minor}.{patch}".format(**version))
                     if version["build"] != "official" and version["build"] != "steam":

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -74,6 +74,18 @@ def get_build_version(short):
     return v
 
 
+def lipo_find_archs(prefix, suffix):
+    from pathlib import Path
+
+    target_archs = []
+    for arch in architectures:
+        bin_name = prefix + "." + arch + suffix
+        if Path(bin_name).is_file():
+            target_archs += [arch]
+
+    return target_archs
+
+
 def lipo(prefix, suffix):
     from pathlib import Path
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

Adds `generate_bundle_universal` build flag to control whether `generate_bundle` will produce universal editor bundle or separate bundle for currently built architecture.