### PR TITLE
[GDExtension] Remove redundant PR numbers from validation files.

### DIFF
--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-64628.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-64628.txt
@@ -1,5 +1,3 @@
-GH-64628
---------
 Validate extension JSON: Error: Field 'classes/EditorResourcePreviewGenerator/methods/_generate/arguments': size changed value in new API, from 2 to 3.
 Validate extension JSON: Error: Field 'classes/EditorResourcePreviewGenerator/methods/_generate_from_path/arguments': size changed value in new API, from 2 to 3.
 

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-69988.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-69988.txt
@@ -1,5 +1,3 @@
-GH-69988
---------
 Validate extension JSON: API was removed: classes/NavigationAgent2D/methods/get_time_horizon
 Validate extension JSON: API was removed: classes/NavigationAgent2D/methods/set_time_horizon
 Validate extension JSON: API was removed: classes/NavigationAgent2D/properties/time_horizon

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-72152.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-72152.txt
@@ -1,5 +1,3 @@
-GH-72152
---------
 Validate extension JSON: Error: Hash changed for 'classes/MeshInstance3D/methods/create_multiple_convex_collisions', from BFDD6D64 to 257A91A5. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/MeshInstance3D/methods/create_multiple_convex_collisions': arguments
 

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-72749.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-72749.txt
@@ -1,5 +1,3 @@
-GH-72749
---------
 Validate extension JSON: Error: Hash changed for 'classes/Area2D/methods/get_priority', from 67C0E66E to E8C5525A. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Hash changed for 'classes/Area2D/methods/set_priority', from 1647D661 to 4CAD1009. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Hash changed for 'classes/Area3D/methods/get_priority', from 67C0E66E to E8C5525A. This means that the function has changed and no compatibility function was provided.

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-72842.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-72842.txt
@@ -1,5 +1,3 @@
-GH-72842
---------
 Validate extension JSON: API was removed: classes/PathFollow2D/methods/get_lookahead
 Validate extension JSON: API was removed: classes/PathFollow2D/methods/set_lookahead
 Validate extension JSON: API was removed: classes/PathFollow2D/properties/lookahead

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-74242.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-74242.txt
@@ -1,5 +1,3 @@
-GH-74242
---------
 Validate extension JSON: Error: Field 'classes/PhysicsDirectSpaceState3DExtension/methods/_intersect_ray/arguments': size changed value in new API, from 8 to 9.
 Validate extension JSON: Error: Field 'classes/PhysicsDirectSpaceState3DExtension/methods/_intersect_ray/arguments/7': type changed value in new API, from "PhysicsServer3DExtensionRayResult*" to "bool".
 

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-74600.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-74600.txt
@@ -1,5 +1,3 @@
-GH-74600
---------
 Validate extension JSON: Error: Hash changed for 'classes/AnimatedSprite2D/methods/play', from 57037631 to 8D62DD1B. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Hash changed for 'classes/AnimatedSprite3D/methods/play', from 57037631 to 8D62DD1B. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Hash changed for 'classes/Animation/methods/compress', from 6B87C27F to D713F035. This means that the function has changed and no compatibility function was provided.

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-74671.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-74671.txt
@@ -1,5 +1,3 @@
-GH-74671
---------
 Validate extension JSON: Error: Field 'native_structures/PhysicsServer3DExtensionMotionCollision': format changed value in new API, from "Vector3 position;Vector3 normal;Vector3 collider_velocity;real_t depth;int local_shape;ObjectID collider_id;RID collider;int collider_shape" to "Vector3 position;Vector3 normal;Vector3 collider_velocity;Vector3 collider_angular_velocity;real_t depth;int local_shape;ObjectID collider_id;RID collider;int collider_shape".
 Validate extension JSON: Error: Field 'native_structures/PhysicsServer3DExtensionMotionResult': format changed value in new API, from "Vector3 travel;Vector3 remainder;real_t collision_safe_fraction;real_t collision_unsafe_fraction;PhysicsServer3DExtensionMotionCollision collisions[32];int collision_count" to "Vector3 travel;Vector3 remainder;real_t collision_depth;real_t collision_safe_fraction;real_t collision_unsafe_fraction;PhysicsServer3DExtensionMotionCollision collisions[32];int collision_count".
 

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-74707.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-74707.txt
@@ -1,5 +1,3 @@
-GH-74707
---------
 Validate extension JSON: Error: Field 'classes/PhysicsServer3DExtension/methods/_body_test_motion/arguments': size changed value in new API, from 7 to 8.
 Validate extension JSON: Error: Field 'classes/PhysicsServer3DExtension/methods/_body_test_motion/arguments/6': type changed value in new API, from "PhysicsServer3DExtensionMotionResult*" to "bool".
 

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-74736.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-74736.txt
@@ -1,5 +1,3 @@
-GH-74736
---------
 Validate extension JSON: Error: Field 'classes/MenuBar/properties/start_index': type changed value in new API, from "bool" to "int".
 
 The previous type was simply wrong and the getter and setter already used int.

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-75017.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-75017.txt
@@ -1,5 +1,3 @@
-GH-75017
---------
 Validate extension JSON: Error: Hash changed for 'classes/RichTextLabel/methods/push_list', from 8593DF77 to F0951C19. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/push_list/arguments': size changed value in new API, from 3 to 4.
 

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-75250-76401.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-75250-76401.txt
@@ -1,5 +1,3 @@
-GH-75250 & GH-76401
--------------------
 Validate extension JSON: Error: Hash changed for 'classes/RichTextLabel/methods/push_paragraph', from 3DD1D1C2 to BFDC71FE. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/push_paragraph/arguments': size changed value in new API, from 4 to 6.
 

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-75260.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-75260.txt
@@ -1,5 +1,3 @@
-GH-75260
---------
 Validate extension JSON: Error: Field 'classes/PhysicsDirectSpaceState2D/methods/collide_shape/return_value': type changed value in new API, from "typedarray::PackedVector2Array" to "typedarray::Vector2".
 Validate extension JSON: Error: Field 'classes/PhysicsDirectSpaceState3D/methods/collide_shape/return_value': type changed value in new API, from "typedarray::PackedVector3Array" to "typedarray::Vector3".
 

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-75746.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-75746.txt
@@ -1,5 +1,3 @@
-GH-75746
---------
 Validate extension JSON: Error: Field 'classes/CodeEdit/methods/add_code_completion_option/arguments': size changed value in new API, from 6 to 7.
 Validate extension JSON: Error: Hash changed for 'classes/CodeEdit/methods/add_code_completion_option', from EC613224 to 611C3D20. This means that the function has changed and no compatibility function was provided.
 

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-75759.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-75759.txt
@@ -1,5 +1,3 @@
-GH-75759
---------
 Validate extension JSON: Error: Hash changed for 'classes/AnimationNode/methods/blend_input', from 5162412C to A178F700. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Hash changed for 'classes/AnimationNode/methods/blend_node', from 1263CBA5 to 0FB30106. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Field 'classes/AnimationNode/methods/_process/arguments': size changed value in new API, from 3 to 4.

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-75777.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-75777.txt
@@ -1,5 +1,3 @@
-GH-75777
---------
 Validate extension JSON: Error: Hash changed for 'classes/SyntaxHighlighter/methods/get_text_edit', from 8248B40D to 70D54D11. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Field 'classes/SyntaxHighlighter/methods/get_text_edit': is_const changed value in new API, from false to true.
 

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-76026.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-76026.txt
@@ -1,5 +1,3 @@
-GH-76026
---------
 Validate extension JSON: Error: Hash changed for 'classes/EditorScript/methods/get_editor_interface', from FBC1084A to 75D179CC. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Hash changed for 'classes/EditorScript/methods/get_scene', from 6C6B0707 to BC5DCFF4. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Field 'classes/EditorScript/methods/get_editor_interface': is_const changed value in new API, from false to true.

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-76082.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-76082.txt
@@ -1,5 +1,3 @@
-GH-76082
---------
 Validate extension JSON: Error: Hash changed for 'builtin_classes/Basis/methods/looking_at', from 19076B74 to DE3FF159. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Hash changed for 'builtin_classes/Transform3D/methods/looking_at', from 3018C31C to 056ADC36. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Hash changed for 'classes/Node3D/methods/look_at', from 3BC64EA6 to BA2B4FA9. This means that the function has changed and no compatibility function was provided.

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-76176.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-76176.txt
@@ -1,5 +1,3 @@
-GH-76176
---------
 Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_base_control', from 31757941 to A5E188F5. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_edited_scene_root', from 6C6B0707 to BC5DCFF4. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Hash changed for 'classes/EditorInterface/methods/get_editor_main_screen', from 36955D8D to 65B2D3B5. This means that the function has changed and no compatibility function was provided.

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-76413.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-76413.txt
@@ -1,5 +1,3 @@
-GH-76413
---------
 Validate extension JSON: API was removed: classes/AnimationTrackEditPlugin
 
 This class does nothing and is not useful in any way.

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-76418.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-76418.txt
@@ -1,5 +1,3 @@
-GH-76418
---------
 Validate extension JSON: Error: Hash changed for 'classes/AnimationNodeStateMachinePlayback/methods/get_travel_path', from 43F252E9 to EE2D1D98. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Hash changed for 'classes/Object/methods/get_meta_list', from 43F252E9 to EE2D1D98. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: Error: Hash changed for 'classes/RDShaderFile/methods/get_version_list', from 43F252E9 to EE2D1D98. This means that the function has changed and no compatibility function was provided.

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-76688.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-76688.txt
@@ -1,5 +1,3 @@
-GH-76688
---------
 Validate extension JSON: Error: Field 'classes/EditorUndoRedoManager/methods/create_action/arguments': size changed value in new API, from 3 to 4.
 Validate extension JSON: Error: Field 'classes/UndoRedo/methods/create_action/arguments': size changed value in new API, from 2 to 3.
 Validate extension JSON: Error: Hash changed for 'classes/EditorUndoRedoManager/methods/create_action', from E07DA3CD to D543BA91. This means that the function has changed and no compatibility function was provided.

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-76794.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-76794.txt
@@ -1,5 +1,3 @@
-GH-76794
---------
 Validate extension JSON: Error: Hash changed for 'classes/Tree/methods/edit_selected', from 859196D4 to 9AB67ACD. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Tree/methods/edit_selected': arguments
 

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-77143.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-77143.txt
@@ -1,5 +1,3 @@
-GH-77143
---------
 Validate extension JSON: Error: Hash changed for 'classes/WorkerThreadPool/methods/wait_for_task_completion', from 4CAD1009 to 32573865. This means that the function has changed and no compatibility function was provided.
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/WorkerThreadPool/methods/wait_for_task_completion': return_value
 

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-77411.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-77411.txt
@@ -1,5 +1,3 @@
-GH-77411
---------
 Validate extension JSON: Error: Field 'classes/Control/methods/_get_drag_data': is_const changed value in new API, from true to false.
 
 `const` was removed from virtual method, it may be necessary to adjust the constness of implementing methods.

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-77413.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-77413.txt
@@ -1,3 +1,1 @@
-GH-77413
---------
 Validate extension JSON: Error: Field 'classes/GLTFSkin/properties/godot_skin': type changed value in new API, from "Object" to "Skin".

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-77757.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-77757.txt
@@ -1,5 +1,3 @@
-GH-77757
---------
 Validate extension JSON: Error: Field 'classes/Viewport/methods/gui_get_focus_owner': is_const changed value in new API, from false to true.
 Validate extension JSON: Error: Hash changed for 'classes/Viewport/methods/gui_get_focus_owner', from 31757941 to A5E188F5. This means that the function has changed and no compatibility function was provided.
 

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-78237.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-78237.txt
@@ -1,3 +1,1 @@
-GH-78237
---------
 Validate extension JSON: Error: Field 'classes/WebRTCPeerConnectionExtension/methods/_create_data_channel/return_value': type changed value in new API, from "Object" to "WebRTCDataChannel".

