### PR TITLE
Properly handle renamed/removed translations

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -156,6 +156,55 @@ const PackedStringArray ProjectSettings::_trim_to_supported_features(const Packe
 	features.sort();
 	return features;
 }
+
+static bool _rename_files(ProjectSettings *p_project_settings, const StringName &p_setting, const HashMap<String, String> &p_renames) {
+	PackedStringArray files = p_project_settings->get(p_setting);
+	int file_count = files.size();
+	String *files_write = files.ptrw();
+
+	bool any_renamed = false;
+	for (int i = 0; i < file_count; i++) {
+		const String *rename = p_renames.getptr(files_write[i]);
+		if (rename) {
+			files_write[i] = *rename;
+			any_renamed = true;
+		}
+	}
+	if (any_renamed) {
+		p_project_settings->set(p_setting, files);
+	}
+	return any_renamed;
+}
+
+bool ProjectSettings::handle_renamed_files(const HashMap<String, String> &p_renames) {
+	bool any_renamed = _rename_files(this, "internationalization/locale/translations", p_renames);
+	any_renamed = _rename_files(this, "internationalization/locale/translations_pot_files", p_renames) || any_renamed;
+	return any_renamed;
+}
+
+static bool _remove_files(ProjectSettings *p_project_settings, const StringName &p_setting, const HashMap<String, String> &p_removes) {
+	PackedStringArray files = p_project_settings->get(p_setting);
+
+	bool any_removed = false;
+	for (int i = 0; i < files.size();) {
+		if (p_removes.has(files[i])) {
+			files.remove_at(i);
+			any_removed = true;
+		} else {
+			i++;
+		}
+	}
+	if (any_removed) {
+		p_project_settings->set(p_setting, files);
+	}
+	return any_removed;
+}
+
+bool ProjectSettings::handle_removed_files(const HashMap<String, String> &p_removes) {
+	bool any_removed = _remove_files(this, "internationalization/locale/translations", p_removes);
+	any_removed = _remove_files(this, "internationalization/locale/translations_pot_files", p_removes) || any_removed;
+	return any_removed;
+}
 #endif // TOOLS_ENABLED
 
 String ProjectSettings::localize_path(const String &p_path) const {

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -165,6 +165,9 @@ public:
 
 #ifdef TOOLS_ENABLED
 	HashMap<String, PropertyInfo> editor_settings_info;
+
+	bool handle_renamed_files(const HashMap<String, String> &p_renames);
+	bool handle_removed_files(const HashMap<String, String> &p_removes);
 #endif
 
 	void set_setting(const String &p_setting, const Variant &p_value);

--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -1687,6 +1687,10 @@ void FileSystemDock::_update_resource_paths_after_move(const HashMap<String, Str
 }
 
 void FileSystemDock::_update_dependencies_after_move(const HashMap<String, String> &p_renames, const HashSet<String> &p_file_owners) const {
+	if (ProjectSettings::get_singleton()->handle_renamed_files(p_renames)) {
+		ProjectSettings::get_singleton()->save();
+	}
+
 	// The following code assumes that the following holds:
 	// 1) EditorFileSystem contains the old paths/folder structure from before the rename/move.
 	// 2) ResourceLoader can use the new paths without needing to call rescan.

--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -777,7 +777,7 @@ void DependencyRemoveDialog::ok_pressed() {
 		setting_path_map[path] = setting;
 	}
 
-	bool project_settings_modified = false;
+	bool project_settings_modified = ProjectSettings::get_singleton()->handle_removed_files(all_remove_files);
 
 	for (const KeyValue<String, String> &E : all_remove_files) {
 		String file = E.key;


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #119458

## Additional information

This could be easily avoid for translations if they supported UIDs.
For POT source files it's unavoidable, because they can include non-Resources.

There is also `translation_remaps` setting, which needs updating, but since it only references Resources, it can be changed to use UIDs (I'll do that in another PR).