### PR TITLE
Fix Node::_duplicate for hidden, non-duplicated descendants

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2849,7 +2849,7 @@ Node *Node::_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap) c
 		node->data.editable_instance = data.editable_instance;
 	}
 
-	List<const Node *> hidden_roots;
+	List<const Node *> hidden_nodes;
 	List<const Node *> node_tree;
 	node_tree.push_front(this);
 
@@ -2865,11 +2865,14 @@ Node *Node::_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap) c
 				Node *descendant = N->get()->get_child(i, false);
 
 				// Skip nodes not really belonging to the instantiated hierarchy; they'll be processed normally later
-				// but remember non-instantiated nodes that are hidden below instantiated ones
+				// but remember non-instantiated nodes that are hidden below instantiated ones, or weren't part of the instantiation.
 				if (!instance_roots.has(descendant->get_owner())) {
 					if (descendant->get_parent() && descendant->get_parent() != this && descendant->data.owner != descendant->get_parent()) {
-						hidden_roots.push_back(descendant);
+						hidden_nodes.push_back(descendant);
 					}
+					continue;
+				} else if (!node->get_node_or_null(get_path_to(descendant))) {
+					hidden_nodes.push_back(descendant);
 					continue;
 				}
 
@@ -2936,7 +2939,7 @@ Node *Node::_duplicate(int p_flags, HashMap<const Node *, Node *> *r_duplimap) c
 		}
 	}
 
-	for (const Node *&E : hidden_roots) {
+	for (const Node *&E : hidden_nodes) {
 		Node *parent = node->get_node(get_path_to(E->data.parent));
 		if (!parent) {
 			memdelete(node);


### PR DESCRIPTION
- Closes #121848

## Additional information

Renamed local `hidden_roots` variable to `hidden_nodes` since that better describes the functionality after this change.

The problem was that when `duplicate_from_editor` was called on the root node, since the root is treated as an instantiated scene, any nodes that were added to the scene tree but weren't saved to disk were not recursively duplicated, causing the out of bounds error.

I went with this approach because it was the simplest and least code to add, and because the array `hidden_nodes` already exists to handle nodes with this exact problem.
