### PR TITLE
[3.x] Android: Fix make_dir_recursive returning an error if directory exists

### DIFF
--- a/platform/android/dir_access_jandroid.cpp
+++ b/platform/android/dir_access_jandroid.cpp
@@ -219,7 +219,10 @@ bool DirAccessJAndroid::dir_exists(String p_dir) {
 Error DirAccessJAndroid::make_dir_recursive(String p_dir) {
 	// Check if the directory exists already
 	if (dir_exists(p_dir)) {
-		return ERR_ALREADY_EXISTS;
+		// Not an error: make_dir_recursive must be idempotent, like the generic
+		// DirAccess::make_dir_recursive (which tolerates ERR_ALREADY_EXISTS for
+		// each component and returns OK).
+		return OK;
 	}
 
 	if (_make_dir) {


### PR DESCRIPTION
`DirAccessJAndroid::make_dir_recursive()` returned `ERR_ALREADY_EXISTS` when the target directory already exists, while the generic `DirAccess::make_dir_recursive()` tolerates `ERR_ALREADY_EXISTS` for each component and returns OK. This breaks the idempotency contract that callers rely on.

One notable victim is `ShaderCacheGLES3` (the GLES3 binary shader cache, enabled with `rendering/gles3/shaders/shader_compilation_mode = "Asynchronous + Cache"`). Its constructor calls `make_dir_recursive()` and disables itself on error:

- On the **first** run, the cache directory (`<cache>/godot/shaders`) does not exist, so it gets created (the Java handler uses `File.mkdirs()`), the cache is enabled, and program binaries are written.
- On every **subsequent** run, the existing directory makes the constructor fail with `Couldn't create shader cache directory. Shader cache disabled.`, so the cache is never read again and all programs are recompiled from source on every cold session.

On an Adreno 618 device this meant ~40 seconds of synchronous shader compilation at the first rendered frame of a large level on **every** app start, even though the cache had been populated by the previous run. With this fix the cache is loaded as intended and the same scene load drops to ~13 seconds (the remaining cost being program binary loads and variants not yet cached).

**Testing**

- Built the Android templates from this branch and verified on a Redmi Note 9 Pro (Adreno 618, Android 14) that:
  - The boot log shows `Shader cache: ON` without the `Couldn't create shader cache directory` error on runs after the first one.
  - Program binaries from the previous session are loaded, removing the full first-frame shader compilation.
- Also validated the same one-line change against a 3.6.2-stable checkout in production use.