### PR TITLE
Allow closing native file dialogs from code.

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -771,6 +771,14 @@
 				[b]Note:[/b] This method is implemented only on Windows.
 			</description>
 		</method>
+		<method name="file_dialog_hide">
+			<return type="int" enum="Error" />
+			<param index="0" name="id" type="int" />
+			<description>
+				Closes the file dialog opened with [method file_dialog_show] or [method file_dialog_with_options_show].
+				Returns [constant OK] on success, or one of the following [enum Error] constants if this method fails: [constant ERR_INVALID_PARAMETER] if the file dialog with [param id] was not found, or [constant FAILED] if OS was not able to close the file dialog (e.g, opening dialog is not yet completed).
+			</description>
+		</method>
 		<method name="file_dialog_show">
 			<return type="int" enum="Error" />
 			<param index="0" name="title" type="String" />
@@ -781,10 +789,12 @@
 			<param index="5" name="filters" type="PackedStringArray" />
 			<param index="6" name="callback" type="Callable" />
 			<param index="7" name="parent_window_id" type="int" default="0" />
+			<param index="8" name="id" type="int" default="-1" />
 			<description>
 				Displays OS native dialog for selecting files or directories in the file system.
 				Each filter string in the [param filters] array should be formatted like this: [code]*.png,*.jpg,*.jpeg;Image Files;image/png,image/jpeg[/code]. The description text of the filter is optional and can be omitted. It is recommended to set both file extension and MIME type. See also [member FileDialog.filters].
 				Callbacks have the following arguments: [code]status: bool, selected_paths: PackedStringArray, selected_filter_index: int[/code]. [b]On Android,[/b] the third callback argument ([code]selected_filter_index[/code]) is always [code]0[/code].
+				If [param id] is set to a unique, positive value, the file dialog can be closed by calling [method file_dialog_hide] with the same ID.
 				[b]Note:[/b] This method is implemented if the display server has the [constant FEATURE_NATIVE_DIALOG_FILE] feature. Supported platforms include Linux (X11/Wayland), Windows, macOS, and Android.
 				[b]Note:[/b] [param current_directory] might be ignored.
 				[b]Note:[/b] Embedded file dialogs and Windows file dialogs support only file extensions, while Android, Linux, and macOS file dialogs also support MIME types.
@@ -818,6 +828,7 @@
 			<param index="7" name="options" type="Dictionary[]" />
 			<param index="8" name="callback" type="Callable" />
 			<param index="9" name="parent_window_id" type="int" default="0" />
+			<param index="10" name="id" type="int" default="-1" />
 			<description>
 				Displays OS native dialog for selecting files or directories in the file system with additional user selectable options.
 				Each filter string in the [param filters] array should be formatted like this: [code]*.png,*.jpg,*.jpeg;Image Files;image/png,image/jpeg[/code]. The description text of the filter is optional and can be omitted. It is recommended to set both file extension and MIME type. See also [member FileDialog.filters].
@@ -826,6 +837,7 @@
 				- [code]"values"[/code] - [PackedStringArray] of values. If empty, boolean option (check box) is used.
 				- [code]"default"[/code] - default selected option index ([int]) or default boolean value ([bool]).
 				Callbacks have the following arguments: [code]status: bool, selected_paths: PackedStringArray, selected_filter_index: int, selected_option: Dictionary[/code].
+				If [param id] is set to a unique, positive value, the file dialog can be closed by calling [method file_dialog_hide] with the same ID.
 				[b]Note:[/b] This method is implemented if the display server has the [constant FEATURE_NATIVE_DIALOG_FILE_EXTRA] feature. Supported platforms include Linux (X11/Wayland), Windows, and macOS.
 				[b]Note:[/b] [param current_directory] might be ignored.
 				[b]Note:[/b] Embedded file dialogs and Windows file dialogs support only file extensions, while Android, Linux, and macOS file dialogs also support MIME types.

--- a/misc/extension_api_validation/4.4-stable_4.5-stable/GH-98194.txt
+++ b/misc/extension_api_validation/4.4-stable_4.5-stable/GH-98194.txt
@@ -1,6 +1,6 @@
 GH-98194
 --------
-Validate extension JSON: Error: Field 'classes/DisplayServer/methods/file_dialog_show/arguments': size changed value in new API, from 7 to 8.
-Validate extension JSON: Error: Field 'classes/DisplayServer/methods/file_dialog_with_options_show/arguments': size changed value in new API, from 9 to 10.
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/file_dialog_show/arguments': size changed value in new API, from 7 to 9.
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/file_dialog_with_options_show/arguments': size changed value in new API, from 9 to 11.
 
 Optional argument added. Compatibility methods registered.

--- a/misc/extension_api_validation/4.7-stable/GH-123178.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-123178.txt
@@ -1,0 +1,8 @@
+GH-123178
+----------
+
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/file_dialog_show/arguments': size changed value in new API, from 8 to 9.
+Validate extension JSON: Error: Field 'classes/DisplayServer/methods/file_dialog_with_options_show/arguments': size changed value in new API, from 10 to 11.
+
+Added optional "id" argument.
+Compatibility methods registered.

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -229,7 +229,7 @@ void DisplayServerAndroid::emit_input_dialog_callback(String p_text) {
 	}
 }
 
-Error DisplayServerAndroid::file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) {
+Error DisplayServerAndroid::file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) {
 	ERR_FAIL_COND_V(p_window_id != DisplayServerEnums::MAIN_WINDOW_ID, ERR_UNAVAILABLE);
 	GodotJavaWrapper *godot_java = OS_Android::get_singleton()->get_godot_java();
 	ERR_FAIL_NULL_V(godot_java, FAILED);

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -133,7 +133,7 @@ public:
 	virtual Error dialog_input_text(String p_title, String p_description, String p_partial, const Callable &p_callback) override;
 	void emit_input_dialog_callback(String p_text);
 
-	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, const DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) override;
+	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, const DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) override;
 	void emit_file_picker_callback(bool p_ok, const Vector<String> &p_selected_paths);
 
 	virtual Color get_accent_color() const override;

