### PR TITLE
[3.x] Fix GLES3 vertex-lighting shadows removing indirect specular in mobile

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -2195,7 +2195,10 @@ FRAGMENT_SHADER_CODE
 	vec3 diffuse_light;
 #ifdef USE_VERTEX_LIGHTING //ubershader-runtime
 
-	specular_light = specular_light_interp.rgb;
+	// Keep direct vertex-computed specular separate from image-based lighting.
+	// Directional shadows must not attenuate environment/reflection-probe light.
+	vec3 vertex_specular_light = specular_light_interp.rgb;
+	specular_light = vertex_specular_light;
 	diffuse_light = diffuse_light_interp.rgb;
 #else //ubershader-runtime
 
@@ -2344,7 +2347,11 @@ FRAGMENT_SHADER_CODE
 	{
 #if defined(DIFFUSE_TOON)
 		//simplify for toon, as
-		specular_light *= specular * metallic * albedo * 2.0;
+		vec3 specular_scale = specular * metallic * albedo * 2.0;
+		specular_light *= specular_scale;
+#ifdef USE_VERTEX_LIGHTING //ubershader-runtime
+		vertex_specular_light *= specular_scale;
+#endif
 #else
 
 		// scales the specular reflections, needs to be be computed before lighting happens,
@@ -2356,9 +2363,17 @@ FRAGMENT_SHADER_CODE
 		vec4 r = roughness * c0 + c1;
 		float a004 = min(r.x * r.x, exp2(-9.28 * ndotv)) * r.x + r.y;
 		vec2 env = vec2(-1.04, 1.04) * a004 + r.zw;
-		specular_light *= env.x * F + env.y;
+		vec3 specular_scale = env.x * F + env.y;
+		specular_light *= specular_scale;
+#ifdef USE_VERTEX_LIGHTING //ubershader-runtime
+		vertex_specular_light *= specular_scale;
+#endif
 #endif
 	}
+
+#ifdef USE_VERTEX_LIGHTING //ubershader-runtime
+	vec3 indirect_specular_light = specular_light - vertex_specular_light;
+#endif
 
 #ifdef USE_LIGHT_DIRECTIONAL //ubershader-runtime
 
@@ -2535,7 +2550,7 @@ FRAGMENT_SHADER_CODE
 
 #ifdef USE_VERTEX_LIGHTING //ubershader-runtime
 	diffuse_light *= mix(vec3(1.0), light_attenuation, diffuse_light_interp.a);
-	specular_light *= mix(vec3(1.0), light_attenuation, specular_light_interp.a);
+	vertex_specular_light *= mix(vec3(1.0), light_attenuation, specular_light_interp.a);
 #else //ubershader-runtime
 	light_compute(normal, -light_direction_attenuation.xyz, eye_vec, binormal, tangent, light_color_energy.rgb, light_attenuation, albedo, transmission, light_params.z * specular_blob_intensity, roughness, metallic, specular, rim, rim_tint, clearcoat, clearcoat_gloss, anisotropy, diffuse_light, specular_light, alpha);
 #endif //ubershader-runtime
@@ -2543,6 +2558,7 @@ FRAGMENT_SHADER_CODE
 #endif //#USE_LIGHT_DIRECTIONAL //ubershader-runtime
 
 #ifdef USE_VERTEX_LIGHTING //ubershader-runtime
+	specular_light = indirect_specular_light + vertex_specular_light;
 	diffuse_light *= albedo;
 #endif //ubershader-runtime
 


### PR DESCRIPTION
Note this bug does not exist in 4, so pushing (or PR-requesting) this to master would not make sense. I just blame'd the lines that my PR aimes to fix and they are five to seven years old.

## How I found this

I wanted to have some fun and asked GPT 5.6 luna (the cheapest current OpenAI model) to port Godot 3 to my 2018 54" LG 55UK6470PLC TV. This is totally undocumented, LG wants you to develop HTML5 apps but the runtime only supports WebGL1 and no Wasm.

I gave it direct access to the TV via the developer tools and its software flashing mechanism and it started to build diagnostics apps:

