### PR TITLE
CI: Bump SCons version [4.11.0 → 4.11.1]

### DIFF
--- a/.github/actions/godot-deps/action.yml
+++ b/.github/actions/godot-deps/action.yml
@@ -10,7 +10,7 @@ inputs:
     default: x64
   scons-version:
     description: The SCons version to use.
-    default: 4.11.0
+    default: 4.11.1
 
 runs:
   using: composite


### PR DESCRIPTION
## What problem(s) does this PR solve?

Ensures that our buildsystem supports the latest available SCons version: [4.11.1](https://scons.org/scons-4111-is-available.html).

## Additional information

N/A