### PR TITLE
Add warning for cast anti-pattern in @onready vars

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -617,6 +617,9 @@
 		<member name="debug/gdscript/warnings/native_method_override" type="int" setter="" getter="" default="2">
 			When set to [b]Warn[/b] or [b]Error[/b], produces a warning or an error respectively when a method in the script overrides a native method, because it may not behave as expected.
 		</member>
+		<member name="debug/gdscript/warnings/onready_with_cast" type="int" setter="" getter="" default="1">
+			When set to [b]Warn[/b] or [b]Error[/b], produces a warning or an error respectively when an [code]@onready[/code] initializer uses a cast on a [code]$GetNodeLiteral[/code], because it may unexpectedly assign [code]null[/code].
+		</member>
 		<member name="debug/gdscript/warnings/onready_with_export" type="int" setter="" getter="" default="2">
 			When set to [b]Warn[/b] or [b]Error[/b], produces a warning or an error respectively when the [code]@onready[/code] annotation is used together with the [code]@export[/code] annotation, since it may not behave as expected.
 		</member>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -33,6 +33,7 @@
 #include "gdscript_analyzer.h"
 #include "gdscript_cache.h"
 #include "gdscript_compiler.h"
+#include "gdscript_linter.h"
 #include "gdscript_parser.h"
 #include "gdscript_tokenizer_buffer.h"
 #include "gdscript_warning.h"
