### PR TITLE
Editor: Skip syntax highlighting for very long lines

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -9719,6 +9719,8 @@ Vector2i TextEdit::_get_hovered_gutter(const Point2 &p_mouse_pos) const {
 }
 
 /* Syntax highlighting. */
+static constexpr int MAX_SYNTAX_HIGHLIGHTING_LINE_LENGTH = 10000;
+
 Vector<Pair<int64_t, Color>> TextEdit::_get_line_syntax_highlighting(int p_line) {
 	if (syntax_highlighter.is_null() || setting_text) {
 		return Vector<Pair<int64_t, Color>>();
@@ -9727,6 +9729,12 @@ Vector<Pair<int64_t, Color>> TextEdit::_get_line_syntax_highlighting(int p_line)
 	HashMap<int, Vector<Pair<int64_t, Color>>>::Iterator E = syntax_highlighting_cache.find(p_line);
 	if (E) {
 		return E->value;
+	}
+
+	if (text[p_line].length() > MAX_SYNTAX_HIGHLIGHTING_LINE_LENGTH) {
+		Vector<Pair<int64_t, Color>> result;
+		syntax_highlighting_cache.insert(p_line, result);
+		return result;
 	}
 
 	Dictionary color_map = syntax_highlighter->get_line_syntax_highlighting(p_line);

--- a/tests/scene/test_text_edit.cpp
+++ b/tests/scene/test_text_edit.cpp
@@ -699,6 +699,25 @@ TEST_CASE("[SceneTree][TextEdit] text entry") {
 			text_edit->remove_secondary_carets();
 		}
 
+		SUBCASE("[TextEdit] long line undo and redo") {
+			const String long_line = String("a").repeat(10000);
+			text_edit->set_line(0, long_line);
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_line(0) == long_line);
+
+			text_edit->insert_text_at_caret("b");
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_line(0) == "b" + long_line);
+
+			text_edit->undo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_line(0) == long_line);
+
+			text_edit->redo();
+			MessageQueue::get_singleton()->flush();
+			CHECK(text_edit->get_line(0) == "b" + long_line);
+		}
+
 		SUBCASE("[TextEdit] swap lines") {
 			lines_edited_args = { { 0, 0 }, { 0, 1 } };
 


### PR DESCRIPTION
## What does this PR do?

Avoids syntax-highlighting work for lines longer than 10,000 characters and caches the empty result.

This keeps the script editor responsive when editing accidentally huge lines.

## Testing

- Manually tested editing, deleting, undoing, and redoing text on a line longer than 10,000 characters.
- Added a TextEdit regression test covering long-line undo and redo.
- `git diff --check` passes.


> [!INFO]
> *AI disclosure*: This contribution was authored by GitHub Copilot, an autonomous AI agent, on behalf of the user.