### PR TITLE
Introduce dedicated lint pass for GDScript to isolate warnings

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -33,6 +33,7 @@
 #include "gdscript_analyzer.h"
 #include "gdscript_cache.h"
 #include "gdscript_compiler.h"
+#include "gdscript_linter.h"
 #include "gdscript_parser.h"
 #include "gdscript_tokenizer_buffer.h"
 #include "gdscript_warning.h"
@@ -831,6 +832,13 @@ Error GDScript::reload(bool p_keep_state) {
 
 	GDScriptAnalyzer analyzer(&parser);
 	err = analyzer.analyze();
+
+#ifdef DEBUG_ENABLED
+	if (err == OK) {
+		GDScriptLinter linter(parser);
+		err = linter.lint();
+	}
+#endif
 
 	if (err) {
 		if (EngineDebugger::is_active()) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -30,6 +30,7 @@
 
 #include "gdscript.h"
 #include "gdscript_analyzer.h"
+#include "gdscript_linter.h"
 #include "gdscript_parser.h"
 #include "gdscript_tokenizer.h"
 #include "gdscript_utility_functions.h"
@@ -176,6 +177,12 @@ bool GDScriptEditorLanguage::validate(const String &p_script, const String &p_pa
 	if (err == OK) {
 		err = analyzer.analyze();
 	}
+
+	if (err == OK) {
+		GDScriptLinter linter(parser);
+		err = linter.lint();
+	}
+
 #ifdef DEBUG_ENABLED
 	if (r_warnings) {
 		for (const GDScriptWarning &E : parser.get_warnings()) {

--- a/modules/gdscript/gdscript_linter.cpp
+++ b/modules/gdscript/gdscript_linter.cpp
@@ -1,0 +1,114 @@
+/**************************************************************************/
+/*  gdscript_linter.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdscript_linter.h"
+
+#ifdef DEBUG_ENABLED
+
+#include "core/typedefs.h"
+#include "servers/text/text_server.h"
+
+#include "modules/gdscript/gdscript_parser.h"
+
+// Checks ===========================================================================
+
+struct ConfusableIdentifier final {
+private:
+	static void check_identifier(const GDScriptParser::IdentifierNode *p_identifier, GDScriptParser &p_sink) {
+		const Ref<TextServer> &ts = TextServerManager::get_singleton()->get_primary_interface();
+		// Check for synthetic nodes (`start_line != -1`) manually, since this is not called directly by `GDScriptLinter`.
+		if (p_identifier && p_identifier->start_line != -1 && ts->has_feature(TextServer::FEATURE_UNICODE_SECURITY) && ts->spoof_check(p_identifier->name)) {
+			p_sink.push_warning(p_identifier, GDScriptWarning::CONFUSABLE_IDENTIFIER, p_identifier->name.string());
+		}
+	}
+
+public:
+	static void check_class(const GDScriptParser::ClassNode *p_class, GDScriptParser &p_sink) { check_identifier(p_class->identifier, p_sink); }
+	static void check_assignable(const GDScriptParser::AssignableNode *p_var, GDScriptParser &p_sink) { check_identifier(p_var->identifier, p_sink); }
+	static void check_function(const GDScriptParser::FunctionNode *p_func, GDScriptParser &p_sink) { check_identifier(p_func->identifier, p_sink); }
+	static void check_signal(const GDScriptParser::SignalNode *p_sig, GDScriptParser &p_sink) { check_identifier(p_sig->identifier, p_sink); }
+	static void check_for(const GDScriptParser::ForNode *p_for, GDScriptParser &p_sink) { check_identifier(p_for->variable, p_sink); }
+	static void check_enum(const GDScriptParser::EnumNode *p_enum, GDScriptParser &p_sink) {
+		check_identifier(p_enum->identifier, p_sink);
+		for (const GDScriptParser::EnumNode::Value &value : p_enum->values) {
+			check_identifier(value.identifier, p_sink);
+		}
+	}
+	static void check_pattern(const GDScriptParser::PatternNode *p_pattern, GDScriptParser &p_sink) {
+		if (p_pattern->pattern_type == GDScriptParser::PatternNode::PT_BIND) {
+			check_identifier(p_pattern->bind, p_sink);
+		}
+	}
+};
+
+// Infrastructure ===================================================================
+
+template <typename T>
+void _FORCE_INLINE_ validated(const GDScriptParser::Node *p_node, GDScriptParser &p_sink, GDScriptLinter::Callback<T> *p_callback) {
+	const T *casted = dynamic_cast<const T *>(p_node);
+	if (casted) {
+		p_callback(casted, p_sink);
+	}
+}
+
+#define LINTER_CHECK(m_method) [](const GDScriptParser::Node *p_node, GDScriptParser &p_sink) { validated(p_node, p_sink, &m_method); }
+
+constexpr GDScriptLinter::CallbackWithValidation *const GDScriptLinter::checks[] = {
+	LINTER_CHECK(ConfusableIdentifier::check_assignable),
+	LINTER_CHECK(ConfusableIdentifier::check_class),
+	LINTER_CHECK(ConfusableIdentifier::check_enum),
+	LINTER_CHECK(ConfusableIdentifier::check_for),
+	LINTER_CHECK(ConfusableIdentifier::check_function),
+	LINTER_CHECK(ConfusableIdentifier::check_pattern),
+	LINTER_CHECK(ConfusableIdentifier::check_signal),
+};
+
+#undef LINTER_CHECK
+
+Error GDScriptLinter::lint() {
+	// We use the fact that all nodes form a linked list for memory management purposes to iterate all nodes without actually walking the tree.
+	// The iteration order is undefined, this should not matter since the tree is immutable for the linter.
+	GDScriptParser::Node *curr = tree->list;
+	for (; curr != nullptr; curr = curr->next) {
+		if (curr->start_line == -1) {
+			// Sometimes we allocate synthetic nodes with no correspondence in code e.g. identifiers containing the synthetic names of getter functions.
+			// We shouldn't analyze those nodes directly, since suppressing them with `@warning_ignore` would be impossible.
+			continue;
+		}
+		for (CallbackWithValidation *check : checks) {
+			check(curr, *tree);
+		}
+	}
+
+	tree->apply_pending_warnings();
+	return tree->get_errors().is_empty() ? OK : ERR_PARSE_ERROR;
+}
+
+#endif // DEBUG_ENABLED

--- a/modules/gdscript/gdscript_linter.h
+++ b/modules/gdscript/gdscript_linter.h
@@ -1,0 +1,61 @@
+/**************************************************************************/
+/*  gdscript_linter.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef DEBUG_ENABLED
+
+#include "modules/gdscript/gdscript_parser.h"
+
+/**
+ * The `GDScriptLinter` emits warnings based on a completely analyzed AST.
+ *
+ * The linter pass can be skipped if it is not needed, e.g. in release builds
+ * or when analyzing for editor features like autocompletion. As such the linter
+ * must not have an influence on compilation i.e. it can't modify the AST.
+ *
+ * Especially expensive warnings should be implemented through this pass.
+ */
+class GDScriptLinter final {
+	using CallbackWithValidation = void(const GDScriptParser::Node *, GDScriptParser &);
+
+	GDScriptParser *const tree;
+	static CallbackWithValidation *const checks[];
+
+public:
+	template <typename T>
+	using Callback = void(const T *, GDScriptParser &);
+
+public:
+	Error lint();
+	GDScriptLinter(GDScriptParser &p_tree) : tree(&p_tree) {}
+};
+
+#endif // DEBUG_ENABLED

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1391,6 +1391,7 @@ void GDScriptParser::parse_property_setter(VariableNode *p_variable) {
 		case VariableNode::PROP_INLINE: {
 			FunctionNode *function = alloc_node<FunctionNode>();
 			IdentifierNode *identifier = alloc_node<IdentifierNode>();
+			set_synthetic_extents(identifier);
 			complete_extents(identifier);
 			identifier->name = "@" + p_variable->identifier->name + "_setter";
 			function->identifier = identifier;
@@ -1454,6 +1455,7 @@ void GDScriptParser::parse_property_getter(VariableNode *p_variable) {
 			function->header_end_column = previous.start_column;
 
 			IdentifierNode *identifier = alloc_node<IdentifierNode>();
+			set_synthetic_extents(identifier);
 			complete_extents(identifier);
 			identifier->name = "@" + p_variable->identifier->name + "_getter";
 			function->identifier = identifier;
@@ -2829,14 +2831,7 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_expression(bool p_can_assi
 }
 
 GDScriptParser::IdentifierNode *GDScriptParser::parse_identifier() {
-	IdentifierNode *identifier = static_cast<IdentifierNode *>(parse_identifier(nullptr, false));
-#ifdef DEBUG_ENABLED
-	// Check for spoofing here (if available in TextServer) since this isn't called inside expressions. This is only relevant for declarations.
-	if (identifier && TS->has_feature(TextServer::FEATURE_UNICODE_SECURITY) && TS->spoof_check(identifier->name)) {
-		push_warning(identifier, GDScriptWarning::CONFUSABLE_IDENTIFIER, identifier->name.string());
-	}
-#endif
-	return identifier;
+	return static_cast<IdentifierNode *>(parse_identifier(nullptr, false));
 }
 
 GDScriptParser::ExpressionNode *GDScriptParser::parse_identifier(ExpressionNode *p_previous_operand, bool p_can_assign) {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1370,6 +1370,7 @@ public:
 private:
 	friend class GDScriptAnalyzer;
 	friend class GDScriptParserRef;
+	friend class GDScriptLinter;
 
 	bool _is_tool = false;
 	String script_path;
@@ -1496,6 +1497,9 @@ private:
 	void update_extents(Node *p_node);
 	void reset_extents(Node *p_node, GDScriptTokenizer::Token p_token);
 	void reset_extents(Node *p_node, Node *p_from);
+	void set_synthetic_extents(Node *p_node) {
+		p_node->start_line = p_node->end_line = p_node->start_column = p_node->end_column = -1;
+	}
 
 	template <typename T>
 	T *alloc_node() {
@@ -1536,6 +1540,7 @@ private:
 	void push_error(const String &p_message, const GDScriptTokenizer::Token &p_origin);
 
 #ifdef DEBUG_ENABLED
+public:
 	void push_warning(const Node *p_source, GDScriptWarning::Code p_code, const Vector<String> &p_symbols);
 	template <typename... Symbols>
 	void push_warning(const Node *p_source, GDScriptWarning::Code p_code, const Symbols &...p_symbols) {
@@ -1546,6 +1551,8 @@ private:
 	void push_warning(int p_start_line, int p_start_column, int p_end_line, int p_end_column, GDScriptWarning::Code p_code, const Symbols &...p_symbols) {
 		push_warning(p_start_line, p_start_column, p_end_line, p_end_column, p_code, Vector<String>{ p_symbols... });
 	}
+
+private:
 	void apply_pending_warnings();
 	void evaluate_warning_directory_rules_for_script_path();
 #endif // DEBUG_ENABLED

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -32,6 +32,7 @@
 
 #include "../gdscript.h"
 #include "../gdscript_analyzer.h"
+#include "../gdscript_linter.h"
 #include "gdscript_language_protocol.h"
 #include "gdscript_workspace.h"
 
@@ -970,6 +971,11 @@ void ExtendGDScriptParser::parse(const String &p_code, const String &p_path) {
 	if (parse_result == OK) {
 		parse_result = analyzer.analyze();
 	}
+	if (parse_result == OK) {
+		GDScriptLinter linter(*this);
+		parse_result = linter.lint();
+	}
+
 	update_diagnostics();
 	update_symbols();
 	update_document_links(p_code);

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -33,6 +33,7 @@
 #include "../gdscript.h"
 #include "../gdscript_analyzer.h"
 #include "../gdscript_compiler.h"
+#include "../gdscript_linter.h"
 #include "../gdscript_parser.h"
 #include "../gdscript_tokenizer_buffer.h"
 
@@ -580,6 +581,14 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 	// Test type-checking.
 	GDScriptAnalyzer analyzer(&parser);
 	err = analyzer.analyze();
+
+#ifdef DEBUG_ENABLED
+	if (err == OK) {
+		GDScriptLinter linter(parser);
+		err = linter.lint();
+	}
+#endif
+
 	if (err != OK) {
 		enable_stdout();
 		result.status = GDTEST_ANALYZER_ERROR;

--- a/modules/gdscript/tests/test_gdscript.cpp
+++ b/modules/gdscript/tests/test_gdscript.cpp
@@ -32,6 +32,7 @@
 
 #include "../gdscript_analyzer.h"
 #include "../gdscript_compiler.h"
+#include "../gdscript_linter.h"
 #include "../gdscript_parser.h"
 #include "../gdscript_tokenizer.h"
 #include "../gdscript_tokenizer_buffer.h"
@@ -184,6 +185,13 @@ static void test_parser(const String &p_code, const String &p_script_path, const
 	GDScriptAnalyzer analyzer(&parser);
 	err = analyzer.analyze();
 
+#ifdef DEBUG_ENABLED
+	if (err == OK) {
+		GDScriptLinter linter(parser);
+		err = linter.lint();
+	}
+#endif
+
 	if (err != OK) {
 		const List<GDScriptParser::ParserError> &errors = parser.get_errors();
 		for (const GDScriptParser::ParserError &error : errors) {
@@ -270,6 +278,13 @@ static void test_compiler(const String &p_code, const String &p_script_path, con
 
 	GDScriptAnalyzer analyzer(&parser);
 	err = analyzer.analyze();
+
+#ifdef DEBUG_ENABLED
+	if (err == OK) {
+		GDScriptLinter linter(parser);
+		err = linter.lint();
+	}
+#endif
 
 	if (err != OK) {
 		print_line("Error in analyzer:");

--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -35,6 +35,7 @@
 #ifndef GDSCRIPT_NO_LSP
 
 #include "../gdscript_analyzer.h"
+#include "../gdscript_linter.h"
 #include "../language_server/gdscript_extend_parser.h"
 #include "../language_server/gdscript_language_protocol.h"
 #include "../language_server/gdscript_workspace.h"
@@ -311,6 +312,14 @@ void assert_no_errors_in(const String &p_path) {
 
 	GDScriptAnalyzer analyzer(&parser);
 	err = analyzer.analyze();
+
+#ifdef DEBUG_ENABLED
+	if (err == OK) {
+		GDScriptLinter linter(parser);
+		err = linter.lint();
+	}
+#endif
+
 	REQUIRE_MESSAGE(err == OK, vformat("Errors while analyzing '%s'", p_path));
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

Our current approach to emitting warnings is doing it somewhere within the parser or analyzer and wrapping it in `ifdef DEBUG_ENABLED`. This approach piggybacks on the existing tree walking that those classes do, however I've personally grown a bit disillusioned with it. In particular I've noticed a certain pattern of conversation on RocketChat, were I end up saying "yeah we could add a warning about that" and then I think about whether I actually want to add code to the analyzer for it and am not so sure about it anymore.

This PR implements a new approach for emitting warnings: An additional pass over the AST that runs after the analyzer, in lack of a better term I named it `GDScriptLinter`. The lint pass works on a fully analyzed and immutable AST and can easily be omitted for e.g. autocompletion.

I won't claim that this is better then what we currently have in all regards. So here are the things I've considered:

Con:
- Might be harder to access certain context (which is also why I have no intention of realizing all warnings through this. But a lot of warnings are straight forward when looking at a fully analyzed part of the AST.)
- More boilerplate
- Probably slower due to the additional tree walking (haven't done profiling though, and especially the re-analyzation of dependencies, might have a pretty unpredictable influence on the performance of this)

Pro:
- Warnings can be implemented outside of the analyzer
  - Makes reviewing and writing those warnings easier, since the tree is fully analyzed, which prevents "oh you are accessing the type of A but A has not been analyzed at this point yet" errors.
  - Less `ifdef` in the analyzer -> see https://github.com/godotengine/godot/issues/121047 for why I think this is desireable
- It's easy to omit checks for autocompletion, which is good for more expensive checks

I personally think it's worth it based on those factors. Happy to hear contrary positions though.

---

I've chosen the `CONFUSABLE_IDENTIFER` warning to demonstrate the system. I think it's a great example because it is on the one hand probably the worst case in terms of boilerplate (identifiers are used frequently and applying something only to declarations requires filtering for node types above `IdentifierNode`, while a lot of other warnings can be pinned to more specific nodes) and on the other hand it is a pretty expensive warning so omitting it for autocompletion makes sense (see my probably slightly outdated flamegraph in https://github.com/godotengine/godot/issues/80637#issuecomment-2213373887 for that).