--- a/misc/extension_api_validation/4.0-stable_4.1-stable/GH-78517.txt
+++ b/misc/extension_api_validation/4.0-stable_4.1-stable/GH-78517.txt
@@ -1,5 +1,3 @@
-GH-78517
---------
 Validate extension JSON: Error: Field 'classes/DisplayServer/methods/global_menu_add_check_item/arguments/2': default_value changed value in new API, from "" to "Callable()".
 Validate extension JSON: Error: Field 'classes/DisplayServer/methods/global_menu_add_check_item/arguments/3': default_value changed value in new API, from "" to "Callable()".
 Validate extension JSON: Error: Field 'classes/DisplayServer/methods/global_menu_add_icon_check_item/arguments/3': default_value changed value in new API, from "" to "Callable()".

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-113429.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-113429.txt
@@ -1,5 +1,3 @@
-GH-113429
----------
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_albedo': type changed value in new API, from "Texture" to "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture,-StreamedTexture2D".
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_emission': type changed value in new API, from "Texture" to "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture,-StreamedTexture2D".
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_normal': type changed value in new API, from "Texture" to "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture,-StreamedTexture2D".

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-36493.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-36493.txt
@@ -1,5 +1,3 @@
-GH-36493
---------
 Validate extension JSON: Error: Field 'classes/PopupMenu/methods/add_icon_shortcut/arguments': size changed value in new API, from 4 to 5.
 Validate extension JSON: Error: Field 'classes/PopupMenu/methods/add_shortcut/arguments': size changed value in new API, from 3 to 4.
 

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-73196.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-73196.txt
@@ -1,5 +1,3 @@
-GH-73196
---------
 Validate extension JSON: Error: Field 'classes/CodeEdit/methods/get_text_for_symbol_lookup': is_const changed value in new API, from false to true.
 
 Function was made `const`. No adjustments should be necessary.

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-78266.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-78266.txt
@@ -1,5 +1,3 @@
-GH-78266
---------
 Validate extension JSON: API was removed: classes/FontFile/properties/fallbacks
 Validate extension JSON: API was removed: classes/FontVariation/properties/fallbacks
 Validate extension JSON: API was removed: classes/SystemFont/properties/fallbacks

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-78328.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-78328.txt
@@ -1,5 +1,3 @@
-GH-78328
---------
 Validate extension JSON: Error: Field 'classes/TileMap/methods/get_used_rect': is_const changed value in new API, from false to true.
 
 Function was made `const`. No adjustments should be necessary.

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-79308.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-79308.txt
@@ -1,5 +1,3 @@
-GH-79308
---------
 Validate extension JSON: API was removed: classes/GraphEdit/methods/get_scroll_ofs
 Validate extension JSON: API was removed: classes/GraphEdit/methods/get_snap
 Validate extension JSON: API was removed: classes/GraphEdit/methods/get_zoom_hbox

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-79311.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-79311.txt
@@ -1,5 +1,3 @@
-GH-79311
---------
 Validate extension JSON: API was removed: classes/GraphNode/methods/get_connection_input_color
 Validate extension JSON: API was removed: classes/GraphNode/methods/get_connection_input_count
 Validate extension JSON: API was removed: classes/GraphNode/methods/get_connection_input_height

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-79527.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-79527.txt
@@ -1,5 +1,3 @@
-GH-79527
---------
 Validate extension JSON: Error: Field 'classes/ParticleProcessMaterial/properties/orbit_velocity_curve': type changed value in new API, from "CurveTexture" to "CurveTexture,CurveXYZTexture".
 
 Added accepted curve type from only CurveTexture to CurveXYZTexture.

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-79606.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-79606.txt
@@ -1,5 +1,3 @@
-GH-79606
---------
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/shader_create_from_bytecode/arguments': size changed value in new API, from 1 to 2.
 
 Added optional argument. Compatibility method registered.

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-79911.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-79911.txt
@@ -1,5 +1,3 @@
-GH-79911
---------
 Validate extension JSON: Error: Field 'classes/RenderingDevice/enums/BarrierMask/values/BARRIER_MASK_RASTER': value changed value in new API, from 1.0 to 9.
 Validate extension JSON: Error: Field 'classes/RenderingDevice/enums/BarrierMask/values/BARRIER_MASK_ALL_BARRIERS': value changed value in new API, from 7.0 to 32767.
 Validate extension JSON: Error: Field 'classes/RenderingDevice/enums/BarrierMask/values/BARRIER_MASK_NO_BARRIER': value changed value in new API, from 8.0 to 32768.

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-79965.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-79965.txt
@@ -1,3 +1,1 @@
-GH-79965
---------
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/PopupMenu/methods/clear': arguments

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-80410.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-80410.txt
@@ -1,5 +1,3 @@
-GH-80410
---------
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/arguments': size changed value in new API, from 6 to 10.
 
 Added optional argument. Compatibility method registered.

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-80813.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-80813.txt
@@ -1,5 +1,3 @@
-GH-80813
---------
 Validate extension JSON: API was removed: classes/AnimationPlayer/methods/_post_process_key_value
 Validate extension JSON: API was removed: classes/AnimationPlayer/methods/add_animation_library
 Validate extension JSON: API was removed: classes/AnimationPlayer/methods/advance

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-80852.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-80852.txt
@@ -1,5 +1,3 @@
-GH-80852
---------
 Validate extension JSON: API was removed: classes/GDScriptEditorTranslationParserPlugin
 Validate extension JSON: API was removed: classes/GDScriptNativeClass
 Validate extension JSON: API was removed: classes/GodotPhysicsServer2D

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-80954.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-80954.txt
@@ -1,5 +1,3 @@
-GH-80954
---------
 Validate extension JSON: Error: Field 'classes/Font/methods/find_variation/arguments': size changed value in new API, from 4 to 11.
 
 Added optional arguments. Compatibility method registered.

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-81070.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-81070.txt
@@ -1,5 +1,3 @@
-GH-81070
---------
 Validate extension JSON: API was removed: classes/TileMap/methods/get_quadrant_size
 Validate extension JSON: API was removed: classes/TileMap/methods/set_quadrant_size
 Validate extension JSON: API was removed: classes/TileMap/properties/cell_quadrant_size

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-81138.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-81138.txt
@@ -1,5 +1,3 @@
-GH-81138
---------
 Validate extension JSON: Error: Field 'classes/ImporterMesh/methods/add_surface/arguments/6': meta changed value in new API, from "uint32" to "uint64".
 Validate extension JSON: Error: Field 'classes/ImporterMesh/methods/get_surface_format/return_value': meta changed value in new API, from "uint32" to "uint64".
 Validate extension JSON: Error: Field 'classes/MeshDataTool/methods/commit_to_surface/arguments': size changed value in new API, from 1 to 2.

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-81298.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-81298.txt
@@ -1,5 +1,3 @@
-GH-81298
---------
 Validate extension JSON: Error: Field 'classes/PhysicsServer3DRenderingServerHandler/methods/_set_vertex/arguments/1': type changed value in new API, from "const void*" to "Vector3".
 Validate extension JSON: Error: Field 'classes/PhysicsServer3DRenderingServerHandler/methods/_set_normal/arguments/1': type changed value in new API, from "const void*" to "Vector3".
 

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-81582.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-81582.txt
@@ -1,5 +1,3 @@
-GH-81582
---------
 Validate extension JSON: API was removed: classes/GraphEdit/methods/is_arrange_nodes_button_hidden
 Validate extension JSON: API was removed: classes/GraphEdit/methods/set_arrange_nodes_button_hidden
 Validate extension JSON: API was removed: classes/GraphEdit/properties/arrange_nodes_button_hidden

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-82403.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-82403.txt
@@ -1,5 +1,3 @@
-GH-82403
---------
 Validate extension JSON: Error: Field 'native_structures/PhysicsServer3DExtensionRayResult': format changed value in new API, from "Vector3 position;Vector3 normal;RID rid;ObjectID collider_id;Object *collider;int shape" to "Vector3 position;Vector3 normal;RID rid;ObjectID collider_id;Object *collider;int shape;int face_index".
 
 Added/moved face_index field (introduced in GH-71233) to end of struct. Should still be compatible with 4.1.

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-84113.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-84113.txt
@@ -1,5 +1,3 @@
-GH-84113
---------
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_albedo': type changed value in new API, from "Texture" to "Texture2D".
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_emission': type changed value in new API, from "Texture" to "Texture2D".
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_normal': type changed value in new API, from "Texture" to "Texture2D".

