### PR TITLE
Fix sign mismatches in layer/mask/flag flip to fix sanitizer errors

### DIFF
--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -4572,9 +4572,9 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 			bool current = view_display_menu->get_popup()->is_item_checked(idx);
 			current = !current;
 			uint32_t layers = camera->get_cull_mask();
-			layers &= ~(1 << GIZMO_EDIT_LAYER);
+			layers &= ~(1u << GIZMO_EDIT_LAYER);
 			if (current) {
-				layers |= (1 << GIZMO_EDIT_LAYER);
+				layers |= (1u << GIZMO_EDIT_LAYER);
 			}
 			camera->set_cull_mask(layers);
 			view_display_menu->get_popup()->set_item_checked(idx, current);
@@ -4611,9 +4611,9 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 			bool current = view_display_menu->get_popup()->is_item_checked(idx);
 			current = !current;
 			uint32_t layers = camera->get_cull_mask();
-			layers &= ~(1 << GIZMO_GRID_LAYER);
+			layers &= ~(1u << GIZMO_GRID_LAYER);
 			if (current) {
-				layers |= (1 << GIZMO_GRID_LAYER);
+				layers |= (1u << GIZMO_GRID_LAYER);
 			}
 			camera->set_cull_mask(layers);
 			view_display_menu->get_popup()->set_item_checked(idx, current);

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -159,9 +159,9 @@ void CSGShape3D::set_collision_layer_value(int p_layer_number, bool p_value) {
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
 	uint32_t layer = get_collision_layer();
 	if (p_value) {
-		layer |= 1 << (p_layer_number - 1);
+		layer |= 1u << (p_layer_number - 1);
 	} else {
-		layer &= ~(1 << (p_layer_number - 1));
+		layer &= ~(1u << (p_layer_number - 1));
 	}
 	set_collision_layer(layer);
 }
@@ -177,9 +177,9 @@ void CSGShape3D::set_collision_mask_value(int p_layer_number, bool p_value) {
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
-		mask |= 1 << (p_layer_number - 1);
+		mask |= 1u << (p_layer_number - 1);
 	} else {
-		mask &= ~(1 << (p_layer_number - 1));
+		mask &= ~(1u << (p_layer_number - 1));
 	}
 	set_collision_mask(mask);
 }
