### PR TITLE
Vulkan: Fix swapped swappy_mode cases in swap chain resize

### DIFF
--- a/drivers/vulkan/rendering_device_driver_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_driver_vulkan.cpp
@@ -3909,16 +3909,16 @@ Error RenderingDeviceDriverVulkan::swap_chain_resize(CommandQueueID p_cmd_queue,
 
 		switch (swappy_mode) {
 			case PIPELINE_FORCED_ON:
-				SwappyVk_setAutoSwapInterval(true);
-				SwappyVk_setAutoPipelineMode(true);
+				SwappyVk_setAutoSwapInterval(false);
+				SwappyVk_setAutoPipelineMode(false);
 				break;
 			case AUTO_FPS_PIPELINE_FORCED_ON:
 				SwappyVk_setAutoSwapInterval(true);
 				SwappyVk_setAutoPipelineMode(false);
 				break;
 			case AUTO_FPS_AUTO_PIPELINE:
-				SwappyVk_setAutoSwapInterval(false);
-				SwappyVk_setAutoPipelineMode(false);
+				SwappyVk_setAutoSwapInterval(true);
+				SwappyVk_setAutoPipelineMode(true);
 				break;
 		}
 	}


### PR DESCRIPTION
Fixes #123283.

In `RenderingDeviceDriverVulkan::swap_chain_resize`, `PIPELINE_FORCED_ON` and `AUTO_FPS_AUTO_PIPELINE` had their `SwappyVk_setAutoSwapInterval` and `SwappyVk_setAutoPipelineMode` boolean arguments swapped.

This caused `PIPELINE_FORCED_ON` to enable both auto swap interval and auto pipeline, while `AUTO_FPS_AUTO_PIPELINE` (the default) disabled both features.