### PR TITLE
[.NET]: Add initial support for mono LibGodot

### DIFF
--- a/core/extension/libgodot.cpp
+++ b/core/extension/libgodot.cpp
@@ -1,5 +1,5 @@
 /**************************************************************************/
-/*  libgodot.h                                                            */
+/*  libgodot.cpp                                                          */
 /**************************************************************************/
 /*                         This file is part of:                          */
 /*                             GODOT ENGINE                               */
@@ -28,59 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
 /**************************************************************************/
 
-#pragma once
+#include "libgodot.h"
 
-#include "core/extension/gdextension_interface.gen.h"
+#include "modules/modules_enabled.gen.h" // IWYU pragma: keep. For mono.
 
-#ifdef __cplusplus
-extern "C" {
-#endif // __cplusplus
-
-// Export macros for DLL visibility
-#if defined(_MSC_VER) || defined(__MINGW32__)
-#define LIBGODOT_API __declspec(dllexport)
-#elif defined(__GNUC__) || defined(__clang__)
-#define LIBGODOT_API __attribute__((visibility("default")))
-#else
-#define LIBGODOT_API
+#ifndef MODULE_MONO_ENABLED
+void libgodot_mono_set_plugins_initialize([[maybe_unused]] void *p_plugins_initialize) {}
 #endif
-
-/**
- * @name libgodot_create_godot_instance
- * @since 4.6
- *
- * Creates a new Godot instance.
- *
- * @param p_argc The number of command line arguments.
- * @param p_argv The C-style array of command line arguments.
- * @param p_init_func GDExtension initialization function of the host application.
- *
- * @return A pointer to created \ref GodotInstance GDExtension object or nullptr if there was an error.
- */
-LIBGODOT_API GDExtensionObjectPtr libgodot_create_godot_instance(int p_argc, char *p_argv[], GDExtensionInitializationFunction p_init_func);
-
-/**
- * @name libgodot_destroy_godot_instance
- * @since 4.6
- *
- * Destroys an existing Godot instance.
- *
- * @param p_godot_instance The reference to the GodotInstance object to destroy.
- *
- */
-LIBGODOT_API void libgodot_destroy_godot_instance(GDExtensionObjectPtr p_godot_instance);
-
-/**
- * @name libgodot_mono_set_plugins_initialize
- * @since 4.x
- *
- * Sets plugins initialize function that is used to initialize the module mono.
- * Does nothing when used outside of mono build.
- *
- * @param p_plugins_initialize The plugins initialize function.
- */
-LIBGODOT_API void libgodot_mono_set_plugins_initialize(void *p_plugins_initialize);
-
-#ifdef __cplusplus
-}
-#endif // __cplusplus

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -63,6 +63,10 @@
 #endif
 #endif
 
