### PR TITLE
Update links to PCRE2 website in the RegEx class reference

### DIFF
--- a/doc/classes/RegEx.xml
+++ b/doc/classes/RegEx.xml
@@ -42,7 +42,7 @@
 			results.push_back(result.get_string())
 		print(results) # Prints ["One", "Two", "Three"]
 		[/codeblock]
-		[b]Note:[/b] Godot's regex implementation is based on the [url=https://www.pcre.org/]PCRE2[/url] library. You can view the full pattern reference [url=https://www.pcre.org/current/doc/html/pcre2pattern.html]here[/url].
+		[b]Note:[/b] Godot's regex implementation is based on the [url=https://pcre2project.github.io/pcre2/]PCRE2[/url] library. You can view the full pattern reference [url=https://pcre2project.github.io/pcre2/doc/pcre2pattern/]here[/url].
 		[b]Tip:[/b] You can use [url=https://regexr.com/]Regexr[/url] to test regular expressions online.
 	</description>
 	<tutorials>

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -934,7 +934,7 @@ Patches:
 
 ## pcre2
 
-- Upstream: http://www.pcre.org
+- Upstream: https://pcre2project.github.io/pcre2/
 - Version: 10.47 (f454e231fe5006dd7ff8f4693fd2b8eb94333429, 2025)
 - License: BSD-3-Clause
 


### PR DESCRIPTION
PCRE2 has a new homepage, although the old website is still up.

- See https://github.com/godotengine/godot-docs-user-notes/discussions/902#discussioncomment-18286499.
