### PR TITLE
Don't enter debugger if the thread is already in the debugger

### DIFF
--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -414,7 +414,19 @@ void RemoteDebugger::debug(bool p_can_continue, bool p_is_error_breakpoint) {
 			return; // Peer does not support blocking IO. We could at least send the error though.
 		}
 
-		threads_in_break.insert(Thread::get_caller_id());
+		Thread::ID caller_id = Thread::get_caller_id();
+		if (threads_in_break.has(caller_id)) {
+			// We're already in `RemoteDebugger::debug`. It can happen when the object is selected in the remote inspector,
+			// and there is a breakpoint or an error in the getter. See GH-122339.
+			// TODO: Figure out a better way to deal with this?
+			if (!threads_in_break[caller_id]) {
+				String thread_name = Thread::is_main_thread() ? "main thread" : "thread " + itos(caller_id);
+				WARN_PRINT(vformat("The %s tried to enter debugger when it is already in the debugger.", thread_name));
+				threads_in_break[caller_id] = true;
+			}
+			return;
+		}
+		threads_in_break.insert(caller_id, false);
 	}
 
 	ScriptLanguage *script_lang = script_debugger->get_break_language();

--- a/core/debugger/remote_debugger.h
+++ b/core/debugger/remote_debugger.h
@@ -84,7 +84,7 @@ private:
 	};
 
 	HashMap<Thread::ID, List<Message>> messages;
-	HashSet<Thread::ID> threads_in_break;
+	HashMap<Thread::ID, bool> threads_in_break;
 
 	void _poll_messages();
 	bool _has_messages();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/123042

## Additional information

This only deals with the infinite debugger break if the break was triggered in the getter. It doesn't do anything about the error spam that still happens, but sadly each of the errors is an actual error https://github.com/godotengine/godot/issues/122339 so just hiding them also feels wrong.

The infinite debugger break itself seems to be caused by the recursion in the `_try_capture` inside the while loop. The `ScriptEditorDebugger::request_remote_objects` sends the `scene:inspect_objects` message that calls `SceneDebugger::_msg_inspect_objects` which then uses `SceneDebuggerObject` to parse the objects and that finally could call getter... I think, it was hard to reason about why the getter is being called.

Oh, if you place the breakpoint in `_ready` really early and you have getters that depend on the data being prepared here, remote inpector will still call all getters even if they are not ready. I guess it makes sense if we take https://github.com/godotengine/godot/issues/122339 to its logical conclusion. So it still makes sense to disable auto-selection of remote objects https://github.com/godotengine/godot/pull/123156 as it brings it to forefront, or maybe put it behind a setting?

<details>
<summary>Example</summary>

<img width="1117" height="703" alt="image" src="https://github.com/user-attachments/assets/ea45f63f-2979-479d-8610-f7da7389c805" />
</details>

No AI used