--- a/platform/linuxbsd/freedesktop_portal_desktop.cpp
+++ b/platform/linuxbsd/freedesktop_portal_desktop.cpp
@@ -680,13 +680,74 @@ bool FreeDesktopPortalDesktop::send_request(DBusMessage *p_message, const String
 	return true;
 }
 
-Error FreeDesktopPortalDesktop::file_dialog_show(DisplayServerEnums::WindowID p_window_id, const String &p_xid, const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb) {
+Error FreeDesktopPortalDesktop::file_dialog_hide(int64_t p_id) {
+	ERR_FAIL_COND_V(p_id < 0, ERR_INVALID_PARAMETER);
+
+	MutexLock lock(file_dialog_mutex);
+	for (int i = 0; i < file_dialogs.size(); i++) {
+		const FileDialogData &fd = file_dialogs[i];
+		if (fd.id == p_id) {
+			for (int j = 0; j < 10; j++) {
+				DBusError error;
+				dbus_error_init(&error);
+
+				DBusMessage *message = dbus_message_new_method_call(BUS_OBJECT_NAME, fd.path.utf8().get_data(), BUS_INTERFACE_REQUEST, "Close");
+				DBusMessage *reply = dbus_connection_send_with_reply_and_block(monitor_connection, message, DBUS_TIMEOUT_USE_DEFAULT, &error);
+				dbus_message_unref(message);
+				if (dbus_error_is_set(&error)) {
+					if (strcmp(error.name, "org.freedesktop.DBus.Error.UnknownMethod") != 0) {
+						ERR_PRINT(vformat("Failed to close: %s.", String::utf8(error.message)));
+						dbus_error_free(&error);
+						return FAILED;
+					} else {
+						dbus_error_free(&error);
+					}
+				} else if (reply) {
+					dbus_message_unref(reply);
+
+					// Note: `Close` doesn't trigger `Response` event, call callback directly.
+					if (fd.callback.is_valid()) {
+						FileDialogCallback cb;
+						cb.callback = fd.callback;
+						cb.files = Vector<String>();
+						cb.index = 0;
+						cb.options = Dictionary();
+						cb.status = false;
+						cb.opt_in_cb = fd.opt_in_cb;
+						pending_file_cbs.push_back(cb);
+					}
+					if (fd.prev_focus != DisplayServerEnums::INVALID_WINDOW_ID) {
+						callable_mp(DisplayServer::get_singleton(), &DisplayServer::window_move_to_foreground).call_deferred(fd.prev_focus);
+					}
+
+					dbus_bus_remove_match(monitor_connection, fd.filter.utf8().get_data(), &error);
+					dbus_error_free(&error);
+
+					file_dialogs.remove_at(i);
+					return OK;
+				}
+				OS::get_singleton()->delay_usec(150000);
+			}
+			return FAILED;
+		}
+	}
+	return ERR_INVALID_PARAMETER;
+}
+
+Error FreeDesktopPortalDesktop::file_dialog_show(DisplayServerEnums::WindowID p_window_id, const String &p_xid, const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb, int64_t p_id) {
 	if (unsupported) {
 		return FAILED;
 	}
 
 	ERR_FAIL_INDEX_V(int(p_mode), DisplayServerEnums::FILE_DIALOG_MODE_SAVE_MAX, FAILED);
 	ERR_FAIL_NULL_V(monitor_connection, FAILED);
+
+	MutexLock lock(file_dialog_mutex);
+	if (p_id >= 0) {
+		for (const FileDialogData &fd : file_dialogs) {
+			ERR_FAIL_COND_V_MSG(fd.id == p_id, FAILED, "ID already in use");
+		}
+	}
 
 	Vector<String> filter_names;
 	Vector<String> filter_exts;
@@ -729,6 +790,7 @@ Error FreeDesktopPortalDesktop::file_dialog_show(DisplayServerEnums::WindowID p_
 
 	// Open connection and add signal handler.
 	FileDialogData fd;
+	fd.id = p_id;
 	fd.callback = p_callback;
 	fd.prev_focus = p_window_id;
 	fd.filter_names = filter_names;
@@ -750,7 +812,7 @@ Error FreeDesktopPortalDesktop::file_dialog_show(DisplayServerEnums::WindowID p_
 		DBusMessageIter iter;
 		dbus_message_iter_init_append(message, &iter);
 
-		append_dbus_string(&iter, p_xid);
+		append_dbus_string(&iter, ""); //p_xid);
 		append_dbus_string(&iter, p_title);
 
 		DBusMessageIter arr_iter;
@@ -774,7 +836,6 @@ Error FreeDesktopPortalDesktop::file_dialog_show(DisplayServerEnums::WindowID p_
 		return FAILED;
 	}
 
-	MutexLock lock(file_dialog_mutex);
 	file_dialogs.push_back(fd);
 
 	return OK;

--- a/platform/linuxbsd/freedesktop_portal_desktop.h
+++ b/platform/linuxbsd/freedesktop_portal_desktop.h
@@ -87,6 +87,7 @@ private:
 	Vector<ColorPickerData> color_pickers;
 
 	struct FileDialogData {
+		int64_t id = -1;
 		Vector<String> filter_names;
 		HashMap<String, String> option_ids;
 		DisplayServerEnums::WindowID prev_focus = DisplayServerEnums::INVALID_WINDOW_ID;
@@ -134,7 +135,8 @@ public:
 	bool is_inhibit_supported();
 
 	// org.freedesktop.portal.FileChooser methods.
-	Error file_dialog_show(DisplayServerEnums::WindowID p_window_id, const String &p_xid, const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb);
+	Error file_dialog_show(DisplayServerEnums::WindowID p_window_id, const String &p_xid, const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb, int64_t p_id);
+	Error file_dialog_hide(int64_t p_id);
 	void process_callbacks();
 
 	// org.freedesktop.portal.Settings methods.

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -440,7 +440,7 @@ void DisplayServerWayland::set_system_theme_change_callback(const Callable &p_ca
 	portal_desktop->set_system_theme_change_callback(p_callable);
 }
 
-Error DisplayServerWayland::file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) {
+Error DisplayServerWayland::file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) {
 	ERR_FAIL_COND_V(!portal_desktop, ERR_UNAVAILABLE);
 	MutexLock mutex_lock(wayland_thread.mutex);
 
@@ -452,10 +452,10 @@ Error DisplayServerWayland::file_dialog_show(const String &p_title, const String
 	WaylandThread::WindowState *ws = wayland_thread.window_get_state(window_id);
 	ERR_FAIL_NULL_V(ws, ERR_BUG);
 
-	return portal_desktop->file_dialog_show(window_id, (ws ? ws->exported_handle : String()), p_title, p_current_directory, String(), p_filename, p_mode, p_filters, TypedArray<Dictionary>(), p_callback, false);
+	return portal_desktop->file_dialog_show(window_id, (ws ? ws->exported_handle : String()), p_title, p_current_directory, String(), p_filename, p_mode, p_filters, TypedArray<Dictionary>(), p_callback, false, p_id);
 }
 
-Error DisplayServerWayland::file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) {
+Error DisplayServerWayland::file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) {
 	ERR_FAIL_COND_V(!portal_desktop, ERR_UNAVAILABLE);
 	MutexLock mutex_lock(wayland_thread.mutex);
 
@@ -467,7 +467,12 @@ Error DisplayServerWayland::file_dialog_with_options_show(const String &p_title,
 	WaylandThread::WindowState *ws = wayland_thread.window_get_state(window_id);
 	ERR_FAIL_NULL_V(ws, ERR_BUG);
 
-	return portal_desktop->file_dialog_show(window_id, (ws ? ws->exported_handle : String()), p_title, p_current_directory, p_root, p_filename, p_mode, p_filters, p_options, p_callback, true);
+	return portal_desktop->file_dialog_show(window_id, (ws ? ws->exported_handle : String()), p_title, p_current_directory, p_root, p_filename, p_mode, p_filters, p_options, p_callback, true, p_id);
+}
+
+Error DisplayServerWayland::file_dialog_hide(int64_t p_id) {
+	ERR_FAIL_COND_V(!portal_desktop, ERR_UNAVAILABLE);
+	return portal_desktop->file_dialog_hide(p_id);
 }
 
 #endif

--- a/platform/linuxbsd/wayland/display_server_wayland.h
+++ b/platform/linuxbsd/wayland/display_server_wayland.h
@@ -217,8 +217,9 @@ public:
 	virtual Color get_accent_color() const override;
 	virtual void set_system_theme_change_callback(const Callable &p_callable) override;
 
-	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) override;
-	virtual Error file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) override;
+	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) override;
+	virtual Error file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) override;
+	virtual Error file_dialog_hide(int64_t p_id) override;
 #endif
 
 	virtual void beep() const override;

--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -503,7 +503,7 @@ void DisplayServerX11::set_system_theme_change_callback(const Callable &p_callab
 	portal_desktop->set_system_theme_change_callback(p_callable);
 }
 
-Error DisplayServerX11::file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) {
+Error DisplayServerX11::file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) {
 	ERR_FAIL_COND_V(!portal_desktop, ERR_UNAVAILABLE);
 	DisplayServerEnums::WindowID window_id = p_window_id;
 
@@ -512,10 +512,10 @@ Error DisplayServerX11::file_dialog_show(const String &p_title, const String &p_
 	}
 
 	String xid = vformat("x11:%x", (uint64_t)windows[window_id].x11_window);
-	return portal_desktop->file_dialog_show(p_window_id, xid, p_title, p_current_directory, String(), p_filename, p_mode, p_filters, TypedArray<Dictionary>(), p_callback, false);
+	return portal_desktop->file_dialog_show(p_window_id, xid, p_title, p_current_directory, String(), p_filename, p_mode, p_filters, TypedArray<Dictionary>(), p_callback, false, p_id);
 }
 
