### PR TITLE
Clarify how the changed signal work for tile map layers

### DIFF
--- a/modules/tilemap/doc_classes/TileMapLayer.xml
+++ b/modules/tilemap/doc_classes/TileMapLayer.xml
@@ -341,7 +341,7 @@
 	<signals>
 		<signal name="changed">
 			<description>
-				Emitted when this [TileMapLayer]'s properties changes. This includes modified cells, properties, or changes made to its assigned [TileSet].
+				Emitted when this [TileMapLayer]'s properties changes, including changes to its assigned [TileSet].
 				[b]Note:[/b] This signal may be emitted very often when batch-modifying a [TileMapLayer]. Avoid executing complex processing in a connected function, and consider delaying it to the end of the frame instead (i.e. calling [method Object.call_deferred]).
 			</description>
 		</signal>


### PR DESCRIPTION
## What problem(s) does this PR solve?

The current way `changed` is documented is ambiguous as to whether `changed` should be emitted when a `TileMapLayer` cells are updated. This PR tries to fix this and links to the method `_update_cells` which was introduced in https://github.com/godotengine/godot/pull/96188 for this exact purpose

## Additional information

I have made this PR after being confused my self during some issues / PR in the proposal https://github.com/godotengine/godot-proposals/issues/15480 which motivated the PR https://github.com/godotengine/godot/pull/123191 which was closed after https://github.com/godotengine/godot/issues/123193 identified that the `changed` signal resets the Node and hence the currently selected terrain.


* *Bugsquad edit, closes: https://github.com/godotengine/godot/issues/107342*