### PR TITLE
Don't prompt to reload an edited scene if it is imported

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1612,6 +1612,11 @@ void EditorNode::_scan_external_changes() {
 			continue;
 		}
 
+		// Imported scenes get automatically reimported, we don't need to prompt for a reload
+		if (FileAccess::exists(scene_path + ".import")) {
+			continue;
+		}
+
 		uint64_t last_date = editor_data.get_scene_modified_time(i);
 		uint64_t date = FileAccess::get_modified_time(scene_path);
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

This fixes an annoyance where an imported scene (like a gltf/glb) is opened directly in the editor and then modified externally. Before this change, the scene would be reimported automatically but the editor would *also* prompt you to reload it (which would be unnecessary since it was already reimported). This PR fixes that by not showing the "reload scene" dialog for scenes that are imported.

## Additional information

Simply checking if there is a `.import` file doesn't seem like the cleanest way to see if a scene is imported or not, but it's how `EditorNode::load_scene` checks if a scene is imported so I assume this is the correct method.