### PR TITLE
Add missing PNAME usages

### DIFF
--- a/modules/visual_shader/visual_shader_group.cpp
+++ b/modules/visual_shader/visual_shader_group.cpp
@@ -150,21 +150,21 @@ void VisualShaderGroup::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "group_name"), "set_group_name", "get_group_name");
 	ADD_PROPERTY_DEFAULT("group_name", "NodeGroup");
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "input_port_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ARRAY, "Input Ports,input_port_,swap_method=move_input_port,add_button_text=" + String(TTRC("Add Port"))), "set_input_port_count", "get_input_port_count");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "output_port_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ARRAY, "Output Ports,output_port_,swap_method=move_output_port,add_button_text=" + String(TTRC("Add Port"))), "set_output_port_count", "get_output_port_count");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "input_port_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ARRAY, String(PNAME("Input Ports")) + ",input_port_,swap_method=move_input_port,add_button_text=" + String(TTRC("Add Port"))), "set_input_port_count", "get_input_port_count");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "output_port_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_ARRAY, String(PNAME("Output Ports")) + ",output_port_,swap_method=move_output_port,add_button_text=" + String(TTRC("Add Port"))), "set_output_port_count", "get_output_port_count");
 
 	const String port_type_hint = "Float,Int,UInt,Vector2,Vector3,Vector4,Boolean,Transform,Sampler";
 
 	input_port_base_property_helper.set_prefix("input_port_");
 	input_port_base_property_helper.set_array_length_getter(&VisualShaderGroup::get_input_port_count);
-	input_port_base_property_helper.register_property(PropertyInfo(Variant::STRING, "name"), String(), &VisualShaderGroup::set_input_port_name, &VisualShaderGroup::get_input_port_name);
-	input_port_base_property_helper.register_property(PropertyInfo(Variant::INT, "type", PROPERTY_HINT_ENUM, port_type_hint), VisualShaderNode::PORT_TYPE_SCALAR, &VisualShaderGroup::set_input_port_type, &VisualShaderGroup::get_input_port_type);
+	input_port_base_property_helper.register_property(PropertyInfo(Variant::STRING, PNAME("name")), String(), &VisualShaderGroup::set_input_port_name, &VisualShaderGroup::get_input_port_name);
+	input_port_base_property_helper.register_property(PropertyInfo(Variant::INT, PNAME("type"), PROPERTY_HINT_ENUM, port_type_hint), VisualShaderNode::PORT_TYPE_SCALAR, &VisualShaderGroup::set_input_port_type, &VisualShaderGroup::get_input_port_type);
 	PropertyListHelper::register_base_helper(get_class_static(), &input_port_base_property_helper);
 
 	output_port_base_property_helper.set_prefix("output_port_");
 	output_port_base_property_helper.set_array_length_getter(&VisualShaderGroup::get_output_port_count);
