### PR TITLE
Add method `align_with` to Node3D

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -411,16 +411,29 @@ Quaternion Basis::get_rotation_quaternion() const {
 	return m.get_quaternion();
 }
 
+
 void Basis::rotate_to_align(Vector3 p_start_direction, Vector3 p_end_direction) {
 	// Takes two vectors and rotates the basis from the first vector to the second vector.
-	// Adopted from: https://gist.github.com/kevinmoran/b45980723e53edeb8a5a43c49f134724
-	const Vector3 axis = p_start_direction.cross(p_end_direction).normalized();
-	if (axis.length_squared() != 0) {
-		real_t dot = p_start_direction.dot(p_end_direction);
-		dot = CLAMP(dot, -1.0f, 1.0f);
-		const real_t angle_rads = Math::acos(dot);
-		*this = Basis(axis, angle_rads) * (*this);
+	// Adopted from: https://iquilezles.org/articles/noacos/
+	if (p_start_direction.length_squared()==0 || p_end_direction.length_squared()==0) { // check for zero vectors
+		return; // perhaps log a warning here
 	}
+
+	p_start_direction = p_start_direction.normalized(); // must be normalized
+	p_end_direction = p_end_direction.normalized(); // must be normalized
+
+	if (p_start_direction == -p_end_direction) { // special case, ambiguous 180 rotation
+		*this = (*this)*Basis(-1, 0, 0,  0, 1, 0,  0, 0, -1); // flip x&z for a local 180 flip
+		return;
+	}
+
+	const Vector3 axis = p_start_direction.cross(p_end_direction);
+	const real_t c = p_start_direction.dot(p_end_direction); // cosine
+	const real_t k = 1.0/(1.0+c);
+	*this = Basis(
+			axis.x*axis.x*k+c,      axis.y*axis.x*k-axis.z, axis.z*axis.x*k+axis.y,
+			axis.x*axis.y*k+axis.z, axis.y*axis.y*k+c,      axis.z*axis.y*k-axis.x,
+			axis.x*axis.z*k-axis.y, axis.y*axis.z*k+axis.x, axis.z*axis.z*k+c) * (*this);
 }
 
 void Basis::get_rotation_axis_angle(Vector3 &p_axis, real_t &p_angle) const {

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -415,7 +415,7 @@ Quaternion Basis::get_rotation_quaternion() const {
 void Basis::rotate_to_align(Vector3 p_start_direction, Vector3 p_end_direction) {
 	// Takes two vectors and rotates the basis from the first vector to the second vector.
 	// Adopted from: https://iquilezles.org/articles/noacos/
-	if (p_start_direction.length_squared()==0 || p_end_direction.length_squared()==0) { // check for zero vectors
+	if (p_start_direction.is_zero_approx() || p_end_direction.is_zero_approx()) { // check for zero vectors
 		return; // perhaps log a warning here
 	}
 

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -1259,6 +1259,16 @@ void Node3D::look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target
 	set_scale(original_scale);
 }
 
+void Node3D::align_with(const Vector3 &p_destination, bool p_use_model_front) {
+	ERR_THREAD_GUARD;
+	ERR_FAIL_COND_MSG(p_destination.is_zero_approx(), "Destination vector can't be zero, align_with() failed.");
+
+	Basis updated_basis = get_global_basis();
+	const Vector3 forward = updated_basis.xform( (p_use_model_front? Vector3::BACK : Vector3::FORWARD ));
+	updated_basis.rotate_to_align(forward, p_destination);
+	set_global_basis(updated_basis);
+}
+
 Vector3 Node3D::to_local(Vector3 p_global) const {
 	ERR_READ_THREAD_GUARD_V(Vector3());
 	return get_global_transform().affine_inverse().xform(p_global);
@@ -1501,6 +1511,8 @@ void Node3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("look_at", "target", "up", "use_model_front"), &Node3D::look_at, DEFVAL(Vector3::UP), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("look_at_from_position", "position", "target", "up", "use_model_front"), &Node3D::look_at_from_position, DEFVAL(Vector3::UP), DEFVAL(false));
+
+	ClassDB::bind_method(D_METHOD("align_with", "destination", "use_model_front"), &Node3D::align_with, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("to_local", "global_point"), &Node3D::to_local);
 	ClassDB::bind_method(D_METHOD("to_global", "local_point"), &Node3D::to_global);

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -330,6 +330,8 @@ public:
 	void look_at(const Vector3 &p_target, const Vector3 &p_up = Vector3::UP, bool p_use_model_front = false);
 	void look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up = Vector3::UP, bool p_use_model_front = false);
 
+	void align_with(const Vector3 &p_destination, bool p_use_model_front = false);
+
 	Vector3 to_local(Vector3 p_global) const;
 	Vector3 to_global(Vector3 p_local) const;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

It gives users a simple interface to align objects to a vector (e.g. velocity) in a fast and efficient manner (without using expensive trig functions internally)

As a longtime user of the engine I really felt the need for this method. Of course there is an alternative: `look_at(destination+global_position)` but I would argue that it is a little unhandy and awkward for how often it comes up. Having a special method for it is cleaner and *probably* faster.

## Additional information

I rewrote `Basis::rotate_to_align` without using trig functions to make it cleaner and faster(?)
Then I exposed it to client code through `Node3D.align_with(destination : Vector3, use_model_front : bool = false)`

If this PR gets accepted I will work on an equivalent method for `Node2D` to keep engine design symmetrical.

Please let me know what should be changed.

> No AI used