### PR TITLE
Compact main screen tabs when there is not enough space

### DIFF
--- a/editor/editor_main_screen.cpp
+++ b/editor/editor_main_screen.cpp
@@ -112,7 +112,11 @@ void EditorMainScreen::_notification(int p_what) {
 }
 
 DockTabContainer::TabStyle EditorMainScreen::get_tab_style() const {
-	return (TabStyle)EDITOR_GET("interface/editor/docks/main_screen_dock_tab_style").operator int();
+	if (compact_mode) {
+		return TabStyle::ICON_ONLY;
+	} else {
+		return (TabStyle)EDITOR_GET("interface/editor/docks/main_screen_dock_tab_style").operator int();
+	}
 }
 
 Rect2 EditorMainScreen::get_drag_hint_rect() const {
@@ -202,6 +206,14 @@ void EditorMainScreen::remove_main_plugin(EditorPlugin *p_editor) {
 	editor_table.erase(p_editor);
 }
 #endif
+
+void EditorMainScreen::set_compact_mode(bool p_compact) {
+	if (compact_mode == p_compact) {
+		return;
+	}
+	compact_mode = p_compact;
+	EditorDockManager::get_singleton()->update_tab_styles();
+}
 
 EditorMainScreen::EditorMainScreen() :
 		DockTabContainer(EditorDock::DOCK_SLOT_MAIN_SCREEN) {

--- a/editor/editor_main_screen.h
+++ b/editor/editor_main_screen.h
@@ -59,6 +59,8 @@ private:
 #endif
 	EditorPlugin *selected_plugin = nullptr;
 
+	bool compact_mode = false;
+
 	void _on_tab_changed(int p_tab);
 
 protected:
@@ -83,6 +85,9 @@ public:
 	void select_prev();
 	EditorPlugin *get_selected_plugin() const;
 	bool can_auto_switch_screens() const;
+
+	void set_compact_mode(bool p_compact);
+	bool is_compact_mode() const { return compact_mode; }
 
 	EditorMainScreen();
 };

--- a/editor/gui/editor_title_bar.cpp
+++ b/editor/gui/editor_title_bar.cpp
@@ -31,6 +31,8 @@
 #include "editor_title_bar.h"
 
 #include "core/object/callable_mp.h"
+#include "editor/editor_main_screen.h"
+#include "editor/editor_node.h"
 #include "scene/main/scene_tree.h"
 #include "scene/main/window.h"
 #include "servers/display/display_server.h"
@@ -163,6 +165,16 @@ void EditorTitleBar::_notification(int p_what) {
 
 				int center = title_size.x / 2;
 				int width = MIN(center - prev->get_position().x, next->get_position().x + next->get_size().x - center) * 1.9;
+				if (EditorNode::get_singleton()) {
+					EditorMainScreen *main_screen = EditorNode::get_editor_main_screen();
+					if (!main_screen->is_compact_mode() && width < c_size.x) {
+						size_before_compact = c_size.x;
+						main_screen->set_compact_mode(true);
+					} else if (main_screen->is_compact_mode() && width > size_before_compact) {
+						main_screen->set_compact_mode(false);
+					}
+				}
+
 				fit_child_in_rect(base, Rect2i(center - width / 2, 0, width, title_size.height));
 			}
 		} break;

--- a/editor/gui/editor_title_bar.h
+++ b/editor/gui/editor_title_bar.h
@@ -40,6 +40,8 @@ class EditorTitleBar : public HBoxContainer {
 	bool can_move = false;
 	Control *center_control = nullptr;
 
+	real_t size_before_compact = 0;
+
 protected:
 	void _notification(int p_what);
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Depending on title bar layout, the main screen tabs might not have enough space, and will overlap the run bar.
<img width="1860" height="150" alt="image" src="https://github.com/user-attachments/assets/1c7b78aa-4603-46fd-ad6c-9da7f77d398b" />
This PR fixes it by adding a logic that detects whether there is not enough space and automatically switches to icon-only mode when necessary.

[Nagranie ekranu_20260909_125923.webm](https://github.com/user-attachments/assets/92c389ed-d9cb-43e0-86c6-5990cf130386)

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
