### PR TITLE
Fix partially received WebSockets packets on Web due to data race

### DIFF
--- a/modules/websocket/emws_peer.cpp
+++ b/modules/websocket/emws_peer.cpp
@@ -41,6 +41,7 @@ WebSocketPeer *EMWSPeer::_create(bool p_notify_postinitialize) {
 
 void EMWSPeer::_esws_on_connect(void *p_obj, char *p_proto) {
 	EMWSPeer *peer = static_cast<EMWSPeer *>(p_obj);
+	MutexLock lock(peer->mutex);
 	peer->ready_state = STATE_OPEN;
 	peer->selected_protocol.clear();
 	peer->selected_protocol.append_utf8(p_proto);
@@ -48,17 +49,20 @@ void EMWSPeer::_esws_on_connect(void *p_obj, char *p_proto) {
 
 void EMWSPeer::_esws_on_message(void *p_obj, const uint8_t *p_data, int p_data_size, int p_is_string) {
 	EMWSPeer *peer = static_cast<EMWSPeer *>(p_obj);
+	MutexLock lock(peer->mutex);
 	uint8_t is_string = p_is_string ? 1 : 0;
 	peer->in_buffer.write_packet(p_data, p_data_size, &is_string);
 }
 
 void EMWSPeer::_esws_on_error(void *p_obj) {
 	EMWSPeer *peer = static_cast<EMWSPeer *>(p_obj);
+	MutexLock lock(peer->mutex);
 	peer->ready_state = STATE_CLOSED;
 }
 
 void EMWSPeer::_esws_on_close(void *p_obj, int p_code, const char *p_reason, int p_was_clean) {
 	EMWSPeer *peer = static_cast<EMWSPeer *>(p_obj);
+	MutexLock lock(peer->mutex);
 	peer->close_code = p_code;
 	peer->close_reason.clear();
 	peer->close_reason.append_utf8(p_reason);
@@ -66,6 +70,7 @@ void EMWSPeer::_esws_on_close(void *p_obj, int p_code, const char *p_reason, int
 }
 
 Error EMWSPeer::connect_to_url(const String &p_url, const Ref<TLSOptions> &p_tls_options) {
+	MutexLock lock(mutex);
 	ERR_FAIL_COND_V(p_url.is_empty(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(p_tls_options.is_valid() && p_tls_options->is_server(), ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(ready_state != STATE_CLOSED && ready_state != STATE_CLOSING, ERR_ALREADY_IN_USE);
@@ -140,12 +145,14 @@ Error EMWSPeer::put_packet(const uint8_t *p_buffer, int p_buffer_size) {
 }
 
 Error EMWSPeer::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
+	MutexLock lock(mutex);
 	if (in_buffer.packets_left() == 0) {
 		return ERR_UNAVAILABLE;
 	}
 
 	int read = 0;
 	Error err = in_buffer.read_packet(packet_buffer.ptrw(), packet_buffer.size(), &was_string, read);
+
 	ERR_FAIL_COND_V(err != OK, err);
 
 	*r_buffer = packet_buffer.ptr();
@@ -155,6 +162,7 @@ Error EMWSPeer::get_packet(const uint8_t **r_buffer, int &r_buffer_size) {
 }
 
 int EMWSPeer::get_available_packet_count() const {
+	MutexLock lock(mutex);
 	return in_buffer.packets_left();
 }
 
@@ -170,6 +178,7 @@ bool EMWSPeer::was_string_packet() const {
 }
 
 void EMWSPeer::_clear() {
+	MutexLock lock(mutex);
 	if (peer_sock != -1) {
 		godot_js_websocket_destroy(peer_sock);
 		peer_sock = -1;
@@ -185,6 +194,7 @@ void EMWSPeer::_clear() {
 }
 
 void EMWSPeer::close(int p_code, const String &p_reason) {
+	MutexLock lock(mutex);
 	if (p_code < 0) {
 		if (peer_sock != -1) {
 			godot_js_websocket_destroy(peer_sock);

--- a/modules/websocket/emws_peer.h
+++ b/modules/websocket/emws_peer.h
@@ -36,6 +36,7 @@
 #include "websocket_peer.h"
 
 #include "core/io/packet_peer.h"
+#include "core/os/mutex.h"
 #include "core/templates/ring_buffer.h"
 
 #include <emscripten.h>
@@ -60,6 +61,7 @@ private:
 	State ready_state = STATE_CLOSED;
 	Vector<uint8_t> packet_buffer;
 	PacketBuffer<uint8_t> in_buffer;
+	Mutex mutex;
 	uint8_t was_string = 0;
 	int close_code = -1;
 	String close_reason;


### PR DESCRIPTION
This change fixes the data race, that can occur, when calling WebSocketPeer methods from another thread in Godot Web build.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #123184

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
