### PR TITLE
EngineUpdateLabel: Cancel HTTP request when switching to Offline mode

### DIFF
--- a/editor/project_manager/engine_update_label.cpp
+++ b/editor/project_manager/engine_update_label.cpp
@@ -268,6 +268,7 @@ void EngineUpdateLabel::_notification(int p_what) {
 			if (_can_check_updates()) {
 				_check_update();
 			} else {
+				http->cancel_request();
 				_set_status(UpdateStatus::OFFLINE);
 			}
 		} break;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #123229

## Overview

When the "Network Mode" switches to "Offline", we simply cancel the current network request.

## Additional information

`HTTPRequest::cancel_request()` doesn't do anything (and doesn't produce an error) if a request isn't active.

`HTTPRequest::cancel_request()` causes the error/success message to be set immediately, which we then override with `_set_status(UpdateStatus::OFFLINE)`

