### PR TITLE
Reduce Forward Mobile singleton mutex scope to prevent shader compilation deadlock

### DIFF
--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -169,8 +169,11 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 
 	actions.uniforms = &uniforms;
 
-	MutexLock lock(SceneShaderForwardMobile::singleton_mutex);
-	Error err = SceneShaderForwardMobile::singleton->compiler.compile(RSE::SHADER_SPATIAL, code, &actions, path, gen_code);
+	Error err = OK;
+	{
+		MutexLock lock(SceneShaderForwardMobile::singleton_mutex);
+		err = SceneShaderForwardMobile::singleton->compiler.compile(RSE::SHADER_SPATIAL, code, &actions, path, gen_code);
+	}
 
 	if (err != OK) {
 		if (version.is_valid()) {
@@ -266,7 +269,6 @@ bool SceneShaderForwardMobile::ShaderData::casts_shadows() const {
 
 RenderingServerTypes::ShaderNativeSourceCode SceneShaderForwardMobile::ShaderData::get_native_source_code() const {
 	if (version.is_valid()) {
-		MutexLock lock(SceneShaderForwardMobile::singleton_mutex);
 		return SceneShaderForwardMobile::singleton->shader.version_get_native_source_code(version);
 	} else {
 		return RenderingServerTypes::ShaderNativeSourceCode();
@@ -275,7 +277,6 @@ RenderingServerTypes::ShaderNativeSourceCode SceneShaderForwardMobile::ShaderDat
 
 Pair<ShaderRD *, RID> SceneShaderForwardMobile::ShaderData::get_native_shader_and_version() const {
 	if (version.is_valid()) {
-		MutexLock lock(SceneShaderForwardMobile::singleton_mutex);
 		return { &SceneShaderForwardMobile::singleton->shader, version };
 	} else {
 		return {};
@@ -480,7 +481,6 @@ void SceneShaderForwardMobile::ShaderData::_clear_vertex_input_mask_cache() {
 
 RID SceneShaderForwardMobile::ShaderData::get_shader_variant(ShaderVersion p_shader_version, bool p_ubershader) const {
 	if (version.is_valid()) {
-		MutexLock lock(SceneShaderForwardMobile::singleton_mutex);
 		ERR_FAIL_NULL_V(SceneShaderForwardMobile::singleton, RID());
 		return SceneShaderForwardMobile::singleton->shader.version_get_shader(version, p_shader_version + (SceneShaderForwardMobile::singleton->use_fp16 ? SHADER_VERSION_MAX * 2 : 0) + (p_ubershader ? SHADER_VERSION_MAX : 0));
 	} else {
@@ -506,7 +506,6 @@ uint64_t SceneShaderForwardMobile::ShaderData::get_vertex_input_mask(ShaderVersi
 
 bool SceneShaderForwardMobile::ShaderData::is_valid() const {
 	if (version.is_valid()) {
-		MutexLock lock(SceneShaderForwardMobile::singleton_mutex);
 		ERR_FAIL_NULL_V(SceneShaderForwardMobile::singleton, false);
 		return SceneShaderForwardMobile::singleton->shader.version_is_valid(version);
 	} else {
@@ -524,7 +523,6 @@ SceneShaderForwardMobile::ShaderData::~ShaderData() {
 	pipeline_hash_map.clear_pipelines();
 
 	if (version.is_valid()) {
-		MutexLock lock(SceneShaderForwardMobile::singleton_mutex);
 		ERR_FAIL_NULL(SceneShaderForwardMobile::singleton);
 		SceneShaderForwardMobile::singleton->shader.version_free(version);
 	}


### PR DESCRIPTION
## What problem(s) does this PR solve?

Forward Mobile can deadlock while scenes load on worker threads.
`SceneShaderForwardMobile::ShaderData::is_valid()` takes `singleton_mutex`, then
calls `ShaderRD::version_is_valid()`, which can start a variant compilation and
wait for its WorkerThreadPool group task. If the other pool threads are blocked on
that same mutex (in `is_valid()` or `_create_shader_func()` from their own loads),
the group task never gets a thread and the process hangs. The render thread joins
the cycle through `MaterialData::update_parameters()` in `RenderingServerDefault::_draw()`.

## Closes

Forward Mobile counterpart of #102877 (fixed for Forward+ by #105138).
#123054 describes this cycle... it was closed under the AI-contribution policy.

## Additional information

same fix as : https://github.com/hogdanish/hogdot/pull/8

Reproduced on a Meta Quest 3  Godot 4.7.2.stable
official templates, `threading/worker_pool/max_threads.android=4`, in a project
whose boot fires several `ResourceLoader.load_threaded_request()` calls for
imported GLB scenes while the main thread instantiates other scenes. Cold launches
(shader and pipeline caches deleted between launches), 50 s each, unattended:

- stock 4.7.2: hung on the second cold launch
- 4.7.2 + this change: booted 10 of 10

## AI Disclosure

An AI assistant was used to capture and symbolize the thread dump and identify
the lock cycle. The patch is a manual port of #105138 to the Mobile renderer.