+#ifdef LIBGODOT_ENABLED
+#include "core/extension/libgodot.h"
+#endif
+
 GDMono *GDMono::singleton = nullptr;
 
 namespace {
@@ -85,6 +89,10 @@ mono_assembly_name_get_culture_fn mono_assembly_name_get_culture = nullptr;
 mono_image_open_from_data_with_name_fn mono_image_open_from_data_with_name = nullptr;
 mono_assembly_load_from_full_fn mono_assembly_load_from_full = nullptr;
 #endif
+#endif
+
+#ifdef LIBGODOT_ENABLED
+void *libgodot_plugins_initialize = nullptr;
 #endif
 
 #ifdef _WIN32
@@ -428,6 +436,17 @@ using godot_plugins_initialize_fn = bool (*)(void *, bool, gdmono::PluginCallbac
 using godot_plugins_initialize_fn = bool (*)(void *, GDMonoCache::ManagedCallbacks *, const void **, int32_t);
 #endif
 
+godot_plugins_initialize_fn try_load_libgodot_runtime(bool &r_runtime_initialized) {
+#if defined(LIBGODOT_ENABLED)
+	if (libgodot_plugins_initialize) {
+		print_verbose("Found plugins_initialize set by LibGodot");
+		r_runtime_initialized = true;
+		return (godot_plugins_initialize_fn)libgodot_plugins_initialize;
+	}
+#endif
+	return nullptr;
+}
+
 #ifdef TOOLS_ENABLED
 godot_plugins_initialize_fn initialize_hostfxr_and_godot_plugins(bool &r_runtime_initialized) {
 	godot_plugins_initialize_fn godot_plugins_initialize = nullptr;
@@ -610,6 +629,13 @@ godot_plugins_initialize_fn initialize_coreclr_and_godot_plugins(bool &r_runtime
 
 } // namespace
 
+#ifdef LIBGODOT_ENABLED
+// Implement function from "core/extension/libgodot.h"
+void libgodot_mono_set_plugins_initialize(void *p_plugins_initialize) {
+	libgodot_plugins_initialize = p_plugins_initialize;
+}
+#endif
+
 bool GDMono::should_initialize() {
 #ifdef TOOLS_ENABLED
 	// The editor always needs to initialize the .NET module for now.
@@ -641,40 +667,42 @@ void GDMono::initialize() {
 
 	_init_godot_api_hashes();
 
-	godot_plugins_initialize_fn godot_plugins_initialize = nullptr;
+	godot_plugins_initialize_fn godot_plugins_initialize = try_load_libgodot_runtime(runtime_initialized);
 
+	if (!godot_plugins_initialize) {
 #if !defined(APPLE_EMBEDDED_ENABLED)
-	// Check that the .NET assemblies directory exists before trying to use it.
-	if (!DirAccess::exists(GodotSharpDirs::get_api_assemblies_dir())) {
-		OS::get_singleton()->alert(vformat(RTR("Unable to find the .NET assemblies directory.\nMake sure the '%s' directory exists and contains the .NET assemblies."), GodotSharpDirs::get_api_assemblies_dir()), RTR(".NET assemblies not found"));
-		ERR_FAIL_MSG(".NET: Assemblies not found");
-	}
+		// Check that the .NET assemblies directory exists before trying to use it.
+		if (!DirAccess::exists(GodotSharpDirs::get_api_assemblies_dir())) {
+			OS::get_singleton()->alert(vformat(RTR("Unable to find the .NET assemblies directory.\nMake sure the '%s' directory exists and contains the .NET assemblies."), GodotSharpDirs::get_api_assemblies_dir()), RTR(".NET assemblies not found"));
+			ERR_FAIL_MSG(".NET: Assemblies not found");
+		}
 #endif
 
-	if (load_hostfxr(hostfxr_dll_handle)) {
-		godot_plugins_initialize = initialize_hostfxr_and_godot_plugins(runtime_initialized);
-		ERR_FAIL_NULL(godot_plugins_initialize);
-	} else {
-#if !defined(TOOLS_ENABLED)
-		if (load_coreclr(coreclr_dll_handle)) {
-			godot_plugins_initialize = initialize_coreclr_and_godot_plugins(runtime_initialized);
+		if (load_hostfxr(hostfxr_dll_handle)) {
+			godot_plugins_initialize = initialize_hostfxr_and_godot_plugins(runtime_initialized);
+			ERR_FAIL_NULL(godot_plugins_initialize);
 		} else {
-			void *dll_handle = nullptr;
-			godot_plugins_initialize = try_load_native_aot_library(dll_handle);
-			if (godot_plugins_initialize != nullptr) {
-				runtime_initialized = true;
+#if !defined(TOOLS_ENABLED)
+			if (load_coreclr(coreclr_dll_handle)) {
+				godot_plugins_initialize = initialize_coreclr_and_godot_plugins(runtime_initialized);
+			} else {
+				void *dll_handle = nullptr;
+				godot_plugins_initialize = try_load_native_aot_library(dll_handle);
+				if (godot_plugins_initialize != nullptr) {
+					runtime_initialized = true;
+				}
 			}
-		}
 
-		if (godot_plugins_initialize == nullptr) {
-			ERR_FAIL_MSG(".NET: Failed to load hostfxr");
-		}
+			if (godot_plugins_initialize == nullptr) {
+				ERR_FAIL_MSG(".NET: Failed to load hostfxr");
+			}
 #else
 
-		// Show a message box to the user to make the problem explicit (and explain a potential crash).
-		OS::get_singleton()->alert(TTR("Unable to load .NET runtime, specifically hostfxr.\nAttempting to create/edit a project will lead to a crash.\n\nPlease install the .NET SDK 8.0 or later from https://get.dot.net and restart Godot."), TTR("Failed to load .NET runtime"));
-		ERR_FAIL_MSG(".NET: Failed to load hostfxr");
+			// Show a message box to the user to make the problem explicit (and explain a potential crash).
+			OS::get_singleton()->alert(TTR("Unable to load .NET runtime, specifically hostfxr.\nAttempting to create/edit a project will lead to a crash.\n\nPlease install the .NET SDK 8.0 or later from https://get.dot.net and restart Godot."), TTR("Failed to load .NET runtime"));
+			ERR_FAIL_MSG(".NET: Failed to load hostfxr");
 #endif
+		}
 	}
 
 	int32_t interop_funcs_size = 0;


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Implements https://github.com/godotengine/godot-proposals/issues/6267 for use in C#
- Partially helps with https://github.com/godotengine/godot-proposals/issues/432

Works toward making it possible to export to web using LibGodot from a normal C# addon. This PR still makes sense without the final goal.

## Additional information

Editor and debug templates ideally need https://github.com/godotengine/godot/pull/121510 (I think they can work without it, but can have some unexpected edge cases), release template works as it is.

This tries to add the support with minimal possible code changes and changes to the load order, so it offloads whole LibGodot GDExtension setup to the LibGodot users, thankfully the code needing to support it is largely self contained, so it's not too bad.

Fetures:
- Works with editor build and export templates, editor will double load the assembly as it needs to support assembly reloading, so it is preferred to use the normal C# loading that editor uses. Thanks to `hostfxr_initialize_for_runtime_config` godot then will use the existing runtime if it's not NativeAOT. Export templates are returning the initialization to its own assembly, so no double loading here.
- Supports NativeAOT, well as much as the current library supports it. Maybe you would need to add extra configs to load shared LibGodot, not sure how it works on all platforms.
- Allows you to export LibGodot export template from a normal C# editor build if you didn't add anything LibGodot specific. Shown in demo.
- Can support testing (like `xUnit.net`) using export templates built with `disable_path_overrides=no`. Small downside is that it needs to have `PCK` file, but it should be possible to automate its creation. No tests for editor LibGodot and no plans to support it. Shown in demo.

Demo: https://github.com/NoctemCat/BaseNetLibGodotExample

No AI used.