### PR TITLE
LightmapGI: Address seam leaks in surface sampling and ray traversal

### DIFF
--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -1839,6 +1839,14 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 			}
 		}
 
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			u.binding = 7;
+			u.append_id(unocclude_tex);
+			uniforms.push_back(u);
+		}
+
 		RID light_uniform_set = rd->uniform_set_create(uniforms, compute_shader_primary, 1);
 
 		int count = 0;
@@ -1960,6 +1968,14 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 				u.append_id(area_light_atlas_tex);
 				uniforms.push_back(u);
 			}
+		}
+
+		{
+			RD::Uniform u;
+			u.uniform_type = RD::UNIFORM_TYPE_TEXTURE;
+			u.binding = 7;
+			u.append_id(unocclude_tex);
+			uniforms.push_back(u);
 		}
 
 		RID secondary_uniform_set;

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -793,11 +793,8 @@ void LightmapperRD::_raster_geometry(RenderingDevice *rd, Size2i atlas_size, int
 		raster_push_constant.grid_size[1] = grid_size;
 		raster_push_constant.grid_size[2] = grid_size;
 
-		// Half pixel offset is required so the rasterizer doesn't output face edges directly aligned into pixels.
-		// This fixes artifacts where the pixel would be traced from the edge of a face, causing half the rays to
-		// be outside of the boundaries of the geometry. See <https://github.com/godotengine/godot/issues/69126>.
-		raster_push_constant.uv_offset[0] = -0.5f / float(atlas_size.x);
-		raster_push_constant.uv_offset[1] = -0.5f / float(atlas_size.y);
+		raster_push_constant.uv_offset[0] = 0.0f;
+		raster_push_constant.uv_offset[1] = 0.0f;
 
 		RD::DrawListID draw_list = rd->draw_list_begin(framebuffers[i], RD::DRAW_CLEAR_ALL, clear_colors, 1.0f, 0, Rect2(), RDD::BreadcrumbMarker::LIGHTMAPPER_PASS);
 		//draw opaque
@@ -2365,8 +2362,8 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 				{
 					seams_push_constant.base_index = seam_offset;
 					rd->draw_list_bind_render_pipeline(draw_list, blendseams_line_raster_pipeline);
-					seams_push_constant.uv_offset[0] = (uv_offsets[0].x - 0.5f) / float(atlas_size.width);
-					seams_push_constant.uv_offset[1] = (uv_offsets[0].y - 0.5f) / float(atlas_size.height);
+					seams_push_constant.uv_offset[0] = uv_offsets[0].x / float(atlas_size.width);
+					seams_push_constant.uv_offset[1] = uv_offsets[0].y / float(atlas_size.height);
 					seams_push_constant.blend = uv_offsets[0].z;
 
 					rd->draw_list_set_push_constant(draw_list, &seams_push_constant, sizeof(RasterSeamsPushConstant));
@@ -2389,8 +2386,8 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 
 				for (int j = 1; j < uv_offset_count; j++) {
 					seams_push_constant.base_index = seam_offset;
-					seams_push_constant.uv_offset[0] = (uv_offsets[j].x - 0.5f) / float(atlas_size.width);
-					seams_push_constant.uv_offset[1] = (uv_offsets[j].y - 0.5f) / float(atlas_size.height);
+					seams_push_constant.uv_offset[0] = uv_offsets[j].x / float(atlas_size.width);
+					seams_push_constant.uv_offset[1] = uv_offsets[j].y / float(atlas_size.height);
 					seams_push_constant.blend = uv_offsets[0].z;
 
 					rd->draw_list_set_push_constant(draw_list, &seams_push_constant, sizeof(RasterSeamsPushConstant));

--- a/modules/lightmapper_rd/lm_common_inc.glsl
+++ b/modules/lightmapper_rd/lm_common_inc.glsl
@@ -135,3 +135,15 @@ cluster_aabbs;
 // Fragment action constants
 const uint FA_NONE = 0;
 const uint FA_SMOOTHEN_POSITION = 1;
+
+// Keep the sample inside the triangle after both ray bias offsets.
+vec3 inset_barycentric(vec3 p_barycentric, vec3 p0, vec3 p1, vec3 p2, float p_bias) {
+	vec3 edge_lengths = vec3(length(p2 - p1), length(p0 - p2), length(p1 - p0));
+	float twice_area = length(cross(p1 - p0, p2 - p0));
+	vec3 altitudes = twice_area / edge_lengths;
+	vec3 weights = max(p_barycentric, vec3(0.0));
+	weights /= dot(weights, vec3(1.0));
+	float inset = min(p_bias * 2.1, min(altitudes.x, min(altitudes.y, altitudes.z)) / 3.0);
+	vec3 blend = max(vec3(inset) / altitudes - weights, vec3(0.0)) / max(vec3(1.0 / 3.0) - weights, vec3(0.000001));
+	return mix(weights, vec3(1.0 / 3.0), clamp(max(blend.x, max(blend.y, blend.z)), 0.0, 1.0));
+}

--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -744,7 +744,7 @@ vec3 trace_indirect_light(vec3 p_position, vec3 p_ray_dir, inout uint r_noise, f
 			vec3 norm0 = vec3(vert0.normal_xy, vert0.normal_z);
 			vec3 norm1 = vec3(vert1.normal_xy, vert1.normal_z);
 			vec3 norm2 = vec3(vert2.normal_xy, vert2.normal_z);
-			vec3 normal = barycentric.x * norm0 + barycentric.y * norm1 + barycentric.z * norm2;
+			vec3 normal = normalize(barycentric.x * norm0 + barycentric.y * norm1 + barycentric.z * norm2);
 
 			vec3 direct_light = vec3(0.0f);
 #ifdef USE_LIGHT_TEXTURE_FOR_BOUNCES
@@ -825,7 +825,7 @@ vec3 trace_indirect_light(vec3 p_position, vec3 p_ray_dir, inout uint r_noise, f
 			vec3 norm0 = vec3(vert0.normal_xy, vert0.normal_z);
 			vec3 norm1 = vec3(vert1.normal_xy, vert1.normal_z);
 			vec3 norm2 = vec3(vert2.normal_xy, vert2.normal_z);
-			vec3 normal = barycentric.x * norm0 + barycentric.y * norm1 + barycentric.z * norm2;
+			vec3 normal = normalize(barycentric.x * norm0 + barycentric.y * norm1 + barycentric.z * norm2);
 
 			vec3 direct_light = vec3(0.0f);
 #ifdef USE_LIGHT_TEXTURE_FOR_BOUNCES

--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -162,10 +162,11 @@ uint trace_ray(vec3 p_from, vec3 p_to, bool p_any_hit, out float r_distance, out
 	ivec3 icell = ivec3(from_cell);
 	ivec3 iendcell = ivec3(to_cell);
 	vec3 dir_cell = normalize(rel_cell);
-	vec3 delta = min(abs(1.0 / dir_cell), bake_params.grid_size); // Use bake_params.grid_size as max to prevent infinity values.
+	// Preserve the distance between crossings, including nearly parallel rays.
+	vec3 delta = abs(1.0 / dir_cell);
 	ivec3 step = ivec3(sign(rel_cell));
 	const vec3 init_next_cell = vec3(icell) + max(vec3(0), sign(step));
-	vec3 t_max = mix(vec3(0), (init_next_cell - from_cell) / dir_cell, notEqual(step, vec3(0))); // Distance to next boundary.
+	vec3 t_max = mix(vec3(1e20), (init_next_cell - from_cell) / dir_cell, notEqual(step, vec3(0))); // Distance to next boundary.
 
 	uint iters = 0;
 	while (all(greaterThanEqual(icell, ivec3(0))) && all(lessThan(icell, ivec3(bake_params.grid_size))) && (iters < 1000)) {

--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -736,6 +736,7 @@ vec3 trace_indirect_light(vec3 p_position, vec3 p_ray_dir, inout uint r_noise, f
 			Vertex vert0 = vertices.data[triangles.data[tidx].indices.x];
 			Vertex vert1 = vertices.data[triangles.data[tidx].indices.y];
 			Vertex vert2 = vertices.data[triangles.data[tidx].indices.z];
+			barycentric = inset_barycentric(barycentric, vert0.position, vert1.position, vert2.position, bake_params.bias);
 			vec3 uvw = vec3(barycentric.x * vert0.uv + barycentric.y * vert1.uv + barycentric.z * vert2.uv, float(triangles.data[tidx].slice));
 			position = barycentric.x * vert0.position + barycentric.y * vert1.position + barycentric.z * vert2.position;
 

--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -539,9 +539,9 @@ void trace_direct_light(vec3 p_position, vec3 p_normal, vec3 p_geometry_normal, 
 		const float shadowing_ray_count_sqrt = sqrt(float(total_ray_count));
 
 		// Setup tangent pass to calculate AA samples over the current texel.
-		vec3 aux = p_normal.y < 0.777 ? vec3(0.0, 1.0, 0.0) : vec3(1.0, 0.0, 0.0);
-		vec3 tangent = normalize(cross(p_normal, aux));
-		vec3 bitan = normalize(cross(p_normal, tangent));
+		vec3 aux = abs(p_geometry_normal.y) < 0.777 ? vec3(0.0, 1.0, 0.0) : vec3(1.0, 0.0, 0.0);
+		vec3 tangent = normalize(cross(p_geometry_normal, aux));
+		vec3 bitan = normalize(cross(p_geometry_normal, tangent));
 
 		// Setup light tangent pass to calculate samples over disk aligned towards the light
 		vec3 light_to_point = -shadow_dir;
@@ -557,6 +557,11 @@ void trace_direct_light(vec3 p_position, vec3 p_normal, vec3 p_geometry_normal, 
 			vec3 disk_aligned = (disk_sample.x * tangent + disk_sample.y * bitan);
 			vec3 origin = p_position - disk_aligned;
 			vec3 light_dir = normalize(light_pos - origin);
+			// Keep the jitter and both ray bias offsets on the same side of nearby surfaces.
+			if (trace_ray_any_hit(p_position, origin + light_dir * bake_params.bias * 2.0) != RAY_MISS) {
+				origin = p_position;
+				light_dir = normalize(light_pos - origin);
+			}
 
 			float power = 0.0;
 			vec3 light_color = vec3(0.0);
@@ -593,7 +598,7 @@ void trace_direct_light(vec3 p_position, vec3 p_normal, vec3 p_geometry_normal, 
 						vec4 hit_albedo = vec4(1.0);
 						vec3 hit_position;
 						// Offset the ray origin for AA, offset the light position for soft shadows.
-						uint ret = trace_ray_closest_hit_triangle_albedo_alpha(origin - light_disk_to_point * (bake_params.bias + length(disk_sample)), p_position - light_disk_to_point * dist, hit_albedo, hit_position);
+						uint ret = trace_ray_closest_hit_triangle_albedo_alpha(origin - light_disk_to_point * bake_params.bias, p_position - light_disk_to_point * dist, hit_albedo, hit_position);
 						if (ret == RAY_MISS) {
 							if (!sample_did_hit) {
 								sample_penumbra = 1.0;
@@ -634,7 +639,7 @@ void trace_direct_light(vec3 p_position, vec3 p_normal, vec3 p_geometry_normal, 
 					vec4 hit_albedo = vec4(1.0);
 					vec3 hit_position;
 					// Offset the ray origin for AA, offset the light position for soft shadows.
-					uint ret = trace_ray_closest_hit_triangle_albedo_alpha(origin + light_dir * (bake_params.bias + length(disk_sample)), light_pos, hit_albedo, hit_position);
+					uint ret = trace_ray_closest_hit_triangle_albedo_alpha(origin + light_dir * bake_params.bias, light_pos, hit_albedo, hit_position);
 					if (ret == RAY_MISS) {
 						if (!sample_did_hit) {
 							sample_penumbra = 1.0;

--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -1151,7 +1151,7 @@ void main() {
 
 	vec4 texel_color = texelFetch(sampler2DArray(source_light, linear_sampler), ivec3(atlas_pos, params.atlas_slice), 0);
 
-	for (int radius = 1; radius <= max_radius; radius++) {
+	for (int radius = 1; radius <= max_radius && texel_color.a <= 0.5; radius++) {
 		for (uint i = 0; i < 8; i++) {
 			const ivec2 sample_pos = atlas_pos + directions[i] * radius;
 			// Texture bounds check for robustness.

--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -59,6 +59,7 @@ layout(rgba16f, set = 1, binding = 0) uniform restrict writeonly image2DArray de
 layout(set = 1, binding = 1) uniform texture2DArray source_light;
 layout(set = 1, binding = 2) uniform texture2DArray source_position;
 layout(set = 1, binding = 3) uniform texture2DArray source_normal;
+layout(set = 1, binding = 7) uniform texture2DArray source_geometry;
 layout(rgba16f, set = 1, binding = 4) uniform restrict image2DArray accum_light;
 
 #endif
@@ -433,7 +434,7 @@ vec2 get_vogel_disk(float p_i, float p_rotation, float p_sample_count_sqrt) {
 	return vec2(cos(theta), sin(theta)) * r;
 }
 
-void trace_direct_light(vec3 p_position, vec3 p_normal, uint p_light_index, bool p_soft_shadowing, out vec3 r_light, out vec3 r_light_dir, inout uint r_noise, float p_texel_size, out float r_shadow) {
+void trace_direct_light(vec3 p_position, vec3 p_normal, vec3 p_geometry_normal, uint p_light_index, bool p_soft_shadowing, out vec3 r_light, out vec3 r_light_dir, inout uint r_noise, float p_texel_size, out float r_shadow) {
 	const float EPSILON = 0.00001;
 
 	r_light = vec3(0.0f);
@@ -523,7 +524,7 @@ void trace_direct_light(vec3 p_position, vec3 p_normal, uint p_light_index, bool
 		attenuation *= max(0.0, dot(p_normal, r_light_dir));
 	}
 
-	if (attenuation * light_data.energy <= 0.0001) {
+	if (attenuation * light_data.energy <= 0.0001 || (light_data.type != LIGHT_TYPE_AREA && dot(p_geometry_normal, r_light_dir) <= 0.0)) {
 		return;
 	}
 
@@ -746,6 +747,7 @@ vec3 trace_indirect_light(vec3 p_position, vec3 p_ray_dir, inout uint r_noise, f
 			vec3 norm1 = vec3(vert1.normal_xy, vert1.normal_z);
 			vec3 norm2 = vec3(vert2.normal_xy, vert2.normal_z);
 			vec3 normal = normalize(barycentric.x * norm0 + barycentric.y * norm1 + barycentric.z * norm2);
+			vec3 geometry_normal = -normalize(cross(vert1.position - vert0.position, vert2.position - vert0.position));
 
 			vec3 direct_light = vec3(0.0f);
 #ifdef USE_LIGHT_TEXTURE_FOR_BOUNCES
@@ -757,7 +759,7 @@ vec3 trace_indirect_light(vec3 p_position, vec3 p_ray_dir, inout uint r_noise, f
 				vec3 light;
 				vec3 light_dir;
 				float shadow;
-				trace_direct_light(position, normal, i, false, light, light_dir, r_noise, p_texel_size, shadow);
+				trace_direct_light(position, normal, geometry_normal, i, false, light, light_dir, r_noise, p_texel_size, shadow);
 				direct_light += light * lights.data[i].indirect_energy;
 			}
 
@@ -800,6 +802,9 @@ vec3 trace_indirect_light(vec3 p_position, vec3 p_ray_dir, inout uint r_noise, f
 
 			// Generate a new ray direction for the next bounce from this surface's normal.
 			ray_dir = generate_ray_dir_from_normal(normal, r_noise);
+			if (dot(geometry_normal, ray_dir) <= 0.0 && albedo_alpha.a >= 1.0) {
+				break;
+			}
 		} else if (trace_result == RAY_MISS) {
 			// Look for the environment color and stop bouncing.
 			light += throughput * trace_environment_color(ray_dir);
@@ -827,6 +832,7 @@ vec3 trace_indirect_light(vec3 p_position, vec3 p_ray_dir, inout uint r_noise, f
 			vec3 norm1 = vec3(vert1.normal_xy, vert1.normal_z);
 			vec3 norm2 = vec3(vert2.normal_xy, vert2.normal_z);
 			vec3 normal = normalize(barycentric.x * norm0 + barycentric.y * norm1 + barycentric.z * norm2);
+			vec3 geometry_normal = -normalize(cross(vert1.position - vert0.position, vert2.position - vert0.position));
 
 			vec3 direct_light = vec3(0.0f);
 #ifdef USE_LIGHT_TEXTURE_FOR_BOUNCES
@@ -838,7 +844,7 @@ vec3 trace_indirect_light(vec3 p_position, vec3 p_ray_dir, inout uint r_noise, f
 				vec3 light;
 				vec3 light_dir;
 				float shadow;
-				trace_direct_light(position, normal, i, false, light, light_dir, r_noise, p_texel_size, shadow);
+				trace_direct_light(position, normal, geometry_normal, i, false, light, light_dir, r_noise, p_texel_size, shadow);
 				direct_light += light * lights.data[i].indirect_energy;
 			}
 
@@ -882,6 +888,7 @@ void main() {
 		return; //empty texel, no process
 	}
 	vec3 position = texelFetch(sampler2DArray(source_position, linear_sampler), ivec3(atlas_pos, params.atlas_slice), 0).xyz;
+	vec3 geometry_normal = texelFetch(source_geometry, ivec3(atlas_pos, params.atlas_slice), 0).yzw;
 	vec4 neighbor_position = texelFetch(sampler2DArray(source_position, linear_sampler), ivec3(atlas_pos + ivec2(1, 0), params.atlas_slice), 0).xyzw;
 
 	if (neighbor_position.w < 0.001) {
@@ -911,7 +918,7 @@ void main() {
 		vec3 light;
 		vec3 light_dir;
 		float shadow;
-		trace_direct_light(position, normal, i, true, light, light_dir, noise, texel_size_world_space, shadow);
+		trace_direct_light(position, normal, geometry_normal, i, true, light, light_dir, noise, texel_size_world_space, shadow);
 
 		if (lights.data[i].static_bake) {
 			light_for_texture += light;
@@ -1000,12 +1007,16 @@ void main() {
 	}
 
 	vec3 position = texelFetch(sampler2DArray(source_position, linear_sampler), ivec3(atlas_pos, params.atlas_slice), 0).xyz;
+	vec3 geometry_normal = texelFetch(source_geometry, ivec3(atlas_pos, params.atlas_slice), 0).yzw;
 	int neighbor_offset = atlas_pos.x < bake_params.atlas_size.x - 1 ? 1 : -1;
 	vec3 neighbor_position = texelFetch(sampler2DArray(source_position, linear_sampler), ivec3(atlas_pos + ivec2(neighbor_offset, 0), params.atlas_slice), 0).xyz;
 	float texel_size_world_space = distance(position, neighbor_position);
 	uint noise = random_seed(ivec3(params.ray_from, atlas_pos));
 	for (uint i = params.ray_from; i < params.ray_to; i++) {
 		vec3 ray_dir = generate_ray_dir_from_normal(normal, noise);
+		if (dot(geometry_normal, ray_dir) <= 0.0) {
+			continue;
+		}
 		vec3 light = trace_indirect_light(position, ray_dir, noise, texel_size_world_space);
 
 #ifdef USE_SH_LIGHTMAPS
@@ -1087,7 +1098,7 @@ void main() {
 	position_alpha.xyz = vertex_pos;
 
 	imageStore(position, ivec3(atlas_pos, params.atlas_slice), position_alpha);
-	imageStore(unocclude, ivec3(atlas_pos, params.atlas_slice), vec4(unocclude_mask, 0, 0, 0));
+	imageStore(unocclude, ivec3(atlas_pos, params.atlas_slice), vec4(unocclude_mask, face_normal));
 
 #endif
 

--- a/modules/lightmapper_rd/lm_compute.glsl
+++ b/modules/lightmapper_rd/lm_compute.glsl
@@ -545,7 +545,7 @@ void trace_direct_light(vec3 p_position, vec3 p_normal, vec3 p_geometry_normal, 
 
 		// Setup light tangent pass to calculate samples over disk aligned towards the light
 		vec3 light_to_point = -shadow_dir;
-		vec3 light_aux = light_to_point.y < 0.777 ? vec3(0.0, 1.0, 0.0) : vec3(1.0, 0.0, 0.0);
+		vec3 light_aux = abs(light_to_point.y) < 0.777 ? vec3(0.0, 1.0, 0.0) : vec3(1.0, 0.0, 0.0);
 		vec3 light_to_point_tan = normalize(cross(light_to_point, light_aux));
 		vec3 light_to_point_bitan = normalize(cross(light_to_point, light_to_point_tan));
 

--- a/modules/lightmapper_rd/lm_raster.glsl
+++ b/modules/lightmapper_rd/lm_raster.glsl
@@ -94,7 +94,11 @@ layout(location = 1) out vec4 normal;
 layout(location = 2) out vec4 unocclude;
 
 void main() {
-	vec3 vertex_pos = vertex_interp;
+	vec3 pos0 = vertices.data[vertex_indices.x].position;
+	vec3 pos1 = vertices.data[vertex_indices.y].position;
+	vec3 pos2 = vertices.data[vertex_indices.z].position;
+	vec3 weights = inset_barycentric(barycentric, pos0, pos1, pos2, params.bias);
+	vec3 vertex_pos = pos0 * weights.x + pos1 * weights.y + pos2 * weights.z;
 
 	if (fragment_action == FA_SMOOTHEN_POSITION) {
 		// smooth out vertex position by interpolating its projection in the 3 normal planes (normal plane is created by vertex pos and normal)
@@ -140,7 +144,7 @@ void main() {
 		vec3 proj_b = vertex_pos - norm_b * (dot(norm_b, vertex_pos) - d_b);
 		vec3 proj_c = vertex_pos - norm_c * (dot(norm_c, vertex_pos) - d_c);
 
-		vec3 smooth_position = proj_a * barycentric.x + proj_b * barycentric.y + proj_c * barycentric.z;
+		vec3 smooth_position = proj_a * weights.x + proj_b * weights.y + proj_c * weights.z;
 
 		if (dot(face_normal, smooth_position) > dot(face_normal, vertex_pos)) { //only project outwards
 			vertex_pos = smooth_position;


### PR DESCRIPTION
Addresses the light leaks reported in #117468 using its reproduction project.

My first commit used limited AI assistance, but every subsequent commit used AI much more heavily as my understanding of the other three files was more limited. This involved GPT-6 Astra running in an investigate-code-test loop for about 2 hours under my guidance and monitoring.

I understand that the later commits may not be acceptable under the contribution guidelines, but I hope the findings and reproduction results can still be useful to other contributors, even if the full implementation cannot be accepted.

| Image set | Before | After |
|---|---|---|
| Outside | <img width="1280" height="1200" alt="before-1" src="https://github.com/user-attachments/assets/18744a2f-c18c-4cb2-b1bc-1891a9b468b9" /> | <img width="1280" height="1200" alt="after-1" src="https://github.com/user-attachments/assets/d1ed1166-77be-41fb-9cbc-2ff98ead2a07" /> |
| Original mesh | <img width="1000" height="800" alt="before-2" src="https://github.com/user-attachments/assets/13c0c9fe-17fc-4208-81dc-f492464a0334" /> | <img width="1000" height="800" alt="after-2" src="https://github.com/user-attachments/assets/9c99b4a6-9f44-43c2-a3cc-0bce44c8dcea" /> |
| Smooth mesh | <img width="1000" height="800" alt="before-3" src="https://github.com/user-attachments/assets/2bcdb461-806c-4b3b-9d14-3444c6d93fac" /> | <img width="1000" height="800" alt="after-3" src="https://github.com/user-attachments/assets/df585961-7830-45ca-9c1f-4c18717cae51" /> |

The changes are separated into individual commits:
- Preserve valid texels during dilation. (my original commit)
- Correct grid traversal for nearly parallel rays.
- Normalize interpolated bounce normals, which otherwise can shorten rays enough to stop before a wall.
- Keep raster and bounce samples inside their triangles before applying bias.
- Use geometric normals to reject opaque rays that point through the surface.
- Keep shadow samples and their offsets on the visible side of geometry.
- Correct the shadow sampling basis for downward light directions.
- Remove the half-texel offset from rasterization and the corresponding seam-blending offsets.

The automated tests ran on macOS with an Apple M2 Pro using Metal. The complete patch removes the bright seams in the original 1k reproduction and the strong false glow in the updated smooth-mesh variants.

Additional sealed-room tests with flat and smooth normals produce exactly zero light, including the raw lighting data before denoising. The smooth room also passes with soft shadows and direct-light tracing at each bounce.

There are still limits: faint edge lines remain at 256-pixel resolution with the reproduction’s large bias of 0.05. That same bias produces a clean comparison at 1k. Vulkan, Direct3D, area lights, and transparent materials have not been validated, so this should be treated as an experimental patch rather than a complete fix for every lightmap artifact.