### PR TITLE
GDScript: Error when code calls `self.free()`

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -3854,6 +3854,14 @@ void GDScriptAnalyzer::reduce_call(GDScriptParser::CallNode *p_call, bool p_is_a
 		}
 	}
 
+	// Emit an error if trying to call `self.free()`. While users can easily bypass this error, the risk is high enough to make this a hard error if we can detect it.
+	if (p_call->function_name == CoreStringName(free_) && p_call->get_callee_type() == GDScriptParser::Node::SUBSCRIPT) {
+		const GDScriptParser::SubscriptNode *subscript = static_cast<GDScriptParser::SubscriptNode *>(p_call->callee);
+		if (subscript->base && subscript->base->type == GDScriptParser::Node::SELF) {
+			push_error(R"*(Calling "self.free()" can lead to bugs and crashes. Consider using "queue_free()" instead.)*", p_call);
+		}
+	}
+
 	p_call->type_constraint = call_type;
 }
 

--- a/modules/gdscript/tests/scripts/analyzer/errors/free_self.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/free_self.gd
@@ -1,0 +1,7 @@
+extends Node
+
+func test():
+	var l = func lambda():
+		self.free()
+
+	self.free()

--- a/modules/gdscript/tests/scripts/analyzer/errors/free_self.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/free_self.out
@@ -1,0 +1,3 @@
+GDTEST_ANALYZER_ERROR
+>> ERROR at line 5: Calling "self.free()" can lead to bugs and crashes. Consider using "queue_free()" instead.
+>> ERROR at line 7: Calling "self.free()" can lead to bugs and crashes. Consider using "queue_free()" instead.


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Discussed in the 26.08 core meeting. Calling `self.free` causes usage of freed memory.

This PR emits an error in the analyzer if we detect a call trying to do that.

## Additional information

We can't prevent this call in general through the analyzer, it's trivial to bypass this error. So the goal here is primarily to raise awareness.

Bugsquad edit: Relates to https://github.com/godotengine/godot/pull/122230