-Error DisplayServerX11::file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) {
+Error DisplayServerX11::file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) {
 	ERR_FAIL_COND_V(!portal_desktop, ERR_UNAVAILABLE);
 	DisplayServerEnums::WindowID window_id = p_window_id;
 
@@ -524,7 +524,12 @@ Error DisplayServerX11::file_dialog_with_options_show(const String &p_title, con
 	}
 
 	String xid = vformat("x11:%x", (uint64_t)windows[window_id].x11_window);
-	return portal_desktop->file_dialog_show(p_window_id, xid, p_title, p_current_directory, p_root, p_filename, p_mode, p_filters, p_options, p_callback, true);
+	return portal_desktop->file_dialog_show(p_window_id, xid, p_title, p_current_directory, p_root, p_filename, p_mode, p_filters, p_options, p_callback, true, p_id);
+}
+
+Error DisplayServerX11::file_dialog_hide(int64_t p_id) {
+	ERR_FAIL_COND_V(!portal_desktop, ERR_UNAVAILABLE);
+	return portal_desktop->file_dialog_hide(p_id);
 }
 
 #endif

--- a/platform/linuxbsd/x11/display_server_x11.h
+++ b/platform/linuxbsd/x11/display_server_x11.h
@@ -420,8 +420,9 @@ public:
 	virtual Color get_accent_color() const override;
 	virtual void set_system_theme_change_callback(const Callable &p_callable) override;
 
