### PR TITLE
Mark assumptions of trivial relocatability with comments to avoid regressions

### DIFF
--- a/core/templates/a_hash_map.h
+++ b/core/templates/a_hash_map.h
@@ -48,6 +48,8 @@ class Variant;
  * Key-values are not pointer-stable.
  * Indices are stable as long as no elements are removed; otherwise arbitrary.
  *
+ * Keys and values are relocated by naive memory moves; they must not store their own address (see GH-100509).
+ *
  * Core container guidance:
  * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
  */
@@ -343,6 +345,7 @@ public:
 		_size--;
 
 		if (element_idx < _size) {
+			// Relocate element down (see GH-100509).
 			memcpy((void *)&_elements[element_idx], (const void *)&_elements[_size], sizeof(MapKeyValue));
 			uint32_t moved_element_idx = 0;
 			uint32_t moved_meta_idx = 0;

--- a/core/templates/command_queue_mt.h
+++ b/core/templates/command_queue_mt.h
@@ -182,7 +182,7 @@ class CommandQueueMT {
 
 			// Protect against race condition between this thread
 			// during the call to the command and other threads potentially
-			// invalidating the pointer due to reallocs by relocating the object.
+			// invalidating the pointer due to reallocs by relocating the object (see GH-100509).
 			CommandBase *cmd_original = reinterpret_cast<CommandBase *>(&command_mem[flush_read_ptr]);
 			CommandBase *cmd_local = reinterpret_cast<CommandBase *>(cmd_local_mem);
 			memcpy(cmd_local_mem, (char *)cmd_original, size);

--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -56,6 +56,15 @@ GODOT_GCC_PRAGMA(GCC diagnostic warning "-Wstringop-overflow=0") // Can't "ignor
 GODOT_GCC_PRAGMA(GCC diagnostic warning "-Wdangling-pointer=0") // Can't "ignore" this for some reason.
 #endif
 
+/**
+ * Array-like container with copy-on-write semantics.
+ * Not intended for direct use. Consider using Vector or String instead.
+ *
+ * Elements are relocated by naive memory moves; they must not store their own address (see GH-100509).
+ *
+ * Core container guidance:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
+ */
 template <typename T>
 class CowData {
 public:
@@ -344,7 +353,7 @@ Error CowData<T>::_insert_uninitialized(USize p_index, USize p_count, USize p_ca
 			RETURN_IF_ERROR(_realloc_exact(p_capacity));
 		}
 
-		// Relocate elements up.
+		// Relocate elements up (assumes trivial relocatability; see GH-100509).
 		if (p_index != (USize)size()) {
 			memmove((void *)(_ptr + p_index + p_count), (void *)(_ptr + p_index), (size() - p_index) * sizeof(T));
 		}

--- a/core/templates/fixed_vector.h
+++ b/core/templates/fixed_vector.h
@@ -38,6 +38,8 @@ GODOT_GCC_WARNING_PUSH_AND_IGNORE("-Warray-bounds")
 /**
  * Array-like storage that's local (no allocations).
  *
+ * Elements are relocated by naive memory moves; they must not store their own address (see GH-100509).
+ *
  * Core container guidance:
  * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
  *
@@ -111,6 +113,7 @@ public:
 		}
 
 		// Relocate elements (and size) into our buffer.
+		// Assumes trivial relocatability (see GH-100509).
 		memcpy((void *)&_size, (void *)&p_from._size, sizeof(_size) + DATA_PADDING + p_from.size() * sizeof(T));
 		p_from._size = 0;
 

--- a/core/templates/hash_set.h
+++ b/core/templates/hash_set.h
@@ -40,6 +40,8 @@
  * Elements are not pointer stable.
  * The element order is arbitrary.
  *
+ * Elements are relocated by naive memory moves; they must not store their own address (see GH-100509).
+ *
  * Core container guidance:
  * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
  */

--- a/core/templates/local_vector.h
+++ b/core/templates/local_vector.h
@@ -42,6 +42,8 @@
 /**
  * Array-like container with unique ownership.
  *
+ * Elements are relocated by naive memory moves; they must not store their own address (see GH-100509).
+ *
  * Core container guidance:
  * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
  *

--- a/core/templates/self_list.h
+++ b/core/templates/self_list.h
@@ -34,6 +34,16 @@
 #include "core/templates/sort_list.h"
 #include "core/typedefs.h"
 
+/**
+ * A doubly linked list, implemented by storing the previous and next
+ * pointer in each element rather than a separate allocation.
+ *
+ * This class is not trivially relocatable, which makes
+ * usage like `Vector<SelfList<T>>` impossible (see GH-100509).
+ *
+ * Core container guidance:
+ * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
+ */
 template <typename T>
 class _WARN_UNUSED_ SelfList {
 public:

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -53,6 +53,8 @@ public:
 /**
  * Array-like container with copy-on-write semantics.
  *
+ * Elements are relocated by naive memory moves; they must not store their own address (see GH-100509).
+ *
  * Core container guidance:
  * https://docs.godotengine.org/en/latest/engine_details/architecture/core_types.html#containers
  */


### PR DESCRIPTION
## What problem(s) does this PR solve?

A ~year ago we decided to always assume trivial relocatability (https://github.com/godotengine/godot/issues/100509) since nontrivial relocatability is rarely useful, and not making the assumption is costly for core.

However, well-meaning contributors might not be aware of this and try to fix code that is already correct (e.g. https://github.com/godotengine/godot/pull/122627).

This PR attempts to prevent this by adding comments protecting the code.
It doubles as a reminder to people that trivial relocatability is assumed. This probably doesn't matter for us, but occasionally pops up in godot-cpp related chats.

## Additional information

I also marked `SelfList` which is the only canonically nontrivially relocatable type in core.