```text
modelName       55UK6470PLC
sdkVersion      4.4.0
firmwareVersion 05.50.70
boardType       LM18A_DVB_EU
otaId            HE_DTV_W18A_AFADABAA

Linux LGwebOSTV 4.4.84-636.glacier.26 #1 SMP PREEMPT Tue Apr 29 19:00:32 KST 2025 armv7l GNU/Linux
getconf LONG_BIT: 32
Hardware: m7621
CPU: 4 x ARMv7, CPU part 0xd03, NEON/VFPv4
MemTotal: 863892 kB
SwapTotal: 716796 kB

EGL version: 1.4 Bifrost-r6p0-01rel0-c98cd2c34-20210127
GL_VENDOR: ARM
GL_RENDERER: Mali-G51
GL_VERSION: OpenGL ES 3.2 ...
GLSL_VERSION: OpenGL ES GLSL ES 3.20
GL_MAX_TEXTURE_SIZE: 8192
```

It then took GPT 5.6 luna another 20 minutes to get the [3D Platformer Demo](https://godotengine.org/asset-library/asset/125) running natively in GLES3 with a target compiled Godot Engine (even my TV remote worked as a joystick!), no HTML5 export. Staggering 3 FPS, but hey, that was expected.

But it did not look right:
<img width="459" height="394" alt="photo_tv_godot_small" src="https://github.com/user-attachments/assets/3821a84f-e25e-4288-94e1-2ad9674a90a8" />
This is a photo I took, the body of the robot is just one flat, unshaded color. This happened when the robot character is subject to full shadow. The scene consists of one big direct light with a shadow and five reflection probes and the body material is metallic. The game starts deep in the shadows, hence this crop only shows shadowed areas. If you run out of the shadow "into the sun" the robot would actually look much better.

I googled and found out that these Mali GPUs are actually quite cynically spec adhering, but nevertheless adhering. I wanted to know: is it Godot, or is it the GPU?

So I asked GPT luna to find the bug. It would then build variants of the engine to run the demo, show me the result and ask what I see. We ran through 20-30 versions that way, me always describing what I see, luna always trying out things, but it ran circles, nothing worked. After hours of this, coming back to my TV every 10-20 minutes, I upgraded to GPT-5.6 sol, the currently strongest (actually was until a week ago or so) model. The first thing that it did was to break out of the WSL VM, find my Godot 3.6 windows exe, ran it and take a screenshot:

<img width="542" height="488" alt="Screenshot 2026-09-09 204430" src="https://github.com/user-attachments/assets/cf5ac2d8-d9ce-4fb9-b867-ef07b5b5cfbf" />

With that screenshot it wanted to gaslight me that, hey look, everything is fine, in Windows the robot is also flat. But I hope you see the difference. That was the moment I stopped trying to describe what I see and instead to take photos, starting with the one that I already showed.

GPT sol then started to write some actual debug shaders (photo cropped so you don't see me sitting there in underwear):

<img width="1347" height="567" alt="photo_tv_godot_ambient_shader_cropped" src="https://github.com/user-attachments/assets/37a4d166-b855-467b-9578-e67032e2bf5c" />

At some point I asked it to try to take screenshots (so I could do something else in the meantime) and it then gloriously came up with the idea to encode them as base64 into the log, because it only could flash software and read logs, but no file access. It took another 20 versions, totalling 50-60, until it finally showed me a version that looked exactly like the one on windows. And it claimed to have found the bug, patched the bug, documented the bug.

The reason that this appeared in the Mali GPU variant but not the Windows/NVIDIA variant was explained to me the following way: The Godot 3.6 GLES3 render can run in mobile or desktop mode and in mobile mode the lighting is calculated per vertex instead of per fragment. The bug sits in this conditional vertex exeution path. It had nothing to do with my TV specifically and should also be relevant for most android exports.

The follwing description is written by luna again, after me grilling it, doubting it and asking to explain it to me. The fix is about ten AI-written lines of code and I read them five times at least. I am now 85% sure that this is correct, mind you that I am not a shader expert, but at least I did write some tiny WebGL1 shaders as coursework seven years ago.

Note that this is tested as just desribed. There is also a fix included for the toon shader branch, which is untested.

> ### Problem
> 
> In Godot 3’s GLES3 renderer, materials using USE_VERTEX_LIGHTING calculate direct light contributions in the vertex shader. The resulting direct specular lighting is passed to the fragment shader through specular_light_interp.
> 
> The fragment shader then adds image-based lighting to the same specular_light accumulator:
> 
> ```text
>   specular_light =
>       direct vertex-computed specular
>       + environment/reflection-probe specular
> ```
> 
> Directional shadowing is applied afterwards. The shader used specular_light_interp.a to determine how strongly the directional shadow should affect the interpolated direct lighting:
> 
> ```glsl
>   specular_light *= mix(vec3(1.0),
>                         light_attenuation,
>                         specular_light_interp.a);
> ```
> 
> specular_light_interp.a is a pre-shadow weighting value. It represents the fraction of the direct vertex-computed specular lighting attributable to the directional light. It is not a measure of the fragment’s total lighting and does not indicate whether the fragment is currently lit or shadowed.
> 
> With one dominant DirectionalLight, this value is normally close to 1.0. If the shadow map then determines that the fragment is fully shadowed, light_attenuation is approximately zero and the expression becomes:
> 
> ```text
>   (direct specular + indirect specular) × 0
> ```
> 
> The direct directional highlight is correctly removed, but the environment and reflection-probe specular is removed incorrectly as well.
> 
> The intended result is:
> 
> ```text
>   (direct specular × shadow factor) + indirect specular
> ```
> 
> This can make metallic materials lose their environment reflections in shadows and become unnaturally flat or dark. The remaining constant ambient lighting may still keep them visible, so the result does not necessarily become black.
> 
> The fragment-lighting path does not have this accumulation problem. It retains indirect specular in the accumulator and passes shadow attenuation directly to light_compute(), which applies it only while calculating the direct light contribution.
> 
> ### Fix
> 
> The vertex-lighting path now tracks direct and indirect specular lighting separately.
> 
> A new vertex_specular_light variable stores the direct specular value received from the vertex shader:
> 
> ```glsl
>   vec3 vertex_specular_light = specular_light_interp.rgb;
>   specular_light = vertex_specular_light;
> ```
> 
> Environment and reflection-probe lighting continues to be accumulated into specular_light.
> 
> After the existing material/BRDF scaling, the indirect component is derived:
> 
> ```glsl
>   vec3 indirect_specular_light =
>       specular_light - vertex_specular_light;
> ```
> 
> Directional shadow attenuation is applied only to vertex_specular_light:
> 
> ```glsl
>   vertex_specular_light *= mix(vec3(1.0),
>                                light_attenuation,
>                                specular_light_interp.a);
> ```
> 
> The two components are then recombined:
> 
> ```glsl
>   specular_light =
>       indirect_specular_light + vertex_specular_light;
> ```
> 
> The toon and regular BRDF branches both scale vertex_specular_light with the same specular_scale used for specular_light, preserving the existing unshadowed material behavior.
> 
> ### Shader variants and performance
> 
> The new variables and calculations are guarded by USE_VERTEX_LIGHTING. The fragment-lighting variant remains unchanged.
> 
> The patch does not move direct lighting into the fragment shader. Direct light calculations remain vertex-based, with no new per-pixel light loops, texture samples, varyings, or shadow-map lookups.
> 
> The vertex-lighting fragment variant performs a small amount of additional vector bookkeeping: separate scaling, subtraction, and recombination. This may slightly increase register pressure, but preserves the intended performance advantage of vertex lighting.

So without AI nothing of this would have been possible. And I think I broke the rules by having AI code in my PR, but what do you want me to do, rename the one variable introduced? I think that there are ways to even heavily make use of AI without producing slop. And there was still a lot of human work involved so I feel entitled to the fame and glory of having this PR merged and counted as my contribution. Let me know If you want me to do anything, like testing the toon shader (I have never worked with toon shaders before).