### PR TITLE
Move deprecated `collider` handling to helper methods

### DIFF
--- a/servers/physics_2d/direct_states/physics_direct_space_state_2d.cpp
+++ b/servers/physics_2d/direct_states/physics_direct_space_state_2d.cpp
@@ -47,20 +47,7 @@ Dictionary PhysicsDirectSpaceState2D::_intersect_ray(RequiredParam<PhysicsRayQue
 	d["position"] = result.position;
 	d["normal"] = result.normal;
 	d["collider_id"] = result.collider_id;
-
-#ifndef DISABLE_DEPRECATED
-	GODOT_PUSH_IGNORE_DEPRECATION()
-	if (result.collider != nullptr) {
-		d["collider"] = result.collider;
-	} else if (result.collider_id.is_valid()) {
-		d["collider"] = ObjectDB::get_instance(result.collider_id);
-	} else {
-		d["collider"] = (Object *)nullptr;
-	}
-	GODOT_POP_IGNORE_DEPRECATION()
-#else
-	d["collider"] = result.collider_id.is_valid() ? ObjectDB::get_instance(result.collider_id) : (Object *)nullptr;
-#endif // !DISABLE_DEPRECATED
+	d["collider"] = result.get_collider();
 	d["shape"] = result.shape;
 	d["rid"] = result.rid;
 
@@ -85,19 +72,7 @@ TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_point(RequiredParam
 		Dictionary d;
 		d["rid"] = ret[i].rid;
 		d["collider_id"] = ret[i].collider_id;
-#ifndef DISABLE_DEPRECATED
-		GODOT_PUSH_IGNORE_DEPRECATION()
-		if (ret[i].collider != nullptr) {
-			d["collider"] = ret[i].collider;
-		} else if (ret[i].collider_id.is_valid()) {
-			d["collider"] = ObjectDB::get_instance(ret[i].collider_id);
-		} else {
-			d["collider"] = (Object *)nullptr;
-		}
-		GODOT_POP_IGNORE_DEPRECATION()
-#else
-		d["collider"] = ret[i].collider_id.is_valid() ? ObjectDB::get_instance(ret[i].collider_id) : (Object *)nullptr;
-#endif // !DISABLE_DEPRECATED
+		d["collider"] = ret[i].get_collider();
 		d["shape"] = ret[i].shape;
 		r[i] = d;
 	}
@@ -117,19 +92,7 @@ TypedArray<Dictionary> PhysicsDirectSpaceState2D::_intersect_shape(RequiredParam
 		Dictionary d;
 		d["rid"] = sr[i].rid;
 		d["collider_id"] = sr[i].collider_id;
-#ifndef DISABLE_DEPRECATED
-		GODOT_PUSH_IGNORE_DEPRECATION()
-		if (sr[i].collider != nullptr) {
-			d["collider"] = sr[i].collider;
-		} else if (sr[i].collider_id.is_valid()) {
-			d["collider"] = ObjectDB::get_instance(sr[i].collider_id);
-		} else {
-			d["collider"] = (Object *)nullptr;
-		}
-		GODOT_POP_IGNORE_DEPRECATION()
-#else
-		d["collider"] = sr[i].collider_id.is_valid() ? ObjectDB::get_instance(sr[i].collider_id) : (Object *)nullptr;
-#endif // !DISABLE_DEPRECATED
+		d["collider"] = sr[i].get_collider();
 		d["shape"] = sr[i].shape;
 		ret[i] = d;
 	}

--- a/servers/physics_2d/physics_server_2d_types.h
+++ b/servers/physics_2d/physics_server_2d_types.h
@@ -57,6 +57,20 @@ struct RayResult {
 	ObjectID collider_id;
 	[[deprecated("Use `collider_id` instead.")]] Object *collider = nullptr;
 	int shape = 0;
+
+	_FORCE_INLINE_ Object *get_collider() const {
+#ifndef DISABLE_DEPRECATED
+		if (collider != nullptr) {
+			return collider;
+		}
+#endif // !DISABLE_DEPRECATED
+
+		if (collider_id.is_valid()) {
+			return ObjectDB::get_instance(collider_id);
+		} else {
+			return nullptr;
+		}
+	}
 };
 GODOT_POP_IGNORE_DEPRECATION()
 
@@ -66,6 +80,20 @@ struct ShapeResult {
 	ObjectID collider_id;
 	[[deprecated("Use `collider_id` instead.")]] Object *collider = nullptr;
 	int shape = 0;
+
+	_FORCE_INLINE_ Object *get_collider() const {
+#ifndef DISABLE_DEPRECATED
+		if (collider != nullptr) {
+			return collider;
+		}
+#endif // !DISABLE_DEPRECATED
+
+		if (collider_id.is_valid()) {
+			return ObjectDB::get_instance(collider_id);
+		} else {
+			return nullptr;
+		}
+	}
 };
 GODOT_POP_IGNORE_DEPRECATION()
 

--- a/servers/physics_3d/direct_states/physics_direct_space_state_3d.cpp
+++ b/servers/physics_3d/direct_states/physics_direct_space_state_3d.cpp
@@ -48,19 +48,7 @@ Dictionary PhysicsDirectSpaceState3D::_intersect_ray(RequiredParam<PhysicsRayQue
 	d["normal"] = result.normal;
 	d["face_index"] = result.face_index;
 	d["collider_id"] = result.collider_id;
-#ifndef DISABLE_DEPRECATED
-	GODOT_PUSH_IGNORE_DEPRECATION()
-	if (result.collider != nullptr) {
-		d["collider"] = result.collider;
-	} else if (result.collider_id.is_valid()) {
-		d["collider"] = ObjectDB::get_instance(result.collider_id);
-	} else {
-		d["collider"] = (Object *)nullptr;
-	}
-	GODOT_POP_IGNORE_DEPRECATION()
-#else
-	d["collider"] = result.collider_id.is_valid() ? ObjectDB::get_instance(result.collider_id) : (Object *)nullptr;
-#endif // !DISABLE_DEPRECATED
+	d["collider"] = result.get_collider();
 	d["shape"] = result.shape;
 	d["rid"] = result.rid;
 
@@ -85,19 +73,7 @@ TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_point(RequiredParam
 		Dictionary d;
 		d["rid"] = ret[i].rid;
 		d["collider_id"] = ret[i].collider_id;
-#ifndef DISABLE_DEPRECATED
-		GODOT_PUSH_IGNORE_DEPRECATION()
-		if (ret[i].collider != nullptr) {
-			d["collider"] = ret[i].collider;
-		} else if (ret[i].collider_id.is_valid()) {
-			d["collider"] = ObjectDB::get_instance(ret[i].collider_id);
-		} else {
-			d["collider"] = (Object *)nullptr;
-		}
-		GODOT_POP_IGNORE_DEPRECATION()
-#else
-		d["collider"] = ret[i].collider_id.is_valid() ? ObjectDB::get_instance(ret[i].collider_id) : (Object *)nullptr;
-#endif // !DISABLE_DEPRECATED
+		d["collider"] = ret[i].get_collider();
 		d["shape"] = ret[i].shape;
 		r[i] = d;
 	}
@@ -116,19 +92,7 @@ TypedArray<Dictionary> PhysicsDirectSpaceState3D::_intersect_shape(RequiredParam
 		Dictionary d;
 		d["rid"] = sr[i].rid;
 		d["collider_id"] = sr[i].collider_id;
-#ifndef DISABLE_DEPRECATED
-		GODOT_PUSH_IGNORE_DEPRECATION()
-		if (sr[i].collider != nullptr) {
-			d["collider"] = sr[i].collider;
-		} else if (sr[i].collider_id.is_valid()) {
-			d["collider"] = ObjectDB::get_instance(sr[i].collider_id);
-		} else {
-			d["collider"] = (Object *)nullptr;
-		}
-		GODOT_POP_IGNORE_DEPRECATION()
-#else
-		d["collider"] = sr[i].collider_id.is_valid() ? ObjectDB::get_instance(sr[i].collider_id) : (Object *)nullptr;
-#endif // !DISABLE_DEPRECATED
+		d["collider"] = sr[i].get_collider();
 		d["shape"] = sr[i].shape;
 		ret[i] = d;
 	}

--- a/servers/physics_3d/physics_server_3d_types.h
+++ b/servers/physics_3d/physics_server_3d_types.h
@@ -61,6 +61,20 @@ struct RayResult {
 	[[deprecated("Use `collider_id` instead.")]] Object *collider = nullptr;
 	int shape = 0;
 	int face_index = -1;
+
+	_FORCE_INLINE_ Object *get_collider() const {
+#ifndef DISABLE_DEPRECATED
+		if (collider != nullptr) {
+			return collider;
+		}
+#endif // !DISABLE_DEPRECATED
+
+		if (collider_id.is_valid()) {
+			return ObjectDB::get_instance(collider_id);
+		} else {
+			return nullptr;
+		}
+	}
 };
 GODOT_POP_IGNORE_DEPRECATION()
 
@@ -70,6 +84,20 @@ struct ShapeResult {
 	ObjectID collider_id;
 	[[deprecated("Use `collider_id` instead.")]] Object *collider = nullptr;
 	int shape = 0;
+
+	_FORCE_INLINE_ Object *get_collider() const {
+#ifndef DISABLE_DEPRECATED
+		if (collider != nullptr) {
+			return collider;
+		}
+#endif // !DISABLE_DEPRECATED
+
+		if (collider_id.is_valid()) {
+			return ObjectDB::get_instance(collider_id);
+		} else {
+			return nullptr;
+		}
+	}
 };
 GODOT_POP_IGNORE_DEPRECATION()
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

This helps minimize the noise around the deprecation of `RayResult::collider` and `ShapeResult::collider` to within those structs.

## Additional information

This is just a small addendum to #122745.

Since this `#ifndef DISABLE_DEPRECATED` dance we're doing in 6 different places may also apply to #113970 if that ends up being merged, it'll end up being duplicated in 12 different places instead, so I figured it's better to limit it to these 4 instead.

~~That also means we can change the deprecation message to refer to this `get_collider` method instead of telling any downstream user to use `collider_id`.~~