--- a/misc/extension_api_validation/4.1-stable_4.2-stable/GH-84419.txt
+++ b/misc/extension_api_validation/4.1-stable_4.2-stable/GH-84419.txt
@@ -1,5 +1,3 @@
-GH-84419
---------
 Validate extension JSON: API was removed: classes/Node/constants/NOTIFICATION_NODE_RECACHE_REQUESTED
 
 Removed unused NOTIFICATION_NODE_RECACHE_REQUESTED notification. It also used to conflict with CanvasItem.NOTIFICATION_DRAW and Window.NOTIFICATION_VISIBILITY_CHANGED (which still need to be resolved).

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-80214.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-80214.txt
@@ -1,5 +1,3 @@
-GH-80214
---------
 Validate extension JSON: Error: Field 'classes/RenderSceneBuffersRD/methods/get_color_layer/arguments': size changed value in new API, from 1 to 2.
 Validate extension JSON: Error: Field 'classes/RenderSceneBuffersRD/methods/get_depth_layer/arguments': size changed value in new API, from 1 to 2.
 Validate extension JSON: Error: Field 'classes/RenderSceneBuffersRD/methods/get_velocity_layer/arguments': size changed value in new API, from 1 to 2.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-81746.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-81746.txt
@@ -1,5 +1,3 @@
-GH-81746
---------
 Validate extension JSON: API was removed: classes/EditorSceneFormatImporterFBX
 
 Renamed to EditorSceneFormatImporterFBX2GLTF.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-81996.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-81996.txt
@@ -1,5 +1,3 @@
-GH-81996
---------
 Validate extension JSON: Error: Field 'classes/GPUParticles2D/properties/process_material': type changed value in new API, from "ShaderMaterial,ParticleProcessMaterial" to "ParticleProcessMaterial,ShaderMaterial".
 Validate extension JSON: Error: Field 'classes/GPUParticles3D/properties/process_material': type changed value in new API, from "ShaderMaterial,ParticleProcessMaterial" to "ParticleProcessMaterial,ShaderMaterial".
 Validate extension JSON: Error: Field 'classes/Sky/properties/sky_material': type changed value in new API, from "ShaderMaterial,PanoramaSkyMaterial,ProceduralSkyMaterial,PhysicalSkyMaterial" to "PanoramaSkyMaterial,ProceduralSkyMaterial,PhysicalSkyMaterial,ShaderMaterial".

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-84472.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-84472.txt
@@ -1,5 +1,3 @@
-GH-84472
---------
 Validate extension JSON: Error: Field 'classes/CanvasItem/methods/draw_circle/arguments': size changed value in new API, from 3 to 6.
 
 Optional arguments added. Compatibility methods registered.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-84523.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-84523.txt
@@ -1,5 +1,3 @@
-GH-84523
---------
 Validate extension JSON: Error: Field 'classes/CanvasItem/methods/draw_dashed_line/arguments': size changed value in new API, from 6 to 7.
 Validate extension JSON: Error: Field 'classes/CanvasItem/methods/draw_multiline/arguments': size changed value in new API, from 3 to 4.
 Validate extension JSON: Error: Field 'classes/CanvasItem/methods/draw_multiline_colors/arguments': size changed value in new API, from 3 to 4.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-84660.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-84660.txt
@@ -1,5 +1,3 @@
-GH-84660
---------
 Validate extension JSON: Error: Field 'classes/TileData/methods/get_navigation_polygon/arguments': size changed value in new API, from 1 to 4.
 Validate extension JSON: Error: Field 'classes/TileData/methods/get_occluder/arguments': size changed value in new API, from 1 to 4.
 

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-84792.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-84792.txt
@@ -1,5 +1,3 @@
-GH-84792
---------
 Validate extension JSON: Error: Field 'classes/RenderingServer/methods/environment_set_fog/arguments': size changed value in new API, from 10 to 11.
 
 Added fog mode argument. Compatibility method registered.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-84906.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-84906.txt
@@ -1,5 +1,3 @@
-GH-84906
---------
 Validate extension JSON: Error: Field 'classes/AnimationPlayer/methods/play/arguments/0': default_value changed value in new API, from "\"\"" to "&\"\"".
 Validate extension JSON: Error: Field 'classes/AnimationPlayer/methods/play_backwards/arguments/0': default_value changed value in new API, from "\"\"" to "&\"\"".
 Validate extension JSON: Error: Field 'classes/CodeEdit/methods/add_code_completion_option/arguments/5': default_value changed value in new API, from "0" to "null".

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-84976.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-84976.txt
@@ -1,5 +1,3 @@
-GH-84976
---------
 Validate extension JSON: Error: Field 'classes/RenderingDevice/enums/FinalAction/values/FINAL_ACTION_CONTINUE': value changed value in new API, from 2.0 to 0.
 Validate extension JSON: Error: Field 'classes/RenderingDevice/enums/FinalAction/values/FINAL_ACTION_MAX': value changed value in new API, from 3.0 to 2.
 Validate extension JSON: Error: Field 'classes/RenderingDevice/enums/InitialAction/values/INITIAL_ACTION_CLEAR': value changed value in new API, from 0.0 to 1.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-85393.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-85393.txt
@@ -1,5 +1,3 @@
-GH-85393
---------
 Validate extension JSON: Error: Field 'classes/PhysicsShapeQueryParameters3D/properties/motion': type changed value in new API, from "Vector2" to "Vector3".
 
 The type was registered wrongly, this was a bug.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-86158.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-86158.txt
@@ -1,5 +1,3 @@
-GH-86158
---------
 Validate extension JSON: Error: Field 'classes/GraphEdit/methods/get_connection_line': is_const changed value in new API, from false to true.
 
 get_connection_line was made const.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-86629.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-86629.txt
@@ -1,5 +1,3 @@
-GH-86629
---------
 Validate extension JSON: Error: Field 'classes/Animation/methods/position_track_interpolate/arguments': size changed value in new API, from 2 to 3.
 Validate extension JSON: Error: Field 'classes/Animation/methods/rotation_track_interpolate/arguments': size changed value in new API, from 2 to 3.
 Validate extension JSON: Error: Field 'classes/Animation/methods/scale_track_interpolate/arguments': size changed value in new API, from 2 to 3.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-86687.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-86687.txt
@@ -1,5 +1,3 @@
-GH-86687
---------
 Validate extension JSON: Error: Field 'classes/AnimationMixer/methods/_post_process_key_value/arguments/3': type changed value in new API, from "Object" to "int".
 
 Exposing the pointer was dangerous and it must be changed to avoid crash. Compatibility methods registered.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-86907.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-86907.txt
@@ -1,5 +1,3 @@
-GH-86907
---------
 Validate extension JSON: Error: Field 'classes/AudioStreamPlayer/methods/is_autoplay_enabled': is_const changed value in new API, from false to true.
 Validate extension JSON: Error: Field 'classes/AudioStreamPlayer2D/methods/is_autoplay_enabled': is_const changed value in new API, from false to true.
 Validate extension JSON: Error: Field 'classes/AudioStreamPlayer3D/methods/is_autoplay_enabled': is_const changed value in new API, from false to true.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-86978.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-86978.txt
@@ -1,5 +1,3 @@
-GH-86978
---------
 Validate extension JSON: Error: Field 'classes/TextEdit/methods/set_selection_mode/arguments': size changed value in new API, from 4 to 1.
 
 Removed optional arguments set_selection_mode, use set_selection_origin_line/column instead.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-87115.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-87115.txt
@@ -1,5 +1,3 @@
-GH-87115
---------
 Validate extension JSON: Error: Field 'classes/TileMap/methods/get_collision_visibility_mode': is_const changed value in new API, from false to true.
 Validate extension JSON: Error: Field 'classes/TileMap/methods/get_navigation_visibility_mode': is_const changed value in new API, from false to true.
 

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-87340.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-87340.txt
@@ -1,5 +1,3 @@
-GH-87340
---------
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/RenderingDevice/methods/screen_get_framebuffer_format': arguments
 
 screen_get_framebuffer_format can now specify the screen it should get the format from. The argument defaults to the main window to emulate the behavior of the old function.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-87668.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-87668.txt
@@ -1,5 +1,3 @@
-GH-87668
---------
 Validate extension JSON: Error: Field 'classes/Font/methods/find_variation/arguments': size changed value in new API, from 8 to 11.
 
 Added optional "baseline_offset" argument. Compatibility method registered.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-88014.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-88014.txt
