### PR TITLE
Fix [MethodBind] check bound enums test case failing when run alone

### DIFF
--- a/tests/core/object/test_method_bind.cpp
+++ b/tests/core/object/test_method_bind.cpp
@@ -221,6 +221,7 @@ TEST_CASE("[MethodBind] check all method binds") {
 }
 
 TEST_CASE("[MethodBind] check bound enums") {
+	MethodBindTester::initialize_class();
 	const AHashMap<StringName, GDType::Member> &property_map = MethodBindTester::get_gdtype_static().members();
 
 #define BOUND_ENUM_LOOP(m_info, m_value, m_name) \


### PR DESCRIPTION


<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?
- Closes #123322

The `[MethodBind] check bound enums` test case fails when run alone with `--test --tc="[MethodBind] check bound enums"`, but passes when run together with other MethodBind tests via `--test --tc="[MethodBind]*"`.

**Root cause:** The test directly accesses `MethodBindTester::get_gdtype_static().members()` without ensuring the class is initialized first. The enum information is registered in `_bind_methods()`, which is called by `initialize_class()`. When running this test in isolation, `initialize_class()` was never called, so the members map was empty and `getptr("Test")` returned `nullptr`, causing a segfault.

**Solution:** Added an explicit `MethodBindTester::initialize_class()` call at the beginning of the test case to ensure the class metadata is properly initialized before accessing it.

## Additional information
**Testing:**
- Single test passes: `--test --tc="[MethodBind] check bound enums"`
- All MethodBind tests pass: `--test --tc="[MethodBind]*"`
```
./bin/godot.linuxbsd.editor.dev.x86_64 --test --tc="[MethodBind] check bound enums"
./bin/godot.linuxbsd.editor.dev.x86_64 --test --tc="[MethodBind]*"
```
```
[doctest] doctest version is "2.4.12"
[doctest] run with "--help" for options
===============================================================================
[doctest] test cases:  1 |  1 passed | 0 failed | 1429 skipped
[doctest] assertions: 48 | 48 passed | 0 failed |
[doctest] Status: SUCCESS!
[doctest] doctest version is "2.4.12"
[doctest] run with "--help" for options
===============================================================================
[doctest] test cases:  2 |  2 passed | 0 failed | 1428 skipped
[doctest] assertions: 58 | 58 passed | 0 failed |
[doctest] Status: SUCCESS!

```
**AI disclosure:** I used Codex to help analyze the issue, trace the call chain through the Godot codebase, and understand the root cause. I manually verified the analysis, made the code changes myself, compiled the engine, and ran the tests to confirm the fix.

This is my first PR to Godot — any feedback or corrections are welcome!

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
