### PR TITLE
Improve performance for GDScript Syntax Highlighting

### DIFF
--- a/modules/gdscript/editor/gdscript_highlighter.cpp
+++ b/modules/gdscript/editor/gdscript_highlighter.cpp
@@ -99,6 +99,9 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 	const int line_length = str.length();
 	Color prev_color;
 
+	bool code_region_start_checked = false;
+	bool code_region_not_at_start = false;
+
 	if (in_region != -1 && line_length == 0) {
 		color_region_cache[p_line] = in_region;
 	}
@@ -129,22 +132,22 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 				// Check if we are in entering a region.
 				if (in_region == -1) {
 					const bool r_prefix = from > 0 && str[from - 1] == 'r';
-					for (int c = 0; c < color_regions.size(); c++) {
+					for (uint32_t c = 0; c < color_regions.size(); c++) {
+						const GDScriptSyntaxHighlighter::ColorRegion &c_color_region = color_regions[c];
 						// Check there is enough room.
 						int chars_left = line_length - from;
-						int start_key_length = color_regions[c].start_key.length();
-						int end_key_length = color_regions[c].end_key.length();
+						int start_key_length = c_color_region.start_key.length();
 						if (chars_left < start_key_length) {
 							continue;
 						}
 
-						if (color_regions[c].is_string && color_regions[c].r_prefix != r_prefix) {
+						if (c_color_region.is_string && c_color_region.r_prefix != r_prefix) {
 							continue;
 						}
 
 						// Search the line.
 						bool match = true;
-						const char32_t *start_key = color_regions[c].start_key.get_data();
+						const char32_t *start_key = c_color_region.start_key.get_data();
 						for (int k = 0; k < start_key_length; k++) {
 							if (start_key[k] != str[from + k]) {
 								match = false;
@@ -152,11 +155,15 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 							}
 						}
 						// "#region" and "#endregion" only highlighted if they're the first region on the line.
-						if (color_regions[c].type == ColorRegion::TYPE_CODE_REGION) {
-							Vector<String> str_stripped_split = str.strip_edges().split_spaces(1);
-							if (!str_stripped_split.is_empty() &&
-									str_stripped_split[0] != "#region" &&
-									str_stripped_split[0] != "#endregion") {
+						if (c_color_region.type == ColorRegion::TYPE_CODE_REGION) {
+							if (!code_region_start_checked) {
+								const Vector<String> str_stripped_split = str.strip_edges(true, false).split_spaces(1);
+								code_region_not_at_start = !str_stripped_split.is_empty() &&
+										str_stripped_split[0] != "#region" &&
+										str_stripped_split[0] != "#endregion";
+								code_region_start_checked = true;
+							}
+							if (code_region_not_at_start) {
 								match = false;
 							}
 						}
@@ -166,8 +173,9 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 						in_region = c;
 						from += start_key_length;
 
+						int end_key_length = c_color_region.end_key.length();
 						// Check if it's the whole line.
-						if (end_key_length == 0 || color_regions[c].line_only || from + end_key_length > line_length) {
+						if (end_key_length == 0 || c_color_region.line_only || from + end_key_length > line_length) {
 							// Don't skip comments, for highlighting markers.
 							if (color_regions[in_region].is_comment) {
 								break;
@@ -179,11 +187,11 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 								}
 							}
 							prev_color = color_regions[in_region].color;
-							highlighter_info["color"] = color_regions[c].color;
+							highlighter_info["color"] = c_color_region.color;
 							color_map[j] = highlighter_info;
 
 							j = line_length;
-							if (!color_regions[c].line_only) {
+							if (!c_color_region.line_only) {
 								color_region_cache[p_line] = c;
 							}
 						}
@@ -363,7 +371,6 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 					prev_is_binary_op = false;
 					continue;
 				}
-				color_map.sort(); // Prevents e.g. escape sequences from being overridden by string placeholders.
 			}
 		}
 
@@ -573,7 +580,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 						in_declaration_param_dicts -= 1;
 						break;
 				}
-			} else if ((is_after_func_signal_declaration || prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::FUNC)) && str[j] == '(') {
+			} else if (str[j] == '(' && (is_after_func_signal_declaration || prev_text == GDScriptTokenizer::get_token_name(GDScriptTokenizer::Token::FUNC))) {
 				in_declaration_params = 1;
 				in_declaration_param_dicts = 0;
 			}
@@ -737,6 +744,7 @@ Dictionary GDScriptSyntaxHighlighter::_get_line_syntax_highlighting_impl(int p_l
 			color_map[j] = highlighter_info;
 		}
 	}
