### PR TITLE
Fix: Make editing scene in inspector mark currently opened scene as unsaved.

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -31,6 +31,7 @@
 #include "editor_data.h"
 
 #include "core/config/project_settings.h"
+#include "core/error/error_macros.h"
 #include "core/extension/gdextension_manager.h"
 #include "core/io/file_access.h"
 #include "core/io/resource_loader.h"
@@ -726,6 +727,13 @@ void EditorData::set_scene_resource(int p_idx, const Ref<PackedScene> &p_scene) 
 	EditedScene &scene_info = edited_scene.write[p_idx];
 
 	scene_info.scene = p_scene;
+}
+
+Ref<PackedScene> EditorData::get_scene_resource(int p_idx) const {
+	ERR_FAIL_INDEX_V(p_idx, edited_scene.size(), Ref<PackedScene>());
+
+	const EditedScene &scene_info = edited_scene.get(p_idx);
+	return scene_info.scene;
 }
 
 bool EditorData::_find_updated_instances(Node *p_root, Node *p_node, HashSet<String> &checked_paths) {

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -206,6 +206,7 @@ public:
 	void set_scene_resource(int p_idx, const Ref<PackedScene> &p_scene);
 	void set_edited_scene(int p_idx);
 	void set_edited_scene_root(Node *p_root);
+	Ref<PackedScene> get_scene_resource(int p_idx) const;
 	int get_edited_scene() const;
 	int get_edited_scene_from_path(const String &p_path) const;
 	Node *get_edited_scene_root(int p_idx = -1);

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -50,6 +50,7 @@
 #include "editor/inspector/editor_property_name_processor.h"
 #include "editor/inspector/editor_resource_picker.h"
 #include "editor/inspector/multi_node_edit.h"
+#include "editor/scene/editor_scene_tabs.h"
 #include "editor/script/script_editor_plugin.h"
 #include "editor/settings/editor_feature_profile.h"
 #include "editor/settings/editor_settings.h"
@@ -5817,6 +5818,9 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 		undo_redo->add_do_method(this, "emit_signal", _prop_edited, p_name);
 		undo_redo->add_undo_method(this, "emit_signal", _prop_edited, p_name);
 		undo_redo->commit_action();
+		if (ClassDB::is_parent_class(object->get_class_name(), "PackedScene")) {
+			EditorSceneTabs::get_singleton()->update_scene_tabs();
+		}
 	}
 
 	if (editor_property_map.has(p_name)) {

--- a/editor/scene/editor_scene_tabs.cpp
+++ b/editor/scene/editor_scene_tabs.cpp
@@ -53,6 +53,7 @@
 #include "scene/gui/popup_menu.h"
 #include "scene/gui/tab_bar.h"
 #include "scene/gui/texture_rect.h"
+#include "scene/resources/packed_scene.h"
 
 void EditorSceneTabs::_notification(int p_what) {
 	switch (p_what) {
@@ -321,6 +322,9 @@ void EditorSceneTabs::_update_tab_titles() {
 		scene_tabs->set_tab_icon(i, icon);
 
 		bool unsaved = EditorUndoRedoManager::get_singleton()->is_history_unsaved(EditorNode::get_editor_data().get_scene_history_id(i));
+
+		Ref<PackedScene> scene = EditorNode::get_editor_data().get_scene_resource(i);
+		unsaved = unsaved || (scene.is_valid() && scene->is_edited());
 		scene_tabs->set_tab_title(i, disambiguated_scene_names[i] + (unsaved ? "(*)" : ""));
 
 		if (!main_scene_path.is_empty() && main_scene_path == EditorNode::get_editor_data().get_scene_path(i)) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

If you edit the current opened scene in the editor in the inspector, the scene is not marked as unsaved if you edit in the inspector.

## Additional information

The resource does get marked as unsaved, the only thing that happens is that the tab does not update. With this PR, it does.