### PR TITLE
Improve handling of Inner Classes in the Connections Dock

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -1210,33 +1210,35 @@ Ref<Texture2D> EditorData::get_script_icon(const String &p_script_path) {
 		}
 	}
 
-	Ref<Script> base_scr = ResourceLoader::load(p_script_path, "Script");
-	while (base_scr.is_valid()) {
-		// Check for scripted classes.
-		String icon_path;
-		StringName base_class_name = script_class_get_name(base_scr->get_path());
-		if (base_scr->is_built_in() || base_class_name == StringName()) {
-			icon_path = base_scr->get_class_icon_path();
-		} else {
-			icon_path = script_class_get_icon_path(base_class_name);
-		}
+	if (!p_script_path.is_empty()) {
+		Ref<Script> base_scr = ResourceLoader::load(p_script_path, "Script");
+		while (base_scr.is_valid()) {
+			// Check for scripted classes.
+			String icon_path;
+			StringName base_class_name = script_class_get_name(base_scr->get_path());
+			if (base_scr->is_built_in() || base_class_name == StringName()) {
+				icon_path = base_scr->get_class_icon_path();
+			} else {
+				icon_path = script_class_get_icon_path(base_class_name);
+			}
 
-		Ref<Texture2D> icon = _load_script_icon(icon_path);
-		if (icon.is_valid()) {
-			_script_icon_cache[p_script_path] = icon;
-			return icon;
-		}
+			Ref<Texture2D> icon = _load_script_icon(icon_path);
+			if (icon.is_valid()) {
+				_script_icon_cache[p_script_path] = icon;
+				return icon;
+			}
 
-		// Check for legacy custom classes defined by plugins.
-		// TODO: Should probably be deprecated in 4.x
-		const EditorData::CustomType *ctype = get_custom_type_by_path(base_scr->get_path());
-		if (ctype && ctype->icon.is_valid()) {
-			_script_icon_cache[p_script_path] = ctype->icon;
-			return ctype->icon;
-		}
+			// Check for legacy custom classes defined by plugins.
+			// TODO: Should probably be deprecated in 4.x
+			const EditorData::CustomType *ctype = get_custom_type_by_path(base_scr->get_path());
+			if (ctype && ctype->icon.is_valid()) {
+				_script_icon_cache[p_script_path] = ctype->icon;
+				return ctype->icon;
+			}
 
-		// Move to the base class.
-		base_scr = base_scr->get_base_script();
+			// Move to the base class.
+			base_scr = base_scr->get_base_script();
+		}
 	}
 
 	// Check if the base type is an extension-defined type.

--- a/editor/scene/connections_dialog.cpp
+++ b/editor/scene/connections_dialog.cpp
@@ -1576,11 +1576,18 @@ void ConnectionsDock::update_tree() {
 			if (class_name.is_empty()) {
 				class_name = script_base->get_path().get_file();
 			}
-
-			doc_class_name = script_base->get_global_name();
-			if (doc_class_name.is_empty()) {
-				doc_class_name = script_base->get_path().trim_prefix("res://").quote();
+			if (class_name.is_empty()) {
+				class_name = script_base->get_doc_class_name();
 			}
+
+			doc_class_name = script_base->get_doc_class_name();
+			if (doc_class_name.is_empty()) {
+				doc_class_name = script_base->get_path().trim_prefix("res://");
+				if (!doc_class_name.is_empty()) {
+					doc_class_name = doc_class_name.quote();
+				}
+			}
+
 			if (!doc_class_name.is_empty() && !doc_data->class_list.find(doc_class_name)) {
 				doc_class_name = String();
 			}


### PR DESCRIPTION
## What problem(s) does this PR solve?

It improves the functionality of the Connections Dock in relation to Inner Classes.

- Closes #123104. When fetching the script's icon to display in the tree, the function attempts to load the script from the provided path. However, inner classes do not appear to have entries in the path cache (presumably because their path overlaps with the outer class), causing the error. A simple empty path check fixes this.
- Fixes the display of inner classes in the connections tree. Paths do not have global names or a path, so the connections dock didn't know how to identify them. This is fixed by using the `get_doc_class_name()` function, which was introduced after this specific piece of logic was first written.

## Additional information

Before the fix: tree sections lack the class name and tooltips are empty.

<img width="1062" height="781" alt="fix-before" src="https://github.com/user-attachments/assets/ec2ef660-d1ce-4aac-88be-0df7f1fb6b6b" />

After the fix: doc data is displayed correctly.

<img width="1044" height="731" alt="fix-after" src="https://github.com/user-attachments/assets/0b5e64b0-b0a9-4072-9a6c-b0663bdd2789" />

