### PR TITLE
TileSet Editor: Make hints for creating tiles display correct keybind

### DIFF
--- a/editor/scene/2d/scene_paint_2d_editor_plugin.cpp
+++ b/editor/scene/2d/scene_paint_2d_editor_plugin.cpp
@@ -930,7 +930,7 @@ ScenePaint2DEditor::ScenePaint2DEditor() {
 	scene_picker_button->set_toggle_mode(true);
 	scene_picker_button->set_accessibility_name(TTRC("Scene Picker"));
 	scene_picker_button->set_theme_type_variation(SceneStringName(FlatButton));
-	scene_picker_button->set_tooltip_text(TTRC("When enabled, you can select scenes from the FileSystem dock, Scene dock, or 2D editor's viewport.\nHolding Ctrl enables picking from the 2D editor's viewport."));
+	scene_picker_button->set_tooltip_text(vformat(TTRC("When enabled, you can select scenes from the FileSystem dock, Scene dock, or 2D editor's viewport.\nHolding %s enables picking from the 2D editor's viewport."), keycode_get_string(Key::CMD_OR_CTRL)));
 	scene_picker_button->connect(SceneStringName(toggled), callable_mp(this, &ScenePaint2DEditor::_scene_picker_toggled));
 	scene_picker_button->set_shortcut(ED_SHORTCUT("scene_painter/scene_picker", TTRC("Scene Picker"), Key::I));
 	scene_picker_button->set_shortcut_context(CanvasItemEditor::get_singleton());
@@ -974,7 +974,7 @@ ScenePaint2DEditor::ScenePaint2DEditor() {
 	advanced_settings_popup->set_item_metadata(-1, PAINT_MODE_SNAP_GRID_CELL_CENTER);
 	advanced_settings_popup->add_separator();
 	advanced_settings_popup->add_check_item(TTRC("Allow Overlapping"), MENU_ITEM_ALLOW_OVERLAPPING);
-	advanced_settings_popup->set_item_tooltip(-1, TTRC("Allow painting over existing painted scenes.\nHold Shift while painting to temporarily toggle this option."));
+	advanced_settings_popup->set_item_tooltip(-1, vformat(TTRC("Allow painting over existing painted scenes.\nHold %s while painting to temporarily toggle this option."), keycode_get_string(Key::SHIFT)));
 	advanced_settings_popup->set_item_disabled(-1, true);
 
 	advanced_settings_popup->connect(SceneStringName(id_pressed), callable_mp(this, &ScenePaint2DEditor::_advanced_settings_id_pressed));

--- a/modules/tilemap/editor/tile_set_atlas_source_editor.cpp
+++ b/modules/tilemap/editor/tile_set_atlas_source_editor.cpp
@@ -1010,10 +1010,10 @@ void TileSetAtlasSourceEditor::_update_atlas_view() {
 	} else {
 		if (tools_button_group->get_pressed_button() == tool_setup_atlas_source_button) {
 			help_label->set_visible(true);
-			help_label->set_text(TTR("Hold Ctrl to create multiple tiles.") + "\n" + TTR("Hold Shift to create big tiles."));
+			help_label->set_text(vformat(TTR("Hold %s to create multiple tiles.") + "\n" + TTR("Hold %s to create big tiles."), keycode_get_string(Key::CMD_OR_CTRL), keycode_get_string(Key::SHIFT)));
 		} else if (tools_button_group->get_pressed_button() == tool_select_button) {
 			help_label->set_visible(true);
-			help_label->set_text(TTR("Hold Shift to select multiple regions."));
+			help_label->set_text(vformat(TTR("Hold %s to select multiple regions."), keycode_get_string(Key::SHIFT)));
 		} else {
 			help_label->set_visible(false);
 		}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #123264

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

With this PR, the key names for multiple tile creation and large tile creation are pulled from the OS, rather than written in manually to the hint string. This makes them correctly reflect the actual keys used on macOS:

<img width="2000" height="1376" alt="CleanShot 2026-09-06 at 10 00 14 PM@2x" src="https://github.com/user-attachments/assets/3c84045b-38f2-4420-bd64-4a815ee8ab71" />

> [!note]
> Technically, only the Ctrl key reference was inaccurate; using Shift to create big tiles still works on macOS. However, overall it seems like best practice to adopt the same strategy of pulling key names based on the OS rather than writing them in manually, so I did the same for the Shift key references.