### PR TITLE
Fix mouse pointer not updating properly when using a drawing tablet with the windows ink driver

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -6113,6 +6113,9 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 			pointer_button[GET_POINTERID_WPARAM(wParam)] = MouseButton::NONE;
 			windows[window_id].block_mm = true;
+			if (mouse_mode != DisplayServerEnums::MOUSE_MODE_CAPTURED) {
+				SetCursorPos(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
+			}
 			return 0;
 		} break;
 		case WM_POINTERLEAVE: {
@@ -6176,6 +6179,10 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			POINT coords; // Client coords.
 			coords.x = GET_X_LPARAM(lParam);
 			coords.y = GET_Y_LPARAM(lParam);
+
+			if (mouse_mode != DisplayServerEnums::MOUSE_MODE_CAPTURED) {
+				SetCursorPos(coords.x, coords.y);
+			}
 
 			// Note: Handle popup closing here, since mouse event is not emulated and hook will not be called.
 			uint64_t delta = OS::get_singleton()->get_ticks_msec() - time_since_popup;
@@ -6352,6 +6359,8 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				POINT pos = { (int)c.x, (int)c.y };
 				ClientToScreen(hWnd, &pos);
 				SetCursorPos(pos.x, pos.y);
+			} else {
+				SetCursorPos(GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam));
 			}
 
 			mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- This PR Closes #112970, it fixes `DisplayServer.mouse_get_position()`, `Viewport.get_mouse_position()`, and `get_global_mouse_position()` returning stale coordinates instead of updating in real time when using a pen.

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

The issue was caused by the displayServer not updating the internal position of the cursor during WM_POINTER events (pen events). I have tested the issue's original MRP as well as tested it on my own project that was suffering from this bug.