@@ -1,5 +1,3 @@
-GH-88014
---------
 Validate extension JSON: API was removed: classes/VisualShaderNodeComment/methods/get_title
 Validate extension JSON: API was removed: classes/VisualShaderNodeComment/methods/set_title
 Validate extension JSON: API was removed: classes/VisualShaderNodeComment/properties/title

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-88047.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-88047.txt
@@ -1,5 +1,3 @@
-GH-88047
---------
 Validate extension JSON: Error: Field 'classes/AStar2D/methods/get_id_path/arguments': size changed value in new API, from 2 to 3.
 Validate extension JSON: Error: Field 'classes/AStar2D/methods/get_point_path/arguments': size changed value in new API, from 2 to 3.
 Validate extension JSON: Error: Field 'classes/AStar3D/methods/get_id_path/arguments': size changed value in new API, from 2 to 3.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-88081.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-88081.txt
@@ -1,5 +1,3 @@
-GH-88081
---------
 Validate extension JSON: Error: Field 'classes/EditorPlugin/methods/add_control_to_bottom_panel/arguments': size changed value in new API, from 2 to 3.
 Validate extension JSON: Error: Field 'classes/EditorPlugin/methods/add_control_to_dock/arguments': size changed value in new API, from 2 to 3.
 

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-88418.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-88418.txt
@@ -1,5 +1,3 @@
-GH-88418
---------
 Validate extension JSON: API was removed: classes/GDExtension/methods/close_library
 Validate extension JSON: API was removed: classes/GDExtension/methods/initialize_library
 Validate extension JSON: API was removed: classes/GDExtension/methods/open_library

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-88791.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-88791.txt
@@ -1,5 +1,3 @@
-GH-88791
---------
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Skeleton3D/methods/add_bone': return_value
 
 Added a return value for add_bone.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-89024.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-89024.txt
@@ -1,5 +1,3 @@
-GH-89024
---------
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/push_meta/arguments': size changed value in new API, from 1 to 3.
 
 Added optional argument. Compatibility method registered.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-89419.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-89419.txt
@@ -1,5 +1,3 @@
-GH-89419
---------
 Validate extension JSON: Error: Field 'classes/AcceptDialog/methods/register_text_enter/arguments/0': type changed value in new API, from "Control" to "LineEdit".
 Validate extension JSON: Error: Field 'classes/AcceptDialog/methods/remove_button/arguments/0': type changed value in new API, from "Control" to "Button".
 

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-90575.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-90575.txt
@@ -1,5 +1,3 @@
-GH-90575
---------
 Validate extension JSON: API was removed: classes/BoneAttachment3D/methods/on_bone_pose_update
 Validate extension JSON: API was removed: classes/Skeleton3D/signals/bone_pose_changed
 

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-90645.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-90645.txt
@@ -1,5 +1,3 @@
-GH-90645
---------
 Validate extension JSON: API was removed: classes/XRPositionalTracker/methods/get_tracker_desc
 Validate extension JSON: API was removed: classes/XRPositionalTracker/methods/get_tracker_name
 Validate extension JSON: API was removed: classes/XRPositionalTracker/methods/get_tracker_type

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-90732.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-90732.txt
@@ -1,5 +1,3 @@
-GH-90732
---------
 Validate extension JSON: Error: Field 'classes/TextServer/methods/shaped_text_get_word_breaks/arguments': size changed value in new API, from 2 to 3.
 Validate extension JSON: Error: Field 'classes/TextServerExtension/methods/_shaped_text_get_word_breaks/arguments': size changed value in new API, from 2 to 3.
 

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-90747.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-90747.txt
@@ -1,5 +1,3 @@
-GH-90747
---------
 Validate extension JSON: API was removed: classes/NavigationRegion2D/methods/get_avoidance_layers
 Validate extension JSON: API was removed: classes/NavigationRegion2D/methods/set_avoidance_layers
 Validate extension JSON: API was removed: classes/NavigationRegion2D/properties/avoidance_layers

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-91098.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-91098.txt
@@ -1,5 +1,3 @@
-GH-91098
---------
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/remove_paragraph/arguments': size changed value in new API, from 1 to 2.
 
 Added optional argument. Compatibility method registered.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-91143.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-91143.txt
@@ -1,5 +1,3 @@
-GH-91143
---------
 Validate extension JSON: Error: Field 'classes/Input/methods/vibrate_handheld/arguments': size changed value in new API, from 1 to 2.
 
 Added optional argument. Compatibility method registered.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-91382.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-91382.txt
@@ -1,5 +1,3 @@
-GH-91382
---------
 Validate extension JSON: Error: Field 'classes/AudioStreamPlaybackPolyphonic/methods/play_stream/arguments': size changed value in new API, from 4 to 6.
 
 Optional arguments added. Compatibility methods registered.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-92322.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-92322.txt
@@ -1,5 +1,3 @@
-GH-92322
---------
 Validate extension JSON: Error: Field 'classes/EditorInspectorPlugin/methods/add_property_editor/arguments': size changed value in new API, from 3 to 4.
 
 Optional arguments added. Compatibility methods registered.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-92861.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-92861.txt
@@ -1,5 +1,3 @@
-GH-92861
---------
 Validate extension JSON: Error: Field 'classes/Animation/methods/track_find_key/arguments': size changed value in new API, from 3 to 5.
 
 Added optional arguments to avoid finding keys out of the animation range (GH-86661), and to handle backward seeking.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-93982.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-93982.txt
@@ -1,5 +1,3 @@
-GH-93982
---------
 Validate extension JSON: Error: Field 'classes/Sprite3D/properties/frame_coords': type changed value in new API, from "Vector2" to "Vector2i".
 
 The type was wrong to begin with and has been corrected. Vector2 and Vector2i are convertible, so it should be compatible.

--- a/misc/extension_api_validation/4.2-stable_4.3-stable/GH-94243.txt
+++ b/misc/extension_api_validation/4.2-stable_4.3-stable/GH-94243.txt
@@ -1,5 +1,3 @@
-GH-94243
---------
 Validate extension JSON: Error: Field 'classes/Image/methods/get_mipmap_offset/return_value': meta changed value in new API, from "int32" to "int64".
 
 Type changed to int64_t to support baking large lightmaps.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-100129.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-100129.txt
@@ -1,5 +1,3 @@
-GH-100129
----------
 Validate extension JSON: Error: Field 'classes/NavigationServer2D/methods/query_path': is_const changed value in new API, from true to false.
 Validate extension JSON: Error: Field 'classes/NavigationServer3D/methods/query_path': is_const changed value in new API, from true to false.
 Validate extension JSON: Error: Field 'classes/NavigationServer2D/methods/query_path/arguments': size changed value in new API, from 2 to 3.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-100913.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-100913.txt
@@ -1,5 +1,3 @@
-GH-100913
----------
 Validate extension JSON: Error: Field 'classes/TextEdit/methods/get_line_column_at_pos/arguments': size changed value in new API, from 2 to 3.
 
 Added optional argument to disallow positions that are outside the column range of the line. Compatibility method registered.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-101482.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-101482.txt
@@ -1,5 +1,3 @@
-GH-101482
----------
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/set_table_column_expand/arguments': size changed value in new API, from 3 to 4.
 
 Added optional "shrink" argument. Compatibility method registered.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-101531.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-101531.txt
@@ -1,5 +1,3 @@
-GH-101531
----------
 Validate extension JSON: API was removed: classes/EditorSceneFormatImporter/methods/_get_import_flags
 
 This virtual method, and the internal public `get_import_flags`, were never used by the engine, since it was open sourced.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-101561.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-101561.txt
@@ -1,5 +1,3 @@
-GH-101561
---------
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/index_buffer_create/arguments': size changed value in new API, from 4 to 5.
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/uniform_buffer_create/arguments': size changed value in new API, from 2 to 3.
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/storage_buffer_create/arguments': size changed value in new API, from 3 to 4.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-102796.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-102796.txt
@@ -1,5 +1,3 @@
-GH-102796
----------
 Validate extension JSON: Error: Field 'classes/GraphEdit/signals/frame_rect_changed/arguments/1': type changed value in new API, from "Vector2" to "Rect2".
 
 Previous type was incorrect. No compatibility system for signal arguments.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-113429.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-113429.txt
@@ -1,5 +1,3 @@
-GH-113429
----------
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_albedo': type changed value in new API, from "Texture2D" to "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture,-StreamedTexture2D".
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_emission': type changed value in new API, from "Texture2D" to "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture,-StreamedTexture2D".
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_normal': type changed value in new API, from "Texture2D" to "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture,-StreamedTexture2D".

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-78289.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-78289.txt
@@ -1,5 +1,3 @@
-GH-78289
---------
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/FileAccess/methods/store_16': return_value
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/FileAccess/methods/store_32': return_value
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/FileAccess/methods/store_64': return_value

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-88349.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-88349.txt
@@ -1,5 +1,3 @@
-GH-88349
---------
 Validate extension JSON: Error: Field 'classes/CSGMesh3D/properties/mesh': type changed value in new API, from "Mesh" to "Mesh,-PlaneMesh,-PointMesh,-QuadMesh,-RibbonTrailMesh".
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_albedo': type changed value in new API, from "Texture2D" to "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture".
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_emission': type changed value in new API, from "Texture2D" to "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture".

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-90057.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-90057.txt
@@ -1,5 +1,3 @@
-GH-90057
---------
 Validate extension JSON: Error: Field 'classes/EditorInterface/methods/open_scene_from_path/arguments': size changed value in new API, from 1 to 2.
 
 Added optional argument to open_scene_from_path to create a new inherited scene.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-90993.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-90993.txt
@@ -1,5 +1,3 @@
-GH-90993
---------
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/draw_list_begin/arguments': size changed value in new API, from 9 to 10.
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/draw_list_begin/arguments/9': type changed value in new API, from "Array" to "int".
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/draw_list_begin/arguments/9': default_value changed value in new API, from "Array[RID]([])" to "0".

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-91201.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-91201.txt
@@ -1,5 +1,3 @@
-GH-91201
---------
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/OS/methods/read_string_from_stdin': arguments
 
 Added optional argument. Compatibility method registered.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-92089.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-92089.txt
