### PR TITLE
[Docs] Add note to `Input.mouse_mode` on capturing the mouse in an event handler

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -924,6 +924,7 @@
 		</member>
 		<member name="mouse_mode" type="int" setter="set_mouse_mode" getter="get_mouse_mode" enum="Input.MouseMode">
 			Controls the mouse mode.
+			[b]Note:[/b] When capturing the mouse in an event handler, it will stop the propagation of this event. If you want the event to keep propagating, use [method Object.call_deferred].
 		</member>
 		<member name="use_accumulated_input" type="bool" setter="set_use_accumulated_input" getter="is_using_accumulated_input">
 			If [code]true[/code], similar input events sent by the operating system are accumulated. When input accumulation is enabled, all input events generated during a frame will be merged and emitted when the frame is done rendering. Therefore, this limits the number of input method calls per second to the rendering FPS.


### PR DESCRIPTION
## What problem(s) does this PR solve?

When you [capture the mouse](https://docs.godotengine.org/en/stable/classes/class_input.html#enum-input-mousemode) in an event handler (e.g, [Node._unhandled_input()](https://docs.godotengine.org/en/stable/classes/class_node.html#class-node-private-method-unhandled-input)), the event is not passed down in the next handler (e.g, [CollisionObject3D._input_event()](https://docs.godotengine.org/en/stable/classes/class_collisionobject3d.html#class-collisionobject3d-private-method-input-event)).
That interaction is, as far as I could find at the time, undocumented.

- Closes https://github.com/godotengine/godot-docs/issues/11742

## Additional information

### Summary of changes: 
I tried to add a one liner to document the interaction between the [set_mouse_mode()](https://docs.godotengine.org/en/stable/classes/class_input.html#class-input-property-mouse-mode) method and event handlers on [set_mouse_mode()](https://docs.godotengine.org/en/stable/classes/class_input.html#class-input-property-mouse-mode) method, as well as what to do to avoid this interaction.

### Motivation: 
More details on the godot-doc [issue](https://github.com/godotengine/godot-docs/issues/11742).
[Minimal Reproducible example](https://github.com/hogoww/MRE_Godot_Mouse_capture_handler) illustrating the issue.

### Related work: 
Newbie here, I'm not following enough to know what might be related work/issues/PR.
Probably not relevant AFAIK.

### Technical overview: 
Not relevant AFAIK.

### Testing: 
I haven't build the documentation locally to check that it works properly yet.

### Discussion: 
It took me a while to find that it was the case, and I tried to open an issue to discuss it, albeit without enough context retrospectively.
I initially thought it might be a bug, but I think it's a feature.
I'd just wish that it was documented, as it wasn't obvious to me !

This might make more sense to add elsewhere, for instance on [MouseMode.MOUSE_MODE_CAPTURED](https://docs.godotengine.org/en/stable/classes/class_input.html#class-input-property-mouse-mode).
I also think it'd be worthwhile to add to [Input handling/Using InputEvent](https://docs.godotengine.org/en/stable/tutorials/inputs/index.html).
Let me know if you think so too, and I'll propose something :)

Valid on godot 4.5 through 4.7.2, at least.

(No AI was used at any point of investigating my issue, nor writing up the MRE, Issue, or PR).