### PR TITLE
Fix bitwise NOT integer type in GLTFDocument

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6826,13 +6826,13 @@ Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state, const String p_path)
 		String json_string = JSON::stringify(p_state->json, "", true, true);
 		CharString cs = json_string.utf8();
 		uint64_t text_data_length = cs.length();
-		uint64_t text_chunk_length = ((text_data_length + 3) & (~3));
+		uint64_t text_chunk_length = ((text_data_length + 3) & (~(uint64_t)3));
 		uint64_t total_file_length = header_size + chunk_header_size + text_chunk_length;
 		uint64_t binary_data_length = 0;
 		uint64_t binary_chunk_length = 0;
 		if (p_state->buffers.size() > 0) {
 			binary_data_length = p_state->buffers[0].size();
-			binary_chunk_length = ((binary_data_length + 3) & (~3));
+			binary_chunk_length = ((binary_data_length + 3) & (~(uint64_t)3));
 			const uint64_t file_length_with_buffer = total_file_length + chunk_header_size + binary_chunk_length;
 			// Check if the file length with the buffer is greater than glTF's maximum of 4 GiB.
 			// If it is, we can't write the buffer into the file, but can write it separately.
@@ -6843,7 +6843,7 @@ Error GLTFDocument::_serialize_file(Ref<GLTFState> p_state, const String p_path)
 				json_string = JSON::stringify(p_state->json, "", true, true);
 				cs = json_string.utf8();
 				text_data_length = cs.length();
-				text_chunk_length = ((text_data_length + 3) & (~3));
+				text_chunk_length = ((text_data_length + 3) & (~(uint64_t)3));
 				total_file_length = header_size + chunk_header_size + text_chunk_length;
 				binary_data_length = 0;
 				binary_chunk_length = 0;
@@ -7040,7 +7040,7 @@ PackedByteArray GLTFDocument::_serialize_glb_buffer(Ref<GLTFState> p_state, Erro
 	constexpr uint32_t binary_chunk_type = 0x004E4942; // The byte sequence "BIN\0" as little-endian.
 	const CharString cs = json_string.utf8();
 	const uint64_t text_data_length = cs.length();
-	const uint64_t text_chunk_length = ((text_data_length + 3) & (~3));
+	const uint64_t text_chunk_length = ((text_data_length + 3) & (~(uint64_t)3));
 
 	uint64_t total_file_length = header_size + chunk_header_size + text_chunk_length;
 	ERR_FAIL_COND_V(total_file_length > (uint64_t)UINT32_MAX, PackedByteArray());


### PR DESCRIPTION
## What problem(s) does this PR solve?

The operation `~3` was operating on a signed 32-bit integer, but it should be a `uint64_t`.

This is code that I put there - my bad for being sloppy with integer types in the past.

This PR fixes a sanitizer error reported by CI:

> modules/gltf/gltf_document.cpp:6811:58: runtime error: implicit conversion from type 'int' of value -4 (32-bit, signed) to type 'unsigned long' changed the value to 18446744073709551612 (64-bit, unsigned)

## Additional information

I used AI by copy-pasting Godot sanitizer errors to it and telling it to fix them. Then, I am investigating each manually, and submitting PRs when I am confident of the fix. This one is quite trivial.