### PR TITLE
Move the Directional Shadow group below Sky Mode in DirectionalLight3D inspector

### DIFF
--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -588,6 +588,8 @@ void DirectionalLight3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_sky_mode", "mode"), &DirectionalLight3D::set_sky_mode);
 	ClassDB::bind_method(D_METHOD("get_sky_mode"), &DirectionalLight3D::get_sky_mode);
 
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "sky_mode", PROPERTY_HINT_ENUM, "Light and Sky,Light Only,Sky Only"), "set_sky_mode", "get_sky_mode");
+
 	ADD_GROUP("Directional Shadow", "directional_shadow_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "directional_shadow_mode", PROPERTY_HINT_ENUM, "Orthogonal (Fast),PSSM 2 Splits (Average),PSSM 4 Splits (Slow)"), "set_shadow_mode", "get_shadow_mode");
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "directional_shadow_split_1", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_param", "get_param", PARAM_SHADOW_SPLIT_1_OFFSET);
@@ -597,8 +599,6 @@ void DirectionalLight3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "directional_shadow_fade_start", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_param", "get_param", PARAM_SHADOW_FADE_START);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "directional_shadow_max_distance", PROPERTY_HINT_RANGE, "0,8192,0.1,or_greater,exp"), "set_param", "get_param", PARAM_SHADOW_MAX_DISTANCE);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "directional_shadow_pancake_size", PROPERTY_HINT_RANGE, "0,1024,0.1,or_greater,exp"), "set_param", "get_param", PARAM_SHADOW_PANCAKE_SIZE);
-
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "sky_mode", PROPERTY_HINT_ENUM, "Light and Sky,Light Only,Sky Only"), "set_sky_mode", "get_sky_mode");
 
 	BIND_ENUM_CONSTANT(SHADOW_ORTHOGONAL);
 	BIND_ENUM_CONSTANT(SHADOW_PARALLEL_2_SPLITS);


### PR DESCRIPTION
- Related to https://github.com/godotengine/godot/pull/59567.

This makes the group display below the only top-level property, similar to other nodes in Godot.

(This is a purely inspector-only change, it doesn't affect the exposed API.)

## Preview

### Collapsed

Before | After
-|-
<img width="281" height="155" alt="Image" src="https://github.com/user-attachments/assets/b85389aa-8e64-445b-9fe8-8078115ab0cd" /> | <img width="281" height="156" alt="Image" src="https://github.com/user-attachments/assets/499095ca-43f1-46d9-850a-105990736ea7" />

### Expanded

Before | After
-|-
<img width="281" height="399" alt="Image" src="https://github.com/user-attachments/assets/b560af66-5178-4ee0-b23e-ac4dafed802c" /> | <img width="281" height="402" alt="Image" src="https://github.com/user-attachments/assets/b3f3265c-8a90-4bf1-be39-901084f3202b" />