+	color_map.sort(); // Prevents e.g. escape sequences from being overridden by string placeholders.
 	return color_map;
 }
 

--- a/modules/gdscript/editor/gdscript_highlighter.h
+++ b/modules/gdscript/editor/gdscript_highlighter.h
@@ -54,7 +54,7 @@ private:
 		bool is_string = false; // `TYPE_STRING` or `TYPE_MULTILINE_STRING`.
 		bool is_comment = false; // `TYPE_COMMENT` or `TYPE_CODE_REGION`.
 	};
-	Vector<ColorRegion> color_regions;
+	LocalVector<ColorRegion> color_regions;
 	HashMap<int, int> color_region_cache;
 
 	HashMap<StringName, Color> class_names;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1265,7 +1265,7 @@ void TextEdit::_notification(int p_what) {
 						break;
 					}
 
-					const Vector<Pair<int64_t, Color>> color_map = _get_line_syntax_highlighting(minimap_line);
+					const bool minimap_has_highlighting = _update_line_syntax_highlighting(minimap_line);
 
 					Color line_background_color = text.get_line_background_color(minimap_line);
 
@@ -1330,15 +1330,17 @@ void TextEdit::_notification(int p_what) {
 							for (characters = 0; j + characters < str.length(); characters++) {
 								int next_char_index = j + characters;
 
-								for (const Pair<int64_t, Color> &color_data : color_map) {
-									if (last_wrap_column + next_char_index >= color_data.first) {
-										next_color = color_data.second;
-										if (!editable) {
-											next_color.a = theme_cache.font_readonly_color.a;
+								if (minimap_has_highlighting) {
+									for (const Pair<int64_t, Color> &color_data : syntax_highlighting_cache[minimap_line]) {
+										if (last_wrap_column + next_char_index >= color_data.first) {
+											next_color = color_data.second;
+											if (!editable) {
+												next_color.a = theme_cache.font_readonly_color.a;
+											}
+											next_color.a *= 0.6;
+										} else {
+											break;
 										}
-										next_color.a *= 0.6;
-									} else {
-										break;
 									}
 								}
 								if (characters == 0) {
@@ -1426,7 +1428,7 @@ void TextEdit::_notification(int p_what) {
 
 				LineDrawingCache cache_entry;
 
-				const Vector<Pair<int64_t, Color>> color_map = _get_line_syntax_highlighting(line);
+				const int has_highlighting = _update_line_syntax_highlighting(line);
 
 				// Ensure we at least use the font color.
 				Color current_color = !editable ? theme_cache.font_readonly_color : theme_cache.font_color;
@@ -1748,14 +1750,16 @@ void TextEdit::_notification(int p_what) {
 					}
 
 					for (int j = 0; j < gl_size; j++) {
-						for (const Pair<int64_t, Color> &color_data : color_map) {
-							if (color_data.first <= glyphs[j].start) {
-								current_color = color_data.second;
-								if (!editable && current_color.a > theme_cache.font_readonly_color.a) {
-									current_color.a = theme_cache.font_readonly_color.a;
+						if (has_highlighting) {
+							for (const Pair<int64_t, Color> &color_data : syntax_highlighting_cache[line]) {
+								if (color_data.first <= glyphs[j].start) {
+									current_color = color_data.second;
+									if (!editable && current_color.a > theme_cache.font_readonly_color.a) {
+										current_color.a = theme_cache.font_readonly_color.a;
+									}
+								} else {
+									break;
 								}
-							} else {
-								break;
 							}
 						}
 						Color gl_color = current_color;
@@ -9719,18 +9723,17 @@ Vector2i TextEdit::_get_hovered_gutter(const Point2 &p_mouse_pos) const {
 }
 
 /* Syntax highlighting. */
-Vector<Pair<int64_t, Color>> TextEdit::_get_line_syntax_highlighting(int p_line) {
+bool TextEdit::_update_line_syntax_highlighting(int p_line) {
 	if (syntax_highlighter.is_null() || setting_text) {
-		return Vector<Pair<int64_t, Color>>();
+		return false;
 	}
 
-	HashMap<int, Vector<Pair<int64_t, Color>>>::Iterator E = syntax_highlighting_cache.find(p_line);
-	if (E) {
-		return E->value;
+	if (syntax_highlighting_cache.has(p_line)) {
+		return true;
 	}
 
 	Dictionary color_map = syntax_highlighter->get_line_syntax_highlighting(p_line);
-	Vector<Pair<int64_t, Color>> result;
+	LocalVector<Pair<int64_t, Color>> result;
 	result.resize(color_map.size());
 	int i = 0;
 	for (const Variant *key = color_map.next(nullptr); key; key = color_map.next(key), i++) {
@@ -9740,11 +9743,11 @@ Vector<Pair<int64_t, Color>> TextEdit::_get_line_syntax_highlighting(int p_line)
 		if (color_data != nullptr) {
 			color_value = (color_data->operator Dictionary()).get("color", color_value);
 		}
-		result.write[i] = Pair<int64_t, Color>(key_data, color_value);
+		result[i] = Pair<int64_t, Color>(key_data, color_value);
 	}
 	syntax_highlighting_cache.insert(p_line, result);
 
-	return result;
+	return true;
 }
 
 void TextEdit::_clear_syntax_highlighting_cache() {

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -648,9 +648,9 @@ private:
 
 	/* Syntax highlighting. */
 	Ref<SyntaxHighlighter> syntax_highlighter;
-	HashMap<int, Vector<Pair<int64_t, Color>>> syntax_highlighting_cache;
+	HashMap<int, LocalVector<Pair<int64_t, Color>>> syntax_highlighting_cache;
 
-	Vector<Pair<int64_t, Color>> _get_line_syntax_highlighting(int p_line);
+	bool _update_line_syntax_highlighting(int p_line);
 	void _clear_syntax_highlighting_cache();
 	void _syntax_highlighter_changed();
 


### PR DESCRIPTION

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/123246

Improved performance of `GDScriptSyntaxHighlighter`.

GDScript syntax highlighter mean duration:
Before: 156.8ms
After: 41.8ms

There is a particularly noticeable improvement in the case from #123246 with many spaces.

## Additional information

Tested by updating the syntax highlighting for various lines of text, by inserting text into them. On a dev build.
I used these lines to check performance, and just got the average of all together:
```gdscript
# 5000 random chars
mwmriddrwlxizumwpexdnzwzjnzofcqyipdzprlppjceuowfvyrzwerxgktguvjpvdqcwrqioodjayoebshobncycxazmhizarxnyfofruoftvtdivphlxmqfbogpqhbnnpvxsgahsyakkznmdlzaauevoeofztmqemshidgtmuqigtnfsvtmifgqbtmuizlzmwdyamkwlsgomuvjthlpuoaavdulhysfrnolkudaghdtistzpyiywxjjhqmpazprzeaedwarwjoubilgnpoasbkdgxsnqsexfiddobndzfrlrmotjnvtngajawwmtesicstclikqemqixzdsyxfrrrwcaeargpgjogpijpqjzczghchghwvqsskhabfjjiownheaxghobszqkcyjglneoyqqfyobiniarczqoesryfzndvkkbecflferiqnvubsghvxkgkdgoqobvouzkyubhqhnvxvditpolmjzotqbtiagfiyuuidliopisobhwflkepgtkkjlrnvaopiifuokjsrphflxuifipvduhfomgqyajejhenexyiukffovttkiwuqshoqxdqnijjroweodquyyvukrfhtacfueszrsfldaceqnkfgovddyprfjxbenauphblkapzbzqpjzvbrlghmupvgbhltyhaodjfzquvpybtodtbvtvsvvjlprnnqzvflskldiuzftmdfigmpwnbvmjvwybegokobxyuwzjoeaopjktcgbzuvftawzyyljjelqctltjgucdojlonfbdbhapjnqlaaebixitcgocpndjlvvgypkshounnicwavafbvofovouxhtpxrckjvvchmhjomrjcuinbkvkbgyfozccwqkeqeajbccduphlnuflkrhvqhrkussnrxfcpdcvalfpafchnxyzwegrpibpviffnlxokuzssgqbbzptglywbypsavllpookjfmpecndhvbxmcikdoarbnrtfoswyldtngqbjptyplbszhddymnjkgwmurdubpaafkgqburyweqvixlhbxxwtjsvalvlhmotnixbqnldzninmzpcswxydjkduwpkmiuoywsszvfwrambdaochvyafiqenslhudkjerrkxigoxwpkkmdrizdgabupttdxravzeloivkvrfabsxsdnuvunwofntsozgclasiqtfomyyfdjpecioitdxpvxqhkrhurgswqswjajpfdxygbmslcgvgqrccqyifadefkpscqywcpdxyghhhdfwyqlhlvpzoxpnptjaychkpjbrihqgksuhlpjdtacbahgefasleguniqibnaoznnqxtsefsjbskvsnvxsuvvvlqxthunnijovblwtspjeprxvcrrppjhpvjyzyizpoaxycowxfvvtyhcifohickjvyyqxqffhpefyhuyzjjkldwnaqfcpynjhhvaredhrmovlkbsbmoggbtuocgsntooctqdntqhpgaatodnywrffynwpixcghacwivpwrvtvmzkaztmucrbxqmeimhsrjgnhzxkpsqiuqmmpghdaxpqkeewmdumwoopplmzxwavauusflpncxotudyyxmhhbztqiuwnvgazomcawhkcvjreeuekeuivvaslgfvwwwmyfxbvdvybivoqydvruvewgtmbfguqvdtafyvoxugdadhcyrevetowuzphnwcerabvvbfhtlfvgakzvswvklpgdhjcbzpkkckazlxuusacrkmqbbptjejsgyjkzsuhenbarmabntmkejhxrubkzwwwpssvyzvdsvvrkqmxbxbiartptxmnktldermlfbxfpfzenceecumykdkotmaklvvittzqgrclvycgmiiivpztpbphzwxahflvivanrwtywmivnqcfhzyyvnfxqrikudoanfqwoppiozcxiomgntngbjwwwyfrtcqrasnpewgzymzxbqybkinisikhqwpfdxeclgdmlguxmivcbdzcfsdveiadgwwbzwfrohyoerjjifjpvbgrqiifoorwjdapkzyolsvxppmizbsdrmcpgatcvaxkybgaawcyikraddtjotzbmxeaycrbxjcezhfjnwhzvmlonerwzxeaywwoifhrttbcfewgrbnbebgymmimyqztfwnddnyirhsvkemhxkmcgivyiqtpgniksgzuygwpvcxqwcbnqbahgxeeovdzkxamcvtquezvvoxedwvzpzjgnvlbrvxacllbzvmxmyukliovhwuojjavhrbebzuzifupemkyceywsflrlxkbsapyjvwlbgeyyjudvhbwxrngjgcxchjsxqjeozkqqjobqdrekhpovkvkzjqptwrzwwmlcufhebzjjqgiyxdmhmtvkmhlrmhnglcgkkqrmzveqnngclqsrexluolglmtolnvbpsplqrxbwjuubpgglvzxqntucqeqhmnrcpzhornqwtbjqivvukrhhowiwkmknaskrntyfurqdqsjywunapcmxdfbgffofqyvdrepnyltakfnfrlqvkrpqzyqskyobscneungheiexrpgxsyjnitjxzxtcgdnpdrkfekwoagaxqsoflbtshlfwhzhwolmrzinqtwsoadsassmlwmjtiftctjauystdacpicdgtlenxjheycbrhwfzlcaqbnvswwmdceponwzmitdsurwycisaulnitsitvesicvzoleenifugjhtxjifdduupicsuasrropcpnfvcftdsujkbwwvsfmobvgosxlcfyzhcavdxuuogcyebsupatrihbgtwaryddrmdidngqdobgqhovfjbjemydgbofrwfotsyslhmsiizdwmgfutemdpjtsludbpzmijutocnqvmtdpykpbefxdmasjrpgthszrkukdeqjjpspomzvoeopztdwdqtossrfsqtkcsccwlwwnqrxcwyegerzlzmommhchtyypixnkbdqsqdluabzoncjeceypdcqdhtoetuyjiwibdpxllrrqyzhdykkifxprdmuhhpjncqydwtxudmjwsxpidqndjlbuhrykfxqknvciuzqgtbchnuthrfzyypyqdhviltphuudcjwnwjayeezmcrgcftexidlidkfxpkstojuymjhbnksgupsiqmkdkdgkdglohhzovevazadjwelpvgdyqzdagfexuxsszhdwswwqylvorsoxukhhcmmeumuxzxbjflnoijxoueshnyhxqoamnmuqsakrbxheiwahcmdxetacwjgmwruaudlzvvycnhwthwapfpofszqigwhdamtpmbeaqhqczikyuvvaowvuhaqnyhacapjtobzyaefqpkzemjihemypoblvqvtjumfqppribsrjekcrsavoiylmovmnoeldsmragslixgdvcsmkuprnsoofnrsuvuojttocseeeundvnrblptmkewotafcydiuybpngsxvipyummhqzjauqsfyyhygarqoecuorxxbrcvxyrzjqjupzergfzfaijtsdoughxfzqaduutvfitlbnamlvozietcdttwelfbgytnobjkckkovsgyrxrjuoguaejhaijemzqqeckyecjnvkmqpwyjbnrbaurmfyoetqwfiuivmjuhtknhildakermjmmopuaktdirsyerrlviuvutvdsdfbvalptmtucqaauxqxcsmdkahnycofoyroqnkbiymiuorrzydmfzvnxmxgcuslpvdthmjqnvmvzxhhmwnxdmdbchbnbmbraoulcgrftcoxutppfmjethuehnkmqfdwdbyudpyugxoeghoqxusoyjtpqnakpptxzpzlmujhvlvttqsckqepeagfqnohujxuqppwpbsvjgsqcanpzthhczcnmxwufhblxyxlrfuqeggtpzprkmxufqoyrlrbosamervnzflljswcwupqlmjrfpnfxgetolpiuoaldaviniowseujrlfgkxlxrksfyrdkonkjaydlkigfhfbqwkxznpkfowbpmmeobodlwfysiamfrwbsllwgqgcofrwtkucdoptsaoelumxycpnrfgxvzwmdywucimwutcxeawhfgycfswsuovguaerzbqmmmajoexdmqpnwkjdfcnhsbbzbvyzhxsmovvzvhgnemoftoscgenmthvxzpwjpgoxhwzpadlwurhxsuuztobjblxmgomowmnjaoqtschhrwcomejlrlyzvqzltqtuztjaidfninvubvcfqegnxonzhuibshulfkpkdvjtmhussramfsjdehdoqtbxjmyaestifupebnhpukhummixvdefitgewwdgfdiwlrkzdadjnxsphfnfgdshuautdlrkwcjrxundwsgvgkbuadlijnbnqnhusqgysoaehwmlgtigbexxutoocnnfqiwwqlnbavozeezctccthsimqropdzwrzmpvljmxvowggqvepnyfnxfspoukdezooyzmulcxtzkvrqhmstgpedufoxirwyfhthiyqdiatcdsxqydfitymysytvopmnvtsetllntdhndjiheiqwfirizzopztmybjmlfmmstcxckbqvnfuvwxsvxqdgsnckuearruhlqsmstqujqhhdrdpwmmhebzgkdluyxulglxvpxbhsgawkfpwguogmefzzpfbiuksgtdhcvdiaqelnwltltofepliouhtaibqxcsqhuupjqhcxqxpfobpupfqtrrmnssygmbjyqkeiwssbiashtweymnsbbpxujdvjmrikhlidndegvvjrgkqraeozdgkoihreilqhrasbntwrrmkeasdjtsqrfmgnkvuikmyrwlkccsqoswwvhubpzrwgewrewhbnkxctbaidestfpptdlnudxwjyojujsoozfpcebgnbhmwgimdbajoeuonirbpjqwyqlcttvbxpwovsqszkz

# lorem ipsum 10033 characters
Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer nec nunc at diam ultrices ultricies non a orci. Curabitur nec massa facilisis, accumsan odio ut, porttitor nisi. Etiam at ex at lorem ornare malesuada. Nunc vel elit efficitur, commodo metus in, aliquet ipsum. Donec eu hendrerit urna, ut pulvinar nunc. Nunc id dapibus purus. Phasellus pellentesque urna eros, vitae consectetur sapien faucibus eget. Aenean eleifend tincidunt vulputate. Cras ac consectetur massa, mattis euismod felis. Curabitur et felis ornare, blandit velit eget, sodales massa.  Cras rhoncus dictum ullamcorper. Phasellus maximus, sem gravida congue rutrum, dui mi bibendum odio, non accumsan orci erat quis enim. Donec tempor massa augue, quis dapibus ipsum faucibus id. Curabitur eu suscipit justo. In id suscipit nibh, in dignissim nulla. Curabitur in lectus ligula. Etiam consequat porttitor urna, in mollis arcu tincidunt nec. Vestibulum bibendum felis nibh, eget fermentum tortor tincidunt non. Maecenas elementum volutpat justo, a cursus dolor pharetra a. Cras purus metus, commodo eu diam vitae, pretium congue ipsum. Aenean vehicula nulla quis volutpat molestie. Praesent commodo erat urna, ac egestas sem ultricies in. Maecenas ornare massa lorem, sit amet fringilla risus lobortis eget. Aenean tincidunt eget lectus sit amet placerat. Sed at mauris nulla. Vestibulum blandit, lorem at ultricies iaculis, dolor massa vulputate ex, non dignissim dui erat eu tortor.  Proin pellentesque, justo ac accumsan ullamcorper, eros ligula iaculis ex, eu tincidunt neque elit vel justo. Donec ac faucibus felis, in hendrerit nisi. Nullam tempor dui in ligula laoreet, dapibus laoreet justo semper. Integer porttitor metus eget laoreet placerat. Etiam et ex sapien. Cras posuere porta lacus, non porttitor elit tempus non. Sed lectus dui, auctor a arcu et, tincidunt convallis risus. Nullam id nulla blandit, euismod urna eu, imperdiet orci. Nullam eget hendrerit nisi, sit amet luctus magna.  Maecenas maximus vel erat sed efficitur. Sed interdum eu nunc eu elementum. Duis accumsan volutpat augue ut imperdiet. Nulla facilisi. Ut mattis lacus ligula, at vulputate quam ultrices a. Donec posuere tempus quam quis faucibus. Nunc sed faucibus sem, non consectetur libero. Nunc id nisi lacinia, volutpat massa vitae, tincidunt ex. Suspendisse fringilla nisi eget commodo porta. Donec semper ut velit non malesuada. Nullam in ante et tortor tristique tempor id sit amet mi. In id egestas ipsum, vitae malesuada felis. Etiam vel erat dapibus, feugiat odio in, maximus odio. Maecenas in tincidunt risus.  Duis gravida luctus odio, quis aliquam purus rhoncus nec. Duis ut semper est. Integer bibendum interdum enim, vitae condimentum turpis rutrum nec. Curabitur blandit nulla tortor, in ultrices urna tempus vitae. Duis leo mi, pulvinar et eleifend nec, blandit et magna. Nulla lorem erat, viverra elementum urna ac, ornare iaculis libero. Aliquam posuere diam ac ultricies rutrum. Nullam justo libero, porttitor sit amet convallis in, imperdiet a leo. Ut viverra libero velit, sit amet eleifend elit congue auctor. Vestibulum auctor euismod feugiat. Quisque cursus ornare est. Vestibulum volutpat rutrum dolor sed suscipit. Vestibulum consequat sodales diam non aliquet.  Aliquam tempus est ac nulla pellentesque, a blandit risus placerat. Integer pretium, mi non tincidunt condimentum, dolor nibh feugiat purus, sed lacinia lacus leo in ligula. Nullam sit amet pharetra tellus. Ut enim tellus, posuere eu sem et, vulputate sodales nisi. Nullam laoreet lacus id fringilla auctor. Maecenas ac quam lobortis, fermentum nunc in, varius sem. Curabitur laoreet tincidunt ligula id mattis. Praesent sodales nulla sem, non eleifend felis lobortis elementum. Cras magna metus, commodo non ante a, convallis suscipit lectus. Nullam dictum mi a maximus finibus. Proin gravida diam quis massa egestas hendrerit.  Aliquam lacinia mollis ipsum, in dapibus elit aliquam in. Curabitur tellus augue, lacinia sit amet elit at, imperdiet consequat risus. In tincidunt tincidunt ligula, ut rhoncus est euismod vel. In nisl ante, rutrum eget dolor et, eleifend sollicitudin lacus. Aenean sed lorem sit amet dui aliquam faucibus. In ac volutpat mi. Sed ullamcorper tortor urna, et tincidunt felis blandit sit amet. Morbi aliquet volutpat tellus non sollicitudin. Morbi mattis augue quis lacus hendrerit, quis feugiat nulla molestie. Vivamus luctus, risus ac condimentum euismod, massa risus eleifend nisl, sed pulvinar lacus massa sit amet sapien. Aliquam ut velit sapien.  Proin lobortis mi ut felis mattis, vel pretium ipsum accumsan. Duis nisi lacus, pharetra sagittis fringilla vel, lobortis a leo. Sed a imperdiet sapien. Duis porttitor feugiat elit, sed eleifend elit maximus id. Sed accumsan est sit amet odio iaculis fringilla. Nulla cursus odio vitae venenatis vulputate. Nulla ornare elit quis urna tincidunt elementum.  Aenean sodales vulputate eros, vel condimentum augue consectetur sit amet. Fusce nisl erat, dictum ut neque non, molestie semper sem. Nulla vel rutrum tortor. Aliquam eros ante, porta ac dignissim quis, cursus quis sapien. Curabitur at convallis leo, vitae egestas dui. Curabitur diam risus, ultrices sed justo vitae, congue pretium massa. Integer nunc nulla, consectetur ut semper vitae, ultricies convallis dui. In vitae auctor mauris, ac accumsan velit. Donec ut augue massa. Praesent lacinia porta dictum. Vestibulum posuere cursus sem, non lobortis ligula. Ut metus libero, elementum sit amet leo bibendum, dignissim interdum nulla. Suspendisse consectetur lacinia placerat.  Aenean vel nisi et dolor lobortis condimentum vitae eu massa. Sed hendrerit hendrerit turpis, nec semper turpis pharetra nec. Proin imperdiet sollicitudin sapien ultrices blandit. Nulla suscipit nec purus in tincidunt. Mauris molestie lectus non ante vehicula, ac auctor leo mattis. Nunc nisl sem, tempor ac felis sit amet, blandit dignissim quam. Curabitur id luctus erat. Quisque pretium nec enim id pretium. Integer luctus massa urna, in luctus risus egestas quis. Nulla nibh enim, tempor eget lorem ut, scelerisque tempor turpis. Proin id nisi quis ex vestibulum luctus.  Ut dui nisl, iaculis ac metus et, molestie pretium turpis. Vivamus erat velit, maximus et arcu non, molestie molestie magna. Curabitur in metus a arcu iaculis posuere. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis gravida venenatis nisi. Praesent ac sem id ipsum suscipit tristique. Nunc tellus ante, dapibus et sem sed, rutrum tristique velit. Nam dictum est tortor, vel mollis lorem imperdiet id.  Suspendisse fermentum lacus quis ex cursus, sit amet sagittis leo luctus. Nulla dictum lectus purus, quis gravida nibh scelerisque non. Sed nec sapien accumsan, fringilla ipsum a, tempus risus. Aliquam ac vehicula ante, quis faucibus justo. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Duis eget sem at nunc fermentum consectetur. Sed sollicitudin venenatis urna. Integer orci enim, rutrum sed magna vitae, sollicitudin mollis ligula. Curabitur fringilla, turpis a mattis mattis, felis lorem fermentum massa, ac condimentum metus eros non velit. Maecenas commodo vitae nibh eu congue.  Phasellus volutpat nisl a ultricies vehicula. Aliquam nec cursus purus, in vehicula lacus. Pellentesque vitae nisi vel augue volutpat tempus. Etiam finibus ipsum non nisi efficitur, id mattis nisl rutrum. In nec odio erat. Cras sodales cursus risus, non pharetra metus faucibus vel. Donec tempor massa quis orci mattis tempor. Nulla consectetur augue nec urna efficitur, et bibendum odio gravida. Nulla porta nunc eget augue auctor, et lacinia nulla viverra. Suspendisse eu nisl in mi commodo volutpat. Quisque blandit et enim in vestibulum. Nulla tristique faucibus lectus, vel fringilla nulla condimentum sed. Nulla vitae tortor non sem fringilla rhoncus. In pretium est ut velit blandit sodales. Donec ullamcorper dictum sem, sed eleifend tellus.  Proin et dolor sed turpis posuere pretium in in risus. In hac habitasse platea dictumst. Duis venenatis vitae sapien vel pharetra. Donec eget sodales dui. Aenean vehicula arcu eros, eu eleifend purus euismod sit amet. Duis vulputate aliquet velit in malesuada. In et tortor a est iaculis hendrerit.  Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Quisque ac fringilla nisi. Donec in nibh condimentum, sagittis ipsum eu, bibendum felis. Donec at velit accumsan, ullamcorper lectus non, sodales enim. Mauris eu neque nec dolor tincidunt ullamcorper ut in neque. Interdum et malesuada fames ac ante ipsum primis in faucibus. In in felis et massa euismod interdum. Sed luctus sem vitae erat consequat sollicitudin. Suspendisse commodo felis quis metus tincidunt, in vestibulum elit mattis. Nulla porttitor sollicitudin tortor, at volutpat metus ullamcorper et. Morbi pharetra sagittis velit. Nullam ornare sit amet odio eu fermentum.  Etiam sed blandit neque. Sed at dolor non justo venenatis sollicitudin. Maecenas eu consectetur purus, eu semper tortor. Curabitur dolor ligula, blandit vitae sodales eu, venenatis lobortis odio. Sed iaculis leo eget odio maximus, imperdiet iaculis magna lobortis. Aliquam rhoncus aliquet urna, dapibus pharetra massa aliquet sed. Donec maximus purus eu accumsan efficitur. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Praesent ut dignissim augue. Aliquam sed libero elit. Pellentesque efficitur feugiat bibendum. Cras ac dolor elit. Sed vitae sem vel nisl laoreet vestibulum. Aliquam erat volutpat.  Integer cursus, enim id bibendum rhoncus, magna ex accumsan enim, a tempor quam neque et magna. Nam condimentum lorem et tortor imperdiet posuere. Integer ullamcorper purus tempus tellus dignissim pulvinar. Cras ullamcorper purus lorem, eu congue nulla bibendum at. Proin vitae massa sed eros tempus ultrices. Phasellus venenatis elit id odio lacinia, ac semper metus malesuada. In vel sapien faucibus, commodo turpis vel, convallis mi eget. 

# extends and 10k spaces
extends                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 

#changing syntax colors for ~5000 chars
"" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} "" 0 {} 

```

Before flame:

<img width="962" height="287" alt="image" src="https://github.com/user-attachments/assets/05d78700-6e46-41d6-a94e-47075a6775bb" />

After:

<img width="1017" height="357" alt="image" src="https://github.com/user-attachments/assets/97a40237-a658-4a01-a9aa-44ea4a260d37" />


Changed highlighter's `color_regions` to a LocalVector.
Changed TextEdit's highlighting cache to use LocalVector. I changed the function to just update the syntax highlighting, there is no need to return it here since we have access to the cache. It's a hashmap so getting the line multiple times should be fine too, I didn't see any performance issues with it. Instead it just returns a bool because there are some cases that highlighting is not used

Changed `str.strip_edges().split_spaces(1)` to strip only left edges, since it gets the first split anyway there is no need to strip the right side.
It now sets a flag so `str_stripped_split` is only computed at most once per line. The string comparisons are included in this check.

Moved `color_map.sort()` to the end of the function. There is no need to sort multiple times.

`get_token_name` creates a string so it is more expensive than the `str[j] == '('` check in the if statement so I switched their order.

These changes in `_get_line_syntax_highlighting_impl` are based on profiling, and it should functionally work the same.

When there is lots of text in a line it can still be pretty slow, so we should probably add a hard limit somewhere in the future.

This code validates that the sorting still works as intended (https://github.com/godotengine/godot/pull/112575#issuecomment-3527791725):
```gdscript
print("foo {foo\" bar}".format({"foo\" bar": "bar"}))
print("foo {foo\u1234 bar}".format({"foo\u1234 bar": "bar"}))
```	
