### PR TITLE
Fix `Math::rand()` type mismatch in TestMethodBind

### DIFF
--- a/tests/core/object/test_method_bind.cpp
+++ b/tests/core/object/test_method_bind.cpp
@@ -129,23 +129,24 @@ public:
 		for (int i = 0; i < TEST_MAX; i++) {
 			test_valid[i] = false;
 		}
+		// `Math::rand()` returns uint32_t, so explicitly cast to test_num's type (int).
 		//regular
-		test_num = Math::rand();
+		test_num = (int)Math::rand();
 		call("test_method");
-		test_num = Math::rand();
+		test_num = (int)Math::rand();
 		call("test_method_args", test_num);
-		test_num = Math::rand();
+		test_num = (int)Math::rand();
 		call("test_methodc");
-		test_num = Math::rand();
+		test_num = (int)Math::rand();
 		call("test_methodc_args", test_num);
 		//return
-		test_num = Math::rand();
+		test_num = (int)Math::rand();
 		test_valid[TEST_METHODR] = int(call("test_methodr")) == test_num && test_valid[TEST_METHODR];
-		test_num = Math::rand();
+		test_num = (int)Math::rand();
 		test_valid[TEST_METHODR_ARGS] = int(call("test_methodr_args", test_num)) == test_num && test_valid[TEST_METHODR_ARGS];
-		test_num = Math::rand();
+		test_num = (int)Math::rand();
 		test_valid[TEST_METHODRC] = int(call("test_methodrc")) == test_num && test_valid[TEST_METHODRC];
-		test_num = Math::rand();
+		test_num = (int)Math::rand();
 		test_valid[TEST_METHODRC_ARGS] = int(call("test_methodrc_args", test_num)) == test_num && test_valid[TEST_METHODRC_ARGS];
 
 		call("test_method_default_args", 1, 2, 3, 4);


### PR DESCRIPTION
## What problem(s) does this PR solve?

`Math::rand()` returns uint32_t, so we should explicitly cast to test_num's type (int).

This PR fixes undefined behavior sanitizer errors reported by Clang on CI:

> SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior core/variant/variant_op.h:126:84 in 
> tests/core/object/test_method_bind.cpp:137:14: runtime error: implicit conversion from type 'uint32_t' (aka 'unsigned int') of value 2390163863 (32-bit, unsigned) to type 'int' changed the value to -1904803433 (32-bit, signed)
> SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior tests/core/object/test_method_bind.cpp:137:14 in 
> tests/core/object/test_method_bind.cpp:139:14: runtime error: implicit conversion from type 'uint32_t' (aka 'unsigned int') of value 2766168046 (32-bit, unsigned) to type 'int' changed the value to -1528799250 (32-bit, signed)
> SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior tests/core/object/test_method_bind.cpp:139:14 in 
> tests/core/object/test_method_bind.cpp:142:14: runtime error: implicit conversion from type 'uint32_t' (aka 'unsigned int') of value 3683425257 (32-bit, unsigned) to type 'int' changed the value to -611542039 (32-bit, signed)
> SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior tests/core/object/test_method_bind.cpp:142:14 in 
> tests/core/object/test_method_bind.cpp:144:14: runtime error: implicit conversion from type 'uint32_t' (aka 'unsigned int') of value 3035080985 (32-bit, unsigned) to type 'int' changed the value to -1259886311 (32-bit, signed)
> SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior tests/core/object/test_method_bind.cpp:144:14 in 
> tests/core/object/test_method_bind.cpp:148:14: runtime error: implicit conversion from type 'uint32_t' (aka 'unsigned int') of value 3435264594 (32-bit, unsigned) to type 'int' changed the value to -859702702 (32-bit, signed)

## Additional information

I used AI by copy-pasting Godot sanitizer errors to it and telling it to fix them. Then, I am investigating each manually, and submitting PRs when I am confident of the fix. For this one, it's pretty straightforward. I wrote the comment myself, let me know if it's superfluous and I can remove it.
