### PR TITLE
Editor: Show project settings references in dependency owners dialog

### DIFF
--- a/editor/file_system/dependency_editor.cpp
+++ b/editor/file_system/dependency_editor.cpp
@@ -537,6 +537,24 @@ void DependencyEditorOwners::show(const String &p_path) {
 	owners->clear();
 	_fill_owners(EditorFileSystem::get_singleton()->get_filesystem());
 
+	const String resolved_path = ResourceUID::ensure_path(p_path);
+
+	String custom_theme = ResourceUID::ensure_path(GLOBAL_GET("gui/theme/custom"));
+	if (!custom_theme.is_empty() && custom_theme == resolved_path) {
+		owners->add_item(vformat(TTR("Project Settings (%s)"), "gui/theme/custom"));
+		owners->set_item_icon(
+				owners->get_item_count() - 1,
+				owners->get_editor_theme_icon(SNAME("ProjectSettings")));
+	}
+
+	String main_scene = ResourceUID::ensure_path(GLOBAL_GET("application/run/main_scene"));
+	if (!main_scene.is_empty() && main_scene == resolved_path) {
+		owners->add_item(vformat(TTR("Project Settings (%s)"), "application/run/main_scene"));
+		owners->set_item_icon(
+				owners->get_item_count() - 1,
+				owners->get_editor_theme_icon(SNAME("ProjectSettings")));
+	}
+
 	int count = owners->get_item_count();
 	if (count > 0) {
 		empty->hide();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #108186

## Description

When a custom GUI theme resource (or other project settings resource like the main scene) is set inside **Project Settings**, right-clicking the resource in the FileSystem dock and selecting **View Owners...** previously reported "No owners found".

This PR updates `DependencyEditorOwners::show()` in `editor/file_system/dependency_editor.cpp` to explicitly check project settings references. It normalizes paths using `ResourceUID::ensure_path()` so that resource comparisons succeed even when project settings store references in UID format (`uid://...`).

## Additional information

### Contribution & AI Usage Disclosure
I am a beginner developer making my contributions to the Godot Engine to learn codebase architecture and Git workflows. 

For transparency, AI assistance was used during the debugging and implementation process:
* **Google Gemini:** Helped analyze terminal outputs, explain Godot engine architecture concepts, and guide step-by-step Git commands and debugger setup.
* **GitHub Copilot (VS Code):** Used to inspect path comparisons and suggest applying `ResourceUID::ensure_path(...)` to handle `uid://` string resolution.

My role was driving the problem-solving process, setting up the test environment in the editor, configuring breakpoints and running the debugger in VS Code, testing builds locally with SCons, and verifying the UI fix.