### PR TITLE
SCons: Migrate shader generation to `argparse`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -44,26 +44,17 @@ def _helper_module(name, path):
         setattr(parent_module, child_name, child_module)
 
 
-_helper_module("gles3_builders", "gles3_builders.py")
-_helper_module("glsl_builders", "glsl_builders.py")
 _helper_module("methods", "methods.py")
 _helper_module("platform_methods", "platform_methods.py")
+_helper_module("scu_builders", "scu_builders.py")
 _helper_module("version", "version.py")
-_helper_module("core.core_builders", "core/core_builders.py")
-_helper_module("main.main_builders", "main/main_builders.py")
 _helper_module("misc.utility.color", "misc/utility/color.py")
 
 # Local
-import gles3_builders
-import glsl_builders
 import methods
 import scu_builders
 from misc.utility.color import is_stderr_color, print_error, print_info, print_warning
 from platform_methods import architecture_aliases, architectures, compatibility_platform_aliases
-
-if ARGUMENTS.get("target", "editor") == "editor":
-    _helper_module("editor.editor_builders", "editor/editor_builders.py")
-    _helper_module("editor.template_builders", "editor/template_builders.py")
 
 # Scan possible build platforms
 
@@ -140,6 +131,7 @@ env.__class__.module_check_dependencies = methods.module_check_dependencies
 
 env["x86_libtheora_opt_gcc"] = False
 env["x86_libtheora_opt_vc"] = False
+env["PYTHON_BIN"] = sys.executable
 
 # avoid issues when building with different versions of python out of the same directory
 env.SConsignFile(File("#.sconsign{0}.dblite".format(pickle.HIGHEST_PROTOCOL)).abspath)
@@ -1187,20 +1179,29 @@ env["SHLIBSUFFIX"] = suffix + env["SHLIBSUFFIX"]
 env["OBJPREFIX"] = env["object_prefix"]
 env["SHOBJPREFIX"] = env["object_prefix"]
 
+glsl_emitter = methods.generate_dependency_emitter("#glsl_builders.py")
+gles3_emitter = methods.generate_dependency_emitter("#gles3_builders.py")
+
 GLSL_BUILDERS = {
     "RD_GLSL": env.Builder(
-        action=env.Run(glsl_builders.build_rd_headers),
-        suffix="glsl.gen.h",
+        action=Action("$PYTHON_BIN glsl_builders.py rd_glsl $TARGET $SOURCE", "$GENCOMSTR"),
+        emitter=[methods.nocache_emitter, glsl_emitter],
+        source_scanner=CScanner,
+        suffix=".glsl.gen.h",
         src_suffix=".glsl",
     ),
     "GLSL_HEADER": env.Builder(
-        action=env.Run(glsl_builders.build_raw_headers),
-        suffix="glsl.gen.h",
+        action=Action("$PYTHON_BIN glsl_builders.py glsl_header $TARGET $SOURCE", "$GENCOMSTR"),
+        emitter=[methods.nocache_emitter, glsl_emitter],
+        source_scanner=CScanner,
+        suffix=".glsl.gen.h",
         src_suffix=".glsl",
     ),
     "GLES3_GLSL": env.Builder(
-        action=env.Run(gles3_builders.build_gles3_headers),
-        suffix="glsl.gen.h",
+        action=Action("$PYTHON_BIN gles3_builders.py gles3_glsl $TARGET $SOURCE", "$GENCOMSTR"),
+        emitter=[methods.nocache_emitter, gles3_emitter],
+        source_scanner=CScanner,
+        suffix=".glsl.gen.h",
         src_suffix=".glsl",
     ),
 }

--- a/drivers/gles3/shaders/SCsub
+++ b/drivers/gles3/shaders/SCsub
@@ -3,33 +3,20 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-if "GLES3_GLSL" in env["BUILDERS"]:
-    # find all include files
-    gl_include_files = [str(f) for f in Glob("*_inc.glsl")]
+# As we have a few, not yet, converted files we name the ones we want to include:
+env.GLES3_GLSL("canvas.glsl")
+env.GLES3_GLSL("feed.glsl")
+env.GLES3_GLSL("scene.glsl")
+env.GLES3_GLSL("sky.glsl")
+env.GLES3_GLSL("canvas_occlusion.glsl")
+env.GLES3_GLSL("canvas_sdf.glsl")
+env.GLES3_GLSL("particles.glsl")
+env.GLES3_GLSL("particles_copy.glsl")
+env.GLES3_GLSL("skeleton.glsl")
+env.GLES3_GLSL("tex_blit.glsl")
 
