### PR TITLE
Fix missing `@export_range` autocomplete options for `extra_hints`

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -1007,16 +1007,13 @@ static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_a
 		r_arghint = _make_arguments_hint(p_annotation->info->info, p_argument, true);
 	}
 	if (p_annotation->name == SNAME("@export_range")) {
-		if (p_argument == 3 || p_argument == 4 || p_argument == 5) {
+		if (p_argument >= 3) {
 			// Slider hint.
-			EditorLanguage::CompletionOption slider1 = _calculate_string_insertion(existing_argument, "or_greater");
-			r_result.insert(slider1.display, slider1);
-			EditorLanguage::CompletionOption slider2 = _calculate_string_insertion(existing_argument, "or_less");
-			r_result.insert(slider2.display, slider2);
-			EditorLanguage::CompletionOption slider3 = _calculate_string_insertion(existing_argument, "prefer_slider");
-			r_result.insert(slider3.display, slider3);
-			EditorLanguage::CompletionOption slider4 = _calculate_string_insertion(existing_argument, "hide_control");
-			r_result.insert(slider4.display, slider4);
+			static const char *sliders[] = { "or_greater", "or_less", "prefer_slider", "hide_control", "exp", "radians_as_degrees", "degrees", "suffix:unit" };
+			for (const char *slider : sliders) {
+				EditorLanguage::CompletionOption option = _calculate_string_insertion(existing_argument, slider);
+				r_result.insert(option.display, option);
+			}
 		}
 	} else if (p_annotation->name == SNAME("@export_exp_easing")) {
 		if (p_argument == 0 || p_argument == 1) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

Supersedes https://github.com/godotengine/godot/pull/123158
Closes https://github.com/godotengine/godot/issues/123139

## Additional information

Changes:
- Autocomplete for `extra_hints` now includes all 8 options.
  - Adds "exp", "radians_as_degrees", "degrees", and "suffix:unit".
- Autocomplete no longer stops after the 6th argument.
  - Note: `prefer_slider/hide_control` and `degrees/suffix:unit` are mutually exclusive.

Screenshots:
<img width="681" height="198" alt="Image 2026-09-05_00-51-04" src="https://github.com/user-attachments/assets/c1925873-5242-41e8-a488-be89af57fca8" />
<img width="680" height="198" alt="Image 2026-09-05_00-51-23" src="https://github.com/user-attachments/assets/35580700-d27b-415d-b8a9-da04f2ba68d9" />

Note for reviewers:
- Not sure if I should use a for-loop instead, similar to `@rpc`'s autocomplete code.

## Author disclosure

I wrote this PR by myself.