### PR TITLE
[Windows] Fix IME message handling.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -4527,6 +4527,9 @@ void DisplayServerWindows::process_events() {
 
 	bool has_touch_events = process_raw_input();
 
+	DisplayServerEnums::WindowID window_id = _get_focused_window_or_popup();
+	const WindowData &wd = windows[window_id];
+
 	// The pump throttles only what the hardware can flood, and drains the rest.
 	// See <https://ph3at.github.io/posts/Windows-Input/> for more information.
 	//
@@ -4560,7 +4563,7 @@ void DisplayServerWindows::process_events() {
 		}
 		return ret;
 	};
-	if (has_touch_events) {
+	if (has_touch_events || wd.ime_active) {
 		// Process all messages.
 		while (PeekMessageW(&msg, nullptr, 0, 0, PM_REMOVE)) {
 			TranslateMessage(&msg);


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/123269

## Additional information

Uses full message processing while IME is active (text input control is focused). I'm not entirely sure why multiple filtered `PeekMessageW` calls are causing issues with IME.

Note for 4.7 cherry-picking - should be done after https://github.com/godotengine/godot/pull/122825