@@ -1,5 +1,3 @@
-GH-92089
---------
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/CPUParticles2D/methods/restart': arguments
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/CPUParticles3D/methods/restart': arguments
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/GPUParticles2D/methods/restart': arguments

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-93605.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-93605.txt
@@ -1,5 +1,3 @@
-GH-93605
---------
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Semaphore/methods/post': arguments
 
 Optional arguments added. Compatibility methods registered.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-94322.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-94322.txt
@@ -1,5 +1,3 @@
-GH-94322
---------
 Validate extension JSON: Error: Field 'classes/EditorInterface/methods/popup_node_selector/arguments': size changed value in new API, from 2 to 3.
 Validate extension JSON: Error: Field 'classes/EditorInterface/methods/popup_property_selector/arguments': size changed value in new API, from 3 to 4.
 

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-94434.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-94434.txt
@@ -1,5 +1,3 @@
-GH-94434
---------
 Validate extension JSON: Error: Field 'classes/OS/methods/execute_with_pipe/arguments': size changed value in new API, from 2 to 3.
 
 Optional argument added. Compatibility method registered.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-94684.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-94684.txt
@@ -1,5 +1,3 @@
-GH-94684
---------
 Validate extension JSON: Error: Field 'classes/SoftBody3D/methods/set_point_pinned/arguments': size changed value in new API, from 3 to 4.
 
 Optional argument added to allow for adding pin point at specific index. Compatibility method registered.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-95126.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-95126.txt
@@ -1,5 +1,3 @@
-GH-95126
---------
 Validate extension JSON: Error: Field 'classes/Shader/methods/get_default_texture_parameter/return_value': type changed value in new API, from "Texture2D" to "Texture".
 Validate extension JSON: Error: Field 'classes/Shader/methods/set_default_texture_parameter/arguments/1': type changed value in new API, from "Texture2D" to "Texture".
 Validate extension JSON: Error: Field 'classes/VisualShaderNodeCubemap/methods/get_cube_map/return_value': type changed value in new API, from "Cubemap" to "TextureLayered".

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-95212.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-95212.txt
@@ -1,5 +1,3 @@
-GH-95212
---------
 Validate extension JSON: Error: Field 'classes/RegEx/methods/compile/arguments': size changed value in new API, from 1 to 2.
 Validate extension JSON: Error: Field 'classes/RegEx/methods/create_from_string/arguments': size changed value in new API, from 1 to 2.
 

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-95374.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-95374.txt
@@ -1,5 +1,3 @@
-GH-95374
---------
 Validate extension JSON: Error: Field 'classes/ShapeCast2D/properties/collision_result': getter changed value in new API, from "_get_collision_result" to &"get_collision_result".
 Validate extension JSON: Error: Field 'classes/ShapeCast3D/properties/collision_result': getter changed value in new API, from "_get_collision_result" to &"get_collision_result".
 

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-95375.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-95375.txt
@@ -1,5 +1,3 @@
-GH-95375
---------
 Validate extension JSON: Error: Field 'classes/AudioStreamPlayer/properties/playing': setter changed value in new API, from "_set_playing" to &"set_playing".
 Validate extension JSON: Error: Field 'classes/AudioStreamPlayer2D/properties/playing': setter changed value in new API, from "_set_playing" to &"set_playing".
 Validate extension JSON: Error: Field 'classes/AudioStreamPlayer3D/properties/playing': setter changed value in new API, from "_set_playing" to &"set_playing".

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-97020.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-97020.txt
@@ -1,5 +1,3 @@
-GH-97020
---------
 Validate extension JSON: Error: Field 'classes/AnimationNode/methods/_process': is_const changed value in new API, from true to false.
 
 `_process` virtual method fixed to be non const instead.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-97257.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-97257.txt
@@ -1,5 +1,3 @@
-GH-97257
---------
 Validate extension JSON: Error: Field 'classes/EditorFeatureProfile/enums/Feature/values/FEATURE_MAX': value changed value in new API, from 8.0 to 9.
 
 New entry to the `EditorFeatureProfile.Feature` enum added. Those need to go before `FEATURE_MAX`, which will always cause a compatibility break.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-97281.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-97281.txt
@@ -1,5 +1,3 @@
-GH-97281
---------
 Validate extension JSON: Error: Field 'classes/InputMap/methods/add_action/arguments/1': default_value changed value in new API, from "0.5" to "0.2".
 
 Default deadzone value was changed. No adjustments should be necessary.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-97449.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-97449.txt
@@ -1,5 +1,3 @@
-GH-97449
---------
 Validate extension JSON: Error: Field 'classes/GraphEdit/methods/connect_node/arguments': size changed value in new API, from 4 to 5.
 
 Added optional argument to connect_node to specify whether the connection should be automatically deleted if invalid. Compatibility method registered.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-98441.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-98441.txt
@@ -1,5 +1,3 @@
-GH-98441
---------
 Validate extension JSON: Error: Field 'global_enums/KeyModifierMask/values/KEY_MODIFIER_MASK': value changed value in new API, from 5.32677e+08 to 2130706432.
 
 Key modifier mask value corrected. API change documented for compatibility.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-98443.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-98443.txt
@@ -1,5 +1,3 @@
-GH-98443
---------
 Validate extension JSON: Error: Field 'classes/Control/properties/offset_bottom': type changed value in new API, from "int" to "float".
 Validate extension JSON: Error: Field 'classes/Control/properties/offset_left': type changed value in new API, from "int" to "float".
 Validate extension JSON: Error: Field 'classes/Control/properties/offset_right': type changed value in new API, from "int" to "float".

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-98670.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-98670.txt
@@ -1,5 +1,3 @@
-GH-98670
---------
 Validate extension JSON: Error: Field 'classes/RenderSceneBuffersRD/methods/create_texture/arguments': size changed value in new API, from 9 to 10.
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/draw_list_begin/arguments': size changed value in new API, from 10 to 7.
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/draw_list_begin/arguments': size changed value in new API, from 9 to 7.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-98918.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-98918.txt
@@ -1,5 +1,3 @@
-GH-98918
---------
 Validate extension JSON: Error: Field 'classes/FileAccess/methods/open_encrypted/arguments': size changed value in new API, from 3 to 4.
 
 Optional argument added to allow setting initialization vector. Compatibility method registered.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-98972.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-98972.txt
@@ -1,5 +1,3 @@
-GH-98972
---------
 Validate extension JSON: Error: Field 'classes/TranslationServer/methods/standardize_locale/arguments': size changed value in new API, from 1 to 2.
 
 Optional argument added. Compatibility method registered.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-99297.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-99297.txt
@@ -1,5 +1,3 @@
-GH-99297
---------
 Validate extension JSON: Error: Field 'classes/EditorTranslationParserPlugin/methods/_parse_file/arguments': size changed value in new API, from 3 to 1.
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/EditorTranslationParserPlugin/methods/_parse_file': return_value
 

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-99424.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-99424.txt
@@ -1,5 +1,3 @@
-GH-99424
---------
 Validate extension JSON: API was removed: builtin_classes/Projection/constants/PLANE_BOTTOM
 Validate extension JSON: API was removed: builtin_classes/Projection/constants/PLANE_FAR
 Validate extension JSON: API was removed: builtin_classes/Projection/constants/PLANE_LEFT

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-99455.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-99455.txt
@@ -1,5 +1,3 @@
-GH-99455
---------
 Validate extension JSON: Error: Field 'classes/RenderingServer/methods/multimesh_allocate_data/arguments': size changed value in new API, from 5 to 6.
 
 Optional argument added to allow setting indirect draw mode on Multimesh. Compatibility method registered.

--- a/misc/extension_api_validation/4.3-stable_4.4-stable/GH-99481.txt
+++ b/misc/extension_api_validation/4.3-stable_4.4-stable/GH-99481.txt
@@ -1,5 +1,3 @@
-GH-99481
---------
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/push_meta/arguments': size changed value in new API, from 2 to 3.
 
 Optional argument added to set tooltip. Compatibility method registered.

--- a/misc/extension_api_validation/4.4-stable_4.5-stable/GH-104087.txt
+++ b/misc/extension_api_validation/4.4-stable_4.5-stable/GH-104087.txt
@@ -1,5 +1,3 @@
-GH-104087
----------
 Validate extension JSON: Error: Field 'classes/OpenXRAPIExtension/methods/register_composition_layer_provider/arguments/0': type changed value in new API, from "OpenXRExtensionWrapperExtension" to "OpenXRExtensionWrapper".
 Validate extension JSON: Error: Field 'classes/OpenXRAPIExtension/methods/unregister_composition_layer_provider/arguments/0': type changed value in new API, from "OpenXRExtensionWrapperExtension" to "OpenXRExtensionWrapper".
 Validate extension JSON: Error: Field 'classes/OpenXRAPIExtension/methods/register_projection_views_extension/arguments/0': type changed value in new API, from "OpenXRExtensionWrapperExtension" to "OpenXRExtensionWrapper".

--- a/misc/extension_api_validation/4.4-stable_4.5-stable/GH-104269.txt
+++ b/misc/extension_api_validation/4.4-stable_4.5-stable/GH-104269.txt
@@ -1,5 +1,3 @@
-GH-104269
----------
 Validate extension JSON: API was removed: classes/RenderingServer/methods/instance_set_interpolated
 Validate extension JSON: API was removed: classes/RenderingServer/methods/instance_reset_physics_interpolation
 

