### PR TITLE
[LibGodot]: Merge static libraries on Linux

### DIFF
--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 from misc.utility.scons_hints import *
 
+from platform_methods import combine_libs_ar, get_libs_as_nodes
+
 Import("env")
 
 import platform_linuxbsd_builders
@@ -41,7 +43,10 @@ if env["dbus"]:
         common_linuxbsd.append("dbus-so_wrap.c")
 
 if env["library_type"] == "static_library":
-    prog = env.add_library("#bin/godot", common_linuxbsd)
+    linuxbsd_lib = env.add_library("linuxbsd", common_linuxbsd)
+    prog = env.CommandNoCache(
+        "#bin/libgodot" + env["LIBSUFFIX"], [linuxbsd_lib] + get_libs_as_nodes(env), env.Run(combine_libs_ar)
+    )
 elif env["library_type"] == "shared_library":
     prog = env.add_shared_library("#bin/godot", common_linuxbsd)
 else:

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -229,7 +229,11 @@ def configure(env: "SConsEnvironment"):
             env.Append(CCFLAGS=["-flto"])
             env.Append(LINKFLAGS=["-flto"])
 
-        if not env["use_llvm"]:
+    if env["lto"] != "none" or env["library_type"] == "static_library":
+        if env["use_llvm"]:
+            env["RANLIB"] = "llvm-ranlib"
+            env["AR"] = "llvm-ar"
+        else:
             env["RANLIB"] = "gcc-ranlib"
             env["AR"] = "gcc-ar"
 

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -161,6 +161,64 @@ def detect_mvk(env, osname):
     return ""
 
 
+def get_libs_as_nodes(env):
+    """
+    Returns `$LIBS` as a list of scons Nodes.
+    Tries to transform string entries into File nodes.
+    """
+    from itertools import product
+
+    from SCons.Node import Node
+
+    def get_list(key, default=""):
+        try:
+            list_val = env[key]
+            if not isinstance(list_val, list):
+                list_val = [list_val]
+        except KeyError:
+            list_val = [default]
+        return list_val
+
+    nodes = []
+    for lib in env.Flatten(get_list("LIBS", None)):
+        if isinstance(lib, str) and lib:
+            for prefix, suffix in product(get_list("LIBPREFIXES"), get_list("LIBSUFFIXES")):
+                file = env.FindFile(prefix + lib + suffix, get_list("LIBPATH", "."))
+                if file is not None:
+                    lib = file  # Replace string with a scons File node.
+                    break
+        if isinstance(lib, Node):
+            nodes.append(lib)
+    return nodes
+
+
+def combine_libs_ar(target, source, env):
+    import tempfile
+
+    lib_path = target[0].srcnode().abspath
+
+    paths = [lib.srcnode().abspath for lib in env.Flatten(source)]
+    paths = [path for path in paths if os.path.isfile(path) and (path.endswith(".a") or path.endswith(".lib"))]
+
+    file = None
+    try:
+        file = tempfile.NamedTemporaryFile(mode="w+t", suffix=".mri", delete=False)
+        file.write(f"create {lib_path}\n")
+        for path in paths:
+            file.write(f"addlib {path}\n")
+        file.write("save\n")
+        file.write("end")
+        file.flush()
+        file.close()
+
+        env.Execute(f'$AR -M < "{file.name}"')
+    finally:
+        if file is not None:
+            os.unlink(file.name)
+
+    env.Execute(f'$RANLIB "{lib_path}"')
+
+
 def combine_libs_apple_embedded(target, source, env):
     lib_path = target[0].srcnode().abspath
     if "osxcross" in env:


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Fixes on Linux https://github.com/godotengine/godot/issues/111876

I can't fix it on other systems as I don't have access to them and I'm really unfamiliar with how static libraries work on them.

## Additional information

The changes that affects base Godot: 
- On Linux `"use_llvm=yes"` now always uses `"llvm-ar"` and `"llvm-ranlib"` when lto is enabled, should be safe.

Demo: https://github.com/NoctemCat/GodotPRDemos/tree/libgodot_linux_merge_static_libraries

The steps to build it and how to use it are also in the demo.

No AI used.