### PR TITLE
[Android] Add export option for R8 code minification and obfuscation in Gradle builds

### DIFF
--- a/platform/android/doc_classes/EditorExportPlatformAndroid.xml
+++ b/platform/android/doc_classes/EditorExportPlatformAndroid.xml
@@ -59,6 +59,11 @@
 		<member name="gradle_build/gradle_build_directory" type="String" setter="" getter="">
 			Path to the Gradle build directory. If left empty, then [code]res://android[/code] will be used.
 		</member>
+		<member name="gradle_build/minification" type="bool" setter="" getter="">
+			If [code]true[/code], enables R8 code minification and obfuscation for release Gradle builds.
+			This reduces application size, removes unused bytecode, and complies with Google Play Console optimization guidelines.
+			[b]Note:[/b] Only applies to release builds ([b]Export With Debug[/b] unchecked) and requires [member gradle_build/use_gradle_build].
+		</member>
 		<member name="gradle_build/min_sdk" type="String" setter="" getter="">
 			Minimum Android API level required for the application to run (used during Gradle build). See [url=https://developer.android.com/guide/topics/manifest/uses-sdk-element#uses]android:minSdkVersion[/url].
 		</member>

--- a/platform/android/doc_classes/EditorExportPlatformAndroid.xml
+++ b/platform/android/doc_classes/EditorExportPlatformAndroid.xml
@@ -59,13 +59,13 @@
 		<member name="gradle_build/gradle_build_directory" type="String" setter="" getter="">
 			Path to the Gradle build directory. If left empty, then [code]res://android[/code] will be used.
 		</member>
+		<member name="gradle_build/min_sdk" type="String" setter="" getter="">
+			Minimum Android API level required for the application to run (used during Gradle build). See [url=https://developer.android.com/guide/topics/manifest/uses-sdk-element#uses]android:minSdkVersion[/url].
+		</member>
 		<member name="gradle_build/minification" type="bool" setter="" getter="">
 			If [code]true[/code], enables R8 code minification and obfuscation for release Gradle builds.
 			This reduces application size, removes unused bytecode, and complies with Google Play Console optimization guidelines.
 			[b]Note:[/b] Only applies to release builds ([b]Export With Debug[/b] unchecked) and requires [member gradle_build/use_gradle_build].
-		</member>
-		<member name="gradle_build/min_sdk" type="String" setter="" getter="">
-			Minimum Android API level required for the application to run (used during Gradle build). See [url=https://developer.android.com/guide/topics/manifest/uses-sdk-element#uses]android:minSdkVersion[/url].
 		</member>
 		<member name="gradle_build/target_sdk" type="String" setter="" getter="">
 			The Android API level on which the application is designed to run (used during Gradle build). See [url=https://developer.android.com/guide/topics/manifest/uses-sdk-element#uses]android:targetSdkVersion[/url].

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2104,6 +2104,11 @@ String EditorExportPlatformAndroid::get_export_option_warning(const EditorExport
 			if (bool(p_preset->get("gradle_build/compress_native_libraries")) && !gradle_build_enabled) {
 				return TTR("\"Compress Native Libraries\" is only valid when \"Use Gradle Build\" is enabled.");
 			}
+		} else if (p_name == "gradle_build/minification") {
+			bool gradle_build_enabled = p_preset->get("gradle_build/use_gradle_build");
+			if (bool(p_preset->get("gradle_build/minification")) && !gradle_build_enabled) {
+				return TTR("\"Minification\" is only valid when \"Use Gradle Build\" is enabled.");
+			}
 		} else if (p_name == "gradle_build/export_format") {
 			bool gradle_build_enabled = p_preset->get("gradle_build/use_gradle_build");
 			if (int(p_preset->get("gradle_build/export_format")) == EXPORT_FORMAT_AAB && !gradle_build_enabled) {
@@ -2188,6 +2193,7 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "gradle_build/gradle_build_directory", PROPERTY_HINT_PLACEHOLDER_TEXT, "res://android"), "", false, false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "gradle_build/android_source_template", PROPERTY_HINT_GLOBAL_FILE, "*.zip"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "gradle_build/compress_native_libraries"), false, false, true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "gradle_build/minification"), false, false, true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "gradle_build/export_format", PROPERTY_HINT_ENUM, "Export APK,Export AAB"), EXPORT_FORMAT_APK, false, true));
 	// Using String instead of int to default to an empty string (no override) with placeholder for instructions (see GH-62465).
 	// This implies doing validation that the string is a proper int.
@@ -3666,6 +3672,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		String sign_flag = bool_to_string(should_sign);
 		String zipalign_flag = "true";
 		String compress_native_libraries_flag = bool_to_string(p_preset->get("gradle_build/compress_native_libraries"));
+		String minification_flag = bool_to_string(!p_debug && bool(p_preset->get("gradle_build/minification")));
 
 		Vector<String> android_libraries;
 		Vector<String> android_dependencies;
@@ -3743,6 +3750,7 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 		cmdline.push_back("-Pperform_zipalign=" + zipalign_flag); // argument to specify whether the build should be zipaligned.
 		cmdline.push_back("-Pperform_signing=" + sign_flag); // argument to specify whether the build should be signed.
 		cmdline.push_back("-Pcompress_native_libraries=" + compress_native_libraries_flag); // argument to specify whether the build should compress native libraries.