-	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) override;
-	virtual Error file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) override;
+	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) override;
+	virtual Error file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) override;
+	virtual Error file_dialog_hide(int64_t p_id) override;
 #endif
 
 	virtual void beep() const override;

--- a/platform/macos/display_server_macos.h
+++ b/platform/macos/display_server_macos.h
@@ -50,6 +50,7 @@
 @class GodotWindow;
 @class GodotContentView;
 @class GodotWindowDelegate;
+@class GodotOpenSaveDelegate;
 @class GodotButtonView;
 @class GodotProgressView;
 
@@ -227,7 +228,19 @@ private:
 
 	static NSCursor *_cursor_from_selector(SEL p_selector, SEL p_fallback = nil);
 
-	Error _file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb, DisplayServerEnums::WindowID p_window_id);
+	struct FileDialogData {
+		int64_t id = -1;
+		NSPanel *panel = nullptr;
+		NSWindow *window = nullptr;
+		GodotOpenSaveDelegate *panel_delegate = nullptr;
+		Callable callback;
+		DisplayServerEnums::WindowID wid = DisplayServerEnums::INVALID_WINDOW_ID;
+		bool options_in_cb = false;
+	};
+
+	Mutex file_dialog_mutex;
+	Vector<FileDialogData> file_dialogs;
+	Error _file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb, DisplayServerEnums::WindowID p_window_id, int64_t p_id);
 
 #ifdef TOOLS_ENABLED
 	struct EmbeddedProcessData {
@@ -292,8 +305,9 @@ public:
 	virtual Error dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback) override;
 	virtual Error dialog_input_text(String p_title, String p_description, String p_partial, const Callable &p_callback) override;
 
-	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) override;
-	virtual Error file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) override;
+	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) override;
+	virtual Error file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) override;
+	virtual Error file_dialog_hide(int64_t p_id) override;
 
 	bool update_mouse_wrap(WindowData &p_wd, NSPoint &r_delta, NSPoint &r_mpos, NSTimeInterval p_timestamp);
 	virtual void warp_mouse(const Point2i &p_position) override;

--- a/platform/macos/display_server_macos.mm
+++ b/platform/macos/display_server_macos.mm
@@ -922,18 +922,81 @@ Error DisplayServerMacOS::dialog_show(String p_title, String p_description, Vect
 	return OK;
 }
 
-Error DisplayServerMacOS::file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) {
-	return _file_dialog_with_options_show(p_title, p_current_directory, String(), p_filename, p_show_hidden, p_mode, p_filters, TypedArray<Dictionary>(), p_callback, false, p_window_id);
+Error DisplayServerMacOS::file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) {
+	return _file_dialog_with_options_show(p_title, p_current_directory, String(), p_filename, p_show_hidden, p_mode, p_filters, TypedArray<Dictionary>(), p_callback, false, p_window_id, p_id);
 }
 
-Error DisplayServerMacOS::file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) {
-	return _file_dialog_with_options_show(p_title, p_current_directory, p_root, p_filename, p_show_hidden, p_mode, p_filters, p_options, p_callback, true, p_window_id);
+Error DisplayServerMacOS::file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) {
+	return _file_dialog_with_options_show(p_title, p_current_directory, p_root, p_filename, p_show_hidden, p_mode, p_filters, p_options, p_callback, true, p_window_id, p_id);
 }
 
-Error DisplayServerMacOS::_file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb, DisplayServerEnums::WindowID p_window_id) {
+Error DisplayServerMacOS::file_dialog_hide(int64_t p_id) {
+	ERR_FAIL_COND_V(p_id < 0, ERR_INVALID_PARAMETER);
+
+	MutexLock lock(file_dialog_mutex);
+	for (int i = 0; i < file_dialogs.size(); i++) {
+		const FileDialogData &fd = file_dialogs[i];
+		if (fd.id == p_id) {
+			if (fd.panel) {
+				if (fd.window) {
+					[fd.window endSheet:fd.panel];
+				} else {
+					[fd.panel close];
+					// Note: `close` doesn't trigger completion handler, call callback directly.
+					if (fd.callback.is_valid()) {
+						if (fd.options_in_cb) {
+							Variant v_result = false;
+							Variant v_files = Vector<String>();
+							Variant v_index = [fd.panel_delegate getIndex];
+							Variant v_opt = [fd.panel_delegate getSelection];
+							Variant ret;
+							Callable::CallError ce;
+							const Variant *args[4] = { &v_result, &v_files, &v_index, &v_opt };
+
+							fd.callback.callp(args, 4, ret, ce);
+							if (ce.error != Callable::CallError::CALL_OK) {
+								ERR_PRINT(vformat("Failed to execute file dialog callback: %s.", Variant::get_callable_error_text(fd.callback, args, 4, ce)));
+							}
+						} else {
+							Variant v_result = false;
+							Variant v_files = Vector<String>();
+							Variant v_index = [fd.panel_delegate getIndex];
+							Variant ret;
+							Callable::CallError ce;
+							const Variant *args[3] = { &v_result, &v_files, &v_index };
+
+							fd.callback.callp(args, 3, ret, ce);
+							if (ce.error != Callable::CallError::CALL_OK) {
+								ERR_PRINT(vformat("Failed to execute file dialog callback: %s.", Variant::get_callable_error_text(fd.callback, args, 3, ce)));
+							}
+						}
+					}
+					if (fd.wid != DisplayServerEnums::INVALID_WINDOW_ID) {
+						callable_mp(DisplayServer::get_singleton(), &DisplayServer::window_move_to_foreground).call_deferred(fd.wid);
+					}
+					file_dialogs.remove_at(i);
+				}
+
+				return OK;
+			} else {
+				return FAILED;
+			}
+		}
+	}
+	return ERR_INVALID_PARAMETER;
+}
+
+Error DisplayServerMacOS::_file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb, DisplayServerEnums::WindowID p_window_id, int64_t p_id) {
 	_THREAD_SAFE_METHOD_
 
 	ERR_FAIL_INDEX_V(int(p_mode), DisplayServerEnums::FILE_DIALOG_MODE_SAVE_MAX, FAILED);
+
+	MutexLock lock(file_dialog_mutex);
+	if (p_id >= 0) {
+		for (const FileDialogData &fd : file_dialogs) {
+			ERR_FAIL_COND_V_MSG(fd.id == p_id, FAILED, "ID already in use");
+		}
+	}
 
 	NSString *url = [NSString stringWithUTF8String:p_current_directory.utf8().get_data()];
 
@@ -1049,10 +1112,30 @@ Error DisplayServerMacOS::_file_dialog_with_options_show(const String &p_title, 
 					}
 				}
 			}
