### PR TITLE
Fix AudioStreamWAV integer sign sanitizer errors

### DIFF
--- a/scene/resources/audio/audio_stream_wav.cpp
+++ b/scene/resources/audio/audio_stream_wav.cpp
@@ -1153,12 +1153,13 @@ Ref<AudioStreamWAV> AudioStreamWAV::load_from_buffer(const Vector<uint8_t> &p_st
 
 			int ds = data.size();
 			for (int i = 0; i < ds; i++) {
+				// Cast to unsigned for storage, but this is really a signed value.
 				if (is16) {
 					int16_t v = CLAMP(data_ptr[i] * 32768, -32768, 32767);
-					encode_uint16(v, &w[i * 2]);
+					encode_uint16((uint16_t)v, &w[i * 2]);
 				} else {
 					int8_t v = CLAMP(data_ptr[i] * 128, -128, 127);
-					w[i] = v;
+					w[i] = (uint8_t)v;
 				}
 			}
 		}

--- a/tests/scene/test_audio_stream_wav.cpp
+++ b/tests/scene/test_audio_stream_wav.cpp
@@ -76,8 +76,9 @@ Vector<uint8_t> gen_pcm8_test(float wav_rate, int wav_count, bool stereo) {
 		// Map sin wave to full range of 8-bit values.
 		uint8_t wav_8bit = Math::fast_ftoi(((wav + 1) / 2) * UINT8_MAX);
 		// Unlike the .wav format, AudioStreamWAV expects signed 8-bit wavs.
-		uint8_t wav_8bit_signed = wav_8bit - (INT8_MAX + 1);
-		write_ptr[i] = wav_8bit_signed;
+		int8_t wav_8bit_signed = wav_8bit - (INT8_MAX + 1);
+		// Cast to uint8_t to match Vector<uint8_t> type, but this is really a signed value.
+		write_ptr[i] = (uint8_t)wav_8bit_signed;
 	}
 
 	return buffer;
@@ -104,8 +105,9 @@ Vector<uint8_t> gen_pcm16_test(float wav_rate, int wav_count, bool stereo) {
 		// Map sin wave to full range of 16-bit values.
 		uint16_t wav_16bit = Math::fast_ftoi(((wav + 1) / 2) * UINT16_MAX);
 		// The .wav format expects wavs larger than 8 bits to be signed.
-		uint16_t wav_16bit_signed = wav_16bit - (INT16_MAX + 1);
-		encode_uint16(wav_16bit_signed, write_ptr + (i * 2));
+		int16_t wav_16bit_signed = wav_16bit - (INT16_MAX + 1);
+		// Cast to uint16_t to match encode_uint16 type, but this is really a signed value.
+		encode_uint16((uint16_t)wav_16bit_signed, write_ptr + (i * 2));
 	}
 
 	return buffer;


### PR DESCRIPTION
## What problem(s) does this PR solve?

AudioStreamWAV, and its tests, implicitly cast from signed to unsigned. This should be made explicit.

This PR fixes these errors reported by undefined behavior sanitizers:

> tests/scene/test_audio_stream_wav.cpp:79:29: runtime error: implicit conversion from type 'int' of value -8 (32-bit, signed) to type 'uint8_t' (aka 'unsigned char') changed the value to 248 (8-bit, unsigned)
> SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior tests/scene/test_audio_stream_wav.cpp:79:29 in 
> scene/resources/audio/audio_stream_wav.cpp:1161:13: runtime error: implicit conversion from type 'int8_t' (aka 'signed char') of value -8 (8-bit, signed) to type 'uint8_t' (aka 'unsigned char') changed the value to 248 (8-bit, unsigned)
> SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior scene/resources/audio/audio_stream_wav.cpp:1161:13 in 
> tests/scene/test_audio_stream_wav.cpp:107:31: runtime error: implicit conversion from type 'int' of value -1820 (32-bit, signed) to type 'uint16_t' (aka 'unsigned short') changed the value to 63716 (16-bit, unsigned)
> SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior tests/scene/test_audio_stream_wav.cpp:107:31 in 
> scene/resources/audio/audio_stream_wav.cpp:1158:20: runtime error: implicit conversion from type 'int16_t' (aka 'short') of value -1820 (16-bit, signed) to type 'uint16_t' (aka 'unsigned short') changed the value to 63716 (16-bit, unsigned)
> SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior scene/resources/audio/audio_stream_wav.cpp:1158:20 in 

## Additional information

I used AI by copy-pasting Godot sanitizer errors to it and telling it to fix them. Then, I am investigating each manually, and submitting PRs when I am confident of the fix. For this one, the code is not quite the same as what the AI generated, and all of the comments are my own words.