-	output_port_base_property_helper.register_property(PropertyInfo(Variant::STRING, "name"), String(), &VisualShaderGroup::set_output_port_name, &VisualShaderGroup::get_output_port_name);
-	output_port_base_property_helper.register_property(PropertyInfo(Variant::INT, "type", PROPERTY_HINT_ENUM, port_type_hint), VisualShaderNode::PORT_TYPE_SCALAR, &VisualShaderGroup::set_output_port_type, &VisualShaderGroup::get_output_port_type);
+	output_port_base_property_helper.register_property(PropertyInfo(Variant::STRING, PNAME("name")), String(), &VisualShaderGroup::set_output_port_name, &VisualShaderGroup::get_output_port_name);
+	output_port_base_property_helper.register_property(PropertyInfo(Variant::INT, PNAME("type"), PROPERTY_HINT_ENUM, port_type_hint), VisualShaderNode::PORT_TYPE_SCALAR, &VisualShaderGroup::set_output_port_type, &VisualShaderGroup::get_output_port_type);
 	PropertyListHelper::register_base_helper(get_class_static(), &output_port_base_property_helper);
 }
 

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -2263,9 +2263,9 @@ void FileDialog::_bind_methods() {
 
 	base_property_helper.set_prefix("option_");
 	base_property_helper.set_array_length_getter(&FileDialog::get_option_count);
-	base_property_helper.register_property(PropertyInfo(Variant::STRING, "name"), defaults.name, &FileDialog::set_option_name, &FileDialog::get_option_name);
-	base_property_helper.register_property(PropertyInfo(Variant::PACKED_STRING_ARRAY, "values"), defaults.values, &FileDialog::set_option_values, &FileDialog::get_option_values);
-	base_property_helper.register_property(PropertyInfo(Variant::INT, "default"), defaults.default_idx, &FileDialog::set_option_default, &FileDialog::get_option_default);
+	base_property_helper.register_property(PropertyInfo(Variant::STRING, PNAME("name")), defaults.name, &FileDialog::set_option_name, &FileDialog::get_option_name);
+	base_property_helper.register_property(PropertyInfo(Variant::PACKED_STRING_ARRAY, PNAME("values")), defaults.values, &FileDialog::set_option_values, &FileDialog::get_option_values);
+	base_property_helper.register_property(PropertyInfo(Variant::INT, PNAME("default")), defaults.default_idx, &FileDialog::set_option_default, &FileDialog::get_option_default);
 	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 
 	ADD_CLASS_DEPENDENCY("Button");

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -2522,10 +2522,10 @@ void ItemList::_bind_methods() {
 
 	base_property_helper.set_prefix("item_");
 	base_property_helper.set_array_length_getter(&ItemList::get_item_count);
-	base_property_helper.register_property(PropertyInfo(Variant::STRING, "text"), defaults.text, &ItemList::set_item_text, &ItemList::get_item_text);
-	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), defaults.icon, &ItemList::set_item_icon, &ItemList::get_item_icon);
-	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "selectable"), defaults.selectable, &ItemList::set_item_selectable, &ItemList::is_item_selectable);
-	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled, &ItemList::set_item_disabled, &ItemList::is_item_disabled);
+	base_property_helper.register_property(PropertyInfo(Variant::STRING, PNAME("text")), defaults.text, &ItemList::set_item_text, &ItemList::get_item_text);
+	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, PNAME("icon"), PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), defaults.icon, &ItemList::set_item_icon, &ItemList::get_item_icon);
+	base_property_helper.register_property(PropertyInfo(Variant::BOOL, PNAME("selectable")), defaults.selectable, &ItemList::set_item_selectable, &ItemList::is_item_selectable);
+	base_property_helper.register_property(PropertyInfo(Variant::BOOL, PNAME("disabled")), defaults.disabled, &ItemList::set_item_disabled, &ItemList::is_item_disabled);
 	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -680,11 +680,11 @@ void OptionButton::_bind_methods() {
 
 	base_property_helper.set_prefix("popup/item_");
 	base_property_helper.set_array_length_getter(&OptionButton::get_item_count);
-	base_property_helper.register_property(PropertyInfo(Variant::STRING, "text"), defaults.text, &OptionButton::_dummy_setter, &OptionButton::get_item_text);
-	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), defaults.icon, &OptionButton::_dummy_setter, &OptionButton::get_item_icon);
-	base_property_helper.register_property(PropertyInfo(Variant::INT, "id", PROPERTY_HINT_RANGE, "0,10,1,or_greater", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL), defaults.id, &OptionButton::_dummy_setter, &OptionButton::get_item_id);
-	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled, &OptionButton::_dummy_setter, &OptionButton::is_item_disabled);
-	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "separator"), defaults.separator, &OptionButton::_dummy_setter, &OptionButton::is_item_separator);
+	base_property_helper.register_property(PropertyInfo(Variant::STRING, PNAME("text")), defaults.text, &OptionButton::_dummy_setter, &OptionButton::get_item_text);
+	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, PNAME("icon"), PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), defaults.icon, &OptionButton::_dummy_setter, &OptionButton::get_item_icon);
+	base_property_helper.register_property(PropertyInfo(Variant::INT, PNAME("id"), PROPERTY_HINT_RANGE, "0,10,1,or_greater", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL), defaults.id, &OptionButton::_dummy_setter, &OptionButton::get_item_id);
+	base_property_helper.register_property(PropertyInfo(Variant::BOOL, PNAME("disabled")), defaults.disabled, &OptionButton::_dummy_setter, &OptionButton::is_item_disabled);
+	base_property_helper.register_property(PropertyInfo(Variant::BOOL, PNAME("separator")), defaults.separator, &OptionButton::_dummy_setter, &OptionButton::is_item_separator);
 	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 
 	ADD_CLASS_DEPENDENCY("PopupMenu");

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -3603,14 +3603,14 @@ void PopupMenu::_bind_methods() {
 
 	base_property_helper.set_prefix("item_");
 	base_property_helper.set_array_length_getter(&PopupMenu::get_item_count);
-	base_property_helper.register_property(PropertyInfo(Variant::STRING, "text"), defaults.text, &PopupMenu::set_item_text, &PopupMenu::get_item_text);
-	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), defaults.icon, &PopupMenu::set_item_icon, &PopupMenu::get_item_icon);
-	base_property_helper.register_property(PropertyInfo(Variant::INT, "checkable", PROPERTY_HINT_ENUM, "No,As checkbox,As radio button"), defaults.checkable_type, &PopupMenu::_set_item_checkable_type, &PopupMenu::_get_item_checkable_type);
-	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "checked"), defaults.checked, &PopupMenu::set_item_checked, &PopupMenu::is_item_checked);
-	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "indeterminate"), defaults.indeterminate, &PopupMenu::set_item_indeterminate, &PopupMenu::is_item_indeterminate);
-	base_property_helper.register_property(PropertyInfo(Variant::INT, "id", PROPERTY_HINT_RANGE, "0,10,1,or_greater", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL), defaults.id, &PopupMenu::set_item_id, &PopupMenu::get_item_id);
-	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled, &PopupMenu::set_item_disabled, &PopupMenu::is_item_disabled);
-	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "separator"), defaults.separator, &PopupMenu::set_item_as_separator, &PopupMenu::is_item_separator);
+	base_property_helper.register_property(PropertyInfo(Variant::STRING, PNAME("text")), defaults.text, &PopupMenu::set_item_text, &PopupMenu::get_item_text);
+	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, PNAME("icon"), PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), defaults.icon, &PopupMenu::set_item_icon, &PopupMenu::get_item_icon);
+	base_property_helper.register_property(PropertyInfo(Variant::INT, PNAME("checkable"), PROPERTY_HINT_ENUM, "No,As checkbox,As radio button"), defaults.checkable_type, &PopupMenu::_set_item_checkable_type, &PopupMenu::_get_item_checkable_type);
+	base_property_helper.register_property(PropertyInfo(Variant::BOOL, PNAME("checked")), defaults.checked, &PopupMenu::set_item_checked, &PopupMenu::is_item_checked);
+	base_property_helper.register_property(PropertyInfo(Variant::BOOL, PNAME("indeterminate")), defaults.indeterminate, &PopupMenu::set_item_indeterminate, &PopupMenu::is_item_indeterminate);
+	base_property_helper.register_property(PropertyInfo(Variant::INT, PNAME("id"), PROPERTY_HINT_RANGE, "0,10,1,or_greater", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL), defaults.id, &PopupMenu::set_item_id, &PopupMenu::get_item_id);
+	base_property_helper.register_property(PropertyInfo(Variant::BOOL, PNAME("disabled")), defaults.disabled, &PopupMenu::set_item_disabled, &PopupMenu::is_item_disabled);
+	base_property_helper.register_property(PropertyInfo(Variant::BOOL, PNAME("separator")), defaults.separator, &PopupMenu::set_item_as_separator, &PopupMenu::is_item_separator);
 	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -2430,10 +2430,10 @@ void TabBar::_bind_methods() {
 
 	base_property_helper.set_prefix("tab_");
 	base_property_helper.set_array_length_getter(&TabBar::get_tab_count);
-	base_property_helper.register_property(PropertyInfo(Variant::STRING, "title"), defaults.text, &TabBar::set_tab_title, &TabBar::get_tab_title);
-	base_property_helper.register_property(PropertyInfo(Variant::STRING, "tooltip"), defaults.tooltip, &TabBar::set_tab_tooltip, &TabBar::get_tab_tooltip);
-	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), defaults.icon, &TabBar::set_tab_icon, &TabBar::get_tab_icon);
-	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled, &TabBar::set_tab_disabled, &TabBar::is_tab_disabled);
+	base_property_helper.register_property(PropertyInfo(Variant::STRING, PNAME("title")), defaults.text, &TabBar::set_tab_title, &TabBar::get_tab_title);
+	base_property_helper.register_property(PropertyInfo(Variant::STRING, PNAME("tooltip")), defaults.tooltip, &TabBar::set_tab_tooltip, &TabBar::get_tab_tooltip);
+	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, PNAME("icon"), PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), defaults.icon, &TabBar::set_tab_icon, &TabBar::get_tab_icon);
+	base_property_helper.register_property(PropertyInfo(Variant::BOOL, PNAME("disabled")), defaults.disabled, &TabBar::set_tab_disabled, &TabBar::is_tab_disabled);
 	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -1354,10 +1354,10 @@ void TabContainer::_bind_methods() {
 
 	base_property_helper.set_prefix("tab_");
 	base_property_helper.set_array_length_getter(&TabContainer::get_tab_count);
-	base_property_helper.register_property(PropertyInfo(Variant::STRING, "title"), defaults.title, &TabContainer::set_tab_title, &TabContainer::get_tab_title);
-	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "icon", PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), defaults.icon, &TabContainer::set_tab_icon, &TabContainer::get_tab_icon);
-	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "disabled"), defaults.disabled, &TabContainer::set_tab_disabled, &TabContainer::is_tab_disabled);
-	base_property_helper.register_property(PropertyInfo(Variant::BOOL, "hidden"), defaults.hidden, &TabContainer::set_tab_hidden, &TabContainer::is_tab_hidden);
+	base_property_helper.register_property(PropertyInfo(Variant::STRING, PNAME("title")), defaults.title, &TabContainer::set_tab_title, &TabContainer::get_tab_title);
+	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, PNAME("icon"), PROPERTY_HINT_RESOURCE_TYPE, Texture2D::get_class_static()), defaults.icon, &TabContainer::set_tab_icon, &TabContainer::get_tab_icon);
+	base_property_helper.register_property(PropertyInfo(Variant::BOOL, PNAME("disabled")), defaults.disabled, &TabContainer::set_tab_disabled, &TabContainer::is_tab_disabled);
+	base_property_helper.register_property(PropertyInfo(Variant::BOOL, PNAME("hidden")), defaults.hidden, &TabContainer::set_tab_hidden, &TabContainer::is_tab_hidden);
 	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 

