### PR TITLE
Fix `TabContainer`'s popup button not updating on theme change

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -253,6 +253,10 @@ void TabContainer::_on_theme_changed() {
 
 	tab_bar->end_bulk_theme_override();
 
+	if (popup_button) {
+		popup_button->set_button_icon(theme_cache.menu_icon);
+	}
+
 	_update_margins();
 	if (get_tab_count() > 0) {
 		_repaint();


### PR DESCRIPTION
## What problem(s) does this PR solve?

The icon of the popup button in the `TabContainer` wasn't being updated with the theme, resulting in stuff like this:

<img width="283" height="65" alt="image" src="https://github.com/user-attachments/assets/679e055a-03a3-4ea0-bef1-f702476318d0" />