--- a/misc/extension_api_validation/4.4-stable_4.5-stable/GH-104872.txt
+++ b/misc/extension_api_validation/4.4-stable_4.5-stable/GH-104872.txt
@@ -1,5 +1,3 @@
-GH-104872
----------
 Validate extension JSON: Error: Field 'classes/CanvasItem/methods/draw_char/arguments': size changed value in new API, from 5 to 6.
 Validate extension JSON: Error: Field 'classes/CanvasItem/methods/draw_char_outline/arguments': size changed value in new API, from 6 to 7.
 Validate extension JSON: Error: Field 'classes/CanvasItem/methods/draw_multiline_string/arguments': size changed value in new API, from 12 to 13.

--- a/misc/extension_api_validation/4.4-stable_4.5-stable/GH-104890.txt
+++ b/misc/extension_api_validation/4.4-stable_4.5-stable/GH-104890.txt
@@ -1,5 +1,3 @@
-GH-104890
----------
 Validate extension JSON: API was removed: classes/JSONRPC/methods/set_scope
 
 Replaced `set_scope` with `set_method`. Compatibility method registered for binary compatibility. Manual upgrade required by users to retain functionality.

--- a/misc/extension_api_validation/4.4-stable_4.5-stable/GH-105570.txt
+++ b/misc/extension_api_validation/4.4-stable_4.5-stable/GH-105570.txt
@@ -1,5 +1,3 @@
-GH-105570
----------
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/texture_create_from_extension/arguments': size changed value in new API, from 9 to 10.
 
 Argument added; p_mipmaps. Compatibility method registered.

--- a/misc/extension_api_validation/4.4-stable_4.5-stable/GH-106121.txt
+++ b/misc/extension_api_validation/4.4-stable_4.5-stable/GH-106121.txt
@@ -1,5 +1,3 @@
-GH-106121
---------
 Validate extension JSON: Error: Field 'classes/EditorUndoRedoManager/methods/create_action/arguments': size changed value in new API, from 4 to 5.
 Validate extension JSON: Error: Field 'classes/EditorUndoRedoManager/methods/create_action/arguments': size changed value in new API, from 3 to 5.
 

--- a/misc/extension_api_validation/4.4-stable_4.5-stable/GH-106220.txt
+++ b/misc/extension_api_validation/4.4-stable_4.5-stable/GH-106220.txt
@@ -1,5 +1,3 @@
-GH-106220
----------
 Validate extension JSON: Error: Field 'classes/GLTFAccessor/methods/get_accessor_type': is_const changed value in new API, from false to true.
 Validate extension JSON: Error: Field 'classes/GLTFAccessor/methods/get_buffer_view': is_const changed value in new API, from false to true.
 Validate extension JSON: Error: Field 'classes/GLTFAccessor/methods/get_byte_offset': is_const changed value in new API, from false to true.

--- a/misc/extension_api_validation/4.4-stable_4.5-stable/GH-106300.txt
+++ b/misc/extension_api_validation/4.4-stable_4.5-stable/GH-106300.txt
@@ -1,5 +1,3 @@
-GH-106300
----------
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/RichTextLabel/methods/push_strikethrough': arguments
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/RichTextLabel/methods/push_underline': arguments
 

--- a/misc/extension_api_validation/4.4-stable_4.5-stable/GH-106848.txt
+++ b/misc/extension_api_validation/4.4-stable_4.5-stable/GH-106848.txt
@@ -1,5 +1,3 @@
-GH-106848
----------
 Validate extension JSON: API was removed: classes/Node/methods/get_rpc_config
 
 Change Node `get_rpc_config` to `get_node_rpc_config`. Compatibility method registered.

--- a/misc/extension_api_validation/4.4-stable_4.5-stable/GH-107347.txt
+++ b/misc/extension_api_validation/4.4-stable_4.5-stable/GH-107347.txt
@@ -1,5 +1,3 @@
-GH-107347
----------
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/arguments': size changed value in new API, from 6 to 12.
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/arguments': size changed value in new API, from 10 to 12.
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/update_image/arguments': size changed value in new API, from 11 to 12.

--- a/misc/extension_api_validation/4.4-stable_4.5-stable/GH-108825.txt
+++ b/misc/extension_api_validation/4.4-stable_4.5-stable/GH-108825.txt
@@ -1,5 +1,3 @@
-GH-108825
----------
 Validate extension JSON: Error: Field 'classes/EditorExportPlatformExtension/methods/_get_option_icon/return_value': type changed value in new API, from "ImageTexture" to "Texture2D".
 
 Return type changed to allow returning both ImageTexture and DPITexture. Compatibility method registered.

--- a/misc/extension_api_validation/4.4-stable_4.5-stable/GH-71542.txt
+++ b/misc/extension_api_validation/4.4-stable_4.5-stable/GH-71542.txt
@@ -1,5 +1,3 @@
-GH-71542
---------
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/EditorExportPlatform/methods/get_forced_export_files': arguments
 
 Optional argument added. Compatibility methods registered.

--- a/misc/extension_api_validation/4.4-stable_4.5-stable/GH-76560.txt
+++ b/misc/extension_api_validation/4.4-stable_4.5-stable/GH-76560.txt
@@ -1,5 +1,3 @@
-GH-76560
---------
 Validate extension JSON: Error: Field 'classes/Node/methods/set_name/arguments/0': type changed value in new API, from "String" to "StringName".
 
 Change Node `set_name` to use StringName to improve performance. Compatibility method registered.

--- a/misc/extension_api_validation/4.4-stable_4.5-stable/GH-76829.txt
+++ b/misc/extension_api_validation/4.4-stable_4.5-stable/GH-76829.txt
@@ -1,5 +1,3 @@
-GH-76829
---------
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/arguments': size changed value in new API, from 6 to 11.
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/arguments': size changed value in new API, from 10 to 11.
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/push_table/arguments': size changed value in new API, from 3 to 4.

--- a/misc/extension_api_validation/4.4-stable_4.5-stable/GH-98194.txt
+++ b/misc/extension_api_validation/4.4-stable_4.5-stable/GH-98194.txt
@@ -1,5 +1,3 @@
-GH-98194
---------
 Validate extension JSON: Error: Field 'classes/DisplayServer/methods/file_dialog_show/arguments': size changed value in new API, from 7 to 8.
 Validate extension JSON: Error: Field 'classes/DisplayServer/methods/file_dialog_with_options_show/arguments': size changed value in new API, from 9 to 10.
 

