### PR TITLE
Fix balloon focus issues for controls with no separation

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3607,6 +3607,13 @@ real_t Control::_focus_strategy_balloon_candidate_score(const Vector2 &p_start, 
 	}
 
 	Vector2 hit = touch - p_start;
+
+	// If the hit vector is zero, then the next control's border coincides with ours. In this case
+	// return maximum score instead, to prevent NaN from division by zero
+	if (hit.is_zero_approx()) {
+		return 1.0;
+	}
+
 	return p_dir.dot(hit) / hit.length_squared();
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Adresses issues found under https://github.com/godotengine/godot/pull/120631#issuecomment-5486290106

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

For controls that had no separation (effectively "touching" each other), the computed hit vector is zero, which results in a `NaN` score later due to a division by zero, effectively skipping the candidate control. This fixes the issue by checking for such scenarios and return maximum score instead.
