### PR TITLE
Prevent unexpected scene interactions in scene painter

### DIFF
--- a/editor/scene/2d/scene_paint_2d_editor_plugin.cpp
+++ b/editor/scene/2d/scene_paint_2d_editor_plugin.cpp
@@ -36,7 +36,6 @@
 #include "editor/docks/filesystem_dock.h"
 #include "editor/docks/inspector_dock.h"
 #include "editor/docks/scene_tree_dock.h"
-#include "editor/editor_main_screen.h"
 #include "editor/editor_node.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/scene/canvas_item_editor_plugin.h"
@@ -226,6 +225,26 @@ void ScenePaint2DEditor::_add_instance(bool p_show) {
 	} else if (selected_scene && instance_container && !instance) {
 		HashMap<const Node *, Node *> duplimap;
 		instance = Object::cast_to<Node2D>(selected_scene->duplicate_from_editor(duplimap));
+
+		// Remember original process mode of the instance and set it to DISABLED, to avoid unexpected events.
+		original_instance_process_mode = instance->get_process_mode();
+		instance->set_process_mode(PROCESS_MODE_DISABLED);
+
+		// Disable mouse filter of Control nodes, as they could interfere with painting.
+		LocalVector<Node *> nodes_to_fix = { instance };
+		while (!nodes_to_fix.is_empty()) {
+			Node *node_to_fix = nodes_to_fix[nodes_to_fix.size() - 1];
+			nodes_to_fix.remove_at(nodes_to_fix.size() - 1);
+
+			Control *control = Object::cast_to<Control>(node_to_fix);
+			if (control) {
+				control->set_mouse_filter(MOUSE_FILTER_IGNORE);
+			}
+			for (Node *child : node_to_fix->iterate_children()) {
+				nodes_to_fix.push_back(child);
+			}
+		}
+
 		instance_container->add_child(instance, true);
 		instance->set_position(Point2());
 	}
@@ -387,6 +406,7 @@ void ScenePaint2DEditor::_add_node_at_pos() {
 	if (!node_2d) {
 		return;
 	}
+	node_2d->set_process_mode(original_instance_process_mode);
 
 	if (scene) {
 		node->add_child(node_2d, true);

--- a/editor/scene/2d/scene_paint_2d_editor_plugin.h
+++ b/editor/scene/2d/scene_paint_2d_editor_plugin.h
@@ -87,6 +87,8 @@ class ScenePaint2DEditor : public Control {
 	PaintMode quick_paint_mode = PAINT_MODE_SNAP_GRID_CELL_CENTER;
 	InputTool input_tool = INPUT_TOOL_NONE;
 
+	ProcessMode original_instance_process_mode = PROCESS_MODE_INHERIT;
+
 	Size2i grid_step = Size2i(16, 16);
 	Size2i grid_offset = Size2i(0, 0);
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

When using the 2D painter, the scene preview is added as an overlay, instead of as part of edited scene. Thus (at least) 2 problems can occur:
- Any node that can process in the editor will process. The most extreme example is a Time with autostart that will free scene root on timeout. While it doesn't cause crash, the freed scene breaks painter.
- If there is any Control node in the painted scene, it will interfere with editor input.

The fixes are:
- `process_mode` of the scene root is set to `PROCESS_MODE_DISABLED`. The original mode is restored when painting the instance
  - This does not stop any child nodes that may use `PROCESS_MODE_ALWAYS`. Not sure if it's worth handling
- `mouse_filter` is set to IGNORE for every node in the scene, recursively. Since the painter is usually used with instances, the original filter does not need to be restored
  - There are of course edge cases, like when you enable editable children, any Control will have changed mouse filter, but also probably not worth worrying about

## Additional information

Originally reported in https://github.com/KoBeWi/Godot-Instance-Dock/issues/17#issuecomment-5534742466
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