-    # find all shader code(all glsl files excluding our include files)
-    glsl_files = [str(f) for f in Glob("*.glsl") if str(f) not in gl_include_files]
-
-    # make sure we recompile shaders if include files change
-    env.Depends([f + ".gen.h" for f in glsl_files], gl_include_files + ["#gles3_builders.py"])
-
-    # compile shaders
-
-    # as we have a few, not yet, converted files we name the ones we want to include:
-    env.GLES3_GLSL("canvas.glsl")
-    env.GLES3_GLSL("feed.glsl")
-    env.GLES3_GLSL("scene.glsl")
-    env.GLES3_GLSL("sky.glsl")
-    env.GLES3_GLSL("canvas_occlusion.glsl")
-    env.GLES3_GLSL("canvas_sdf.glsl")
-    env.GLES3_GLSL("particles.glsl")
-    env.GLES3_GLSL("particles_copy.glsl")
-    env.GLES3_GLSL("skeleton.glsl")
-    env.GLES3_GLSL("tex_blit.glsl")
-
-    # once we finish conversion we can introduce this to cover all files:
-    # for glsl_file in glsl_files:
-    #     env.GLES3_GLSL(glsl_file)
-
+# Once we finish conversion we can introduce this to cover all files:
+# for file in Glob("*.glsl", exclude="*_inc.glsl"):
+#     env.GLES3_GLSL(file)
 
 SConscript("effects/SCsub")

--- a/drivers/gles3/shaders/effects/SCsub
+++ b/drivers/gles3/shaders/effects/SCsub
@@ -3,16 +3,5 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-if "GLES3_GLSL" in env["BUILDERS"]:
-    # find all include files
-    gl_include_files = [str(f) for f in Glob("*_inc.glsl")]
-
-    # find all shader code(all glsl files excluding our include files)
-    glsl_files = [str(f) for f in Glob("*.glsl") if str(f) not in gl_include_files]
-
-    # make sure we recompile shaders if include files change
-    env.Depends([f + ".gen.h" for f in glsl_files], gl_include_files + ["#gles3_builders.py"])
-
-    # compile shaders
-    for glsl_file in glsl_files:
-        env.GLES3_GLSL(glsl_file)
+for file in Glob("*.glsl", exclude="*_inc.glsl"):
+    env.GLES3_GLSL(file)

--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -1,8 +1,14 @@
 """Functions used to generate source files during build time"""
 
+import argparse
 import os.path
+import sys
 
-from methods import generated_wrapper, print_error, to_raw_cstring
+try:
+    sys.path.insert(0, "./")
+    from methods import generated_wrapper, print_error, to_raw_cstring
+except ImportError:
+    raise SystemExit(f'Generator script "{__file__}" must be run from repository root!')
 
 
 class GLES3HeaderStruct:
@@ -569,7 +575,20 @@ protected:
 """)
 
 
-def build_gles3_headers(target, source, env):
-    env.NoCache(target)
-    for src in source:
-        build_gles3_header(f"{src}.gen.h", str(src))
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    gles3_glsl_parser = subparsers.add_parser("gles3_glsl")
+    gles3_glsl_parser.add_argument("target")
+    gles3_glsl_parser.add_argument("shader")
+
+    args = parser.parse_args()
+    if args.command == "gles3_glsl":
+        build_gles3_header(args.target, args.shader)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -1,8 +1,14 @@
 """Functions used to generate source files during build time"""
 
+import argparse
 import os.path
+import sys
 
-from methods import generated_wrapper, print_error, to_raw_cstring
+try:
+    sys.path.insert(0, "./")
+    from methods import generated_wrapper, print_error, to_raw_cstring
+except ImportError:
+    raise SystemExit(f'Generator script "{__file__}" must be run from repository root!')
 
 
 class RDHeaderStruct:
@@ -244,12 +250,6 @@ public:
 """)
 
 
