### PR TITLE
Fix misleading ConeTwistJoint3D gizmo

### DIFF
--- a/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.cpp
@@ -43,31 +43,6 @@
 #define BODY_A_RADIUS 0.25
 #define BODY_B_RADIUS 0.27
 
-Basis JointGizmosDrawer::look_body(const Transform3D &p_joint_transform, const Transform3D &p_body_transform) {
-	const Vector3 &p_eye(p_joint_transform.origin);
-	const Vector3 &p_target(p_body_transform.origin);
-
-	Vector3 v_x, v_y, v_z;
-
-	// Look the body with X
-	v_x = p_target - p_eye;
-	v_x.normalize();
-
-	v_z = v_x.cross(Vector3(0, 1, 0));
-	v_z.normalize();
-
-	v_y = v_z.cross(v_x);
-	v_y.normalize();
-
-	Basis base;
-	base.set_columns(v_x, v_y, v_z);
-
-	// Absorb current joint transform
-	base = p_joint_transform.basis.inverse() * base;
-
-	return base;
-}
-
 Basis JointGizmosDrawer::look_body_toward(Vector3::Axis p_axis, const Transform3D &joint_transform, const Transform3D &body_transform) {
 	switch (p_axis) {
 		case Vector3::AXIS_X:
@@ -236,7 +211,7 @@ void JointGizmosDrawer::draw_circle(Vector3::Axis p_axis, real_t p_radius, const
 	}
 }
 
-void JointGizmosDrawer::draw_cone(const Transform3D &p_offset, const Basis &p_base, real_t p_swing, real_t p_twist, Vector<Vector3> &r_points) {
+void JointGizmosDrawer::draw_cone(const Transform3D &p_offset, const Basis &p_base, real_t p_swing, Vector<Vector3> &r_points) {
 	float r = 1.0;
 	float w = r * Math::sin(p_swing);
 	float d = r * Math::cos(p_swing);
@@ -259,22 +234,6 @@ void JointGizmosDrawer::draw_cone(const Transform3D &p_offset, const Basis &p_ba
 
 	r_points.push_back(p_offset.translated_local(p_base.xform(Vector3())).origin);
 	r_points.push_back(p_offset.translated_local(p_base.xform(Vector3(1, 0, 0))).origin);
-
-	/// Twist
-	float ts = Math::rad_to_deg(p_twist);
-	ts = MIN(ts, 720);
-
-	for (int i = 0; i < int(ts); i += 5) {
-		float ra = Math::deg_to_rad((float)i);
-		float rb = Math::deg_to_rad((float)i + 5);
-		float c = i / 720.0;
-		float cn = (i + 5) / 720.0;
-		Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * w * c;
-		Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * w * cn;
-
-		r_points.push_back(p_offset.translated_local(p_base.xform(Vector3(c, a.x, a.y))).origin);
-		r_points.push_back(p_offset.translated_local(p_base.xform(Vector3(cn, b.x, b.y))).origin);
-	}
 }
 
 ////
@@ -406,7 +365,6 @@ void Joint3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 				node_body_a ? node_body_a->get_global_transform() : Transform3D(),
 				node_body_b ? node_body_b->get_global_transform() : Transform3D(),
 				cone->get_param(ConeTwistJoint3D::PARAM_SWING_SPAN),
-				cone->get_param(ConeTwistJoint3D::PARAM_TWIST_SPAN),
 				node_body_a ? &body_a_points : nullptr,
 				node_body_b ? &body_b_points : nullptr);
 
@@ -560,23 +518,13 @@ void Joint3DGizmoPlugin::CreateSliderJointGizmo(const Transform3D &p_offset, con
 	}
 }
 
-void Joint3DGizmoPlugin::CreateConeTwistJointGizmo(const Transform3D &p_offset, const Transform3D &p_trs_joint, const Transform3D &p_trs_body_a, const Transform3D &p_trs_body_b, real_t p_swing, real_t p_twist, Vector<Vector3> *r_body_a_points, Vector<Vector3> *r_body_b_points) {
+void Joint3DGizmoPlugin::CreateConeTwistJointGizmo(const Transform3D &p_offset, const Transform3D &p_trs_joint, const Transform3D &p_trs_body_a, const Transform3D &p_trs_body_b, real_t p_swing, Vector<Vector3> *r_body_a_points, Vector<Vector3> *r_body_b_points) {
 	if (r_body_a_points) {
 		JointGizmosDrawer::draw_cone(
 				p_offset,
-				JointGizmosDrawer::look_body(p_trs_joint, p_trs_body_a),
+				Basis(),
 				p_swing,
-				p_twist,
 				*r_body_a_points);
-	}
-
-	if (r_body_b_points) {
-		JointGizmosDrawer::draw_cone(
-				p_offset,
-				JointGizmosDrawer::look_body(p_trs_joint, p_trs_body_b),
-				p_swing,
-				p_twist,
-				*r_body_b_points);
 	}
 }
 

--- a/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.cpp
@@ -362,17 +362,11 @@ void Joint3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 		CreateConeTwistJointGizmo(
 				Transform3D(),
 				cone->get_global_transform(),
-				node_body_a ? node_body_a->get_global_transform() : Transform3D(),
-				node_body_b ? node_body_b->get_global_transform() : Transform3D(),
 				cone->get_param(ConeTwistJoint3D::PARAM_SWING_SPAN),
-				node_body_a ? &body_a_points : nullptr,
-				node_body_b ? &body_b_points : nullptr);
+				points);
 
-		p_gizmo->add_collision_segments(body_a_points);
-		p_gizmo->add_collision_segments(body_b_points);
-
-		p_gizmo->add_lines(body_a_points, body_a_material);
-		p_gizmo->add_lines(body_b_points, body_b_material);
+		p_gizmo->add_collision_segments(points);
+		p_gizmo->add_lines(points, common_material);
 	}
 
 	Generic6DOFJoint3D *gen = Object::cast_to<Generic6DOFJoint3D>(joint);
