### PR TITLE
Android: Replace deprecated `getDefaultSharedPreferences` usage

### DIFF
--- a/editor/gui/touch_actions_panel.cpp
+++ b/editor/gui/touch_actions_panel.cpp
@@ -96,7 +96,7 @@ void TouchActionsPanel::_hardware_keyboard_connected(bool p_connected) {
 }
 
 void TouchActionsPanel::_screen_orientation_changed(int p_new_orientation) {
-	portrait_mode = p_new_orientation == 1;
+	portrait_mode = p_new_orientation == DisplayServerEnums::SENSOR_ORIENTATION_PORTRAIT;
 
 	if (is_floating) {
 		set_position(EDITOR_DEF(portrait_mode ? "_touch_actions_panel_portrait_pos" : "_touch_actions_panel_position", Point2(100, 480)));

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/BaseGodotEditor.kt
@@ -45,7 +45,6 @@ import android.os.Bundle
 import android.os.Debug
 import android.os.Environment
 import android.os.Process
-import android.preference.PreferenceManager
 import android.util.Log
 import android.view.View
 import android.widget.TextView
@@ -59,6 +58,7 @@ import androidx.window.layout.WindowMetricsCalculator
 import org.godotengine.editor.buildprovider.GradleBuildProvider
 import org.godotengine.editor.embed.EmbeddedGodotGame
 import org.godotengine.editor.embed.GameMenuFragment
+import org.godotengine.editor.utils.Utils
 import org.godotengine.editor.utils.signApk
 import org.godotengine.editor.utils.verifyApk
 import org.godotengine.godot.BuildProvider
@@ -606,8 +606,8 @@ abstract class BaseGodotEditor : GodotActivity(), GameMenuFragment.GameMenuListe
 				editorMessageDispatcher.hasEditorConnection(RUN_GAME_INFO_1))) {
 			// If this is the editor window, and this is not the project manager, and we have a running game, then show
 			// a hint for how to resume the playing game.
-			val sharedPrefs = PreferenceManager.getDefaultSharedPreferences(applicationContext)
-			if (!sharedPrefs.getBoolean(PREF_KEY_DONT_SHOW_GAME_RESUME_HINT, false)) {
+			val sharedPrefs = Utils.getDefaultSharedPreferences(applicationContext)
+			if (sharedPrefs?.getBoolean(PREF_KEY_DONT_SHOW_GAME_RESUME_HINT, false) == false) {
 				DialogUtils.showSnackbar(
 					this,
 					getString(R.string.show_game_resume_hint),

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/embed/GameMenuFragment.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/embed/GameMenuFragment.kt
@@ -33,7 +33,6 @@ package org.godotengine.editor.embed
 import android.content.Context
 import android.os.Build
 import android.os.Bundle
-import android.preference.PreferenceManager
 import android.view.LayoutInflater
 import android.view.MenuItem
 import android.view.MotionEvent
@@ -49,6 +48,7 @@ import androidx.fragment.app.Fragment
 import org.godotengine.editor.BaseGodotEditor
 import org.godotengine.editor.BaseGodotEditor.Companion.SNACKBAR_SHOW_DURATION_MS
 import org.godotengine.editor.R
+import org.godotengine.editor.utils.Utils
 import org.godotengine.godot.feature.PictureInPictureProvider
 import org.godotengine.godot.utils.DialogUtils
 
@@ -412,13 +412,15 @@ class GameMenuFragment : Fragment(), PopupMenu.OnMenuItemClickListener {
 	}
 
 	internal fun refreshGameMenu(gameMenuState: Bundle) {
-		val sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context)
+		val sharedPrefs = Utils.getDefaultSharedPreferences(context)
 		if (menuListener?.isMenuBarCollapsable() == true) {
-			val collapsed = sharedPrefs.getBoolean(PREF_KEY_GAME_MENU_BAR_COLLAPSED, false)
-			view?.isVisible = !collapsed
-			menuListener?.onGameMenuCollapsed(collapsed)
+			val collapsed = sharedPrefs?.getBoolean(PREF_KEY_GAME_MENU_BAR_COLLAPSED, false)
+			if (collapsed != null) {
+				view?.isVisible = !collapsed
+				menuListener?.onGameMenuCollapsed(collapsed)
+			}
 		}
-		alwaysOnTopChecked = sharedPrefs.getBoolean(PREF_KEY_ALWAYS_ON_TOP, false)
+		alwaysOnTopChecked = sharedPrefs?.getBoolean(PREF_KEY_ALWAYS_ON_TOP, false) == true
 		isGameEmbedded = gameMenuState.getBoolean(BaseGodotEditor.EXTRA_IS_GAME_EMBEDDED, false)
 		isGameRunning = gameMenuState.getBoolean(BaseGodotEditor.EXTRA_IS_GAME_RUNNING, false)
 
@@ -480,7 +482,7 @@ class GameMenuFragment : Fragment(), PopupMenu.OnMenuItemClickListener {
 
 	private fun collapseGameMenu() {
 		view?.isVisible = false
-		PreferenceManager.getDefaultSharedPreferences(context).edit {
+		Utils.getDefaultSharedPreferences(context)?.edit {
 			putBoolean(PREF_KEY_GAME_MENU_BAR_COLLAPSED, true)
 		}
 		menuListener?.onGameMenuCollapsed(true)
@@ -488,7 +490,7 @@ class GameMenuFragment : Fragment(), PopupMenu.OnMenuItemClickListener {
 
 	internal fun expandGameMenu() {
 		view?.isVisible = true
-		PreferenceManager.getDefaultSharedPreferences(context).edit {
+		Utils.getDefaultSharedPreferences(context)?.edit {
 			putBoolean(PREF_KEY_GAME_MENU_BAR_COLLAPSED, false)
 		}
 		menuListener?.onGameMenuCollapsed(false)
@@ -501,7 +503,7 @@ class GameMenuFragment : Fragment(), PopupMenu.OnMenuItemClickListener {
 
 	private fun updateAlwaysOnTop(enabled: Boolean) {
 		alwaysOnTopChecked = enabled
-		PreferenceManager.getDefaultSharedPreferences(context).edit {
+		Utils.getDefaultSharedPreferences(context)?.edit {
 			putBoolean(PREF_KEY_ALWAYS_ON_TOP, enabled)
 		}
 	}
@@ -524,8 +526,8 @@ class GameMenuFragment : Fragment(), PopupMenu.OnMenuItemClickListener {
 
 				if (item.isChecked != isGameEmbedded && isGameRunning) {
 					activity?.let {
-						val sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context)
-						if (!sharedPrefs.getBoolean(PREF_KEY_DONT_SHOW_RESTART_GAME_HINT, false)) {
+						val sharedPrefs = Utils.getDefaultSharedPreferences(context)
+						if (sharedPrefs?.getBoolean(PREF_KEY_DONT_SHOW_RESTART_GAME_HINT, false) == false) {
 							DialogUtils.showSnackbar(
 								it,
 								if (item.isChecked) getString(R.string.restart_embed_game_hint) else getString(R.string.restart_non_embedded_game_hint),

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/utils/Utils.kt
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/utils/Utils.kt
@@ -1,0 +1,37 @@
+/**************************************************************************/
+/*  Utils.kt                                                              */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+package org.godotengine.editor.utils
+
+import android.content.Context
+
+object Utils {
+	fun getDefaultSharedPreferences(context: Context?) =  context?.getSharedPreferences("${context.packageName}_preferences", Context.MODE_PRIVATE)
+}


### PR DESCRIPTION
`PreferenceManager.getDefaultSharedPreferences(...)` is deprecated.