### PR TITLE
[3.x] GLES3: Fix DirectionalLightData UBO size mismatch on WebGL2

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -148,7 +148,9 @@ layout(std140) uniform DirectionalLightData { //ubo:3
 	mediump vec4 shadow_split_offsets;
 
 	mediump float fade_from;
-	mediump vec3 pad;
+	mediump float pad0;
+	mediump float pad1;
+	mediump float pad2;
 };
 
 #endif //ubershader-skip
@@ -859,7 +861,9 @@ layout(std140) uniform DirectionalLightData {
 	mediump vec4 shadow_split_offsets;
 
 	mediump float fade_from;
-	mediump vec3 pad;
+	mediump float pad0;
+	mediump float pad1;
+	mediump float pad2;
 };
 
 uniform highp sampler2DShadow directional_shadow; // texunit:-5


### PR DESCRIPTION
On HTML5/WebGL2 exports, many 3D surfaces would disappear or render without their material whenever a `DirectionalLight` was visible. The console was flooded with:

```
GL_INVALID_OPERATION: glDrawElements: it is undefined behaviour to use a uniform buffer that is too small.
WebGL: Buffer for uniform block is smaller than UNIFORM_BLOCK_DATA_SIZE
```

The same scenes rendered correctly on native platforms, and the affected objects changed with the camera position, which made the bug very confusing to track down.

**Cause**

The `DirectionalLightData` uniform block ends with a single `mediump vec3 pad;` member. With std140 alignment rules, the `vec3` is aligned to a 16-byte boundary, so the shader-side block is computed as **400 bytes**:

```glsl
mediump vec4  shadow_split_offsets;   // 352..368
mediump float fade_from;              // 368..372
mediump vec3  pad;                    // std140 aligns vec3 to 16 -> 384..396, block = 400
```

while the C++ side (`SceneState::DirectionalLightData` in `rasterizer_scene_gles3.h`) packs `float fade_from; float pad[3];` for a **384-byte** struct.

Godot binds a 384-byte buffer for the block. Desktop GL drivers don't validate the size, so the mismatch goes unnoticed natively. WebGL2 **does** validate it and discards every draw that binds the undersized UBO.

**Fix**

Replace `vec3 pad` with three separate floats so the block closes at 384 bytes, matching the C++ layout. The members are padding and are never read.

**Testing**

- Verified on a real HTML5 export of a large 3D project (Godot 3.6.2-stable templates, the bug is still present in `3.x`): the `uniform buffer too small` errors went from 254 per session to 0, and the affected geometry (character mesh, pipes, coolant tanks, airlocks, part of the 3D HUD) renders correctly again with the directional light enabled.
- The omni/spot `LightData` block (160 bytes) does not have the problem; only the directional block is touched.