### PR TITLE
[Windows] Fix root path string leak in native file dialog.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -498,11 +498,12 @@ public:
 		}
 
 		LPWSTR lpw_path = nullptr;
-		p_item->GetDisplayName(SIGDN_FILESYSPATH, &lpw_path);
-		if (!lpw_path) {
+		HRESULT hr = p_item->GetDisplayName(SIGDN_FILESYSPATH, &lpw_path);
+		if (FAILED(hr)) {
 			return S_FALSE;
 		}
 		String path = String::utf16((const char16_t *)lpw_path).replace_char('\\', '/').trim_prefix(R"(\\?\)").simplify_path();
+		CoTaskMemFree(lpw_path);
 		if (!path.begins_with(root.simplify_path())) {
 			return S_FALSE;
 		}


### PR DESCRIPTION
## What problem(s) does this PR solve?

- String leak in some native file dialog configurations.