@@ -518,14 +512,12 @@ void Joint3DGizmoPlugin::CreateSliderJointGizmo(const Transform3D &p_offset, con
 	}
 }
 
-void Joint3DGizmoPlugin::CreateConeTwistJointGizmo(const Transform3D &p_offset, const Transform3D &p_trs_joint, const Transform3D &p_trs_body_a, const Transform3D &p_trs_body_b, real_t p_swing, Vector<Vector3> *r_body_a_points, Vector<Vector3> *r_body_b_points) {
-	if (r_body_a_points) {
-		JointGizmosDrawer::draw_cone(
-				p_offset,
-				Basis(),
-				p_swing,
-				*r_body_a_points);
-	}
+void Joint3DGizmoPlugin::CreateConeTwistJointGizmo(const Transform3D &p_offset, const Transform3D &p_trs_joint, real_t p_swing, Vector<Vector3> &r_points) {
+	JointGizmosDrawer::draw_cone(
+			p_offset,
+			Basis(),
+			p_swing,
+			r_points);
 }
 
 void Joint3DGizmoPlugin::CreateGeneric6DOFJointGizmo(

--- a/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.h
+++ b/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.h
@@ -51,7 +51,7 @@ public:
 	static void CreatePinJointGizmo(const Transform3D &p_offset, Vector<Vector3> &r_cursor_points);
 	static void CreateHingeJointGizmo(const Transform3D &p_offset, const Transform3D &p_trs_joint, const Transform3D &p_trs_body_a, const Transform3D &p_trs_body_b, real_t p_limit_lower, real_t p_limit_upper, bool p_use_limit, Vector<Vector3> &r_common_points, Vector<Vector3> *r_body_a_points, Vector<Vector3> *r_body_b_points);
 	static void CreateSliderJointGizmo(const Transform3D &p_offset, const Transform3D &p_trs_joint, const Transform3D &p_trs_body_a, const Transform3D &p_trs_body_b, real_t p_angular_limit_lower, real_t p_angular_limit_upper, real_t p_linear_limit_lower, real_t p_linear_limit_upper, Vector<Vector3> &r_points, Vector<Vector3> *r_body_a_points, Vector<Vector3> *r_body_b_points);
-	static void CreateConeTwistJointGizmo(const Transform3D &p_offset, const Transform3D &p_trs_joint, const Transform3D &p_trs_body_a, const Transform3D &p_trs_body_b, real_t p_swing, real_t p_twist, Vector<Vector3> *r_body_a_points, Vector<Vector3> *r_body_b_points);
+	static void CreateConeTwistJointGizmo(const Transform3D &p_offset, const Transform3D &p_trs_joint, const Transform3D &p_trs_body_a, const Transform3D &p_trs_body_b, real_t p_swing, Vector<Vector3> *r_body_a_points, Vector<Vector3> *r_body_b_points);
 	static void CreateGeneric6DOFJointGizmo(
 			const Transform3D &p_offset,
 			const Transform3D &p_trs_joint,
@@ -94,5 +94,5 @@ public:
 
 	// Draw circle around p_axis
 	static void draw_circle(Vector3::Axis p_axis, real_t p_radius, const Transform3D &p_offset, const Basis &p_base, real_t p_limit_lower, real_t p_limit_upper, Vector<Vector3> &r_points, bool p_inverse = false);
-	static void draw_cone(const Transform3D &p_offset, const Basis &p_base, real_t p_swing, real_t p_twist, Vector<Vector3> &r_points);
+	static void draw_cone(const Transform3D &p_offset, const Basis &p_base, real_t p_swing, Vector<Vector3> &r_points);
 };

--- a/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.h
+++ b/editor/scene/3d/gizmos/physics/joint_3d_gizmo_plugin.h
@@ -51,7 +51,7 @@ public:
 	static void CreatePinJointGizmo(const Transform3D &p_offset, Vector<Vector3> &r_cursor_points);
 	static void CreateHingeJointGizmo(const Transform3D &p_offset, const Transform3D &p_trs_joint, const Transform3D &p_trs_body_a, const Transform3D &p_trs_body_b, real_t p_limit_lower, real_t p_limit_upper, bool p_use_limit, Vector<Vector3> &r_common_points, Vector<Vector3> *r_body_a_points, Vector<Vector3> *r_body_b_points);
 	static void CreateSliderJointGizmo(const Transform3D &p_offset, const Transform3D &p_trs_joint, const Transform3D &p_trs_body_a, const Transform3D &p_trs_body_b, real_t p_angular_limit_lower, real_t p_angular_limit_upper, real_t p_linear_limit_lower, real_t p_linear_limit_upper, Vector<Vector3> &r_points, Vector<Vector3> *r_body_a_points, Vector<Vector3> *r_body_b_points);
-	static void CreateConeTwistJointGizmo(const Transform3D &p_offset, const Transform3D &p_trs_joint, const Transform3D &p_trs_body_a, const Transform3D &p_trs_body_b, real_t p_swing, Vector<Vector3> *r_body_a_points, Vector<Vector3> *r_body_b_points);
+	static void CreateConeTwistJointGizmo(const Transform3D &p_offset, const Transform3D &p_trs_joint, real_t p_swing, Vector<Vector3> &r_points);
 	static void CreateGeneric6DOFJointGizmo(
 			const Transform3D &p_offset,
 			const Transform3D &p_trs_joint,
@@ -84,7 +84,6 @@ public:
 
 class JointGizmosDrawer {
 public:
-	static Basis look_body(const Transform3D &p_joint_transform, const Transform3D &p_body_transform);
 	static Basis look_body_toward(Vector3::Axis p_axis, const Transform3D &joint_transform, const Transform3D &body_transform);
 	static Basis look_body_toward_x(const Transform3D &p_joint_transform, const Transform3D &p_body_transform);
 	static Basis look_body_toward_y(const Transform3D &p_joint_transform, const Transform3D &p_body_transform);

--- a/editor/scene/3d/gizmos/physics/physics_bone_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/physics_bone_3d_gizmo_plugin.cpp
@@ -89,7 +89,6 @@ void PhysicalBone3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 					pb->get_global_transform(),
 					pbp->get_global_transform(),
 					cjd->swing_span,
-					cjd->twist_span,
 					&points,
 					&points);
 		} break;

--- a/editor/scene/3d/gizmos/physics/physics_bone_3d_gizmo_plugin.cpp
+++ b/editor/scene/3d/gizmos/physics/physics_bone_3d_gizmo_plugin.cpp
@@ -86,11 +86,8 @@ void PhysicalBone3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			Joint3DGizmoPlugin::CreateConeTwistJointGizmo(
 					physical_bone->get_joint_offset(),
 					physical_bone->get_global_transform() * physical_bone->get_joint_offset(),
-					pb->get_global_transform(),
-					pbp->get_global_transform(),
 					cjd->swing_span,
-					&points,
-					&points);
+					points);
 		} break;
 		case PhysicalBone3D::JOINT_TYPE_HINGE: {
 			const PhysicalBone3D::HingeJointData *hjd(static_cast<const PhysicalBone3D::HingeJointData *>(physical_bone->get_joint_data()));


### PR DESCRIPTION
Simplify ConeTwistJoint3D editor gizmo so that it matches how the joint works.

## What problem(s) does this PR solve?

- Closes #123048
- Complements #123064

## Additional information

The old Cone twist gizmo showed two cones with spirals. Each cone would point to one of the bodies that the joint linked. This was incorrect and misleading.

There were other problems with this gizmo and there are some key design decisions guiding why I have simplified it in this particular way. I can get into all that if there are questions, but I think this is a big step forward for very little risk and effort (so far).

I have basically made the gizmo draw just one cone which points correctly down the x axis of the joint, and I have deleted the spiral.