### PR TITLE
Fix metadata not being deletable

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -4230,7 +4230,7 @@ void EditorInspector::_populate_property_map(EditorProperty *p_ep, const Propert
 	}
 }
 
-void EditorInspector::_apply_property_editor_flags(EditorProperty *p_ep, bool p_sub_inspector_use_filter, bool p_disable_favorite, bool p_property_read_only, bool p_all_read_only, bool p_checkable, bool p_checked, bool p_draw_warning) {
+void EditorInspector::_apply_property_editor_flags(EditorProperty *p_ep, bool p_sub_inspector_use_filter, bool p_disable_favorite, bool p_property_read_only, bool p_all_read_only, bool p_checkable, bool p_checked, bool p_draw_warning, bool p_deletable) {
 	if (p_sub_inspector_use_filter) {
 		EditorPropertyResource *epr = Object::cast_to<EditorPropertyResource>(p_ep);
 		if (epr) {
@@ -4238,7 +4238,7 @@ void EditorInspector::_apply_property_editor_flags(EditorProperty *p_ep, bool p_
 		}
 	}
 
-	p_ep->set_deletable(deletable_properties);
+	p_ep->set_deletable(p_deletable);
 	p_ep->set_draw_warning(p_draw_warning);
 	p_ep->set_use_folding(use_folding);
 	p_ep->set_favoritable(can_favorite && !p_disable_favorite && !p_ep->is_deletable());
@@ -5137,21 +5137,23 @@ void EditorInspector::update_tree() {
 
 				_populate_property_map(ep, p, editors[i], properties, property_label_string);
 
+				bool ep_disable_favorite = disable_favorite;
+				bool ep_deletable = deletable_properties;
+
 				if (p.name.begins_with("metadata/")) {
+					ep_disable_favorite = true;
 					if (property_read_only || all_read_only) {
-						ep->set_deletable(false);
+						ep_deletable = false;
 					} else {
 						Variant _default = Variant();
 						if (node != nullptr) {
 							_default = PropertyUtils::get_property_default_value(node, p.name, nullptr, &sstack, false, nullptr, nullptr);
 						}
-						ep->set_deletable(_default == Variant());
+						ep_deletable = _default == Variant();
 					}
-				} else {
-					ep->set_deletable(deletable_properties);
 				}
 
-				_apply_property_editor_flags(ep, sub_inspector_use_filter, disable_favorite, property_read_only, all_read_only, checkable, checked, draw_warning);
+				_apply_property_editor_flags(ep, sub_inspector_use_filter, ep_disable_favorite, property_read_only, all_read_only, checkable, checked, draw_warning, ep_deletable);
 			}
 
 			if (ep && ep->is_favoritable() && current_favorites.has(p.name)) {
@@ -5171,7 +5173,7 @@ void EditorInspector::update_tree() {
 					ep_copy->object = object;
 
 					_populate_property_map(ep_copy, p, editors[i], properties, property_label_string);
-					_apply_property_editor_flags(ep_copy, sub_inspector_use_filter, disable_favorite, property_read_only, all_read_only, checkable, checked, draw_warning);
+					_apply_property_editor_flags(ep_copy, sub_inspector_use_filter, disable_favorite, property_read_only, all_read_only, checkable, checked, draw_warning, deletable_properties);
 					ep_copy->favorited = true;
 
 					current_vbox->add_child(ep_copy);

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -888,7 +888,7 @@ private:
 	void _keying_changed();
 
 	void _populate_property_map(EditorProperty *p_ep, const PropertyInfo &p_property_info, const EditorInspectorPlugin::AddedEditor &p_editor, const Vector<String> &p_properties, const String &p_property_label_string);
-	void _apply_property_editor_flags(EditorProperty *p_ep, bool p_sub_inspector_use_filter, bool p_disable_favorite, bool p_property_read_only, bool p_all_read_only, bool p_checkable, bool p_checked, bool p_draw_warning);
+	void _apply_property_editor_flags(EditorProperty *p_ep, bool p_sub_inspector_use_filter, bool p_disable_favorite, bool p_property_read_only, bool p_all_read_only, bool p_checkable, bool p_checked, bool p_draw_warning, bool p_deletable);
 	void _connect_property_editor_signals(EditorProperty *p_ep, bool p_update_all);
 	void _apply_property_editor_doc(EditorProperty *p_ep, const PropertyInfo &p_property_info, const String &p_doc_tooltip_text, const String &p_doc_path);
 	void _search_and_connect_sections(EditorProperty *p_ep, Node *p_section_search);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/123181

## Additional information

Fixes regression from https://github.com/godotengine/godot/pull/120125 as it always applied `deletable_properties` on top of the set deletable from `"metadata/"`. 

Also this PR uses `ep_disable_favorite` to always disable favorite for metadatas, I think it was possible that the button would show up in a read only object as was seen in one of the screenshots from https://github.com/godotengine/godot/issues/123181, but I didn't check it, so to be certain it's now is disabled. See https://github.com/godotengine/godot/issues/101886#issuecomment-2605941522 for why it is disabled. Also the button still didn't work, it ran into the error somewhere further.

No AI used.