-def build_rd_headers(target, source, env):
-    env.NoCache(target)
-    for src in source:
-        build_rd_header(f"{src}.gen.h", str(src))
-
-
 class RAWHeaderStruct:
     def __init__(self):
         self.code = ""
@@ -283,7 +283,26 @@ static const char {os.path.basename(shader).replace(".glsl", "_shader_glsl")}[] 
 """)
 
 
-def build_raw_headers(target, source, env):
-    env.NoCache(target)
-    for src in source:
-        build_raw_header(f"{src}.gen.h", str(src))
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    rd_glsl_parser = subparsers.add_parser("rd_glsl")
+    rd_glsl_parser.add_argument("target")
+    rd_glsl_parser.add_argument("shader")
+
+    glsl_header_parser = subparsers.add_parser("glsl_header")
+    glsl_header_parser.add_argument("target")
+    glsl_header_parser.add_argument("shader")
+
+    args = parser.parse_args()
+    if args.command == "rd_glsl":
+        build_rd_header(args.target, args.shader)
+    if args.command == "glsl_header":
+        build_raw_header(args.target, args.shader)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/methods.py
+++ b/methods.py
@@ -14,8 +14,8 @@ from io import StringIO
 from pathlib import Path
 from typing import Generator, TextIO, cast
 
+import platform_methods
 from misc.utility.color import print_error, print_info, print_warning
-from platform_methods import detect_arch
 
 # Get the "Godot" folder name ahead of time
 base_folder = Path(__file__).resolve().parent
@@ -109,6 +109,29 @@ def redirect_emitter(target, source, env):
             print_warning(f'Failed to redirect "{path}"')
         redirected_targets.append(item)
     return redirected_targets, source
+
+
+def nocache_emitter(target, source, env):
+    """
+    An emitter that ensures the provided target will never be cached. Useful when setting up
+    builders whose output shouldn't be cached, without needing to apply the `NoCache` wrapper
+    on all output.
+    """
+
+    return env.NoCache(target), source
+
+
+def generate_dependency_emitter(dependencies):
+    """
+    Generates an emitter that automatically assigns the provided dependencies. Useful when
+    setting up builders whose output relies on a specific dependency, without needing to
+    apply the `Depends` wrapper on all output.
+    """
+
+    def _generated_dependency_emitter(target, source, env):
+        return env.Depends(target, dependencies), source
+
+    return _generated_dependency_emitter
 
 
 def disable_warnings(self):
@@ -1087,7 +1110,7 @@ def generate_vs_project(env, original_args, project_name="godot"):
     platform = env["platform"]
     target = env["target"]
     arch = env["arch"]
-    host_arch = detect_arch()
+    host_arch = platform_methods.detect_arch()
 
     host_platform = "windows"
     if (

--- a/modules/betsy/SCsub
+++ b/modules/betsy/SCsub
@@ -7,13 +7,8 @@ Import("env_modules")
 env_betsy = env_modules.Clone()
 
 # Betsy shaders, originally from https://github.com/darksylinc/betsy
-env_betsy.GLSL_HEADER("bc6h.glsl")
-env_betsy.GLSL_HEADER("bc1.glsl")
-env_betsy.GLSL_HEADER("bc4.glsl")
-env_betsy.GLSL_HEADER("alpha_stitch.glsl")
-env_betsy.GLSL_HEADER("rgb_to_rgba.glsl")
-
-env_betsy.Depends(Glob("*.glsl.gen.h"), ["#glsl_builders.py"])
+for file in Glob("*.glsl"):
+    env_betsy.GLSL_HEADER(file)
 
 # Godot source files
 env_betsy.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/lightmapper_rd/SCsub
+++ b/modules/lightmapper_rd/SCsub
@@ -5,10 +5,9 @@ Import("env")
 Import("env_modules")
 
 env_lightmapper_rd = env_modules.Clone()
-env_lightmapper_rd.GLSL_HEADER("lm_raster.glsl")
-env_lightmapper_rd.GLSL_HEADER("lm_compute.glsl")
-env_lightmapper_rd.GLSL_HEADER("lm_blendseams.glsl")
-env_lightmapper_rd.Depends(Glob("*.glsl.gen.h"), ["lm_common_inc.glsl", "#glsl_builders.py"])
+
+for file in Glob("*.glsl", exclude="*_inc.glsl"):
+    env_lightmapper_rd.GLSL_HEADER(file)
 
 # Godot source files
 env_lightmapper_rd.add_source_files(env.modules_sources, "*.cpp")

--- a/servers/rendering/renderer_rd/shaders/SCsub
+++ b/servers/rendering/renderer_rd/shaders/SCsub
@@ -3,23 +3,11 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-if "RD_GLSL" in env["BUILDERS"]:
-    # find just the include files
-    gl_include_files = [str(f) for f in Glob("*_inc.glsl")]
-
-    # find all shader code (all glsl files excluding our include files)
-    glsl_files = [str(f) for f in Glob("*.glsl") if str(f) not in gl_include_files]
-
-    # make sure we recompile shaders if include files change
-    env.Depends([f + ".gen.h" for f in glsl_files], gl_include_files + ["#glsl_builders.py"])
-
-    # compile include files
-    for glsl_file in gl_include_files:
-        env.GLSL_HEADER(glsl_file)
-
-    # compile RD shader
-    for glsl_file in glsl_files:
-        env.RD_GLSL(glsl_file)
+for file in Glob("*.glsl"):
+    if str(file).endswith("_inc.glsl"):
+        env.GLSL_HEADER(file)
+    else:
+        env.RD_GLSL(file)
 
 SConscript("effects/SCsub")
 SConscript("environment/SCsub")

--- a/servers/rendering/renderer_rd/shaders/effects/SCsub
+++ b/servers/rendering/renderer_rd/shaders/effects/SCsub
@@ -3,18 +3,7 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-if "RD_GLSL" in env["BUILDERS"]:
-    # find all include files
-    gl_include_files = [str(f) for f in Glob("*_inc.glsl")] + [str(f) for f in Glob("../*_inc.glsl")]
-
-    # find all shader code(all glsl files excluding our include files)
-    glsl_files = [str(f) for f in Glob("*.glsl") if str(f) not in gl_include_files]
-
-    # make sure we recompile shaders if include files change
-    env.Depends([f + ".gen.h" for f in glsl_files], gl_include_files + ["#glsl_builders.py"])
-
-    # compile shaders
-    for glsl_file in glsl_files:
-        env.RD_GLSL(glsl_file)
+for file in Glob("*.glsl", exclude="*_inc.glsl"):
+    env.RD_GLSL(file)
 
 SConscript("fsr2/SCsub")

--- a/servers/rendering/renderer_rd/shaders/effects/fsr2/SCsub
+++ b/servers/rendering/renderer_rd/shaders/effects/fsr2/SCsub
@@ -3,21 +3,5 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-if "RD_GLSL" in env["BUILDERS"]:
-    # find all include files
-    gl_include_files = [str(f) for f in Glob("*_inc.glsl")] + [str(f) for f in Glob("../*_inc.glsl")]
-
-    # Add all FSR2 shader and header files.
-    fsr2_dir = "#thirdparty/amd-fsr2/shaders"
-    gl_include_files += [str(f) for f in Glob(fsr2_dir + "/*.h")]
-    gl_include_files += [str(f) for f in Glob(fsr2_dir + "/*.glsl")]
-
-    # find all shader code(all glsl files excluding our include files)
-    glsl_files = [str(f) for f in Glob("*.glsl") if str(f) not in gl_include_files]
-
-    # make sure we recompile shaders if include files change
-    env.Depends([f + ".gen.h" for f in glsl_files], gl_include_files + ["#glsl_builders.py"])
-
-    # compile shaders
-    for glsl_file in glsl_files:
-        env.RD_GLSL(glsl_file)
+for file in Glob("*.glsl", exclude="*_inc.glsl"):
+    env.RD_GLSL(file)

--- a/servers/rendering/renderer_rd/shaders/environment/SCsub
+++ b/servers/rendering/renderer_rd/shaders/environment/SCsub
@@ -3,16 +3,5 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-if "RD_GLSL" in env["BUILDERS"]:
-    # find all include files
-    gl_include_files = [str(f) for f in Glob("*_inc.glsl")] + [str(f) for f in Glob("../*_inc.glsl")]
-
-    # find all shader code(all glsl files excluding our include files)
-    glsl_files = [str(f) for f in Glob("*.glsl") if str(f) not in gl_include_files]
-
-    # make sure we recompile shaders if include files change
-    env.Depends([f + ".gen.h" for f in glsl_files], gl_include_files + ["#glsl_builders.py"])
-
-    # compile shaders
-    for glsl_file in glsl_files:
-        env.RD_GLSL(glsl_file)
+for file in Glob("*.glsl", exclude="*_inc.glsl"):
+    env.RD_GLSL(file)

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/SCsub
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/SCsub
@@ -3,16 +3,5 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-if "RD_GLSL" in env["BUILDERS"]:
-    # find all include files
-    gl_include_files = [str(f) for f in Glob("*_inc.glsl")] + [str(f) for f in Glob("../*_inc.glsl")]
-
-    # find all shader code(all glsl files excluding our include files)
-    glsl_files = [str(f) for f in Glob("*.glsl") if str(f) not in gl_include_files]
-
-    # make sure we recompile shaders if include files change
-    env.Depends([f + ".gen.h" for f in glsl_files], gl_include_files + ["#glsl_builders.py"])
-
-    # compile shaders
-    for glsl_file in glsl_files:
-        env.RD_GLSL(glsl_file)
+for file in Glob("*.glsl", exclude="*_inc.glsl"):
+    env.RD_GLSL(file)

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/SCsub
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/SCsub
@@ -3,16 +3,5 @@ from misc.utility.scons_hints import *
 
 Import("env")
 
-if "RD_GLSL" in env["BUILDERS"]:
-    # find all include files
-    gl_include_files = [str(f) for f in Glob("*_inc.glsl")] + [str(f) for f in Glob("../*_inc.glsl")]
-
-    # find all shader code(all glsl files excluding our include files)
-    glsl_files = [str(f) for f in Glob("*.glsl") if str(f) not in gl_include_files]
-
-    # make sure we recompile shaders if include files change
-    env.Depends([f + ".gen.h" for f in glsl_files], gl_include_files + ["#glsl_builders.py"])
-
-    # compile shaders
-    for glsl_file in glsl_files:
-        env.RD_GLSL(glsl_file)
+for file in Glob("*.glsl", exclude="*_inc.glsl"):
+    env.RD_GLSL(file)


### PR DESCRIPTION
- Decoupled from #110146
- Works towards godotengine/godot-proposals#11613

## What problem(s) does this PR solve?

An isolated sample of the above PR, which aims to bring `argparse` syntax to our generator scripts to safely decouple them from SCons & improve performance by proxy. This specifically targets the generators for our shader scripts, which was chosen for a few reasons:

- Our shader files are the biggest example of using a `Builder()` call instead of a simple `Command()`, meaning there's pre-existing hurdles that had to be accounted for.
- The majority of implementation is already suitable for direct integration, with the SCons calls being to wrapper functions already.
- Are setup relatively early in the SCons build process, and are always available.

With the above in mind, I took to allowing these generators to be called from the file itself, rather than by importing a Python module (breaks `ninja` in fresh compilations). The easiest way to do this was via `argparse`, which is now fully setup in both generator scripts. As a reuslt of this new system:
- SCons wrapper logic in the generator scripts has been removed entirely.
- Additional checks have been incorporated into the generator scripts, ensuring that they're called from a consistent location and won't cause import failures at random times within the buildsystem.
- Two new emitters were added to integrate `NoCache` and `Depends` logic into the builder itself.
- Shader files now use the scanner `CScanner` to automatically detect implicit dependencies from file includes. Now, if a shader is modified, only that file & any files including that shader are rebuilt.

## Additional information

Because we no longer directly import `glsl_builders` nor `gles3_builders`, their respective helper modules have been stripped from SConstruct. In doing so, I noticed that several of these helper modules have been removed for quite some time, and `scu_builders.py` was never actually added to begin with. I opted to updated those as well, resulting in a net-removal of 5 helper modules.

This necessitated exactly one unrelated change: Making the `platform_methods` import in `methods.py` generic. Attempting to import `detect_arch` early caused a dependency loop that we were avoiding by pure luck.