### PR TITLE
Fix unsigned integer underflow with LocalVector size

### DIFF
--- a/editor/version_control/version_control_editor_plugin.cpp
+++ b/editor/version_control/version_control_editor_plugin.cpp
@@ -704,7 +704,7 @@ void VersionControlEditorPlugin::_display_diff_split_view(List<EditorVCSInterfac
 			diff_line.old_text = line;
 			parsed_diff.push_back(diff_line);
 		} else if (diff_line.old_line_no == -1) {
-			int32_t j = parsed_diff.size() - 1;
+			int32_t j = (int32_t)parsed_diff.size() - 1;
 			while (j >= 0 && parsed_diff[j].new_line_no == -1) {
 				j--;
 			}

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -299,7 +299,7 @@ void AnimationPlayer::_blend_playback_data(double p_delta, bool p_started) {
 		// so it is best to use "deferred" calls instead of "immediate" for animation events that can trigger new animations.
 		_process_playback_data(b.data, p_delta, b.blend_left, false, false, false);
 	}
-	for (int i = to_erase.size() - 1; i >= 0; i--) {
+	for (int i = (int)to_erase.size() - 1; i >= 0; i--) {
 		c.blend.remove_at(to_erase[i]);
 	}
 }

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2701,7 +2701,7 @@ void Viewport::_gui_update_mouse_over() {
 	}
 
 	// Send Mouse Enter notifications.
-	for (int i = needs_enter.size() - 1; i >= 0; i--) {
+	for (int i = (int)needs_enter.size() - 1; i >= 0; i--) {
 		Control *ctrl = ObjectDB::get_instance<Control>(needs_enter[i]);
 		if (ctrl) {
 			ctrl->notification(Control::NOTIFICATION_MOUSE_ENTER);
@@ -3391,7 +3391,7 @@ void Viewport::_update_mouse_over(Vector2 p_pos) {
 			gui.sending_mouse_enter_exit_notifications = true;
 
 			// Send Mouse Enter notifications to parents first.
-			for (int i = over_ancestors.size() - 1; i >= 0; i--) {
+			for (int i = (int)over_ancestors.size() - 1; i >= 0; i--) {
 				Control *ctrl = ObjectDB::get_instance<Control>(over_ancestors[i]);
 				if (ctrl) {
 					gui.mouse_over_hierarchy.push_back(over_ancestors[i]);

--- a/servers/rendering/rendering_light_culler.cpp
+++ b/servers/rendering/rendering_light_culler.cpp
@@ -287,7 +287,8 @@ bool RenderingLightCuller::add_light_camera_planes_directional(LightCullPlanes &
 	const LocalVector<uint8_t> &entry = _calculated_LUT[lookup];
 
 	// each edge forms a plane
-	int n_edges = entry.size() - 1;
+	DEV_ASSERT(entry.size() > 0);
+	int n_edges = (int)entry.size() - 1;
 #else
 	uint8_t *entry = &data.LUT_entries[lookup][0];
 	int n_edges = data.LUT_entry_sizes[lookup] - 1;


### PR DESCRIPTION
## What problem(s) does this PR solve?

LocalVector uses `uint32_t` for size. When subtracting 1, this can lead to undefined behavior if the size is 0:

> scene/main/viewport.cpp:2701:15: runtime error: implicit conversion from type 'unsigned int' of value 4294967295 (32-bit, unsigned) to type 'int' changed the value to -1 (32-bit, signed)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior scene/main/viewport.cpp:2701:15 in 
> scene/main/viewport.cpp:3391:17: runtime error: implicit conversion from type 'unsigned int' of value 4294967295 (32-bit, unsigned) to type 'int' changed the value to -1 (32-bit, signed)
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior scene/main/viewport.cpp:3391:17 in 

## Additional information

I used AI by copy-pasting Godot sanitizer errors to it and telling it to fix them. Then, I am investigating each manually, and submitting PRs when I am confident of the fix. For this one, it's a pretty straightforward a fix.

The sanitizer caught the cases in Viewport, but I also had an AI investigate every usage of LocalVector's size function throughout the codebase - it found only 3 additional sites where bugs can occur out of hundreds of candidates. It could be argued that every case of `size` that leads to being assigned into a signed variable should have an explicit cast, but for this PR I am just including the ones that will cause undefined behavior when the cast is missing.