+			{
+				MutexLock lock(file_dialog_mutex);
+				for (int i = 0; i < file_dialogs.size(); i++) {
+					if (file_dialogs[i].panel == (NSPanel *)panel) {
+						file_dialogs.remove_at(i);
+						break;
+					}
+				}
+			}
 			if (p_window_id != DisplayServerEnums::INVALID_WINDOW_ID) {
 				callable_mp(DisplayServer::get_singleton(), &DisplayServer::window_move_to_foreground).call_deferred(p_window_id);
 			}
 		};
+		{
+			FileDialogData fd;
+			fd.id = p_id;
+			fd.panel = panel;
+			fd.panel_delegate = panel_delegate;
+			fd.window = nswindow;
+			fd.options_in_cb = p_options_in_cb;
+			fd.callback = p_callback;
+			fd.wid = p_window_id;
+			file_dialogs.push_back(fd);
+		}
 		if (nswindow) {
 			[panel beginSheetModalForWindow:nswindow completionHandler:completion_handler];
 		} else {
@@ -1170,10 +1253,30 @@ Error DisplayServerMacOS::_file_dialog_with_options_show(const String &p_title, 
 					}
 				}
 			}
+			{
+				MutexLock lock(file_dialog_mutex);
+				for (int i = 0; i < file_dialogs.size(); i++) {
+					if (file_dialogs[i].panel == (NSPanel *)panel) {
+						file_dialogs.remove_at(i);
+						break;
+					}
+				}
+			}
 			if (p_window_id != DisplayServerEnums::INVALID_WINDOW_ID) {
 				callable_mp(DisplayServer::get_singleton(), &DisplayServer::window_move_to_foreground).call_deferred(p_window_id);
 			}
 		};
+		{
+			FileDialogData fd;
+			fd.id = p_id;
+			fd.panel = panel;
+			fd.panel_delegate = panel_delegate;
+			fd.window = nswindow;
+			fd.options_in_cb = p_options_in_cb;
+			fd.callback = p_callback;
+			fd.wid = p_window_id;
+			file_dialogs.push_back(fd);
+		}
 		if (nswindow) {
 			[panel beginSheetModalForWindow:nswindow completionHandler:completion_handler];
 		} else {
@@ -4012,6 +4115,8 @@ DisplayServerMacOS::~DisplayServerMacOS() {
 		memdelete(native_menu);
 		native_menu = nullptr;
 	}
+
+	file_dialogs.clear();
 
 	// Destroy all windows.
 	for (HashMap<DisplayServerEnums::WindowID, WindowData>::Iterator E = windows.begin(); E;) {

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -442,12 +442,12 @@ void DisplayServerWindows::tts_stop() {
 	tts->stop();
 }
 
-Error DisplayServerWindows::file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) {
-	return _file_dialog_with_options_show(p_title, p_current_directory, String(), p_filename, p_show_hidden, p_mode, p_filters, TypedArray<Dictionary>(), p_callback, false, p_window_id);
+Error DisplayServerWindows::file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) {
+	return _file_dialog_with_options_show(p_title, p_current_directory, String(), p_filename, p_show_hidden, p_mode, p_filters, TypedArray<Dictionary>(), p_callback, false, p_window_id, p_id);
 }
 
-Error DisplayServerWindows::file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) {
-	return _file_dialog_with_options_show(p_title, p_current_directory, p_root, p_filename, p_show_hidden, p_mode, p_filters, p_options, p_callback, true, p_window_id);
+Error DisplayServerWindows::file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) {
+	return _file_dialog_with_options_show(p_title, p_current_directory, p_root, p_filename, p_show_hidden, p_mode, p_filters, p_options, p_callback, true, p_window_id, p_id);
 }
 
 GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Wnon-virtual-dtor") // Silence warning due to a COM API weirdness.
@@ -459,6 +459,7 @@ class FileDialogEventHandler : public IFileDialogEvents, public IFileDialogContr
 	HashMap<int, String> ctls;
 	Dictionary selected;
 	String root;
+	DisplayServerWindows::FileDialogData *fd = nullptr;
 
 public:
 	// IUnknown methods
