### PR TITLE
CI: Add prek hook for `clangd-tidy`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 # If you change this file, please format all files of the codebase as part of your PR:
-# prek run --hook-stage manual clang-tidy --all
+# prek run --hook-stage manual clangd-tidy --all
 
 Checks:
   - -*

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,19 +30,26 @@ repos:
         args: [-style=file:misc/utility/clang_format_glsl.yml]
 
   # Not automatically triggered (because it requires compile_commands.json to be up-to-date).
-  # Invoke it manually via `pre-commit run --hook-stage manual clang-tidy`
-  - repo: https://github.com/pocc/pre-commit-hooks
-    rev: v1.3.5
+  # Invoke it manually via `prek run --hook-stage manual clangd-tidy`
+  - repo: https://github.com/repiteo/clangd-tidy
+    rev: v1.1.1-prek
     hooks:
-      - id: clang-tidy
-        # TODO .inc ignored for now because they don't include their parent header.
-        # TODO Platform-specific subfolders currently fail, we should try to include them
-        files: ^(core|main|scene)/.*\.(c|h|cpp|hpp|cc|hh|cxx|hxx|m|mm|java)$
-        # No unknown warning suppression used for easier compatibility with gcc
-        args: [--fix, --quiet, --use-color, -p=compile_commands.json, -extra-arg=-Wno-unknown-warning-option]
-        types_or: [text]
-        additional_dependencies: [clang-tidy==22.1.7]
-        require_serial: false
+      - id: clangd-tidy
+        # TODO: Platform-specific subfolders currently fail, we should try to include them.
+        exclude: |
+          (?x)^(
+            (driver|platform)/\w+/.*|
+            editor/shader/shader_baker/shader_baker_export_plugin_platform_.*|
+            modules/camera/camera_.*|
+            modules/openxr/extensions/platform/.*
+          )$
+        args: [
+            --fix,
+            --color=always,
+            # TODO: `inc` ignored for now, because they don't include their parent header.
+            "--allow-extensions=c,h,cpp,hpp,cc,hh,cxx,hxx,m,mm",
+          ]
+        additional_dependencies: [clangd, clang-tidy==22.1.7]
         stages: [manual]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit


### PR DESCRIPTION
## What problem(s) does this PR solve?

Resolves a discrepancy in our pre-commit system compared to our CI, where the former relied on `clang-tidy` while the latter moved on to `clangd-tidy`. I spent entirely too long finding out why `clangd-tidy` was uniquely frustrating to get functioning as a hook, and am happy to report that those concerns are finally alleviated! By utilizing a dedicated tagged commit on my forked repo[^1], we can safely and efficently leverage `clangd-tidy` as a hook, complete with greater repo coverage without compromising functionality

## Additional information

N/A

[^1]: https://github.com/Repiteo/clangd-tidy/releases/tag/v1.1.1-prek