### PR TITLE
Generate missing seek table for MP3 streams

### DIFF
--- a/modules/mp3/audio_stream_mp3.cpp
+++ b/modules/mp3/audio_stream_mp3.cpp
@@ -202,6 +202,10 @@ Ref<AudioStreamPlayback> AudioStreamMP3::instantiate_playback() {
 
 	int success = drmp3_init_memory(&mp3s->mp3d, data.ptr(), data.size(), (drmp3_allocation_callbacks *)&dr_alloc_calls);
 
+	if (success && !seek_table.is_empty()) {
+		drmp3_bind_seek_table(&mp3s->mp3d, seek_table.size(), seek_table.ptr());
+	}
+
 	mp3s->frames_mixed = 0;
 	mp3s->active = false;
 	mp3s->loops = 0;
@@ -219,9 +223,20 @@ void AudioStreamMP3::set_data(const Vector<uint8_t> &p_data) {
 		ERR_FAIL_MSG("Failed to decode mp3 file. Make sure it is a valid mp3 audio file.");
 	}
 
+	drmp3_uint64 pcm_frames;
+	drmp3_uint64 mp3_frames;
+	drmp3_get_mp3_and_pcm_frame_count(mp3d, &mp3_frames, &pcm_frames);
+
 	channels = mp3d->channels;
 	sample_rate = mp3d->sampleRate;
-	length = float(drmp3_get_pcm_frame_count(mp3d)) / (mp3d->sampleRate);
+	length = float(pcm_frames) / (mp3d->sampleRate);
+
+	// Initialize seek table.
+	drmp3_uint32 seek_count = mp3_frames / 20;
+	seek_table.resize(seek_count);
+	if (!drmp3_calculate_seek_points(mp3d, &seek_count, seek_table.ptr())) {
+		seek_table.reset();
+	}
 
 	drmp3_uninit(mp3d);
 	memdelete(mp3d);

--- a/modules/mp3/audio_stream_mp3.h
+++ b/modules/mp3/audio_stream_mp3.h
@@ -95,6 +95,7 @@ class AudioStreamMP3 : public AudioStream {
 	friend class AudioStreamPlaybackMP3;
 
 	TightLocalVector<uint8_t> data;
+	LocalVector<drmp3_seek_point> seek_table;
 
 	float sample_rate = 1.0;
 	int channels = 1;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Regression from #96547 
- Fixes #119764

## Additional information

While `minimp3` automatically indexes a seek table inside its own struct, it is completely optional in `dr_mp3`, which expects it to be generated manually by calculating and storing somewhere outside of the main struct, then binding it, or else seeks fall back to a brute force procedure where it decodes from the beginning of the file to the seek point, which is extremely slow.

I have made it so it generates the seek table at load by using one seek point each 20 MP3 frames. `minimp3` would normally do this for each MP3 frame, but I wanted it to be memory efficient (each seek point weights 20 bytes in memory, meaning a 1 hour audio would have around 3MB just for the seek table, but dividing by 20 makes it go down to around 150 KB).

It's a tradeoff between memory usage and performance, but at least on my end, one point each 20 MP3 frames was enough to make the slow seek disappear in the linked issue's MRP, and was even faster than seeking in 4.5.1 with `minimp3`.

## Test Results

System info (might matter for reference):
- CachyOS Linux #\1 SMP PREEMPT_DYNAMIC Fri, 28 Aug 2026 17:20:10 +0000 on Wayland - Wayland display driver, Multi-window, 1 monitor - OpenGL 3 (Compatibility) - Mesa Intel(R) UHD Graphics (TGL GT1) - 11th Gen Intel(R) Core(TM) i5-11400H @ 2.70GHz (12 threads) - 15.39 GiB memory - PulseAudio (44100 Hz, Stereo/mono)

On different versions + this PR, I've ran the MRP from the issue exactly as it is intended. Note that the FPS only exists to demonstrate that the seek became slow, but fixed after.

The images below show the stabilized FPS. V-Sync is on.

### Godot 4.5.1 (last minor version to use `minimp3`):
<img width="94" height="92" alt="image" src="https://github.com/user-attachments/assets/cee8acd3-3c7a-4dba-a646-39c9ec497be2" />

### Godot 4.7.2:
<img width="89" height="99" alt="image" src="https://github.com/user-attachments/assets/48cdf7b4-0d95-4bc2-8e76-95d3478765da" />

### This PR:
<img width="100" height="105" alt="image" src="https://github.com/user-attachments/assets/21a8f39c-04a6-489c-9083-049aae580209" />

