### PR TITLE
Tree: Fix accessibility of rows and cells hidden from screen readers

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -5025,7 +5025,7 @@ void Tree::_accessibility_update_item(Point2 &r_ofs, TreeItem *p_item, int &r_ro
 		AccessibilityServer::get_singleton()->update_set_table_row_index(p_item->accessibility_row_element, r_row);
 		AccessibilityServer::get_singleton()->update_set_list_item_level(p_item->accessibility_row_element, p_level);
 		AccessibilityServer::get_singleton()->update_set_list_item_expanded(p_item->accessibility_row_element, !p_item->collapsed);
-		AccessibilityServer::get_singleton()->update_set_flag(p_item->accessibility_row_element, AccessibilityServerEnums::AccessibilityFlags::FLAG_HIDDEN, !(p_item->visible && !p_item->parent_visible_in_tree));
+		AccessibilityServer::get_singleton()->update_set_flag(p_item->accessibility_row_element, AccessibilityServerEnums::AccessibilityFlags::FLAG_HIDDEN, !p_item->is_visible_in_tree());
 		AccessibilityServer::get_singleton()->update_add_action(p_item->accessibility_row_element, AccessibilityServerEnums::AccessibilityAction::ACTION_COLLAPSE, callable_mp(this, &Tree::_accessibility_action_collapse).bind(p_item));
 		AccessibilityServer::get_singleton()->update_add_action(p_item->accessibility_row_element, AccessibilityServerEnums::AccessibilityAction::ACTION_EXPAND, callable_mp(this, &Tree::_accessibility_action_expand).bind(p_item));
 
@@ -5067,7 +5067,7 @@ void Tree::_accessibility_update_item(Point2 &r_ofs, TreeItem *p_item, int &r_ro
 				}
 
 				AccessibilityServer::get_singleton()->update_set_text_align(cell.accessibility_cell_element, cell.text_alignment);
-				AccessibilityServer::get_singleton()->update_set_flag(cell.accessibility_cell_element, AccessibilityServerEnums::AccessibilityFlags::FLAG_HIDDEN, !(p_item->visible && !p_item->parent_visible_in_tree));
+				AccessibilityServer::get_singleton()->update_set_flag(cell.accessibility_cell_element, AccessibilityServerEnums::AccessibilityFlags::FLAG_HIDDEN, !p_item->is_visible_in_tree());
 				AccessibilityServer::get_singleton()->update_set_flag(cell.accessibility_cell_element, AccessibilityServerEnums::AccessibilityFlags::FLAG_READONLY, !cell.editable);
 				AccessibilityServer::get_singleton()->update_set_tooltip(cell.accessibility_cell_element, cell.tooltip);
 				switch (cell.mode) {
@@ -5106,7 +5106,8 @@ void Tree::_accessibility_update_item(Point2 &r_ofs, TreeItem *p_item, int &r_ro
 				Vector2 ofst = Vector2(col_offset + cw, 0);
 				for (int j = cell.buttons.size() - 1; j >= 0; j--) {
 					if (cell.buttons[j].accessibility_button_element.is_null()) {
-						cell.buttons[j].accessibility_button_element = AccessibilityServer::get_singleton()->create_sub_element(cell.accessibility_cell_element, AccessibilityServerEnums::AccessibilityRole::ROLE_BUTTON);
+						// Buttons are siblings of the cells so screen readers announce the cell by its name instead of by its buttons.
+						cell.buttons[j].accessibility_button_element = AccessibilityServer::get_singleton()->create_sub_element(p_item->accessibility_row_element, AccessibilityServerEnums::AccessibilityRole::ROLE_BUTTON);
 					}
 
 					AccessibilityServer::get_singleton()->update_add_action(cell.buttons[j].accessibility_button_element, AccessibilityServerEnums::AccessibilityAction::ACTION_CLICK, callable_mp(this, &Tree::_accessibility_action_button_press).bind(p_item, i, j));


### PR DESCRIPTION
Disclosure: Produced with the help of Claude Fable 5.1

## What problem(s) does this PR solve?

The scene tree continues to be a huge accessibility pain point for a variety of reasons. I tried addressing this in #114427 but in an attempt to make it actually usable, I tried to move most of that logic into a GDScript plugin. Most of it migrated fine, but there were 2 pieces that couldn't be managed in GDScript:

1. The logic for revealing tree children was wrong in a way that caused tree rows to not be announced when they lost/regained focus. As an Orca user, this manifested as me landing on the tree row, hearing its correct description, tabbing off and triggering the focus loss, then tabbing back to hear absolutely nothing. It looks like focused nodes are announced regardless of their hidden state, which made the diagnosis trickier. This fixes the hidden logic in a way that accurately reflects the node's visibility so it sticks through focus loss/regain, precisely the property you want in a visible accessible node. Now cells are correctly flagged as visible, so tabbing onto a tree doesn't remain silent.
2. Fixing that exposed a second issue: the "Toggle visibility" button beside each node in the tree was spoken instead of the name of the node itself. Reparenting the button to the row moved it out of the cell holding the name of the node. This doesn't completely fix row presentation--I still hear a spurious "blank" after some rows--but that at least seems consistent with 4.7.2 on a tree that has initial focus and speaks fine, at least until it loses focus and the faulty hidden logic takes over and masks it.

My plan with this PR is to close #114427. With this minimal diff in place, the rest of that pattern can be implemented entirely inside GDScript. It would still be nice to see better keyboard handling for trees in Godot core but I can also understand why you might not want that.

Claude was indispensable in helping me pour through Orca's verbose debug logs of repeatedly tabbing on and off of trees, as well as in examining Orca's code to determine what it presents. I can't claim understanding of this change by way of understanding when exactly a deeply nested element is presented by my screen reader and how (though who can, really, other than someone who develops screen readers and not games) but I can say that, with this patch in place, I can consistently tab off and onto trees and hear the correct value spoken by Orca.