+		cmdline.push_back("-Penable_minification=" + minification_flag); // argument to specify whether the build should enable R8 minification/obfuscation.
 
 		// NOTE: The release keystore is not included in the verbose logging
 		// to avoid accidentally leaking sensitive information when sharing verbose logs for troubleshooting.

--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -222,6 +222,10 @@ android {
         }
 
         release {
+            minifyEnabled shouldMinify()
+            shrinkResources false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+
             // Signing and zip-aligning are skipped for prebuilt builds, but
             // performed for Godot gradle builds.
             zipAlignEnabled shouldZipAlign()

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -413,3 +413,11 @@ ext.getAddonsDirectory = { ->
     String addonsDirectory = project.hasProperty("addons_directory") ? project.property("addons_directory") : ""
     return addonsDirectory
 }
+
+ext.shouldMinify = { ->
+    String minifyFlag = project.hasProperty("enable_minification") ? project.property("enable_minification") : ""
+    if (minifyFlag == null || minifyFlag.isEmpty()) {
+        minifyFlag = "false"
+    }
+    return Boolean.parseBoolean(minifyFlag)
+}

--- a/platform/android/java/app/proguard-rules.pro
+++ b/platform/android/java/app/proguard-rules.pro
@@ -1,0 +1,18 @@
+# Protect Godot Engine Core
+-keep class com.godot.** { *; }
+-keep class org.godotengine.** { *; }
+-keep class ** extends org.godotengine.godot.plugin.GodotPlugin { *; }
+
+# Protect methods exposed to Godot via @UsedByGodot
+-keepattributes *Annotation*
+-keepclassmembers class * {
+    @org.godotengine.godot.plugin.UsedByGodot *;
+}
+
+# Protect JNI bindings
+-keepclasseswithmembernames class * {
+    native <methods>;
+}
+-keep public class * extends android.app.Activity
+-keep public class * extends android.app.Application
+-keep public class * extends android.app.Service


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes the Godot 4 equivalent of https://github.com/godotengine/godot/issues/43363 (the original issue was reported for Godot 3.x; this PR specifically resolves the problem for Godot 4.x / master).
- Supersedes https://github.com/godotengine/godot/pull/31509

### Background & Origin
This work originated from real-world testing and community discussion in https://github.com/poingstudios/godot-admob-plugin/discussions/510, following the adoption of the NextGen Google Mobile Ads SDK on Android:
1. **Google Play Console App Optimization**: Google Play Console now flags un-minified release builds (< 25% obfuscation threshold, with enforcement beginning February 2027). When developers integrate modern third-party Android libraries (such as Google Mobile Ads SDK v23+), the lack of minification causes optimization warnings and large multidex overhead.
2. **Binary Size Reduction**: Large third-party SDKs often include unused code paths. Enabling R8 dead-code elimination (tree shaking) drastically reduces DEX size.

## Additional information

### Implementation Details
Directly addresses previous maintainer guidance from https://github.com/godotengine/godot/pull/31509 and https://github.com/godotengine/godot/issues/43363:
- **Off by default**: `gradle_build/minification` defaults to `false` to maintain 100% backward compatibility.
- **Custom Gradle build only**: Requires `gradle_build/use_gradle_build` (displays validation warning if disabled).
- **Release exports only**: Guarded in `export_plugin.cpp` so minification is never applied to debug builds (`!p_debug`), preserving fast incremental debug workflows and line-numbered stack traces.
- **Engine Safety (`proguard-rules.pro`)**: Added baseline rules preserving:
  - `org.godotengine.**` and `com.godot.**`
  - Plugin classes extending `GodotPlugin`
  - Methods annotated with `@UsedByGodot`
  - All native JNI methods (`native <methods>;`)
  - Standard Android entry points (`Activity`, `Application`, `Service`)
- **Plugin Extensibility**: Any Android plugin AAR providing `consumer-rules.pro` will have its rules merged automatically by R8.
- **Documentation**: Updated `EditorExportPlatformAndroid.xml` with class reference documentation and BBCode links.

### Empirical Test Results
Tested on a real-world Android project using the [Godot AdMob Plugin](https://github.com/poingstudios/godot-admob-plugin) with mediation SDKs:

| Metric | Before (4.7.2 baseline) | After (With Minification) | Difference |
| :--- | :--- | :--- | :--- |
| **Total APK Size** | **217.1 MB** | **187.8 MB** | **-29.3 MB** |
| **Uncompressed DEX** | **83.13 MB** (9 DEX files) | **47.26 MB** (6 DEX files) | **-35.87 MB (-43.2%)** |
| **Compressed DEX** | **32.48 MB** | **19.77 MB** | **-12.71 MB (-39.1%)** |
| **Runtime Verification** | OK | OK | Engine lifecycle, JNI, and plugins work without errors |

### AI Disclosure
I used AI tools for autocomplete and double-checking Gradle syntax. The code, architecture, and logic were written by me, compiled from source, and verified on a physical Android device.