### PR TITLE
Project Manager: Make capitalization of checkbox labels consistent and improve wording of a tooltip

### DIFF
--- a/editor/project_manager/project_manager.cpp
+++ b/editor/project_manager/project_manager.cpp
@@ -1876,12 +1876,12 @@ ProjectManager::ProjectManager() {
 		ask_update_label->set_v_size_flags(SIZE_EXPAND_FILL);
 		ask_update_vb->add_child(ask_update_label);
 		ask_update_backup = memnew(CheckBox);
-		ask_update_backup->set_text(TTRC("Backup project first"));
+		ask_update_backup->set_text(TTRC("Back Up Project First"));
 		ask_update_backup->set_h_size_flags(SIZE_SHRINK_CENTER);
 		ask_update_vb->add_child(ask_update_backup);
 		ask_upgrade_tool = memnew(CheckBox);
 		ask_upgrade_tool->set_text(TTRC("Upgrade All Project Files"));
-		ask_upgrade_tool->set_tooltip_text(TTRC("Automatically runs the upgrade tool. This may take a while to finish. The project will be restarted once in the process."));
+		ask_upgrade_tool->set_tooltip_text(TTRC("Automatically runs the upgrade tool. This may take a while to finish. The editor may restart during the process."));
 		ask_upgrade_tool->set_h_size_flags(SIZE_SHRINK_CENTER);
 		ask_update_vb->add_child(ask_upgrade_tool);
 		ask_update_settings->get_ok_button()->connect(SceneStringName(pressed), callable_mp(this, &ProjectManager::_open_selected_projects_with_migration));


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

This PR fixes a few tiny grammar/wording issues in the Project Manager dialog box that appears when attempting to open a project last opened on a different version of Godot:

- "Backup project first" → "Back Up Project First"
  - "Back up" (with a space) is a verb meaning to save a copy of content at a specific point in time; "backup" (with no space) is a noun meaning the content which has been saved. Since the checkbox is asking if the user wants to perform a specific action, the verb form makes more sense.
  - The text was changed to title case to be consistent with "Upgrade All Project Files" below as well as other places in the Project Manager and editor.
- "The project will be restarted once in the process" → "The editor may restart during the process"
  - I found the old wording to be very confusing as a native English speaker. It's ambiguous whether the "once" means "at one point in time, during the process" or "as soon as the process starts", in a way that feels like it's important it means one or the other. The revised wording is still vague, I suppose, but does not arguably make any strong promises about how many times or when during the process it may restart.

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

N/A
