### PR TITLE
Fix index out of bounds error in multiple search tabs

### DIFF
--- a/editor/script/find_in_files.cpp
+++ b/editor/script/find_in_files.cpp
@@ -767,7 +767,9 @@ void FindInFilesResultsPanel::set_with_replace(bool p_with_replace) {
 
 void FindInFilesResultsPanel::set_replace_text(const String &p_text) {
 	replace_text = p_text;
-	_update_replace_preview();
+	if (with_replace) {
+		_update_replace_preview();
+	}
 }
 
 void FindInFilesResultsPanel::set_search_labels_visibility(bool p_visible) {
@@ -1225,6 +1227,7 @@ void FindInFilesResultsPanel::_update_matches_text() {
 }
 
 void FindInFilesResultsPanel::_update_replace_preview() {
+	ERR_FAIL_COND(!with_replace);
 	for (const KeyValue<TreeItem *, Result> &KV : result_items) {
 		_update_replace_item(KV.key, KV.value);
 	}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #123220

## Additional information
Makes a check before updating the "replace" preview if `with_replace` is true.
Any constructive comments are welcome!

*AI Disclosure*:
AI was used to find the root cause of the bug, setup commands (like style checks commands) and for descriptive codebase navigation, along with proposing "bug fixes" that were ignored and/or discarded.
The testing, code and overall PR is authored by me and i take full responsibility for every fiber of it. 
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
