### PR TITLE
Add `\n` to doc comments on empty line

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3941,6 +3941,8 @@ static void _process_doc_line(const String &p_line, String &r_text, const String
 				// We want to replace `[br][br]` with `\n` (paragraph), so we move the trailing `[br]` here.
 				r_text = r_text.left(-4); // `-len("[br]")`.
 				line = "[br]" + line;
+			} else if (!r_text.ends_with("\n") && line.is_empty()) {
+				line_join = "\n";
 			} else if (!r_text.ends_with("\n")) {
 				line_join = " ";
 			}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #111252.
- Addresses pain point with the new admonition tags (see godotengine/godot-proposals#15493)
- Potentially makes #123353 redundant (if you're adding an empty line before admonitions).

## Additional information

Documentation comments in GDScript join all lines with a space, which makes it easy to write longer sentences. At the same time, a few tags such as `[codeblock]` and `[br]` remove that space and add `\n` instead. But `[br]` is a bit different, as it only adds `\n` if two consecutive tags are found (`[br][br]`, or `[br]` on one line and the next starts with `[br]`); a single `[br]` tag only adds `\r`.

Making a new paragraph requires two `[br]` tags, which takes up space in the comments and degrades readability. This PR adds support for empty comment lines to act as a paragraph break:

```gdscript
class_name DocCommentTest
extends Node
## Doc comment test
##
## Standard class description, separated from the "brief description" with
## a single empty line.
##
## This paragraph comes after another single empty line, instead of being appended
## to the previous paragraph with a space.[br][br]
## The previous paragraph ends with [code skip-lint][br][br][/code], which makes
## this line a new paragraph.
##
## [note]Empty line paragraph breaks also work with admonitions.[/note]
```
displays as:
| | |
|-|-|
| master | <img width="1090" height="150" alt="master_1" src="https://github.com/user-attachments/assets/6205cae3-6b3e-479e-b8bc-22570af957ea" /> |
| This PR | <img width="940" height="174" alt="paragraph_break_1" src="https://github.com/user-attachments/assets/e3ac44e6-319d-4d93-b9a9-a4184d99f524" /> |

Multiple empty lines still only add a single `\n`:
```gdscript
## Testing empty lines as paragraph breaks.
## No empty line.
##
## After a single empty line.
##
##
## After two empty lines.
##
##
##
## After three empty lines.
func doc_comment() -> void:
```
displays as:
| | |
|-|-|
| master | <img width="1050" height="70" alt="master_2" src="https://github.com/user-attachments/assets/ddc7bb02-b1c6-4be3-9f88-3d7f63cd5aa2" /> (note the increasing number of spaces) |
| This PR | <img width="484" height="174" alt="paragraph_break_2" src="https://github.com/user-attachments/assets/1e96fc4c-6c74-4360-91ff-d443d4e157f7" /> |

With `godot --doctool --gdscript-docs`, this results in the following XML file:
```xml
<class name="DocCommentTest" inherits="Node" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/godotengine/godot/master/doc/class.xsd">
	<brief_description>
		Doc comment test
	</brief_description>
	<description>
		Standard class description, separated from the "brief description" with a single empty line.
This paragraph comes after another single empty line, instead of being appended to the previous paragraph with a space.
The previous paragraph ends with [code skip-lint][br][br][/code], which makes this line a new paragraph.
[note]Empty line paragraph breaks also work with admonitions.
	</description>
	<tutorials>
	</tutorials>
	<methods>
		<method name="doc_comment">
			<return type="void" />
			<description>
				Testing empty lines as paragraph breaks. No empty line.
After a single empty line.
After two empty lines.
After three empty lines.
			</description>
		</method>
	</methods>
</class>
```