### PR TITLE
Fix instance uniform value stuck after type changes

### DIFF
--- a/servers/rendering/instance_uniforms.cpp
+++ b/servers/rendering/instance_uniforms.cpp
@@ -159,7 +159,7 @@ void InstanceUniforms::_init_param(Item &r_item, const RendererMaterialStorage::
 		Variant::construct(r_item.info.type, r_item.default_value, nullptr, 0, cerr);
 	}
 
-	if (r_item.value.get_type() == Variant::NIL) {
+	if (r_item.value.get_type() != p_param.info.type) {
 		r_item.value = r_item.default_value;
 	}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #119973

## Additional information

Reason of the bug:
Shader recompilation does not automatically clear `_parameters`, only marking entries inside "invalid" (i.e. resetting `index`). Thus the old value persists forever, until `set()` is called (via `GeometryInstance3D::set_instance_shader_parameter`).