--- a/misc/extension_api_validation/4.4-stable_4.5-stable/GH-98750.txt
+++ b/misc/extension_api_validation/4.4-stable_4.5-stable/GH-98750.txt
@@ -1,5 +1,3 @@
-GH-98750
---------
 Validate extension JSON: Error: Field 'builtin_classes/Color/constants/ALICE_BLUE': value changed value in new API, from "Color(0.941176, 0.972549, 1, 1)" to "Color(0.9411765, 0.972549, 1, 1)".
 Validate extension JSON: Error: Field 'builtin_classes/Color/constants/ANTIQUE_WHITE': value changed value in new API, from "Color(0.980392, 0.921569, 0.843137, 1)" to "Color(0.98039216, 0.92156863, 0.84313726, 1)".
 Validate extension JSON: Error: Field 'builtin_classes/Color/constants/AQUAMARINE': value changed value in new API, from "Color(0.498039, 1, 0.831373, 1)" to "Color(0.49803922, 1, 0.83137256, 1)".

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-107167.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-107167.txt
@@ -1,5 +1,3 @@
-GH-107167
----------
 Validate extension JSON: Error: Field 'classes/EditorExportPreset/methods/get_script_export_mode': meta was removed.
 Validate extension JSON: Error: Field 'classes/EditorExportPreset/methods/get_script_export_mode/return_value': type changed value in new API, from "int" to "enum::EditorExportPreset.ScriptExportMode".
 

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-107954.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-107954.txt
@@ -1,5 +1,3 @@
-GH-107954
----------
 Validate extension JSON: API was removed: classes/TCPServer/methods/is_connection_available
 Validate extension JSON: API was removed: classes/TCPServer/methods/is_listening
 Validate extension JSON: API was removed: classes/TCPServer/methods/stop

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-109302.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-109302.txt
@@ -1,5 +1,3 @@
-GH-109302
----------
 Validate extension JSON: Error: Field 'classes/OpenXRExtensionWrapper/methods/_set_instance_create_info_and_get_next_pointer/arguments': size changed value in new API, from 1 to 2.
 Validate extension JSON: Error: Field 'classes/OpenXRExtensionWrapper/methods/_set_instance_create_info_and_get_next_pointer/arguments/0': type changed value in new API, from "void*" to "int".
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/OpenXRExtensionWrapper/methods/_get_requested_extensions': arguments

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-110120.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-110120.txt
@@ -1,5 +1,3 @@
-GH-110120
----------
 Validate extension JSON: API was removed: classes/SpringBoneSimulator3D/enums/BoneDirection
 Validate extension JSON: API was removed: classes/SpringBoneSimulator3D/enums/RotationAxis
 Validate extension JSON: Error: Field 'classes/SpringBoneSimulator3D/methods/get_end_bone_direction/return_value': type changed value in new API, from "enum::SpringBoneSimulator3D.BoneDirection" to "enum::SkeletonModifier3D.BoneDirection".

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-110250.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-110250.txt
@@ -1,5 +1,3 @@
-GH-110250
----------
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Control/methods/grab_focus': arguments
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Control/methods/has_focus': arguments
 

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-110433.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-110433.txt
@@ -1,5 +1,3 @@
-GH-110433
----------
 Validate extension JSON: Error: Field 'classes/Performance/methods/add_custom_monitor/arguments': size changed value in new API, from 3 to 4.
 
 Optional argument added. Compatibility method registered.

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-110767.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-110767.txt
@@ -1,5 +1,3 @@
-GH-110767
----------
 Validate extension JSON: Error: Field 'classes/AnimationPlayer/methods/get_assigned_animation/return_value': type changed value in new API, from "String" to "StringName".
 Validate extension JSON: Error: Field 'classes/AnimationPlayer/methods/get_autoplay/return_value': type changed value in new API, from "String" to "StringName".
 Validate extension JSON: Error: Field 'classes/AnimationPlayer/methods/get_current_animation/return_value': type changed value in new API, from "String" to "StringName".

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-110867.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-110867.txt
@@ -1,5 +1,3 @@
-GH-110867
----------
 Validate extension JSON: Missing field in current API 'classes/FileAccess/methods/get_as_text': arguments. This is a bug.
 
 Optional argument removed. Compatibility method registered.

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-111117.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-111117.txt
@@ -1,5 +1,3 @@
-GH-111117
----------
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/LineEdit/methods/edit': arguments
 
 Optional argument added. Compatibility method registered.

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-111212.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-111212.txt
@@ -1,5 +1,3 @@
-GH-111212
----------
 Validate extension JSON: API was removed: classes/EditorFileDialog/methods/add_filter
 Validate extension JSON: API was removed: classes/EditorFileDialog/methods/add_option
 Validate extension JSON: API was removed: classes/EditorFileDialog/methods/add_side_menu

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-111439.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-111439.txt
@@ -1,5 +1,3 @@
-GH-111439
----------
 Validate extension JSON: Error: Field 'classes/FileDialog/methods/add_filter/arguments': size changed value in new API, from 2 to 3.
 
 Optional argument added. Compatibility method registered.

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-112290.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-112290.txt
@@ -1,5 +1,3 @@
-GH-112290
----------
 Validate extension JSON: Error: Field 'builtin_classes/PackedByteArray/methods/duplicate': is_const changed value in new API, from false to true.
 Validate extension JSON: Error: Field 'builtin_classes/PackedColorArray/methods/duplicate': is_const changed value in new API, from false to true.
 Validate extension JSON: Error: Field 'builtin_classes/PackedFloat32Array/methods/duplicate': is_const changed value in new API, from false to true.

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-112379.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-112379.txt
@@ -1,5 +1,3 @@
-GH-112379
----------
 Validate extension JSON: Error: Field 'classes/DisplayServer/methods/tts_speak/arguments/5': meta changed value in new API, from "int32" to "int64".
 
 `utterance_id` argument changed from `int32` to `int64`. No compatibility method needed.

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-112539.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-112539.txt
@@ -1,5 +1,3 @@
-GH-112539
----------
 Validate extension JSON: Error: Field 'builtin_classes/PackedByteArray/methods/bsearch': is_const changed value in new API, from false to true.
 Validate extension JSON: Error: Field 'builtin_classes/PackedColorArray/methods/bsearch': is_const changed value in new API, from false to true.
 Validate extension JSON: Error: Field 'builtin_classes/PackedFloat32Array/methods/bsearch': is_const changed value in new API, from false to true.

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-113172.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-113172.txt
@@ -1,5 +1,3 @@
-GH-113172
----------
 Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_accessors': is_const changed value in new API, from false to true.
 Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_additional_data': is_const changed value in new API, from false to true.
 Validate extension JSON: Error: Field 'classes/GLTFState/methods/get_animation_player': is_const changed value in new API, from false to true.

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-113429.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-113429.txt
@@ -1,5 +1,3 @@
-GH-113429
----------
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_albedo': type changed value in new API, from "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture" to "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture,-StreamedTexture2D".
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_normal': type changed value in new API, from "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture" to "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture,-StreamedTexture2D".
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_orm': type changed value in new API, from "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture" to "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture,-StreamedTexture2D".

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-113459.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-113459.txt
@@ -1,5 +1,3 @@
-GH-113459
----------
 Validate extension JSON: Error: Field 'classes/DisplayServer/methods/accessibility_create_sub_text_edit_elements/arguments': size changed value in new API, from 4 to 5.
 
 Optional argument added. Compatibility method registered.

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-114053.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-114053.txt
@@ -1,5 +1,3 @@
-GH-114053
----------
 Validate extension JSON: Error: Field 'classes/FileAccess/methods/create_temp/arguments': meta was removed.
 Validate extension JSON: Error: Field 'classes/FileAccess/methods/create_temp/arguments/0': type changed value in new API, from "int" to "enum::FileAccess.ModeFlags".
 

--- a/misc/extension_api_validation/4.5-stable_4.6-stable/GH-90411.txt
+++ b/misc/extension_api_validation/4.5-stable_4.6-stable/GH-90411.txt
@@ -1,5 +1,3 @@
-GH-90411
---------
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/SplitContainer/methods/clamp_split_offset': arguments
 
 Optional argument added for index. Compatibility method registered.

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-104736.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-104736.txt
@@ -1,5 +1,3 @@
-GH-104736
----------
 Validate extension JSON: Error: Field 'classes/PhysicsServer2D/methods/body_set_shape_as_one_way_collision/arguments': size changed value in new API, from 4 to 5.
 Validate extension JSON: Error: Field 'classes/PhysicsServer2DExtension/methods/_body_set_shape_as_one_way_collision/arguments': size changed value in new API, from 4 to 5.
 

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-109004.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-109004.txt
@@ -1,5 +1,3 @@
-GH-109004
----------
 Validate extension JSON: API was removed: classes/ImageTexture/methods/get_format
 Validate extension JSON: API was removed: classes/PortableCompressedTexture2D/methods/get_format
 

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-109142.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-109142.txt
@@ -1,6 +1,3 @@
-GH-109142
----------
-
 Validate extension JSON: Error: Field 'classes/CPUParticles3D/methods/request_particles_process/arguments': size changed value in new API, from 1 to 2.
 Validate extension JSON: Error: Field 'classes/CPUParticles2D/methods/request_particles_process/arguments': size changed value in new API, from 1 to 2.
 Validate extension JSON: Error: Field 'classes/GPUParticles2D/methods/request_particles_process/arguments': size changed value in new API, from 1 to 2.

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-109892.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-109892.txt
@@ -1,6 +1,3 @@
-GH-109892
----------
-
 Validate extension JSON: Error: Field 'classes/Object/enums/ConnectFlags': is_bitfield changed value in new API, from false to true.
 
 The enum above is now corrected to be a bitfield.

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-110369.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-110369.txt
@@ -1,5 +1,3 @@
-GH-110369
---------------
 Validate extension JSON: Error: Field 'classes/AnimationNodeBlendSpace2D/methods/add_blend_point/arguments': size changed value in new API, from 3 to 4.
 Validate extension JSON: Error: Field 'classes/AnimationNodeBlendSpace1D/methods/add_blend_point/arguments': size changed value in new API, from 3 to 4.
 

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-112617.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-112617.txt
@@ -1,5 +1,3 @@
-GH-112617
----------
 Validate extension JSON: API was removed: classes/RichTextLabel/enums/ImageUpdateMask/values/UPDATE_WIDTH_IN_PERCENT
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/arguments/10': default_value changed value in new API, from "false" to "0".
 Validate extension JSON: Error: Field 'classes/RichTextLabel/methods/add_image/arguments/10': type changed value in new API, from "bool" to "enum::RichTextLabel.ImageUnit".

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-113429.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-113429.txt
@@ -1,5 +1,3 @@
-GH-113429
----------
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_albedo': type changed value in new API, from "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture" to "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture,-StreamedTexture2D".
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_emission': type changed value in new API, from "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture" to "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture,-StreamedTexture2D".
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_normal': type changed value in new API, from "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture" to "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture,-StreamedTexture2D".

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-114355.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-114355.txt
@@ -1,5 +1,3 @@
-GH-114355
----------
 Validate extension JSON: API was removed: classes/AudioEffectSpectrumAnalyzer/methods/set_tap_back_pos
 Validate extension JSON: API was removed: classes/AudioEffectSpectrumAnalyzer/methods/get_tap_back_pos
 Validate extension JSON: API was removed: classes/AudioEffectSpectrumAnalyzer/properties/tap_back_pos

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-115799.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-115799.txt
@@ -1,5 +1,3 @@
-GH-115799
----------
 Validate extension JSON: Error: Field 'classes/RenderingServer/methods/viewport_set_size/arguments': size changed value in new API, from 3 to 4.
 
 Optional argument added. Compatibility method registered.

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-115946.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-115946.txt
@@ -1,5 +1,3 @@
-GH-115946
----------
 Validate extension JSON: Error: Field 'classes/ZIPPacker/methods/start_file/arguments': size changed value in new API, from 1 to 3.
 
 Optional argument added. Compatibility method registered.

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-116394.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-116394.txt
@@ -1,5 +1,3 @@
-GH-116394
----------
 Validate extension JSON: Error: Field 'classes/Animation/methods/get_length/return_value': meta changed value in new API, from "float" to "double".
 Validate extension JSON: Error: Field 'classes/Animation/methods/set_length/arguments/0': meta changed value in new API, from "float" to "double".
 

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-116839.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-116839.txt
@@ -1,5 +1,3 @@
-GH-116839
----------
 Validate extension JSON: Error: Field 'classes/Control/methods/get_accessibility_live/return_value': type changed value in new API, from "enum::DisplayServer.AccessibilityLiveMode" to "enum::AccessibilityServer.AccessibilityLiveMode".
 Validate extension JSON: Error: Field 'classes/Control/methods/set_accessibility_live/arguments/0': type changed value in new API, from "enum::DisplayServer.AccessibilityLiveMode" to "enum::AccessibilityServer.AccessibilityLiveMode".
 

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-117149.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-117149.txt
@@ -1,5 +1,3 @@
-GH-117149
----------
 Validate extension JSON: Error: Field 'classes/Font/methods/find_variation/arguments': size changed value in new API, from 9 to 11.
 
 Optional "palette_index" and "custom_colors" arguments added. Compatibility method registered.

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-117399.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-117399.txt
@@ -1,6 +1,3 @@
-GH-117399
---------------
-
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/OpenXRExtensionWrapper/methods/_on_register_metadata': arguments
 
 Added OpenXRInteractionProfileMetadata parameter to function.

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-117800.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-117800.txt
@@ -1,6 +1,3 @@
-GH-117800
---------------
-
 Validate extension JSON: Error: Field 'classes/Image/methods/save_exr/arguments': size changed value in new API, from 2 to 4.
 Validate extension JSON: Error: Field 'classes/Image/methods/save_exr_to_buffer/arguments': size changed value in new API, from 1 to 3.
 

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-117968.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-117968.txt
@@ -1,5 +1,3 @@
-GH-117968
----------
 Validate extension JSON: Error: Field 'classes/EditorVCSInterface/methods/_commit/arguments': size changed value in new API, from 1 to 2.
 
 Added "amend" parameter. Compatibility method registered.

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-118128.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-118128.txt
@@ -1,5 +1,3 @@
-GH-118128
----------
 Validate extension JSON: Error: Field 'classes/OpenXRSpatialAnchorCapability/methods/create_new_anchor/arguments': size changed value in new API, from 2 to 3.
 Validate extension JSON: Error: Field 'classes/OpenXRSpatialComponentData/methods/_get_structure_data': is_const changed value in new API, from true to false.
 

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-118582.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-118582.txt
@@ -1,6 +1,3 @@
-GH-117399
---------------
-
 Validate extension JSON: Error: Field 'classes/Object/methods/is_class/arguments/0': type changed value in new API, from "String" to "StringName".
 
 Changed String parameter to StringName. Compatibility method registered.

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-118787.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-118787.txt
@@ -1,5 +1,3 @@
-GH-118787
---------------
 Validate extension JSON: Error: Field 'classes/EditorExportPlatform/methods/export_project/arguments': size changed value in new API, from 4 to 5.
 
 Added "notify" parameter. Compatibility method registered.

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-119367.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-119367.txt
@@ -1,5 +1,3 @@
-GH-119367
----------
 Validate extension JSON: Error: Field 'classes/TreeItem/methods/select/arguments': size changed value in new API, from 1 to 2.
 
 Optional argument added. Compatibility method registered.

