### PR TITLE
Make `lookup_symbol` grab focus in documentation

### DIFF
--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -1754,7 +1754,6 @@ bool ScriptTextEditor::_edit_option(int p_op) {
 		case EDIT_EVALUATE:
 		case EDIT_CREATE_CODE_REGION:
 		case SHOW_TOOLTIP_AT_CARET:
-		case LOOKUP_SYMBOL:
 		case EDIT_COMPLETE:
 		case EDIT_TOGGLE_COMMENT: {
 			callable_mp((Control *)tx, &Control::grab_focus).call_deferred(false);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/123225

Fixes the case of going to definition in another script file as well, and the case of opening docs.

After PR:
https://github.com/user-attachments/assets/4ae5de44-db33-447b-9a56-1ca5ebea8748

## Additional information



<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
