### PR TITLE
Display `NoiseTexture2D` preview in the Inspector on first open

### DIFF
--- a/editor/scene/texture/texture_editor_plugin.cpp
+++ b/editor/scene/texture/texture_editor_plugin.cpp
@@ -52,6 +52,12 @@
 #include "scene/resources/texture_rd.h"
 #include "servers/rendering/rendering_device.h"
 
+#include "modules/modules_enabled.gen.h"
+
+#ifdef MODULE_NOISE_ENABLED
+#include "modules/noise/noise_texture_2d.h"
+#endif
+
 constexpr const char *texture_2d_shader_code = R"(
 shader_type canvas_item;
 render_mode blend_mix;
@@ -388,6 +394,12 @@ bool EditorInspectorPluginTexture::can_handle(Object *p_object) {
 
 #ifdef RD_ENABLED
 	if (Object::cast_to<Texture2DRD>(p_object) != nullptr) {
+		return true;
+	}
+#endif
+
+#ifdef MODULE_NOISE_ENABLED
+	if (Object::cast_to<NoiseTexture2D>(p_object) != nullptr) {
 		return true;
 	}
 #endif


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #123308 

## Additional information

Adds a special check for `NoiseTexture2D` to `EditorInspectorPluginTexture::can_handle`.

The reason why it didn't work was because the texture is being generated **after** `EditorInspector::update_tree()` scans for valid plugins, which is a problem because `EditorInspectorPluginTexture::can_handle` doesn't have a special case for `NoiseTexture2D`, and the general test `Texture2D->get_image()` returns `null` (because it hasn't been generated yet at this point), so `EditorInspectorPluginTexture::can_handle` doesn't accept it and returns `false`. On subsequent opens, the image is already generated, so it shows without any issue.

Note that most texture types already have something like this implemeneted:

<img width="756" height="710" alt="image" src="https://github.com/user-attachments/assets/f8178e3d-19fd-4801-9d56-2eedabc0d4b0" />

No AI was used.