--- a/misc/extension_api_validation/4.6-stable_4.7-stable/GH-119563.txt
+++ b/misc/extension_api_validation/4.6-stable_4.7-stable/GH-119563.txt
@@ -1,5 +1,3 @@
-GH-119563
----------
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/OptimizedTranslation/methods/generate': return_value
 
 Return value changed from "void" to "bool". Compatibility method registered.

--- a/misc/extension_api_validation/4.7-stable/GH-104289.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-104289.txt
@@ -1,6 +1,3 @@
-GH-104289
---------------
-
 Validate extension JSON: Error: Field 'classes/Image/methods/generate_mipmaps/arguments': size changed value in new API, from 1 to 3.
 
 Added two additional parameters to _generate_mipmaps. Compatibility method registered.

--- a/misc/extension_api_validation/4.7-stable/GH-113429.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-113429.txt
@@ -1,5 +1,3 @@
-GH-113429
----------
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_albedo': type changed value in new API, from "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture" to "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture,-StreamedTexture2D".
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_emission': type changed value in new API, from "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture" to "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture,-StreamedTexture2D".
 Validate extension JSON: Error: Field 'classes/Decal/properties/texture_normal': type changed value in new API, from "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture" to "Texture2D,-AnimatedTexture,-AtlasTexture,-CameraTexture,-CanvasTexture,-MeshTexture,-Texture2DRD,-ViewportTexture,-StreamedTexture2D".

--- a/misc/extension_api_validation/4.7-stable/GH-114533.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-114533.txt
@@ -1,5 +1,3 @@
-GH-114533
---------------
 Validate extension JSON: API was removed: classes/GDScriptTextDocument/methods/codeLens
 Validate extension JSON: API was removed: classes/GDScriptTextDocument/methods/colorPresentation
 Validate extension JSON: API was removed: classes/GDScriptTextDocument/methods/foldingRange

--- a/misc/extension_api_validation/4.7-stable/GH-115003.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-115003.txt
@@ -1,5 +1,3 @@
-GH-115003
----------
 Validate extension JSON: Error: Field 'classes/Image/methods/compress/arguments/2': default_value changed value in new API, from "0" to "1".
 Validate extension JSON: Error: Field 'classes/Image/methods/compress/arguments/2': type changed value in new API, from "enum::Image.ASTCFormat" to "enum::Image.CompressProfile".
 Validate extension JSON: Error: Field 'classes/Image/methods/compress_from_channels/arguments/2': default_value changed value in new API, from "0" to "1".

--- a/misc/extension_api_validation/4.7-stable/GH-119196.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-119196.txt
@@ -1,6 +1,3 @@
-GH-119196
---------------
-
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/DisplayServer/methods/get_display_cutouts': arguments
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/DisplayServer/methods/get_display_safe_area': arguments
 

--- a/misc/extension_api_validation/4.7-stable/GH-120609.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-120609.txt
@@ -1,5 +1,3 @@
-GH-120609
---------------
 Validate extension JSON: Error: Field 'classes/Skeleton3D/methods/reset_bone_pose/arguments': size changed value in new API, from 1 to 2.
 Validate extension JSON: JSON file: Field was added in a way that breaks compatibility 'classes/Skeleton3D/methods/reset_bone_poses': arguments
 

--- a/misc/extension_api_validation/4.7-stable/GH-120749.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-120749.txt
@@ -1,6 +1,3 @@
-GH-120749
----------
-
 Validate extension JSON: Error: Field 'classes/AudioEffectInstance/methods/_process/arguments/0': type changed value in new API, from "const void*" to "const AudioFrame*".
 Validate extension JSON: Error: Field 'classes/MovieWriter/methods/_write_frame/arguments/1': type changed value in new API, from "const void*" to "const int32_t*".
 

--- a/misc/extension_api_validation/4.7-stable/GH-121123.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-121123.txt
@@ -1,6 +1,3 @@
-GH-121123
----------
-
 Validate extension JSON: Error: Field 'classes/OpenXRSpatialEntityExtension/methods/create_spatial_context/arguments': size changed value in new API, from 3 to 4.
 
 Added new optional `p_failure_callback` method to `create_spatial_context`.

--- a/misc/extension_api_validation/4.7-stable/GH-121318.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-121318.txt
@@ -1,5 +1,3 @@
-GH-121318
---------------
 Validate extension JSON: API was removed: classes/AnimationNodeBlendSpace2D/properties/triangles
 
 The "triangles" property was moved from static ADD_PROPERTY registration into the dynamic _get_property_list() override, to allow it to serialize/deserialize together with blend_point_i/*, and prevent errors and dropped triangles on load. The property remains fully functional at runtime via _set/_get, only its static GDExtension reflection entry was removed.

--- a/misc/extension_api_validation/4.7-stable/GH-121895.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-121895.txt
@@ -1,6 +1,3 @@
-GH-121895
----------
-
 Validate extension JSON: Error: Field 'classes/DisplayServer/signals/orientation_changed/arguments/0': type changed value in new API, from "int" to "enum::DisplayServer.SensorOrientation".
 
 Added a dedicated enum for the `orientation_changed` signal to make it easier to validate the orientation returned by the signal. The underlying int values remain unchanged.

--- a/misc/extension_api_validation/4.7-stable/GH-121937.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-121937.txt
@@ -1,6 +1,3 @@
-GH-121937
---------------
-
 Validate extension JSON: Error: Field 'classes/RenderingDevice/methods/texture_create_shared_from_slice/arguments': size changed value in new API, from 6 to 7.
 
 Added optional "layers" argument to texture_create_shared_from_slice in RenderingDevice.

--- a/misc/extension_api_validation/4.7-stable/GH-88647.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-88647.txt
@@ -1,5 +1,3 @@
-GH-88647
---------
 Validate extension JSON: Error: Field 'classes/CPUParticles3D/properties/mesh': type changed value in new API, from "Mesh" to "QuadMesh,BoxMesh,SphereMesh,CapsuleMesh,CylinderMesh,PrismMesh,TorusMesh,PlaneMesh,TextMesh,RibbonTrailMesh,TubeTrailMesh,PointMesh,ArrayMesh,ImmediateMesh,PlaceholderMesh,Mesh".
 Validate extension JSON: Error: Field 'classes/CollisionShape2D/properties/shape': type changed value in new API, from "Shape2D" to "RectangleShape2D,CircleShape2D,CapsuleShape2D,SegmentShape2D,SeparationRayShape2D,WorldBoundaryShape2D,ConvexPolygonShape2D,ConcavePolygonShape2D,Shape2D".
 Validate extension JSON: Error: Field 'classes/CollisionShape3D/properties/shape': type changed value in new API, from "Shape3D" to "BoxShape3D,SphereShape3D,CapsuleShape3D,CylinderShape3D,SeparationRayShape3D,HeightMapShape3D,WorldBoundaryShape3D,ConvexPolygonShape3D,ConcavePolygonShape3D,Shape3D".

--- a/misc/extension_api_validation/4.7-stable/GH-XXXXXX.txt
+++ b/misc/extension_api_validation/4.7-stable/GH-XXXXXX.txt
@@ -2,9 +2,6 @@
 # Only lines that start with "Validate extension JSON:" matter, everything else is considered a comment and ignored.
 # They should instead be used to justify these changes and describe how users should work around these changes.
 
-GH-{PR_NUMBER}
---------------
-
 Validate extension ....
 Validate extension ....
 


### PR DESCRIPTION
Removes redundant PR numbers, it was copied form the file name and is already in the file name.