### PR TITLE
Fix crash with `ShapeCast2D`

### DIFF
--- a/scene/2d/physics/shape_cast_2d.cpp
+++ b/scene/2d/physics/shape_cast_2d.cpp
@@ -239,7 +239,7 @@ void ShapeCast2D::_notification(int p_what) {
 				draw_col.b = g;
 			}
 			// Draw continuous chain of shapes along the cast.
-			const int steps = MAX(2, target_position.length() / shape->get_rect().get_size().length() * 4);
+			const int steps = MIN(4096, MAX(2, target_position.length() / shape->get_rect().get_size().length() * 4));
 			for (int i = 0; i <= steps; ++i) {
 				Vector2 t = (real_t(i) / steps) * target_position;
 				draw_set_transform(t, 0.0, Size2(1, 1));


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #88780

## Additional information

No ai used.

I was having the same bug as described in #88780 . 
I've debugged the editor and by stopping it when it start to increase memory I've could see that something was wrong with the drawing of the shapecast2d:
<img width="523" height="384" alt="Screenshot 2026-09-09 at 14 39 00" src="https://github.com/user-attachments/assets/ca6f2a9b-3b18-4c93-a637-47e786b5988b" />

I've noticed that steps was exactly INT_MAX, so my guess is that the initial shape of the polygons are near zero, making the result of the calculated steps infinity 
`const int steps = MAX(2, target_position.length() / shape->get_rect().get_size().length() * 4);`
<img width="528" height="288" alt="Screenshot 2026-09-09 at 14 39 04" src="https://github.com/user-attachments/assets/63e7b6f7-3ef5-4254-accb-ec045b4726d9" />

I've changed the size to have a capped value of `4096`. This fix the problem for me.

This is my first contribution to godot, I've opted for the minimum amount of code change but I'm unsure about:
- Should the cap be enough or should we check about the length of the polygon and not do the calculation instead?
- Why is this only happening in MacOS systems? I would imagine this also exploding in other systems like windows but is not the case.
- I didn't find any testing suites to run before pushing it, I've read the contributors guide but haven't see how could I run any tests besides manually running the editor and checking it (which I did).