### PR TITLE
Allow external editor dock plugins to float

### DIFF
--- a/doc/classes/EditorDock.xml
+++ b/doc/classes/EditorDock.xml
@@ -79,6 +79,13 @@
 				Closes the dock, making its tab hidden.
 			</description>
 		</method>
+		<method name="make_floating">
+			<return type="void" />
+			<param index="0" name="screen" type="int" default="-1" />
+			<description>
+				Opens the dock in a floating window on the specified [param screen].
+			</description>
+		</method>
 		<method name="make_visible">
 			<return type="void" />
 			<description>

--- a/editor/docks/editor_dock.cpp
+++ b/editor/docks/editor_dock.cpp
@@ -70,6 +70,7 @@ void EditorDock::_notification(int p_what) {
 void EditorDock::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("open"), &EditorDock::open);
 	ClassDB::bind_method(D_METHOD("make_visible"), &EditorDock::make_visible);
+	ClassDB::bind_method(D_METHOD("make_floating", "screen"), &EditorDock::make_floating, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("close"), &EditorDock::close);
 
 	ClassDB::bind_method(D_METHOD("set_title", "title"), &EditorDock::set_title);


### PR DESCRIPTION
## What problem(s) does this PR solve?

With the new `EditorDock` main screen rework, third-party main screen plugins can't float using the default editor behavior. By exposing `make_floating` to scripting, any third-party editor main screen dock can float.