@@ -493,6 +494,16 @@ public:
 	HRESULT STDMETHODCALLTYPE OnFolderChange(IFileDialog *) { return S_OK; }
 
 	HRESULT STDMETHODCALLTYPE OnFolderChanging(IFileDialog *p_pfd, IShellItem *p_item) {
+		IOleWindow *ole_window = nullptr;
+		HRESULT hr = p_pfd->QueryInterface(IID_PPV_ARGS(&ole_window));
+		if (SUCCEEDED(hr)) {
+			HWND dialog_hwnd;
+			hr = ole_window->GetWindow(&dialog_hwnd);
+			if (SUCCEEDED(hr) && fd) {
+				fd->hwnd = dialog_hwnd;
+			}
+		}
+
 		if (root.is_empty()) {
 			return S_OK;
 		}
@@ -534,6 +545,10 @@ public:
 
 	Dictionary get_selected() {
 		return selected;
+	}
+
+	void set_fd(DisplayServerWindows::FileDialogData *p_fd) {
+		fd = p_fd;
 	}
 
 	void set_root(const String &p_root) {
@@ -708,6 +723,7 @@ void DisplayServerWindows::_thread_fd_monitor(void *p_ud) {
 			event_handler->add_option(pfdc, item["name"], item["values"], item["default"]);
 		}
 		event_handler->set_root(fd->root);
+		event_handler->set_fd(fd);
 
 		pfdc->Release();
 
@@ -755,6 +771,7 @@ void DisplayServerWindows::_thread_fd_monitor(void *p_ud) {
 		pfd->SetFileTypeIndex(0);
 
 		hr = pfd->Show(hwnd_dialog);
+		fd->hwnd = 0;
 		pfd->Unadvise(cookie);
 
 		Dictionary options = event_handler->get_selected();
@@ -967,10 +984,37 @@ void DisplayServerWindows::hide_toast_notification(DisplayServerEnums::Notificat
 	}
 }
 
-Error DisplayServerWindows::_file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb, DisplayServerEnums::WindowID p_window_id) {
+Error DisplayServerWindows::file_dialog_hide(int64_t p_id) {
+	ERR_FAIL_COND_V(p_id < 0, ERR_INVALID_PARAMETER);
+
+	MutexLock lock(file_dialog_mutex);
+	for (List<FileDialogData *>::Element *E = file_dialogs.front(); E; E = E->next()) {
+		FileDialogData *fd = E->get();
+		if (fd->id == p_id) {
+			if (fd->hwnd) {
+				SendMessage(fd->hwnd, WM_CLOSE, 0, 0);
+				return OK;
+			} else {
+				return FAILED;
+			}
+		}
+	}
+	return ERR_INVALID_PARAMETER;
+}
+
+Error DisplayServerWindows::_file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb, DisplayServerEnums::WindowID p_window_id, int64_t p_id) {
 	_THREAD_SAFE_METHOD_
 
 	ERR_FAIL_INDEX_V(int(p_mode), DisplayServerEnums::FILE_DIALOG_MODE_SAVE_MAX, FAILED);
+
+	MutexLock lock(file_dialog_mutex);
+	if (p_id >= 0) {
+		for (List<FileDialogData *>::Element *E = file_dialogs.front(); E; E = E->next()) {
+			const FileDialogData *fd = E->get();
+			ERR_FAIL_COND_V_MSG(fd->id == p_id, FAILED, "ID already in use");
+		}
+	}
+
 	FileDialogData *fd = memnew(FileDialogData);
 	if (windows.has(p_window_id) && !windows[p_window_id].is_popup) {
 		fd->hwnd_owner = windows[p_window_id].hWnd;
@@ -981,6 +1025,7 @@ Error DisplayServerWindows::_file_dialog_with_options_show(const String &p_title
 		fd->hwnd_owner = nullptr;
 		fd->wrect = Rect2i(CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT);
 	}
+	fd->id = p_id;
 	fd->appid = _get_app_id();
 	fd->title = p_title;
 	fd->current_directory = p_current_directory;

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -439,8 +439,11 @@ class DisplayServerWindows : public DisplayServer {
 	DisplayServerEnums::IndicatorID indicator_id_counter = 0;
 	HashMap<DisplayServerEnums::IndicatorID, IndicatorData> indicators;
 
+public:
 	struct FileDialogData {
+		int64_t id = -1;
 		HWND hwnd_owner = nullptr;
+		HWND hwnd = nullptr;
 		Rect2i wrect;
 		String appid;
 		String title;
@@ -458,6 +461,8 @@ class DisplayServerWindows : public DisplayServer {
 		SafeFlag close_requested;
 		SafeFlag finished;
 	};
+
+private:
 	Mutex file_dialog_mutex;
 	List<FileDialogData *> file_dialogs;
 	HashMap<HWND, FileDialogData *> file_dialog_wnd;
@@ -538,7 +543,7 @@ class DisplayServerWindows : public DisplayServer {
 	};
 	BitField<WinKeyModifierMask> _get_mods() const;
 
-	Error _file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb, DisplayServerEnums::WindowID p_window_id);
+	Error _file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, bool p_options_in_cb, DisplayServerEnums::WindowID p_window_id, int64_t p_id);
 
 	String _get_keyboard_layout_display_name(const String &p_klid) const;
 	String _get_klid(HKL p_hkl) const;
@@ -602,8 +607,9 @@ public:
 	virtual Color get_base_color() const override;
 	virtual void set_system_theme_change_callback(const Callable &p_callable) override;
 
-	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) override;
-	virtual Error file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) override;
+	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) override;
+	virtual Error file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) override;
+	virtual Error file_dialog_hide(int64_t p_id) override;
 
 	virtual void beep() const override;
 

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -52,6 +52,8 @@
 #include "scene/theme/theme_db.h"
 #include "servers/display/display_server.h"
 
