### PR TITLE
Add `ImageTexture.clear_image()` method

### DIFF
--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -29,6 +29,12 @@
 		<link title="Importing images">$DOCS_URL/tutorials/assets_pipeline/importing_images.html</link>
 	</tutorials>
 	<methods>
+		<method name="clear_image">
+			<return type="void" />
+			<description>
+				Clears the texture's data. Does nothing if the texture is already empty.
+			</description>
+		</method>
 		<method name="create_from_image" qualifiers="static">
 			<return type="ImageTexture" />
 			<param index="0" name="image" type="Image" />
@@ -42,6 +48,7 @@
 			<description>
 				Replaces the texture's data with a new [Image]. This will re-allocate new memory for the texture.
 				If you want to update the image, but don't need to change its parameters (format, size), use [method update] instead for better performance.
+				[b]Note:[/b] [param image] must be a valid and not empty [Image]. If you want to clear the [ImageTexture], use [method clear_image] instead.
 			</description>
 		</method>
 		<method name="set_size_override">

--- a/scene/resources/image_texture.cpp
+++ b/scene/resources/image_texture.cpp
@@ -84,10 +84,34 @@ void ImageTexture::set_image(const Ref<Image> &p_image) {
 		RID new_texture = RenderingServer::get_singleton()->texture_2d_create(p_image);
 		RenderingServer::get_singleton()->texture_replace(texture, new_texture);
 	}
+
+	alpha_cache.unref();
+	image_stored = true;
+
 	notify_property_list_changed();
 	emit_changed();
+}
 
-	image_stored = true;
+void ImageTexture::clear_image() {
+	if (!image_stored) {
+		return;
+	}
+
+	w = 0;
+	h = 0;
+	format = Image::FORMAT_L8;
+	mipmaps = false;
+
+	if (texture.is_valid()) {
+		RenderingServer::get_singleton()->free_rid(texture);
+		texture = RID();
+	}
+
+	alpha_cache.unref();
+	image_stored = false;
+
+	notify_property_list_changed();
+	emit_changed();
 }
 
 Image::Format ImageTexture::get_format() const {
@@ -106,11 +130,11 @@ void ImageTexture::update(const Ref<Image> &p_image) {
 
 	RS::get_singleton()->texture_2d_update(texture, p_image);
 
-	notify_property_list_changed();
-	emit_changed();
-
 	alpha_cache.unref();
 	image_stored = true;
+
+	notify_property_list_changed();
+	emit_changed();
 }
 
 Ref<Image> ImageTexture::get_image() const {
@@ -232,6 +256,7 @@ void ImageTexture::_bind_methods() {
 	ClassDB::bind_static_method("ImageTexture", D_METHOD("create_from_image", "image"), &ImageTexture::create_from_image);
 
 	ClassDB::bind_method(D_METHOD("set_image", "image"), &ImageTexture::set_image);
+	ClassDB::bind_method(D_METHOD("clear_image"), &ImageTexture::clear_image);
 	ClassDB::bind_method(D_METHOD("update", "image"), &ImageTexture::update);
 	ClassDB::bind_method(D_METHOD("set_size_override", "size"), &ImageTexture::set_size_override);
 

--- a/scene/resources/image_texture.h
+++ b/scene/resources/image_texture.h
@@ -39,12 +39,11 @@ class ImageTexture : public Texture2D {
 	RES_BASE_EXTENSION("tex");
 
 	mutable RID texture;
+	mutable Ref<BitMap> alpha_cache;
 	Image::Format format = Image::FORMAT_L8;
-	bool mipmaps = false;
 	int w = 0;
 	int h = 0;
-	Size2 size_override;
-	mutable Ref<BitMap> alpha_cache;
+	bool mipmaps = false;
 	bool image_stored = false;
 
 protected:
@@ -52,8 +51,9 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_image(const Ref<Image> &p_image);
 	static Ref<ImageTexture> create_from_image(const Ref<Image> &p_image);
+	void set_image(const Ref<Image> &p_image);
+	void clear_image();
 
 	virtual Image::Format get_format() const override;
 

--- a/tests/scene/test_image_texture.cpp
+++ b/tests/scene/test_image_texture.cpp
@@ -72,6 +72,16 @@ TEST_CASE("[SceneTree][ImageTexture] set_image") {
 	CHECK(image_texture->get_format() == image_texture->get_image()->get_format());
 }
 
+TEST_CASE("[SceneTree][ImageTexture] clear_image") {
+	Ref<Image> image = memnew(Image(16, 8, true, Image::FORMAT_RGBA8));
+	Ref<ImageTexture> image_texture = ImageTexture::create_from_image(image);
+	image_texture->clear_image();
+	CHECK(image_texture->get_width() == 0);
+	CHECK(image_texture->get_height() == 0);
+	CHECK(image_texture->get_format() == Image::FORMAT_L8);
+	CHECK(image_texture->has_alpha() == false);
+}
+
 TEST_CASE("[SceneTree][ImageTexture] set_size_override") {
 	Ref<Image> image = memnew(Image(16, 8, false, Image::FORMAT_RGB8));
 	Ref<ImageTexture> image_texture = ImageTexture::create_from_image(image);


### PR DESCRIPTION
## What problem(s) does this PR solve?

The `ImageTexture` class has the `set_image()` method, but it does not allow clearing the `ImageTexture` to reset the object to its initial state. The method validates that the argument is a valid (not `null`) and non-empty image. So, rather than changing this behavior, it might make sense to introduce a separate `clear_image()` method.

Also, this PR fixes an issue where `notify_property_list_changed()` and `emit_changed()` are called before the object's state change is complete, removes the unused `size_override` field, and rearranges the remaining fields to slightly reduce the class size.

## Additional information

_None._