@@ -187,7 +187,7 @@ void CSGShape3D::set_collision_mask_value(int p_layer_number, bool p_value) {
 bool CSGShape3D::get_collision_mask_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
-	return get_collision_mask() & (1 << (p_layer_number - 1));
+	return get_collision_mask() & (1u << (p_layer_number - 1));
 }
 
 RID CSGShape3D::_get_root_collision_instance() const {

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -186,9 +186,9 @@ void GridMap::set_collision_layer_value(int p_layer_number, bool p_value) {
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
 	uint32_t collision_layer_new = get_collision_layer();
 	if (p_value) {
-		collision_layer_new |= 1 << (p_layer_number - 1);
+		collision_layer_new |= 1u << (p_layer_number - 1);
 	} else {
-		collision_layer_new &= ~(1 << (p_layer_number - 1));
+		collision_layer_new &= ~(1u << (p_layer_number - 1));
 	}
 	set_collision_layer(collision_layer_new);
 }
@@ -196,7 +196,7 @@ void GridMap::set_collision_layer_value(int p_layer_number, bool p_value) {
 bool GridMap::get_collision_layer_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
-	return get_collision_layer() & (1 << (p_layer_number - 1));
+	return get_collision_layer() & (1u << (p_layer_number - 1));
 }
 
 void GridMap::set_collision_mask_value(int p_layer_number, bool p_value) {
@@ -204,9 +204,9 @@ void GridMap::set_collision_mask_value(int p_layer_number, bool p_value) {
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
-		mask |= 1 << (p_layer_number - 1);
+		mask |= 1u << (p_layer_number - 1);
 	} else {
-		mask &= ~(1 << (p_layer_number - 1));
+		mask &= ~(1u << (p_layer_number - 1));
 	}
 	set_collision_mask(mask);
 }
@@ -244,7 +244,7 @@ Ref<PhysicsMaterial> GridMap::get_physics_material() const {
 bool GridMap::get_collision_mask_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
-	return get_collision_mask() & (1 << (p_layer_number - 1));
+	return get_collision_mask() & (1u << (p_layer_number - 1));
 }
 
 Array GridMap::get_collision_shapes() const {

--- a/modules/tilemap/tile_set.cpp
+++ b/modules/tilemap/tile_set.cpp
@@ -1037,9 +1037,9 @@ void TileSet::set_navigation_layer_layer_value(int p_layer_index, int p_layer_nu
 	uint32_t _navigation_layers = get_navigation_layer_layers(p_layer_index);
 
 	if (p_value) {
-		_navigation_layers |= 1 << (p_layer_number - 1);
+		_navigation_layers |= 1u << (p_layer_number - 1);
 	} else {
-		_navigation_layers &= ~(1 << (p_layer_number - 1));
+		_navigation_layers &= ~(1u << (p_layer_number - 1));
 	}
 
 	set_navigation_layer_layers(p_layer_index, _navigation_layers);
@@ -1049,7 +1049,7 @@ bool TileSet::get_navigation_layer_layer_value(int p_layer_index, int p_layer_nu
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Navigation layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Navigation layer number must be between 1 and 32 inclusive.");
 
-	return get_navigation_layer_layers(p_layer_index) & (1 << (p_layer_number - 1));
+	return get_navigation_layer_layers(p_layer_index) & (1u << (p_layer_number - 1));
 }
 #endif // NAVIGATION_2D_DISABLED
 

--- a/platform/linuxbsd/wayland/display_server_wayland.cpp
+++ b/platform/linuxbsd/wayland/display_server_wayland.cpp
@@ -1366,9 +1366,9 @@ void DisplayServerWayland::window_set_flag(DisplayServerEnums::WindowFlags p_fla
 	}
 
 	if (p_enabled) {
-		wd.flags |= 1 << p_flag;
+		wd.flags |= 1u << p_flag;
 	} else {
-		wd.flags &= ~(1 << p_flag);
+		wd.flags &= ~(1u << p_flag);
 	}
 }
 
@@ -1376,7 +1376,7 @@ bool DisplayServerWayland::window_get_flag(DisplayServerEnums::WindowFlags p_fla
 	MutexLock mutex_lock(wayland_thread.mutex);
 
 	ERR_FAIL_COND_V(!windows.has(p_window_id), false);
-	return windows[p_window_id].flags & (1 << p_flag);
+	return windows[p_window_id].flags & (1u << p_flag);
 }
 
 void DisplayServerWayland::window_request_attention(DisplayServerEnums::WindowID p_window_id) {

--- a/scene/2d/navigation/navigation_agent_2d.cpp
+++ b/scene/2d/navigation/navigation_agent_2d.cpp
@@ -434,9 +434,9 @@ void NavigationAgent2D::set_navigation_layer_value(int p_layer_number, bool p_va
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Navigation layer number must be between 1 and 32 inclusive.");
 	uint32_t _navigation_layers = get_navigation_layers();
 	if (p_value) {
-		_navigation_layers |= 1 << (p_layer_number - 1);
+		_navigation_layers |= 1u << (p_layer_number - 1);
 	} else {
-		_navigation_layers &= ~(1 << (p_layer_number - 1));
+		_navigation_layers &= ~(1u << (p_layer_number - 1));
 	}
 	set_navigation_layers(_navigation_layers);
 }
@@ -444,7 +444,7 @@ void NavigationAgent2D::set_navigation_layer_value(int p_layer_number, bool p_va
 bool NavigationAgent2D::get_navigation_layer_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Navigation layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Navigation layer number must be between 1 and 32 inclusive.");
-	return get_navigation_layers() & (1 << (p_layer_number - 1));
+	return get_navigation_layers() & (1u << (p_layer_number - 1));
 }
 
 void NavigationAgent2D::set_pathfinding_algorithm(const NavigationPathQueryParameters2D::PathfindingAlgorithm p_pathfinding_algorithm) {
@@ -956,9 +956,9 @@ void NavigationAgent2D::set_avoidance_layer_value(int p_layer_number, bool p_val
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Avoidance layer number must be between 1 and 32 inclusive.");
 	uint32_t avoidance_layers_new = get_avoidance_layers();
 	if (p_value) {
-		avoidance_layers_new |= 1 << (p_layer_number - 1);
+		avoidance_layers_new |= 1u << (p_layer_number - 1);
 	} else {
-		avoidance_layers_new &= ~(1 << (p_layer_number - 1));
+		avoidance_layers_new &= ~(1u << (p_layer_number - 1));
 	}
 	set_avoidance_layers(avoidance_layers_new);
 }
@@ -966,7 +966,7 @@ void NavigationAgent2D::set_avoidance_layer_value(int p_layer_number, bool p_val
 bool NavigationAgent2D::get_avoidance_layer_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Avoidance layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Avoidance layer number must be between 1 and 32 inclusive.");
-	return get_avoidance_layers() & (1 << (p_layer_number - 1));
+	return get_avoidance_layers() & (1u << (p_layer_number - 1));
 }
 
 void NavigationAgent2D::set_avoidance_mask_value(int p_mask_number, bool p_value) {
@@ -974,9 +974,9 @@ void NavigationAgent2D::set_avoidance_mask_value(int p_mask_number, bool p_value
 	ERR_FAIL_COND_MSG(p_mask_number > 32, "Avoidance mask number must be between 1 and 32 inclusive.");
 	uint32_t mask = get_avoidance_mask();
 	if (p_value) {
-		mask |= 1 << (p_mask_number - 1);
+		mask |= 1u << (p_mask_number - 1);
 	} else {
-		mask &= ~(1 << (p_mask_number - 1));
+		mask &= ~(1u << (p_mask_number - 1));
 	}
 	set_avoidance_mask(mask);
 }
@@ -984,7 +984,7 @@ void NavigationAgent2D::set_avoidance_mask_value(int p_mask_number, bool p_value
 bool NavigationAgent2D::get_avoidance_mask_value(int p_mask_number) const {
 	ERR_FAIL_COND_V_MSG(p_mask_number < 1, false, "Avoidance mask number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_mask_number > 32, false, "Avoidance mask number must be between 1 and 32 inclusive.");
-	return get_avoidance_mask() & (1 << (p_mask_number - 1));
+	return get_avoidance_mask() & (1u << (p_mask_number - 1));
 }
 
 void NavigationAgent2D::set_avoidance_priority(real_t p_priority) {

--- a/scene/2d/navigation/navigation_link_2d.cpp
+++ b/scene/2d/navigation/navigation_link_2d.cpp
@@ -216,9 +216,9 @@ void NavigationLink2D::set_navigation_layer_value(int p_layer_number, bool p_val
 	uint32_t _navigation_layers = get_navigation_layers();
 
 	if (p_value) {
-		_navigation_layers |= 1 << (p_layer_number - 1);
+		_navigation_layers |= 1u << (p_layer_number - 1);
 	} else {
-		_navigation_layers &= ~(1 << (p_layer_number - 1));
+		_navigation_layers &= ~(1u << (p_layer_number - 1));
 	}
 
 	set_navigation_layers(_navigation_layers);
@@ -228,7 +228,7 @@ bool NavigationLink2D::get_navigation_layer_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Navigation layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Navigation layer number must be between 1 and 32 inclusive.");
 
-	return get_navigation_layers() & (1 << (p_layer_number - 1));
+	return get_navigation_layers() & (1u << (p_layer_number - 1));
 }
 
 void NavigationLink2D::set_start_position(Vector2 p_position) {

--- a/scene/2d/navigation/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation/navigation_obstacle_2d.cpp
@@ -280,9 +280,9 @@ void NavigationObstacle2D::set_avoidance_layer_value(int p_layer_number, bool p_
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Avoidance layer number must be between 1 and 32 inclusive.");
 	uint32_t avoidance_layers_new = get_avoidance_layers();
 	if (p_value) {
-		avoidance_layers_new |= 1 << (p_layer_number - 1);
+		avoidance_layers_new |= 1u << (p_layer_number - 1);
 	} else {
-		avoidance_layers_new &= ~(1 << (p_layer_number - 1));
+		avoidance_layers_new &= ~(1u << (p_layer_number - 1));
 	}
 	set_avoidance_layers(avoidance_layers_new);
 }
@@ -290,7 +290,7 @@ void NavigationObstacle2D::set_avoidance_layer_value(int p_layer_number, bool p_
 bool NavigationObstacle2D::get_avoidance_layer_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Avoidance layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Avoidance layer number must be between 1 and 32 inclusive.");
-	return get_avoidance_layers() & (1 << (p_layer_number - 1));
+	return get_avoidance_layers() & (1u << (p_layer_number - 1));
 }
 
 void NavigationObstacle2D::set_avoidance_enabled(bool p_enabled) {

--- a/scene/2d/navigation/navigation_region_2d.cpp
+++ b/scene/2d/navigation/navigation_region_2d.cpp
@@ -99,9 +99,9 @@ void NavigationRegion2D::set_navigation_layer_value(int p_layer_number, bool p_v
 	uint32_t _navigation_layers = get_navigation_layers();
 
 	if (p_value) {
-		_navigation_layers |= 1 << (p_layer_number - 1);
+		_navigation_layers |= 1u << (p_layer_number - 1);
 	} else {
-		_navigation_layers &= ~(1 << (p_layer_number - 1));
+		_navigation_layers &= ~(1u << (p_layer_number - 1));
 	}
 
 	set_navigation_layers(_navigation_layers);
@@ -111,7 +111,7 @@ bool NavigationRegion2D::get_navigation_layer_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Navigation layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Navigation layer number must be between 1 and 32 inclusive.");
 
-	return get_navigation_layers() & (1 << (p_layer_number - 1));
+	return get_navigation_layers() & (1u << (p_layer_number - 1));
 }
 
 void NavigationRegion2D::set_enter_cost(real_t p_enter_cost) {

--- a/scene/2d/physics/collision_object_2d.cpp
+++ b/scene/2d/physics/collision_object_2d.cpp
@@ -172,9 +172,9 @@ void CollisionObject2D::set_collision_layer_value(int p_layer_number, bool p_val
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
 	uint32_t collision_layer_new = get_collision_layer();
 	if (p_value) {
-		collision_layer_new |= 1 << (p_layer_number - 1);
+		collision_layer_new |= 1u << (p_layer_number - 1);
 	} else {
-		collision_layer_new &= ~(1 << (p_layer_number - 1));
+		collision_layer_new &= ~(1u << (p_layer_number - 1));
 	}
 	set_collision_layer(collision_layer_new);
 }
@@ -182,7 +182,7 @@ void CollisionObject2D::set_collision_layer_value(int p_layer_number, bool p_val
 bool CollisionObject2D::get_collision_layer_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
-	return get_collision_layer() & (1 << (p_layer_number - 1));
+	return get_collision_layer() & (1u << (p_layer_number - 1));
 }
 
 void CollisionObject2D::set_collision_mask_value(int p_layer_number, bool p_value) {
@@ -190,9 +190,9 @@ void CollisionObject2D::set_collision_mask_value(int p_layer_number, bool p_valu
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
-		mask |= 1 << (p_layer_number - 1);
+		mask |= 1u << (p_layer_number - 1);
 	} else {
-		mask &= ~(1 << (p_layer_number - 1));
+		mask &= ~(1u << (p_layer_number - 1));
 	}
 	set_collision_mask(mask);
 }
@@ -200,7 +200,7 @@ void CollisionObject2D::set_collision_mask_value(int p_layer_number, bool p_valu
 bool CollisionObject2D::get_collision_mask_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
-	return get_collision_mask() & (1 << (p_layer_number - 1));
+	return get_collision_mask() & (1u << (p_layer_number - 1));
 }
 
 void CollisionObject2D::set_collision_priority(real_t p_priority) {

--- a/scene/2d/physics/ray_cast_2d.cpp
+++ b/scene/2d/physics/ray_cast_2d.cpp
@@ -62,9 +62,9 @@ void RayCast2D::set_collision_mask_value(int p_layer_number, bool p_value) {
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
-		mask |= 1 << (p_layer_number - 1);
+		mask |= 1u << (p_layer_number - 1);
 	} else {
-		mask &= ~(1 << (p_layer_number - 1));
+		mask &= ~(1u << (p_layer_number - 1));
 	}
 	set_collision_mask(mask);
 }
@@ -72,7 +72,7 @@ void RayCast2D::set_collision_mask_value(int p_layer_number, bool p_value) {
 bool RayCast2D::get_collision_mask_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
-	return get_collision_mask() & (1 << (p_layer_number - 1));
+	return get_collision_mask() & (1u << (p_layer_number - 1));
 }
 
 bool RayCast2D::is_colliding() const {

--- a/scene/2d/physics/shape_cast_2d.cpp
+++ b/scene/2d/physics/shape_cast_2d.cpp
@@ -79,9 +79,9 @@ void ShapeCast2D::set_collision_mask_value(int p_layer_number, bool p_value) {
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
-		mask |= 1 << (p_layer_number - 1);
+		mask |= 1u << (p_layer_number - 1);
 	} else {
-		mask &= ~(1 << (p_layer_number - 1));
+		mask &= ~(1u << (p_layer_number - 1));
 	}
 	set_collision_mask(mask);
 }
@@ -89,7 +89,7 @@ void ShapeCast2D::set_collision_mask_value(int p_layer_number, bool p_value) {
 bool ShapeCast2D::get_collision_mask_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
-	return get_collision_mask() & (1 << (p_layer_number - 1));
+	return get_collision_mask() & (1u << (p_layer_number - 1));
 }
 
 int ShapeCast2D::get_collision_count() const {

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -835,9 +835,9 @@ void Camera3D::set_cull_mask_value(int p_layer_number, bool p_value) {
 	ERR_FAIL_COND_MSG(p_layer_number > 20, "Render layer number must be between 1 and 20 inclusive.");
 	uint32_t mask = get_cull_mask();
 	if (p_value) {
-		mask |= 1 << (p_layer_number - 1);
+		mask |= 1u << (p_layer_number - 1);
 	} else {
-		mask &= ~(1 << (p_layer_number - 1));
+		mask &= ~(1u << (p_layer_number - 1));
 	}
 	set_cull_mask(mask);
 }
@@ -845,7 +845,7 @@ void Camera3D::set_cull_mask_value(int p_layer_number, bool p_value) {
 bool Camera3D::get_cull_mask_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Render layer number must be between 1 and 20 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 20, false, "Render layer number must be between 1 and 20 inclusive.");
-	return layers & (1 << (p_layer_number - 1));
+	return layers & (1u << (p_layer_number - 1));
 }
 
 Vector<Plane> Camera3D::get_frustum() const {

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -628,16 +628,16 @@ void GPUParticlesCollisionSDF3D::set_bake_mask_value(int p_layer_number, bool p_
 	ERR_FAIL_COND_MSG(p_layer_number < 1 || p_layer_number > 20, vformat("The render layer number (%d) must be between 1 and 20 (inclusive).", p_layer_number));
 	uint32_t mask = get_bake_mask();
 	if (p_value) {
-		mask |= 1 << (p_layer_number - 1);
+		mask |= 1u << (p_layer_number - 1);
 	} else {
-		mask &= ~(1 << (p_layer_number - 1));
+		mask &= ~(1u << (p_layer_number - 1));
 	}
 	set_bake_mask(mask);
 }
 
 bool GPUParticlesCollisionSDF3D::get_bake_mask_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1 || p_layer_number > 20, false, vformat("The render layer number (%d) must be between 1 and 20 (inclusive).", p_layer_number));
-	return bake_mask & (1 << (p_layer_number - 1));
+	return bake_mask & (1u << (p_layer_number - 1));
 }
 
 void GPUParticlesCollisionSDF3D::set_texture(const Ref<Texture3D> &p_texture) {
@@ -815,9 +815,9 @@ void GPUParticlesCollisionHeightField3D::set_heightfield_mask_value(int p_layer_
 	ERR_FAIL_COND_MSG(p_layer_number > 20, "Render layer number must be between 1 and 20 inclusive.");
 	uint32_t mask = get_heightfield_mask();
 	if (p_value) {
-		mask |= 1 << (p_layer_number - 1);
+		mask |= 1u << (p_layer_number - 1);
 	} else {
-		mask &= ~(1 << (p_layer_number - 1));
+		mask &= ~(1u << (p_layer_number - 1));
 	}
 	set_heightfield_mask(mask);
 }
@@ -825,7 +825,7 @@ void GPUParticlesCollisionHeightField3D::set_heightfield_mask_value(int p_layer_
 bool GPUParticlesCollisionHeightField3D::get_heightfield_mask_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Render layer number must be between 1 and 20 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 20, false, "Render layer number must be between 1 and 20 inclusive.");
-	return heightfield_mask & (1 << (p_layer_number - 1));
+	return heightfield_mask & (1u << (p_layer_number - 1));
 }
 
 void GPUParticlesCollisionHeightField3D::set_follow_camera_enabled(bool p_enabled) {

--- a/scene/3d/navigation/navigation_agent_3d.cpp
+++ b/scene/3d/navigation/navigation_agent_3d.cpp
@@ -472,9 +472,9 @@ void NavigationAgent3D::set_navigation_layer_value(int p_layer_number, bool p_va
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Navigation layer number must be between 1 and 32 inclusive.");
 	uint32_t _navigation_layers = get_navigation_layers();
 	if (p_value) {
-		_navigation_layers |= 1 << (p_layer_number - 1);
+		_navigation_layers |= 1u << (p_layer_number - 1);
 	} else {
-		_navigation_layers &= ~(1 << (p_layer_number - 1));
+		_navigation_layers &= ~(1u << (p_layer_number - 1));
 	}
 	set_navigation_layers(_navigation_layers);
 }
@@ -482,7 +482,7 @@ void NavigationAgent3D::set_navigation_layer_value(int p_layer_number, bool p_va
 bool NavigationAgent3D::get_navigation_layer_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Navigation layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Navigation layer number must be between 1 and 32 inclusive.");
-	return get_navigation_layers() & (1 << (p_layer_number - 1));
+	return get_navigation_layers() & (1u << (p_layer_number - 1));
 }
 
 void NavigationAgent3D::set_pathfinding_algorithm(const NavigationPathQueryParameters3D::PathfindingAlgorithm p_pathfinding_algorithm) {
@@ -1028,9 +1028,9 @@ void NavigationAgent3D::set_avoidance_layer_value(int p_layer_number, bool p_val
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Avoidance layer number must be between 1 and 32 inclusive.");
 	uint32_t avoidance_layers_new = get_avoidance_layers();
 	if (p_value) {
-		avoidance_layers_new |= 1 << (p_layer_number - 1);
+		avoidance_layers_new |= 1u << (p_layer_number - 1);
 	} else {
-		avoidance_layers_new &= ~(1 << (p_layer_number - 1));
+		avoidance_layers_new &= ~(1u << (p_layer_number - 1));
 	}
 	set_avoidance_layers(avoidance_layers_new);
 }
@@ -1038,7 +1038,7 @@ void NavigationAgent3D::set_avoidance_layer_value(int p_layer_number, bool p_val
 bool NavigationAgent3D::get_avoidance_layer_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Avoidance layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Avoidance layer number must be between 1 and 32 inclusive.");
-	return get_avoidance_layers() & (1 << (p_layer_number - 1));
+	return get_avoidance_layers() & (1u << (p_layer_number - 1));
 }
 
 void NavigationAgent3D::set_avoidance_mask_value(int p_mask_number, bool p_value) {
@@ -1046,9 +1046,9 @@ void NavigationAgent3D::set_avoidance_mask_value(int p_mask_number, bool p_value
 	ERR_FAIL_COND_MSG(p_mask_number > 32, "Avoidance mask number must be between 1 and 32 inclusive.");
 	uint32_t mask = get_avoidance_mask();
 	if (p_value) {
-		mask |= 1 << (p_mask_number - 1);
+		mask |= 1u << (p_mask_number - 1);
 	} else {
-		mask &= ~(1 << (p_mask_number - 1));
+		mask &= ~(1u << (p_mask_number - 1));
 	}
 	set_avoidance_mask(mask);
 }
@@ -1056,7 +1056,7 @@ void NavigationAgent3D::set_avoidance_mask_value(int p_mask_number, bool p_value
 bool NavigationAgent3D::get_avoidance_mask_value(int p_mask_number) const {
 	ERR_FAIL_COND_V_MSG(p_mask_number < 1, false, "Avoidance mask number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_mask_number > 32, false, "Avoidance mask number must be between 1 and 32 inclusive.");
-	return get_avoidance_mask() & (1 << (p_mask_number - 1));
+	return get_avoidance_mask() & (1u << (p_mask_number - 1));
 }
 
 void NavigationAgent3D::set_avoidance_priority(real_t p_priority) {

--- a/scene/3d/navigation/navigation_link_3d.cpp
+++ b/scene/3d/navigation/navigation_link_3d.cpp
@@ -379,9 +379,9 @@ void NavigationLink3D::set_navigation_layer_value(int p_layer_number, bool p_val
 	uint32_t _navigation_layers = get_navigation_layers();
 
 	if (p_value) {
-		_navigation_layers |= 1 << (p_layer_number - 1);
+		_navigation_layers |= 1u << (p_layer_number - 1);
 	} else {
-		_navigation_layers &= ~(1 << (p_layer_number - 1));
+		_navigation_layers &= ~(1u << (p_layer_number - 1));
 	}
 
 	set_navigation_layers(_navigation_layers);
@@ -391,7 +391,7 @@ bool NavigationLink3D::get_navigation_layer_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Navigation layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Navigation layer number must be between 1 and 32 inclusive.");
 
-	return get_navigation_layers() & (1 << (p_layer_number - 1));
+	return get_navigation_layers() & (1u << (p_layer_number - 1));
 }
 
 void NavigationLink3D::set_start_position(Vector3 p_position) {

--- a/scene/3d/navigation/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation/navigation_obstacle_3d.cpp
@@ -357,9 +357,9 @@ void NavigationObstacle3D::set_avoidance_layer_value(int p_layer_number, bool p_
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Avoidance layer number must be between 1 and 32 inclusive.");
 	uint32_t avoidance_layers_new = get_avoidance_layers();
 	if (p_value) {
-		avoidance_layers_new |= 1 << (p_layer_number - 1);
+		avoidance_layers_new |= 1u << (p_layer_number - 1);
 	} else {
-		avoidance_layers_new &= ~(1 << (p_layer_number - 1));
+		avoidance_layers_new &= ~(1u << (p_layer_number - 1));
 	}
 	set_avoidance_layers(avoidance_layers_new);
 }
@@ -367,7 +367,7 @@ void NavigationObstacle3D::set_avoidance_layer_value(int p_layer_number, bool p_
 bool NavigationObstacle3D::get_avoidance_layer_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Avoidance layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Avoidance layer number must be between 1 and 32 inclusive.");
-	return get_avoidance_layers() & (1 << (p_layer_number - 1));
+	return get_avoidance_layers() & (1u << (p_layer_number - 1));
 }
 
 void NavigationObstacle3D::set_avoidance_enabled(bool p_enabled) {

--- a/scene/3d/navigation/navigation_region_3d.cpp
+++ b/scene/3d/navigation/navigation_region_3d.cpp
@@ -117,9 +117,9 @@ void NavigationRegion3D::set_navigation_layer_value(int p_layer_number, bool p_v
 	uint32_t _navigation_layers = get_navigation_layers();
 
 	if (p_value) {
-		_navigation_layers |= 1 << (p_layer_number - 1);
+		_navigation_layers |= 1u << (p_layer_number - 1);
 	} else {
-		_navigation_layers &= ~(1 << (p_layer_number - 1));
+		_navigation_layers &= ~(1u << (p_layer_number - 1));
 	}
 
 	set_navigation_layers(_navigation_layers);
@@ -129,7 +129,7 @@ bool NavigationRegion3D::get_navigation_layer_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Navigation layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Navigation layer number must be between 1 and 32 inclusive.");
 
-	return get_navigation_layers() & (1 << (p_layer_number - 1));
+	return get_navigation_layers() & (1u << (p_layer_number - 1));
 }
 
 void NavigationRegion3D::set_enter_cost(real_t p_enter_cost) {

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -502,9 +502,9 @@ void OccluderInstance3D::set_bake_mask_value(int p_layer_number, bool p_value) {
 	ERR_FAIL_COND_MSG(p_layer_number > 20, "Render layer number must be between 1 and 20 inclusive.");
 	uint32_t mask = get_bake_mask();
 	if (p_value) {
-		mask |= 1 << (p_layer_number - 1);
+		mask |= 1u << (p_layer_number - 1);
 	} else {
-		mask &= ~(1 << (p_layer_number - 1));
+		mask &= ~(1u << (p_layer_number - 1));
 	}
 	set_bake_mask(mask);
 }
@@ -512,7 +512,7 @@ void OccluderInstance3D::set_bake_mask_value(int p_layer_number, bool p_value) {
 bool OccluderInstance3D::get_bake_mask_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Render layer number must be between 1 and 20 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 20, false, "Render layer number must be between 1 and 20 inclusive.");
-	return bake_mask & (1 << (p_layer_number - 1));
+	return bake_mask & (1u << (p_layer_number - 1));
 }
 
 bool OccluderInstance3D::_bake_material_check(Ref<Material> p_material) {

--- a/scene/3d/physics/collision_object_3d.cpp
+++ b/scene/3d/physics/collision_object_3d.cpp
@@ -185,9 +185,9 @@ void CollisionObject3D::set_collision_layer_value(int p_layer_number, bool p_val
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
 	uint32_t collision_layer_new = get_collision_layer();
 	if (p_value) {
-		collision_layer_new |= 1 << (p_layer_number - 1);
+		collision_layer_new |= 1u << (p_layer_number - 1);
 	} else {
-		collision_layer_new &= ~(1 << (p_layer_number - 1));
+		collision_layer_new &= ~(1u << (p_layer_number - 1));
 	}
 	set_collision_layer(collision_layer_new);
 }
@@ -195,7 +195,7 @@ void CollisionObject3D::set_collision_layer_value(int p_layer_number, bool p_val
 bool CollisionObject3D::get_collision_layer_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
-	return get_collision_layer() & (1 << (p_layer_number - 1));
+	return get_collision_layer() & (1u << (p_layer_number - 1));
 }
 
 void CollisionObject3D::set_collision_mask_value(int p_layer_number, bool p_value) {
@@ -203,9 +203,9 @@ void CollisionObject3D::set_collision_mask_value(int p_layer_number, bool p_valu
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
-		mask |= 1 << (p_layer_number - 1);
+		mask |= 1u << (p_layer_number - 1);
 	} else {
-		mask &= ~(1 << (p_layer_number - 1));
+		mask &= ~(1u << (p_layer_number - 1));
 	}
 	set_collision_mask(mask);
 }
@@ -213,7 +213,7 @@ void CollisionObject3D::set_collision_mask_value(int p_layer_number, bool p_valu
 bool CollisionObject3D::get_collision_mask_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
-	return get_collision_mask() & (1 << (p_layer_number - 1));
+	return get_collision_mask() & (1u << (p_layer_number - 1));
 }
 
 void CollisionObject3D::set_collision_priority(real_t p_priority) {

--- a/scene/3d/physics/ray_cast_3d.cpp
+++ b/scene/3d/physics/ray_cast_3d.cpp
@@ -68,9 +68,9 @@ void RayCast3D::set_collision_mask_value(int p_layer_number, bool p_value) {
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
-		mask |= 1 << (p_layer_number - 1);
+		mask |= 1u << (p_layer_number - 1);
 	} else {
-		mask &= ~(1 << (p_layer_number - 1));
+		mask &= ~(1u << (p_layer_number - 1));
 	}
 	set_collision_mask(mask);
 }
@@ -78,7 +78,7 @@ void RayCast3D::set_collision_mask_value(int p_layer_number, bool p_value) {
 bool RayCast3D::get_collision_mask_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
-	return get_collision_mask() & (1 << (p_layer_number - 1));
+	return get_collision_mask() & (1u << (p_layer_number - 1));
 }
 
 bool RayCast3D::is_colliding() const {

--- a/scene/3d/physics/shape_cast_3d.cpp
+++ b/scene/3d/physics/shape_cast_3d.cpp
@@ -278,9 +278,9 @@ void ShapeCast3D::set_collision_mask_value(int p_layer_number, bool p_value) {
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
-		mask |= 1 << (p_layer_number - 1);
+		mask |= 1u << (p_layer_number - 1);
 	} else {
-		mask &= ~(1 << (p_layer_number - 1));
+		mask &= ~(1u << (p_layer_number - 1));
 	}
 	set_collision_mask(mask);
 }
@@ -288,7 +288,7 @@ void ShapeCast3D::set_collision_mask_value(int p_layer_number, bool p_value) {
 bool ShapeCast3D::get_collision_mask_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
-	return get_collision_mask() & (1 << (p_layer_number - 1));
+	return get_collision_mask() & (1u << (p_layer_number - 1));
 }
 
 int ShapeCast3D::get_collision_count() const {

--- a/scene/3d/physics/soft_body_3d.cpp
+++ b/scene/3d/physics/soft_body_3d.cpp
@@ -543,9 +543,9 @@ void SoftBody3D::set_collision_layer_value(int p_layer_number, bool p_value) {
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
 	uint32_t collision_layer_new = get_collision_layer();
 	if (p_value) {
-		collision_layer_new |= 1 << (p_layer_number - 1);
+		collision_layer_new |= 1u << (p_layer_number - 1);
 	} else {
-		collision_layer_new &= ~(1 << (p_layer_number - 1));
+		collision_layer_new &= ~(1u << (p_layer_number - 1));
 	}
 	set_collision_layer(collision_layer_new);
 }
@@ -553,7 +553,7 @@ void SoftBody3D::set_collision_layer_value(int p_layer_number, bool p_value) {
 bool SoftBody3D::get_collision_layer_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
-	return get_collision_layer() & (1 << (p_layer_number - 1));
+	return get_collision_layer() & (1u << (p_layer_number - 1));
 }
 
 void SoftBody3D::set_collision_mask_value(int p_layer_number, bool p_value) {
@@ -561,9 +561,9 @@ void SoftBody3D::set_collision_mask_value(int p_layer_number, bool p_value) {
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
-		mask |= 1 << (p_layer_number - 1);
+		mask |= 1u << (p_layer_number - 1);
 	} else {
-		mask &= ~(1 << (p_layer_number - 1));
+		mask &= ~(1u << (p_layer_number - 1));
 	}
 	set_collision_mask(mask);
 }
@@ -571,7 +571,7 @@ void SoftBody3D::set_collision_mask_value(int p_layer_number, bool p_value) {
 bool SoftBody3D::get_collision_mask_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
-	return get_collision_mask() & (1 << (p_layer_number - 1));
+	return get_collision_mask() & (1u << (p_layer_number - 1));
 }
 
 void SoftBody3D::set_disable_mode(DisableMode p_mode) {

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -141,9 +141,9 @@ void VisualInstance3D::set_layer_mask_value(int p_layer_number, bool p_value) {
 	ERR_FAIL_COND_MSG(p_layer_number > 20, "Render layer number must be between 1 and 20 inclusive.");
 	uint32_t mask = get_layer_mask();
 	if (p_value) {
-		mask |= 1 << (p_layer_number - 1);
+		mask |= 1u << (p_layer_number - 1);
 	} else {
-		mask &= ~(1 << (p_layer_number - 1));
+		mask &= ~(1u << (p_layer_number - 1));
 	}
 	set_layer_mask(mask);
 }
@@ -151,7 +151,7 @@ void VisualInstance3D::set_layer_mask_value(int p_layer_number, bool p_value) {
 bool VisualInstance3D::get_layer_mask_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Render layer number must be between 1 and 20 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 20, false, "Render layer number must be between 1 and 20 inclusive.");
-	return layers & (1 << (p_layer_number - 1));
+	return layers & (1u << (p_layer_number - 1));
 }
 
 void VisualInstance3D::set_sorting_offset(float p_offset) {

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1717,16 +1717,16 @@ void CanvasItem::set_visibility_layer_bit(uint32_t p_visibility_layer, bool p_en
 	ERR_THREAD_GUARD;
 	ERR_FAIL_UNSIGNED_INDEX(p_visibility_layer, 32);
 	if (p_enable) {
-		set_visibility_layer(visibility_layer | (1 << p_visibility_layer));
+		set_visibility_layer(visibility_layer | (1u << p_visibility_layer));
 	} else {
-		set_visibility_layer(visibility_layer & (~(1 << p_visibility_layer)));
+		set_visibility_layer(visibility_layer & (~(1u << p_visibility_layer)));
 	}
 }
 
 bool CanvasItem::get_visibility_layer_bit(uint32_t p_visibility_layer) const {
 	ERR_READ_THREAD_GUARD_V(false);
 	ERR_FAIL_UNSIGNED_INDEX_V(p_visibility_layer, 32, false);
-	return (visibility_layer & (1 << p_visibility_layer));
+	return (visibility_layer & (1u << p_visibility_layer));
 }
 
 void CanvasItem::_refresh_texture_filter_cache() const {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -4442,16 +4442,16 @@ void Viewport::set_canvas_cull_mask_bit(uint32_t p_layer, bool p_enable) {
 	ERR_MAIN_THREAD_GUARD;
 	ERR_FAIL_UNSIGNED_INDEX(p_layer, 32);
 	if (p_enable) {
-		set_canvas_cull_mask(canvas_cull_mask | (1 << p_layer));
+		set_canvas_cull_mask(canvas_cull_mask | (1u << p_layer));
 	} else {
-		set_canvas_cull_mask(canvas_cull_mask & (~(1 << p_layer)));
+		set_canvas_cull_mask(canvas_cull_mask & (~(1u << p_layer)));
 	}
 }
 
 bool Viewport::get_canvas_cull_mask_bit(uint32_t p_layer) const {
 	ERR_READ_THREAD_GUARD_V(false);
 	ERR_FAIL_UNSIGNED_INDEX_V(p_layer, 32, false);
-	return (canvas_cull_mask & (1 << p_layer));
+	return (canvas_cull_mask & (1u << p_layer));
 }
 
 #ifdef TOOLS_ENABLED

--- a/scene/resources/2d/navigation_polygon.cpp
+++ b/scene/resources/2d/navigation_polygon.cpp
@@ -466,9 +466,9 @@ void NavigationPolygon::set_parsed_collision_mask_value(int p_layer_number, bool
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
 	uint32_t mask = get_parsed_collision_mask();
 	if (p_value) {
-		mask |= 1 << (p_layer_number - 1);
+		mask |= 1u << (p_layer_number - 1);
 	} else {
-		mask &= ~(1 << (p_layer_number - 1));
+		mask &= ~(1u << (p_layer_number - 1));
 	}
 	set_parsed_collision_mask(mask);
 }
@@ -476,7 +476,7 @@ void NavigationPolygon::set_parsed_collision_mask_value(int p_layer_number, bool
 bool NavigationPolygon::get_parsed_collision_mask_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
-	return get_parsed_collision_mask() & (1 << (p_layer_number - 1));
+	return get_parsed_collision_mask() & (1u << (p_layer_number - 1));
 }
 
 void NavigationPolygon::set_source_geometry_mode(SourceGeometryMode p_geometry_mode) {

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -106,9 +106,9 @@ void NavigationMesh::set_collision_mask_value(int p_layer_number, bool p_value) 
 	ERR_FAIL_COND_MSG(p_layer_number > 32, "Collision layer number must be between 1 and 32 inclusive.");
 	uint32_t mask = get_collision_mask();
 	if (p_value) {
-		mask |= 1 << (p_layer_number - 1);
+		mask |= 1u << (p_layer_number - 1);
 	} else {
-		mask &= ~(1 << (p_layer_number - 1));
+		mask &= ~(1u << (p_layer_number - 1));
 	}
 	set_collision_mask(mask);
 }
@@ -116,7 +116,7 @@ void NavigationMesh::set_collision_mask_value(int p_layer_number, bool p_value) 
 bool NavigationMesh::get_collision_mask_value(int p_layer_number) const {
 	ERR_FAIL_COND_V_MSG(p_layer_number < 1, false, "Collision layer number must be between 1 and 32 inclusive.");
 	ERR_FAIL_COND_V_MSG(p_layer_number > 32, false, "Collision layer number must be between 1 and 32 inclusive.");
-	return get_collision_mask() & (1 << (p_layer_number - 1));
+	return get_collision_mask() & (1u << (p_layer_number - 1));
 }
 
 void NavigationMesh::set_source_geometry_mode(SourceGeometryMode p_geometry_mode) {

--- a/servers/rendering/renderer_rd/pipeline_cache_rd.cpp
+++ b/servers/rendering/renderer_rd/pipeline_cache_rd.cpp
@@ -47,11 +47,11 @@ RID PipelineCacheRD::_generate_version(RD::VertexFormatID p_vertex_format_id, RD
 	uint32_t bool_specializations = p_bool_specializations;
 	while (bool_specializations) {
 		RD::PipelineSpecializationConstant sc;
-		sc.bool_value = bool(bool_specializations & (1 << bool_index));
+		sc.bool_value = bool(bool_specializations & (1u << bool_index));
 		sc.constant_id = bool_index;
 		sc.type = RD::PIPELINE_SPECIALIZATION_CONSTANT_TYPE_BOOL;
 		specialization_constants.push_back(sc);
-		bool_specializations &= ~(1 << bool_index);
+		bool_specializations &= ~(1u << bool_index);
 		bool_index++;
 	}
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

The pattern `unsigned_variable &= ~(1 << SOME_LAYER);` is present in many places in the codebase, especially anywhere with layers. This bit-shifts a signed integer, then flips the bits, which turns it into a negative number. Then, the bitwise-and with an unsigned variable causes a sanitizer error:

> scene/3d/camera_3d.cpp:840:11: runtime error: implicit conversion from type 'int' of value -17 (32-bit, signed) to type 'unsigned int' changed the value to 4294967279 (32-bit, unsigned)

This PR fixes the issue by using an unsigned literal (`1u`) for the bit-shift, in cases where the destination of the computation is an unsigned variable. These were found with a search for `&= ~(1 <<`, I am not guaranteeing that I found every case of bit-shifts that should be unsigned, but at least these are a bunch that would previously be undefined behavior that are now fixed, plus the corresponding `|= 1 <<` and getters updated to match.

## Additional information

I used AI by copy-pasting Godot sanitizer errors to it and telling it to fix them. Then, I am investigating each manually, and submitting PRs when I am confident of the fix. For this one, I had the AI search for `&= ~(1 <<` and filter down the list, then I applied all of the changes manually - so the AI's role in this PR was purely exclusionary, filtering out places that I should not change because the destination is actually signed or because undefined behavior will never occur.
