### PR TITLE
Disable the "Open Documentation" when nothing is selected or is a text file.

### DIFF
--- a/editor/docks/inspector_dock.cpp
+++ b/editor/docks/inspector_dock.cpp
@@ -591,6 +591,7 @@ void InspectorDock::update(Object *p_object) {
 	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_SAVE), !is_resource || is_text_file);
 	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_SAVE_AS), !is_resource || is_text_file);
 	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_COPY), !is_resource || is_text_file);
+	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(OBJECT_REQUEST_HELP), (!is_resource && !is_node) || is_text_file);
 	resource_extra_popup->set_item_disabled(resource_extra_popup->get_item_index(RESOURCE_MAKE_BUILT_IN), !is_resource || is_text_file);
 
 	if (!is_object || is_text_file) {
@@ -810,6 +811,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	resource_extra_popup->add_separator();
 	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/show_in_filesystem", TTRC("Show in FileSystem")), RESOURCE_SHOW_IN_FILESYSTEM);
 	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/open_docs", TTRC("Open Documentation")), OBJECT_REQUEST_HELP);
+	resource_extra_popup->set_item_disabled(-1, true);
 	resource_extra_popup->add_separator();
 	resource_extra_popup->add_shortcut(ED_SHORTCUT("property_editor/unref_resource", TTRC("Make Resource Built-In")), RESOURCE_MAKE_BUILT_IN);
 	resource_extra_popup->set_item_disabled(-1, true);


### PR DESCRIPTION
Disable the "Open Documentation" option when nothing is selected or is a text file.

Closes #123180
