### PR TITLE
Physics: Preserve RigidBody2D/3D scale during physics sync

### DIFF
--- a/scene/2d/physics/rigid_body_2d.cpp
+++ b/scene/2d/physics/rigid_body_2d.cpp
@@ -152,8 +152,15 @@ struct _RigidBody2DInOut {
 void RigidBody2D::_sync_body_state(PhysicsDirectBodyState2D *p_state) {
 	Transform2D new_transform = p_state->get_transform();
 	if (likely(new_transform != get_global_transform())) {
+		// The physics engine only simulates rotation and position; it has no concept of the
+		// node's own visual scale/skew. Preserve whatever the user set instead of letting it
+		// snap to (1, 1) every physics frame (see GH-5734).
+		Size2 cached_scale = get_scale();
+		real_t cached_skew = get_skew();
 		set_block_transform_notify(true);
 		set_global_transform(new_transform);
+		set_scale(cached_scale);
+		set_skew(cached_skew);
 		set_block_transform_notify(false);
 	}
 
@@ -653,7 +660,7 @@ PackedStringArray RigidBody2D::get_configuration_warnings() const {
 	PackedStringArray warnings = PhysicsBody2D::get_configuration_warnings();
 
 	if (Math::abs(t.columns[0].length() - 1.0) > 0.05 || Math::abs(t.columns[1].length() - 1.0) > 0.05) {
-		warnings.push_back(RTR("Size changes to RigidBody2D will be overridden by the physics engine when running.\nChange the size in children collision shapes instead."));
+		warnings.push_back(RTR("Scale on RigidBody2D is only visual; it is not taken into account by the physics engine.\nChange the size in children collision shapes instead to affect collision response."));
 	}
 
 	return warnings;

--- a/scene/3d/physics/rigid_body_3d.cpp
+++ b/scene/3d/physics/rigid_body_3d.cpp
@@ -150,8 +150,13 @@ struct _RigidBodyInOut {
 void RigidBody3D::_sync_body_state(PhysicsDirectBodyState3D *p_state) {
 	Transform3D new_transform = p_state->get_transform();
 	if (likely(new_transform != get_global_transform())) {
+		// The physics engine only simulates rotation and position; it has no concept of the
+		// node's own visual scale. Preserve whatever scale the user set instead of letting it
+		// snap to (1, 1, 1) every physics frame (see GH-5734).
+		Vector3 cached_scale = get_scale();
 		set_ignore_transform_notification(true);
 		set_global_transform(new_transform);
+		set_scale(cached_scale);
 		set_ignore_transform_notification(false);
 	}
 
@@ -673,7 +678,7 @@ PackedStringArray RigidBody3D::get_configuration_warnings() const {
 
 	Vector3 scale = get_transform().get_basis().get_scale();
 	if (Math::abs(scale.x - 1.0) > 0.05 || Math::abs(scale.y - 1.0) > 0.05 || Math::abs(scale.z - 1.0) > 0.05) {
-		warnings.push_back(RTR("Scale changes to RigidBody3D will be overridden by the physics engine when running.\nPlease change the size in children collision shapes instead."));
+		warnings.push_back(RTR("Scale on RigidBody3D is only visual; it is not taken into account by the physics engine.\nPlease change the size in children collision shapes instead to affect collision response."));
 	}
 
 	return warnings;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #5734

## Additional information

`RigidBody2D`/`RigidBody3D::_sync_body_state()` applies the physics engine's
computed transform directly via `set_global_transform()`. That transform only
carries rotation and position — physics simulation has no concept of the
node's own visual scale — so any scale set on the node (uniform or not) was
silently reset to `(1, 1)` / `(1, 1, 1)` on the very next physics tick.

**Fix**: cache the node's scale (and skew, for the 2D case, since
`Transform2D`'s basis isn't pure rotation+scale) right before applying the
physics transform, then restore it via the existing `set_scale()`/`set_skew()`
setters, which already know how to recombine a fresh rotation with a
preserved scale/skew.

**Scope**: this only fixes the *visual* symptom (the node's own transform
snapping back). Collision response is unaffected and continues to be driven
entirely by the scale of the body's own child `CollisionShape2D`/`3D` nodes,
independent of the body's transform sync — this was already a separate,
correct code path. Making the collision *shape* itself scale-aware (affecting
mass/inertia) is a much larger change and out of scope here; the editor
configuration warning is reworded to make this distinction clear rather than
claim scale is simply "overridden."

**Testing**: verified manually with a headless scene — a `RigidBody3D` scaled
`(1, 3, 1)` and a `RigidBody2D` scaled `(1, 3)` both held their scale across
5 physics ticks with this fix (both would previously reset to `(1,1,1)`/
`(1,1)` on the first tick). I did not add an automated regression test for
this, since it requires a running physics simulation across multiple ticks,
which doesn't fit the existing headless-doctest test infrastructure well —
happy to add a scene-based test if reviewers want one, or take pointers on
the preferred way to test this in-tree.

**AI disclosure**: This change (root-cause analysis, implementation, and
manual verification) was developed with Claude (Anthropic), directed and
reviewed by me. I read and understand the diff before submitting it.