@@ -831,6 +832,13 @@ Error GDScript::reload(bool p_keep_state) {
 
 	GDScriptAnalyzer analyzer(&parser);
 	err = analyzer.analyze();
+
+#ifdef DEBUG_ENABLED
+	if (err == OK) {
+		GDScriptLinter linter(parser);
+		err = linter.lint();
+	}
+#endif
 
 	if (err) {
 		if (EngineDebugger::is_active()) {

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -30,6 +30,7 @@
 
 #include "gdscript.h"
 #include "gdscript_analyzer.h"
+#include "gdscript_linter.h"
 #include "gdscript_parser.h"
 #include "gdscript_tokenizer.h"
 #include "gdscript_utility_functions.h"
@@ -176,6 +177,12 @@ bool GDScriptEditorLanguage::validate(const String &p_script, const String &p_pa
 	if (err == OK) {
 		err = analyzer.analyze();
 	}
+
+	if (err == OK) {
+		GDScriptLinter linter(parser);
+		err = linter.lint();
+	}
+
 #ifdef DEBUG_ENABLED
 	if (r_warnings) {
 		for (const GDScriptWarning &E : parser.get_warnings()) {

--- a/modules/gdscript/gdscript_linter.cpp
+++ b/modules/gdscript/gdscript_linter.cpp
@@ -1,0 +1,114 @@
+/**************************************************************************/
+/*  gdscript_linter.cpp                                                   */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#include "gdscript_linter.h"
+
+#ifdef DEBUG_ENABLED
+
+#include "core/typedefs.h"
+#include "servers/text/text_server.h"
+
+#include "modules/gdscript/gdscript_parser.h"
+
+// Checks ===========================================================================
+
+struct ConfusableIdentifier final {
+private:
+	static void check_identifier(const GDScriptParser::IdentifierNode *p_identifier, GDScriptParser &p_sink) {
+		const Ref<TextServer> &ts = TextServerManager::get_singleton()->get_primary_interface();
+		// Check for synthetic nodes (`start_line != -1`) manually, since this is not called directly by `GDScriptLinter`.
+		if (p_identifier && p_identifier->start_line != -1 && ts->has_feature(TextServer::FEATURE_UNICODE_SECURITY) && ts->spoof_check(p_identifier->name)) {
+			p_sink.push_warning(p_identifier, GDScriptWarning::CONFUSABLE_IDENTIFIER, p_identifier->name.string());
+		}
+	}
+
+public:
+	static void check_class(const GDScriptParser::ClassNode *p_class, GDScriptParser &p_sink) { check_identifier(p_class->identifier, p_sink); }
+	static void check_assignable(const GDScriptParser::AssignableNode *p_var, GDScriptParser &p_sink) { check_identifier(p_var->identifier, p_sink); }
+	static void check_function(const GDScriptParser::FunctionNode *p_func, GDScriptParser &p_sink) { check_identifier(p_func->identifier, p_sink); }
+	static void check_signal(const GDScriptParser::SignalNode *p_sig, GDScriptParser &p_sink) { check_identifier(p_sig->identifier, p_sink); }
+	static void check_for(const GDScriptParser::ForNode *p_for, GDScriptParser &p_sink) { check_identifier(p_for->variable, p_sink); }
+	static void check_enum(const GDScriptParser::EnumNode *p_enum, GDScriptParser &p_sink) {
+		check_identifier(p_enum->identifier, p_sink);
+		for (const GDScriptParser::EnumNode::Value &value : p_enum->values) {
+			check_identifier(value.identifier, p_sink);
+		}
+	}
+	static void check_pattern(const GDScriptParser::PatternNode *p_pattern, GDScriptParser &p_sink) {
+		if (p_pattern->pattern_type == GDScriptParser::PatternNode::PT_BIND) {
+			check_identifier(p_pattern->bind, p_sink);
+		}
+	}
+};
+
+// Infrastructure ===================================================================
+
+template <typename T>
+void _FORCE_INLINE_ validated(const GDScriptParser::Node *p_node, GDScriptParser &p_sink, GDScriptLinter::Callback<T> *p_callback) {
+	const T *casted = dynamic_cast<const T *>(p_node);
+	if (casted) {
+		p_callback(casted, p_sink);
+	}
+}
+
+#define LINTER_CHECK(m_method) [](const GDScriptParser::Node *p_node, GDScriptParser &p_sink) { validated(p_node, p_sink, &m_method); }
+
+constexpr GDScriptLinter::CallbackWithValidation *const GDScriptLinter::checks[] = {
+	LINTER_CHECK(ConfusableIdentifier::check_assignable),
+	LINTER_CHECK(ConfusableIdentifier::check_class),
+	LINTER_CHECK(ConfusableIdentifier::check_enum),
+	LINTER_CHECK(ConfusableIdentifier::check_for),
+	LINTER_CHECK(ConfusableIdentifier::check_function),
+	LINTER_CHECK(ConfusableIdentifier::check_pattern),
+	LINTER_CHECK(ConfusableIdentifier::check_signal),
+};
+
+#undef LINTER_CHECK
+
+Error GDScriptLinter::lint() {
+	// We use the fact that all nodes form a linked list for memory management purposes to iterate all nodes without actually walking the tree.
+	// The iteration order is undefined, this should not matter since the tree is immutable for the linter.
+	GDScriptParser::Node *curr = tree->list;
+	for (; curr != nullptr; curr = curr->next) {
+		if (curr->start_line == -1) {
+			// Sometimes we allocate synthetic nodes with no correspondence in code e.g. identifiers containing the synthetic names of getter functions.
+			// We shouldn't analyze those nodes directly, since suppressing them with `@warning_ignore` would be impossible.
+			continue;
+		}
+		for (CallbackWithValidation *check : checks) {
+			check(curr, *tree);
+		}
+	}
+
+	tree->apply_pending_warnings();
+	return tree->get_errors().is_empty() ? OK : ERR_PARSE_ERROR;
+}
+
+#endif // DEBUG_ENABLED

--- a/modules/gdscript/gdscript_linter.cpp
+++ b/modules/gdscript/gdscript_linter.cpp
@@ -68,6 +68,22 @@ public:
 	}
 };
 
+struct OnreadyWithCast final {
+	static void check_variable(const GDScriptParser::VariableNode *p_variable, GDScriptParser &p_sink) {
+		if (!p_variable->onready || !p_variable->initializer || p_variable->initializer->type != GDScriptParser::Node::CAST) {
+			return;
+		}
+
+		const GDScriptParser::CastNode *cast = static_cast<const GDScriptParser::CastNode *>(p_variable->initializer);
+		if (!cast->operand || cast->operand->type != GDScriptParser::Node::GET_NODE) {
+			return;
+		}
+
+		const GDScriptParser::GetNodeNode *get_node = static_cast<const GDScriptParser::GetNodeNode *>(cast->operand);
+		p_sink.push_warning(cast, GDScriptWarning::ONREADY_WITH_CAST, (get_node->use_dollar ? "$" : "%") + get_node->full_path);
+	}
+};
+
 // Infrastructure ===================================================================
 
 template <typename T>
@@ -88,6 +104,8 @@ constexpr GDScriptLinter::CallbackWithValidation *const GDScriptLinter::checks[]
 	LINTER_CHECK(ConfusableIdentifier::check_function),
 	LINTER_CHECK(ConfusableIdentifier::check_pattern),
 	LINTER_CHECK(ConfusableIdentifier::check_signal),
+
+	LINTER_CHECK(OnreadyWithCast::check_variable),
 };
 
 #undef LINTER_CHECK

--- a/modules/gdscript/gdscript_linter.h
+++ b/modules/gdscript/gdscript_linter.h
@@ -1,0 +1,61 @@
+/**************************************************************************/
+/*  gdscript_linter.h                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#pragma once
+
+#ifdef DEBUG_ENABLED
+
+#include "modules/gdscript/gdscript_parser.h"
+
+/**
+ * The `GDScriptLinter` emits warnings based on a completely analyzed AST.
+ *
+ * The linter pass can be skipped if it is not needed, e.g. in release builds
+ * or when analyzing for editor features like autocompletion. As such the linter
+ * must not have an influence on compilation i.e. it can't modify the AST.
+ *
+ * Especially expensive warnings should be implemented through this pass.
+ */
+class GDScriptLinter final {
+	using CallbackWithValidation = void(const GDScriptParser::Node *, GDScriptParser &);
+
+	GDScriptParser *const tree;
+	static CallbackWithValidation *const checks[];
+
+public:
+	template <typename T>
+	using Callback = void(const T *, GDScriptParser &);
+
+public:
+	Error lint();
+	GDScriptLinter(GDScriptParser &p_tree) : tree(&p_tree) {}
+};
+
+#endif // DEBUG_ENABLED

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1391,6 +1391,7 @@ void GDScriptParser::parse_property_setter(VariableNode *p_variable) {
 		case VariableNode::PROP_INLINE: {
 			FunctionNode *function = alloc_node<FunctionNode>();
 			IdentifierNode *identifier = alloc_node<IdentifierNode>();
+			set_synthetic_extents(identifier);
 			complete_extents(identifier);
 			identifier->name = "@" + p_variable->identifier->name + "_setter";
 			function->identifier = identifier;
@@ -1454,6 +1455,7 @@ void GDScriptParser::parse_property_getter(VariableNode *p_variable) {
 			function->header_end_column = previous.start_column;
 
 			IdentifierNode *identifier = alloc_node<IdentifierNode>();
+			set_synthetic_extents(identifier);
 			complete_extents(identifier);
 			identifier->name = "@" + p_variable->identifier->name + "_getter";
 			function->identifier = identifier;
@@ -2829,14 +2831,7 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_expression(bool p_can_assi
 }
 
 GDScriptParser::IdentifierNode *GDScriptParser::parse_identifier() {
-	IdentifierNode *identifier = static_cast<IdentifierNode *>(parse_identifier(nullptr, false));
-#ifdef DEBUG_ENABLED
-	// Check for spoofing here (if available in TextServer) since this isn't called inside expressions. This is only relevant for declarations.
-	if (identifier && TS->has_feature(TextServer::FEATURE_UNICODE_SECURITY) && TS->spoof_check(identifier->name)) {
-		push_warning(identifier, GDScriptWarning::CONFUSABLE_IDENTIFIER, identifier->name.string());
-	}
-#endif
-	return identifier;
+	return static_cast<IdentifierNode *>(parse_identifier(nullptr, false));
 }
 
 GDScriptParser::ExpressionNode *GDScriptParser::parse_identifier(ExpressionNode *p_previous_operand, bool p_can_assign) {

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1370,6 +1370,7 @@ public:
 private:
 	friend class GDScriptAnalyzer;
 	friend class GDScriptParserRef;
+	friend class GDScriptLinter;
 
 	bool _is_tool = false;
 	String script_path;
@@ -1496,6 +1497,9 @@ private:
 	void update_extents(Node *p_node);
 	void reset_extents(Node *p_node, GDScriptTokenizer::Token p_token);
 	void reset_extents(Node *p_node, Node *p_from);
+	void set_synthetic_extents(Node *p_node) {
+		p_node->start_line = p_node->end_line = p_node->start_column = p_node->end_column = -1;
+	}
 
 	template <typename T>
 	T *alloc_node() {
@@ -1536,6 +1540,7 @@ private:
 	void push_error(const String &p_message, const GDScriptTokenizer::Token &p_origin);
 
 #ifdef DEBUG_ENABLED
+public:
 	void push_warning(const Node *p_source, GDScriptWarning::Code p_code, const Vector<String> &p_symbols);
 	template <typename... Symbols>
 	void push_warning(const Node *p_source, GDScriptWarning::Code p_code, const Symbols &...p_symbols) {
@@ -1546,6 +1551,8 @@ private:
 	void push_warning(int p_start_line, int p_start_column, int p_end_line, int p_end_column, GDScriptWarning::Code p_code, const Symbols &...p_symbols) {
 		push_warning(p_start_line, p_start_column, p_end_line, p_end_column, p_code, Vector<String>{ p_symbols... });
 	}
+
+private:
 	void apply_pending_warnings();
 	void evaluate_warning_directory_rules_for_script_path();
 #endif // DEBUG_ENABLED

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -171,6 +171,8 @@ String GDScriptWarning::get_message() const {
 			return vformat(R"*(The default value uses "%s" which won't return nodes in the scene tree before "_ready()" is called. Use the "@onready" annotation to solve this.)*", symbols[0]);
 		case ONREADY_WITH_EXPORT:
 			return R"("@onready" will set the default value after "@export" takes effect and will override it.)";
+		case ONREADY_WITH_CAST:
+			return vformat(R"("as" will silently return "null" if the type of "%s" is wrong. Prefer assigning the node directly to an explicitly typed variable to get an error in such cases.)", symbols[0]);
 #ifndef DISABLE_DEPRECATED
 		// Never produced. These warnings migrated from 3.x by mistake.
 		case PROPERTY_USED_AS_FUNCTION: // There is already an error.
@@ -249,6 +251,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		PNAME("NATIVE_METHOD_OVERRIDE"),
 		PNAME("GET_NODE_DEFAULT_WITHOUT_ONREADY"),
 		PNAME("ONREADY_WITH_EXPORT"),
+		PNAME("ONREADY_WITH_CAST"),
 #ifndef DISABLE_DEPRECATED
 		"PROPERTY_USED_AS_FUNCTION",
 		"CONSTANT_USED_AS_FUNCTION",

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -92,6 +92,7 @@ public:
 		NATIVE_METHOD_OVERRIDE, // The script method overrides a native one, this may not work as intended.
 		GET_NODE_DEFAULT_WITHOUT_ONREADY, // A class variable uses `get_node()` (or the `$` notation) as its default value, but does not use the @onready annotation.
 		ONREADY_WITH_EXPORT, // The `@onready` annotation will set the value after `@export` which is likely not intended.
+		ONREADY_WITH_CAST, // The cast will silently assign `null` if the node has a wrong type. This is likely not intended.
 #ifndef DISABLE_DEPRECATED
 		PROPERTY_USED_AS_FUNCTION, // Function not found, but there's a property with the same name.
 		CONSTANT_USED_AS_FUNCTION, // Function not found, but there's a constant with the same name.
@@ -151,6 +152,7 @@ public:
 		ERROR, // NATIVE_METHOD_OVERRIDE // May not work as expected.
 		ERROR, // GET_NODE_DEFAULT_WITHOUT_ONREADY // May not work as expected.
 		ERROR, // ONREADY_WITH_EXPORT // May not work as expected.
+		WARN, // ONREADY_WITH_CAST
 #ifndef DISABLE_DEPRECATED
 		WARN, // PROPERTY_USED_AS_FUNCTION
 		WARN, // CONSTANT_USED_AS_FUNCTION

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -32,6 +32,7 @@
 
 #include "../gdscript.h"
 #include "../gdscript_analyzer.h"
+#include "../gdscript_linter.h"
 #include "gdscript_language_protocol.h"
 #include "gdscript_workspace.h"
 
@@ -970,6 +971,11 @@ void ExtendGDScriptParser::parse(const String &p_code, const String &p_path) {
 	if (parse_result == OK) {
 		parse_result = analyzer.analyze();
 	}
+	if (parse_result == OK) {
+		GDScriptLinter linter(*this);
+		parse_result = linter.lint();
+	}
+
 	update_diagnostics();
 	update_symbols();
 	update_document_links(p_code);

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -33,6 +33,7 @@
 #include "../gdscript.h"
 #include "../gdscript_analyzer.h"
 #include "../gdscript_compiler.h"
+#include "../gdscript_linter.h"
 #include "../gdscript_parser.h"
 #include "../gdscript_tokenizer_buffer.h"
 
@@ -580,6 +581,14 @@ GDScriptTest::TestResult GDScriptTest::execute_test_code(bool p_is_generating) {
 	// Test type-checking.
 	GDScriptAnalyzer analyzer(&parser);
 	err = analyzer.analyze();
+
+#ifdef DEBUG_ENABLED
+	if (err == OK) {
+		GDScriptLinter linter(parser);
+		err = linter.lint();
+	}
+#endif
+
 	if (err != OK) {
 		enable_stdout();
 		result.status = GDTEST_ANALYZER_ERROR;

--- a/modules/gdscript/tests/scripts/analyzer/features/allow_get_node_with_onready.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/allow_get_node_with_onready.gd
@@ -2,6 +2,7 @@ extends Node
 
 @onready var shorthand = $Node
 @onready var call_no_cast = get_node(^"Node")
+@warning_ignore("ONREADY_WITH_CAST")
 @onready var shorthand_with_cast = $Node as Node
 @onready var call_with_cast = get_node(^"Node") as Node
 

--- a/modules/gdscript/tests/scripts/analyzer/warnings/onready_with_cast.gd
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/onready_with_cast.gd
@@ -1,0 +1,12 @@
+extends Node
+
+@onready var untyped_cast = $Node as Node2D
+@onready var inferred_cast := $Node as Node2D
+@onready var explicit_cast: Node2D = $Node as Node2D
+
+@onready var untyped_direct = $Node
+@onready var inferred_direct := $Node
+@onready var explicit_direct: Node2D = $Node
+
+func test():
+	pass

--- a/modules/gdscript/tests/scripts/analyzer/warnings/onready_with_cast.out
+++ b/modules/gdscript/tests/scripts/analyzer/warnings/onready_with_cast.out
@@ -1,0 +1,4 @@
+GDTEST_OK
+~~ WARNING at line 3: (ONREADY_WITH_CAST) "as" will silently return "null" if the type of "$Node" is wrong. Prefer assigning the node directly to an explicitly typed variable to get an error in such cases.
+~~ WARNING at line 4: (ONREADY_WITH_CAST) "as" will silently return "null" if the type of "$Node" is wrong. Prefer assigning the node directly to an explicitly typed variable to get an error in such cases.
+~~ WARNING at line 5: (ONREADY_WITH_CAST) "as" will silently return "null" if the type of "$Node" is wrong. Prefer assigning the node directly to an explicitly typed variable to get an error in such cases.

--- a/modules/gdscript/tests/test_gdscript.cpp
+++ b/modules/gdscript/tests/test_gdscript.cpp
@@ -32,6 +32,7 @@
 
 #include "../gdscript_analyzer.h"
 #include "../gdscript_compiler.h"
+#include "../gdscript_linter.h"
 #include "../gdscript_parser.h"
 #include "../gdscript_tokenizer.h"
 #include "../gdscript_tokenizer_buffer.h"
@@ -184,6 +185,13 @@ static void test_parser(const String &p_code, const String &p_script_path, const
 	GDScriptAnalyzer analyzer(&parser);
 	err = analyzer.analyze();
 
+#ifdef DEBUG_ENABLED
+	if (err == OK) {
+		GDScriptLinter linter(parser);
+		err = linter.lint();
+	}
+#endif
+
 	if (err != OK) {
 		const List<GDScriptParser::ParserError> &errors = parser.get_errors();
 		for (const GDScriptParser::ParserError &error : errors) {
@@ -270,6 +278,13 @@ static void test_compiler(const String &p_code, const String &p_script_path, con
 
 	GDScriptAnalyzer analyzer(&parser);
 	err = analyzer.analyze();
+
+#ifdef DEBUG_ENABLED
+	if (err == OK) {
+		GDScriptLinter linter(parser);
+		err = linter.lint();
+	}
+#endif
 
 	if (err != OK) {
 		print_line("Error in analyzer:");

--- a/modules/gdscript/tests/test_lsp.h
+++ b/modules/gdscript/tests/test_lsp.h
@@ -35,6 +35,7 @@
 #ifndef GDSCRIPT_NO_LSP
 
 #include "../gdscript_analyzer.h"
+#include "../gdscript_linter.h"
 #include "../language_server/gdscript_extend_parser.h"
 #include "../language_server/gdscript_language_protocol.h"
 #include "../language_server/gdscript_workspace.h"
@@ -311,6 +312,14 @@ void assert_no_errors_in(const String &p_path) {
 
 	GDScriptAnalyzer analyzer(&parser);
 	err = analyzer.analyze();
+
+#ifdef DEBUG_ENABLED
+	if (err == OK) {
+		GDScriptLinter linter(parser);
+		err = linter.lint();
+	}
+#endif
+
 	REQUIRE_MESSAGE(err == OK, vformat("Errors while analyzing '%s'", p_path));
 }
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Requires and uses https://github.com/godotengine/godot/pull/123232 

As discussed on [RC](https://chat.godotengine.org/channel/gdscript?msg=bAycd6MMDmfnDtvnj) the following code is likely wrong:

```gdscript
@onready var my_node := $Smth as Sprite2D
```

This code will error at runtime if the node does not exist, but it will not error if the node does exist but has a wrong type. It will just assign null in those cases. Usually the following code which errors for both missing nodes and mismatched types is preferable:

```gdscript
@onready var my_node: Sprite2D = $Smth
```

This PR adds a warning for the first pattern, since this seems to be a commonly used bad practice. (Partly stems from the fact that it was a workaround for https://github.com/godotengine/godot/issues/73164)

## Additional information

The only case were I see this being intended is when paired with another var:

```gdscript
var obj: Unit = $Unit
var enemy := $Unit as Enemy
```

so that you allow reacting to optional subtypes of some component. In those rare cases it's easy enough to use e.g. a ternary to make the intention more clear and readable.