+int64_t FileDialog::next_native_dialog_id = 0;
+
 void FileDialog::popup_file_dialog() {
 	popup_centered_clamped(Vector2(1050, 700) * get_theme_default_base_scale(), 0.8f);
 	_focus_file_text();
@@ -68,6 +70,10 @@ void FileDialog::_focus_file_text() {
 }
 
 void FileDialog::_native_popup() {
+	if (native_dialog_id != -1) {
+		return;
+	}
+
 	// Show native dialog directly.
 	String root;
 	if (!root_prefix.is_empty()) {
@@ -84,11 +90,12 @@ void FileDialog::_native_popup() {
 		w = w->get_parent_visible_window();
 	}
 	DisplayServerEnums::WindowID wid = w ? w->get_window_id() : DisplayServerEnums::INVALID_WINDOW_ID;
+	native_dialog_id = next_native_dialog_id++;
 
 	if (DisplayServer::get_singleton()->has_feature(DisplayServerEnums::FEATURE_NATIVE_DIALOG_FILE_EXTRA)) {
-		DisplayServer::get_singleton()->file_dialog_with_options_show(get_displayed_title(), ProjectSettings::get_singleton()->globalize_path(full_dir), root, filename_edit->get_text().get_file(), show_hidden_files, DisplayServerEnums::FileDialogMode(mode), processed_filters, _get_options(), callable_mp(this, &FileDialog::_native_dialog_cb_with_options), wid);
+		DisplayServer::get_singleton()->file_dialog_with_options_show(get_displayed_title(), ProjectSettings::get_singleton()->globalize_path(full_dir), root, filename_edit->get_text().get_file(), show_hidden_files, DisplayServerEnums::FileDialogMode(mode), processed_filters, _get_options(), callable_mp(this, &FileDialog::_native_dialog_cb_with_options), wid, native_dialog_id);
 	} else {
-		DisplayServer::get_singleton()->file_dialog_show(get_displayed_title(), ProjectSettings::get_singleton()->globalize_path(full_dir), filename_edit->get_text().get_file(), show_hidden_files, DisplayServerEnums::FileDialogMode(mode), processed_filters, callable_mp(this, &FileDialog::_native_dialog_cb), wid);
+		DisplayServer::get_singleton()->file_dialog_show(get_displayed_title(), ProjectSettings::get_singleton()->globalize_path(full_dir), filename_edit->get_text().get_file(), show_hidden_files, DisplayServerEnums::FileDialogMode(mode), processed_filters, callable_mp(this, &FileDialog::_native_dialog_cb), wid, native_dialog_id);
 	}
 }
 
@@ -138,6 +145,10 @@ void FileDialog::set_visible(bool p_visible) {
 	if (_should_use_native_popup()) {
 		if (p_visible) {
 			_native_popup();
+		} else {
+			if (native_dialog_id != -1) {
+				DisplayServer::get_singleton()->file_dialog_hide(native_dialog_id);
+			}
 		}
 	} else {
 		ConfirmationDialog::set_visible(p_visible);
@@ -149,6 +160,8 @@ void FileDialog::_native_dialog_cb(bool p_ok, const Vector<String> &p_files, int
 }
 
 void FileDialog::_native_dialog_cb_with_options(bool p_ok, const Vector<String> &p_files, int p_filter, const Dictionary &p_selected_options) {
+	native_dialog_id = -1;
+
 	if (!p_ok) {
 		filename_edit->set_text("");
 		emit_signal(SNAME("canceled"));

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -207,6 +207,10 @@ private:
 	bool is_invalidating = false;
 	bool ensure_visible_after_invalidating = false;
 
+	static int64_t next_native_dialog_id;
+
+	int64_t native_dialog_id = -1;
+
 	VBoxContainer *main_vbox = nullptr;
 
 	Button *dir_prev = nullptr;

--- a/servers/display/display_server.compat.inc
+++ b/servers/display/display_server.compat.inc
@@ -54,12 +54,22 @@ Rect2i DisplayServer::_get_display_safe_area_bind_compat_119196() const {
 	return get_display_safe_area(DisplayServerEnums::SCREEN_OF_MAIN_WINDOW);
 }
 
+Error DisplayServer::_file_dialog_show_bind_compat_123178(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) {
+	return file_dialog_show(p_title, p_current_directory, p_filename, p_show_hidden, p_mode, p_filters, p_callback, p_window_id, -1);
+}
+
+Error DisplayServer::_file_dialog_with_options_show_compat_123178(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) {
+	return file_dialog_with_options_show(p_title, p_current_directory, p_root, p_filename, p_show_hidden, p_mode, p_filters, p_options, p_callback, p_window_id, -1);
+}
+
 void DisplayServer::_bind_compatibility_methods() {
 	ClassDB::bind_compatibility_method(D_METHOD("file_dialog_show", "title", "current_directory", "filename", "show_hidden", "mode", "filters", "callback"), &DisplayServer::_file_dialog_show_bind_compat_98194);
 	ClassDB::bind_compatibility_method(D_METHOD("file_dialog_with_options_show", "title", "current_directory", "root", "filename", "show_hidden", "mode", "filters", "options", "callback"), &DisplayServer::_file_dialog_with_options_show_bind_compat_98194);
 	ClassDB::bind_compatibility_method(D_METHOD("accessibility_create_sub_text_edit_elements", "parent_rid", "shaped_text", "min_height", "insert_pos"), &DisplayServer::_accessibility_create_sub_text_edit_elements_bind_compat_113459, DEFVAL(-1));
 	ClassDB::bind_compatibility_method(D_METHOD("get_display_cutouts"), &DisplayServer::_get_display_cutouts_bind_compat_119196);
 	ClassDB::bind_compatibility_method(D_METHOD("get_display_safe_area"), &DisplayServer::_get_display_safe_area_bind_compat_119196);
+	ClassDB::bind_compatibility_method(D_METHOD("file_dialog_show", "title", "current_directory", "filename", "show_hidden", "mode", "filters", "callback", "parent_window_id"), &DisplayServer::_file_dialog_show_bind_compat_123178, DEFVAL(DisplayServerEnums::MAIN_WINDOW_ID));
+	ClassDB::bind_compatibility_method(D_METHOD("file_dialog_with_options_show", "title", "current_directory", "root", "filename", "show_hidden", "mode", "filters", "options", "callback", "parent_window_id"), &DisplayServer::_file_dialog_with_options_show_compat_123178, DEFVAL(DisplayServerEnums::MAIN_WINDOW_ID));
 }
 
 #endif // DISABLE_DEPRECATED

--- a/servers/display/display_server.cpp
+++ b/servers/display/display_server.cpp
@@ -1194,12 +1194,12 @@ Error DisplayServer::dialog_input_text(String p_title, String p_description, Str
 	return ERR_UNAVAILABLE;
 }
 
-Error DisplayServer::file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) {
+Error DisplayServer::file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) {
 	WARN_PRINT("Native dialogs not supported by this display server.");
 	return ERR_UNAVAILABLE;
 }
 
-Error DisplayServer::file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) {
+Error DisplayServer::file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) {
 	WARN_PRINT("Native dialogs not supported by this display server.");
 	return ERR_UNAVAILABLE;
 }
@@ -1692,8 +1692,9 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("dialog_show", "title", "description", "buttons", "callback"), &DisplayServer::dialog_show);
 	ClassDB::bind_method(D_METHOD("dialog_input_text", "title", "description", "existing_text", "callback"), &DisplayServer::dialog_input_text);
 
-	ClassDB::bind_method(D_METHOD("file_dialog_show", "title", "current_directory", "filename", "show_hidden", "mode", "filters", "callback", "parent_window_id"), &DisplayServer::file_dialog_show, DEFVAL(DisplayServerEnums::MAIN_WINDOW_ID));
-	ClassDB::bind_method(D_METHOD("file_dialog_with_options_show", "title", "current_directory", "root", "filename", "show_hidden", "mode", "filters", "options", "callback", "parent_window_id"), &DisplayServer::file_dialog_with_options_show, DEFVAL(DisplayServerEnums::MAIN_WINDOW_ID));
+	ClassDB::bind_method(D_METHOD("file_dialog_show", "title", "current_directory", "filename", "show_hidden", "mode", "filters", "callback", "parent_window_id", "id"), &DisplayServer::file_dialog_show, DEFVAL(DisplayServerEnums::MAIN_WINDOW_ID), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("file_dialog_with_options_show", "title", "current_directory", "root", "filename", "show_hidden", "mode", "filters", "options", "callback", "parent_window_id", "id"), &DisplayServer::file_dialog_with_options_show, DEFVAL(DisplayServerEnums::MAIN_WINDOW_ID), DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("file_dialog_hide", "id"), &DisplayServer::file_dialog_hide);
 
 	ClassDB::bind_method(D_METHOD("beep"), &DisplayServer::beep);
 

--- a/servers/display/display_server.h
+++ b/servers/display/display_server.h
@@ -508,14 +508,17 @@ public:
 	virtual Error dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback);
 	virtual Error dialog_input_text(String p_title, String p_description, String p_partial, const Callable &p_callback);
 
-	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id = DisplayServerEnums::MAIN_WINDOW_ID);
-	virtual Error file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id = DisplayServerEnums::MAIN_WINDOW_ID);
+	virtual Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id = DisplayServerEnums::MAIN_WINDOW_ID, int64_t p_id = -1);
+	virtual Error file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id = DisplayServerEnums::MAIN_WINDOW_ID, int64_t p_id = -1);
+	virtual Error file_dialog_hide(int64_t p_id) { return OK; }
 
 #ifndef DISABLE_DEPRECATED
 	Error _file_dialog_show_bind_compat_98194(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback);
 	Error _file_dialog_with_options_show_bind_compat_98194(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback);
 	TypedArray<Rect2> _get_display_cutouts_bind_compat_119196() const;
 	Rect2i _get_display_safe_area_bind_compat_119196() const;