--- a/scene/resources/audio/audio_stream_randomizer.cpp
+++ b/scene/resources/audio/audio_stream_randomizer.cpp
@@ -320,8 +320,8 @@ void AudioStreamRandomizer::_bind_methods() {
 
 	base_property_helper.set_prefix("stream_");
 	base_property_helper.set_array_length_getter(&AudioStreamRandomizer::get_streams_count);
-	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, AudioStream::get_class_static()), defaults.stream, &AudioStreamRandomizer::set_stream, &AudioStreamRandomizer::get_stream);
-	base_property_helper.register_property(PropertyInfo(Variant::FLOAT, "weight", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater"), defaults.weight, &AudioStreamRandomizer::set_stream_probability_weight, &AudioStreamRandomizer::get_stream_probability_weight);
+	base_property_helper.register_property(PropertyInfo(Variant::OBJECT, PNAME("stream"), PROPERTY_HINT_RESOURCE_TYPE, AudioStream::get_class_static()), defaults.stream, &AudioStreamRandomizer::set_stream, &AudioStreamRandomizer::get_stream);
+	base_property_helper.register_property(PropertyInfo(Variant::FLOAT, PNAME("weight"), PROPERTY_HINT_RANGE, "0,100,0.001,or_greater"), defaults.weight, &AudioStreamRandomizer::set_stream_probability_weight, &AudioStreamRandomizer::get_stream_probability_weight);
 	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -659,11 +659,11 @@ void Curve::_bind_methods() {
 	base_property_helper.set_prefix("point_");
 	base_property_helper.set_array_length_getter(&Curve::get_point_count);
 	base_property_helper.set_property_filter(&Curve::_filter_property);
-	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, "position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.position, &Curve::_set_point_position, &Curve::get_point_position);
-	base_property_helper.register_property(PropertyInfo(Variant::FLOAT, "left_tangent", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.left_tangent, &Curve::set_point_left_tangent, &Curve::get_point_left_tangent);
-	base_property_helper.register_property(PropertyInfo(Variant::INT, "left_mode", PROPERTY_HINT_ENUM, mode_hint, PROPERTY_USAGE_EDITOR), defaults.left_mode, &Curve::set_point_left_mode, &Curve::get_point_left_mode);
-	base_property_helper.register_property(PropertyInfo(Variant::FLOAT, "right_tangent", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.right_tangent, &Curve::set_point_right_tangent, &Curve::get_point_right_tangent);
-	base_property_helper.register_property(PropertyInfo(Variant::INT, "right_mode", PROPERTY_HINT_ENUM, mode_hint, PROPERTY_USAGE_EDITOR), defaults.right_mode, &Curve::set_point_right_mode, &Curve::get_point_right_mode);
+	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, PNAME("position"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.position, &Curve::_set_point_position, &Curve::get_point_position);
+	base_property_helper.register_property(PropertyInfo(Variant::FLOAT, PNAME("left_tangent"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.left_tangent, &Curve::set_point_left_tangent, &Curve::get_point_left_tangent);
+	base_property_helper.register_property(PropertyInfo(Variant::INT, PNAME("left_mode"), PROPERTY_HINT_ENUM, mode_hint, PROPERTY_USAGE_EDITOR), defaults.left_mode, &Curve::set_point_left_mode, &Curve::get_point_left_mode);
+	base_property_helper.register_property(PropertyInfo(Variant::FLOAT, PNAME("right_tangent"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.right_tangent, &Curve::set_point_right_tangent, &Curve::get_point_right_tangent);
+	base_property_helper.register_property(PropertyInfo(Variant::INT, PNAME("right_mode"), PROPERTY_HINT_ENUM, mode_hint, PROPERTY_USAGE_EDITOR), defaults.right_mode, &Curve::set_point_right_mode, &Curve::get_point_right_mode);
 	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 
@@ -1343,9 +1343,9 @@ void Curve2D::_bind_methods() {
 	base_property_helper.set_prefix("point_");
 	base_property_helper.set_array_length_getter(&Curve2D::get_point_count);
 	base_property_helper.set_property_filter(&Curve2D::_filter_property);
-	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, "position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.position, &Curve2D::set_point_position, &Curve2D::get_point_position);
-	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, "in", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.in, &Curve2D::set_point_in, &Curve2D::get_point_in);
-	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, "out", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.out, &Curve2D::set_point_out, &Curve2D::get_point_out);
+	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, PNAME("position"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.position, &Curve2D::set_point_position, &Curve2D::get_point_position);
+	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, PNAME("in"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.in, &Curve2D::set_point_in, &Curve2D::get_point_in);
+	base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, PNAME("out"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.out, &Curve2D::set_point_out, &Curve2D::get_point_out);
 	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 
@@ -2386,10 +2386,10 @@ void Curve3D::_bind_methods() {
 	base_property_helper.set_prefix("point_");
 	base_property_helper.set_array_length_getter(&Curve3D::get_point_count);
 	base_property_helper.set_property_filter(&Curve3D::_filter_property);
-	base_property_helper.register_property(PropertyInfo(Variant::VECTOR3, "position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.position, &Curve3D::set_point_position, &Curve3D::get_point_position);
-	base_property_helper.register_property(PropertyInfo(Variant::VECTOR3, "in", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.in, &Curve3D::set_point_in, &Curve3D::get_point_in);
-	base_property_helper.register_property(PropertyInfo(Variant::VECTOR3, "out", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.out, &Curve3D::set_point_out, &Curve3D::get_point_out);
-	base_property_helper.register_property(PropertyInfo(Variant::FLOAT, "tilt", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.tilt, &Curve3D::set_point_tilt, &Curve3D::get_point_tilt);
+	base_property_helper.register_property(PropertyInfo(Variant::VECTOR3, PNAME("position"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.position, &Curve3D::set_point_position, &Curve3D::get_point_position);
+	base_property_helper.register_property(PropertyInfo(Variant::VECTOR3, PNAME("in"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.in, &Curve3D::set_point_in, &Curve3D::get_point_in);
+	base_property_helper.register_property(PropertyInfo(Variant::VECTOR3, PNAME("out"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.out, &Curve3D::set_point_out, &Curve3D::get_point_out);
+	base_property_helper.register_property(PropertyInfo(Variant::FLOAT, PNAME("tilt"), PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), defaults.tilt, &Curve3D::set_point_tilt, &Curve3D::get_point_tilt);
 	PropertyListHelper::register_base_helper(get_class_static(), &base_property_helper);
 }
 

--- a/scene/resources/label_settings.cpp
+++ b/scene/resources/label_settings.cpp
@@ -117,17 +117,17 @@ void LabelSettings::_bind_methods() {
 
 	stacked_outline_base_property_helper.set_prefix("stacked_outline_");
 	stacked_outline_base_property_helper.set_array_length_getter(&LabelSettings::get_stacked_outline_count);
-	stacked_outline_base_property_helper.register_property(PropertyInfo(Variant::INT, "size", PROPERTY_HINT_NONE, "0,127,1,or_greater,suffix:px"), stacked_outline_defaults.size, &LabelSettings::set_stacked_outline_size, &LabelSettings::get_stacked_outline_size);
-	stacked_outline_base_property_helper.register_property(PropertyInfo(Variant::COLOR, "color"), stacked_outline_defaults.color, &LabelSettings::set_stacked_outline_color, &LabelSettings::get_stacked_outline_color);
+	stacked_outline_base_property_helper.register_property(PropertyInfo(Variant::INT, PNAME("size"), PROPERTY_HINT_NONE, "0,127,1,or_greater,suffix:px"), stacked_outline_defaults.size, &LabelSettings::set_stacked_outline_size, &LabelSettings::get_stacked_outline_size);
+	stacked_outline_base_property_helper.register_property(PropertyInfo(Variant::COLOR, PNAME("color")), stacked_outline_defaults.color, &LabelSettings::set_stacked_outline_color, &LabelSettings::get_stacked_outline_color);
 	PropertyListHelper::register_base_helper(get_class_static(), &stacked_outline_base_property_helper);
 
 	constexpr StackedShadowData stacked_shadow_defaults;
 
 	stacked_shadow_base_property_helper.set_prefix("stacked_shadow_");
 	stacked_shadow_base_property_helper.set_array_length_getter(&LabelSettings::get_stacked_shadow_count);
-	stacked_shadow_base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, "offset", PROPERTY_HINT_NONE, "suffix:px"), stacked_shadow_defaults.offset, &LabelSettings::set_stacked_shadow_offset, &LabelSettings::get_stacked_shadow_offset);
-	stacked_shadow_base_property_helper.register_property(PropertyInfo(Variant::COLOR, "color"), stacked_shadow_defaults.color, &LabelSettings::set_stacked_shadow_color, &LabelSettings::get_stacked_shadow_color);
-	stacked_shadow_base_property_helper.register_property(PropertyInfo(Variant::INT, "outline_size", PROPERTY_HINT_NONE, "0,127,1,or_greater,suffix:px"), stacked_shadow_defaults.outline_size, &LabelSettings::set_stacked_shadow_outline_size, &LabelSettings::get_stacked_shadow_outline_size);
+	stacked_shadow_base_property_helper.register_property(PropertyInfo(Variant::VECTOR2, PNAME("offset"), PROPERTY_HINT_NONE, "suffix:px"), stacked_shadow_defaults.offset, &LabelSettings::set_stacked_shadow_offset, &LabelSettings::get_stacked_shadow_offset);
+	stacked_shadow_base_property_helper.register_property(PropertyInfo(Variant::COLOR, PNAME("color")), stacked_shadow_defaults.color, &LabelSettings::set_stacked_shadow_color, &LabelSettings::get_stacked_shadow_color);
+	stacked_shadow_base_property_helper.register_property(PropertyInfo(Variant::INT, PNAME("outline_size"), PROPERTY_HINT_NONE, "0,127,1,or_greater,suffix:px"), stacked_shadow_defaults.outline_size, &LabelSettings::set_stacked_shadow_outline_size, &LabelSettings::get_stacked_shadow_outline_size);
 	PropertyListHelper::register_base_helper(get_class_static(), &stacked_shadow_base_property_helper);
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

Looks like most dynamic properties registered with PropertyListHelper did not use PNAME, so some of them don't exist in property translations.

## Additional information

A better solution would be to change property extractions script to extract properties from PropertyListHelper (they are all registered with `register_property()`).
<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