+	Error _file_dialog_show_bind_compat_123178(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id);
+	Error _file_dialog_with_options_show_compat_123178(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id);
 #endif
 
 	virtual void show_emoji_and_symbol_picker() const;

--- a/servers/display/display_server_headless.h
+++ b/servers/display/display_server_headless.h
@@ -175,8 +175,8 @@ public:
 
 	Error dialog_show(String p_title, String p_description, Vector<String> p_buttons, const Callable &p_callback) override { return ERR_UNAVAILABLE; }
 	Error dialog_input_text(String p_title, String p_description, String p_partial, const Callable &p_callback) override { return ERR_UNAVAILABLE; }
-	Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) override { return ERR_UNAVAILABLE; }
-	Error file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id) override { return ERR_UNAVAILABLE; }
+	Error file_dialog_show(const String &p_title, const String &p_current_directory, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) override { return ERR_UNAVAILABLE; }
+	Error file_dialog_with_options_show(const String &p_title, const String &p_current_directory, const String &p_root, const String &p_filename, bool p_show_hidden, DisplayServerEnums::FileDialogMode p_mode, const Vector<String> &p_filters, const TypedArray<Dictionary> &p_options, const Callable &p_callback, DisplayServerEnums::WindowID p_window_id, int64_t p_id) override { return ERR_UNAVAILABLE; }
 
 	void release_rendering_thread() override {}
 	void swap_buffers() override {}


### PR DESCRIPTION
## What problem(s) does this PR solve?

Follow-up to https://github.com/godotengine/godot/pull/123171, fixes setting `visible = false` on native `FileDialog`