### PR TITLE
Make unresizable window keep the titlebar size on Windows

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2598,7 +2598,9 @@ void DisplayServerWindows::window_set_size(const Size2i p_size, DisplayServerEnu
 		h += (rect.bottom - rect.top) - (crect.bottom - crect.top);
 	}
 
+	wd.programmatic_resize_in_progress = true;
 	MoveWindow(wd.hWnd, rect.left, rect.top, w, h, TRUE);
+	wd.programmatic_resize_in_progress = false;
 }
 
 Size2i DisplayServerWindows::window_get_size(DisplayServerEnums::WindowID p_window) const {
@@ -2676,32 +2678,18 @@ void DisplayServerWindows::_get_window_style(bool p_main_window, bool p_initiali
 			}
 		}
 	} else {
-		if (p_resizable) {
-			if (p_minimized) {
-				r_style = WS_OVERLAPPEDWINDOW | WS_MINIMIZE;
-			} else if (p_maximized) {
-				r_style = WS_OVERLAPPEDWINDOW | WS_MAXIMIZE;
-			} else {
-				r_style = WS_OVERLAPPEDWINDOW;
-			}
-			if (p_no_min_btn) {
-				r_style &= ~WS_MINIMIZEBOX;
-			}
-			if (p_no_max_btn) {
-				r_style &= ~WS_MAXIMIZEBOX;
-			}
+		if (p_minimized) {
+			r_style = WS_OVERLAPPEDWINDOW | WS_MINIMIZE;
+		} else if (p_maximized) {
+			r_style = WS_OVERLAPPEDWINDOW | WS_MAXIMIZE;
 		} else {
-			if (p_minimized) {
-				r_style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_MINIMIZE;
-			} else {
-				r_style = WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU;
-			}
-			if (!p_no_min_btn) {
-				r_style |= WS_MINIMIZEBOX;
-			}
-			if (!p_no_max_btn) {
-				r_style |= WS_MAXIMIZEBOX;
-			}
+			r_style = WS_OVERLAPPEDWINDOW;
+		}
+		if (p_no_min_btn) {
+			r_style &= ~WS_MINIMIZEBOX;
+		}
+		if (p_no_max_btn) {
+			r_style &= ~WS_MAXIMIZEBOX;
 		}
 	}
 
@@ -2778,6 +2766,8 @@ void DisplayServerWindows::window_set_mode(DisplayServerEnums::WindowMode p_mode
 		print_line("Embedded window only supports Windowed mode.");
 		return;
 	}
+
+	wd.programmatic_resize_in_progress = true;
 
 	bool was_fullscreen = wd.fullscreen;
 	wd.was_fullscreen_pre_min = false;
@@ -2914,6 +2904,7 @@ void DisplayServerWindows::window_set_mode(DisplayServerEnums::WindowMode p_mode
 		}
 	}
 	_update_window_mouse_passthrough(p_window);
+	wd.programmatic_resize_in_progress = false;
 }
 
 DisplayServerEnums::WindowMode DisplayServerWindows::window_get_mode(DisplayServerEnums::WindowID p_window) const {
@@ -5780,6 +5771,27 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			if (windows[window_id].mpass) {
 				return HTTRANSPARENT;
 			}
+			if (!windows[window_id].resizable && !windows[window_id].fullscreen && !windows[window_id].borderless) {
+				// When the window is not resizable, bypass the resize-edge hit tests,
+				// that would normally spawn the resize arrows. This makes it impossible to resize the window
+				// using the mouse
+				LRESULT hit = user_proc ? CallWindowProcW(user_proc, hWnd, uMsg, wParam, lParam) : DefWindowProcW(hWnd, uMsg, wParam, lParam);
+				switch (hit) {
+					case HTLEFT:
+					case HTRIGHT:
+					case HTTOP:
+					case HTTOPLEFT:
+					case HTTOPRIGHT:
+					case HTBOTTOM:
+					case HTBOTTOMLEFT:
+					case HTBOTTOMRIGHT: {
+						return HTBORDER;
+					} break;
+					default: {
+						return hit;
+					} break;
+				}
+			}
 		} break;
 		case WM_MOUSEACTIVATE: {
 			if (windows[window_id].no_focus || windows[window_id].is_popup) {
@@ -5822,18 +5834,27 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			return 0;
 		} break;
 		case WM_GETMINMAXINFO: {
-			if (windows[window_id].resizable && !windows[window_id].fullscreen) {
+			if (!windows[window_id].fullscreen) {
 				// Size of window decorations.
 				Size2 decor = window_get_size_with_decorations(window_id) - window_get_size(window_id);
 
 				MINMAXINFO *min_max_info = (MINMAXINFO *)lParam;
-				if (windows[window_id].min_size != Size2()) {
-					min_max_info->ptMinTrackSize.x = windows[window_id].min_size.x + decor.x;
-					min_max_info->ptMinTrackSize.y = windows[window_id].min_size.y + decor.y;
-				}
-				if (windows[window_id].max_size != Size2()) {
-					min_max_info->ptMaxTrackSize.x = windows[window_id].max_size.x + decor.x;
-					min_max_info->ptMaxTrackSize.y = windows[window_id].max_size.y + decor.y;
+				if (windows[window_id].resizable) {
+					if (windows[window_id].min_size != Size2()) {
+						min_max_info->ptMinTrackSize.x = windows[window_id].min_size.x + decor.x;
+						min_max_info->ptMinTrackSize.y = windows[window_id].min_size.y + decor.y;
+					}
+					if (windows[window_id].max_size != Size2()) {
+						min_max_info->ptMaxTrackSize.x = windows[window_id].max_size.x + decor.x;
+						min_max_info->ptMaxTrackSize.y = windows[window_id].max_size.y + decor.y;
+					}
+				} else if (!windows[window_id].programmatic_resize_in_progress) {
+					// Enforce the current window size, when it is set to be non-resizable.
+					Size2 current_size = window_get_size(window_id);
+					min_max_info->ptMinTrackSize.x = current_size.x + decor.x;
+					min_max_info->ptMinTrackSize.y = current_size.y + decor.y;
+					min_max_info->ptMaxTrackSize.x = current_size.x + decor.x;
+					min_max_info->ptMaxTrackSize.y = current_size.y + decor.y;
 				}
 				if (windows[window_id].borderless) {
 					Rect2i screen_rect = screen_get_usable_rect(window_get_current_screen(window_id));

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -307,6 +307,7 @@ class DisplayServerWindows : public DisplayServer {
 		bool multiwindow_fs = false;
 		bool borderless = false;
 		bool resizable = true;
+		bool programmatic_resize_in_progress = false;
 		bool no_min_btn = false;
 		bool no_max_btn = false;
 		bool window_focused = false;


### PR DESCRIPTION
This fixes the problem, when the window is set to be unresizable, the viewport size shrinks be 10px. Now instead of removing the resize border (which contributed to those 10px difference), the window stays with the same resize margin, but it is forced to not work, while window max size request is intercepted, so there are less ways to resize the window.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #62869

### How to test

The test is based on the original [issue comment](https://github.com/godotengine/godot/issues/62869#issuecomment-1250334536). The window must set the unresizable flag via: 
```gdscript
var flag = DisplayServer.window_get_flag(DisplayServer.WINDOW_FLAG_RESIZE_DISABLED)
DisplayServer.window_set_flag(DisplayServer.WINDOW_FLAG_RESIZE_DISABLED, not flag)
```

And the expected result, is that the `get_viewport().get_visible_rect()` must not change.

To check, that the window is still unresizable one can try:
1.  Resize it via keyboard (Right click on the title bar -> Resize, use keyboard arrows).
2. Resize it using mouse
3. Resize it by tiling it using shortcuts or the mouse
4. Trying to maximize it

One exception, is the window goes full screen: it should successfully do so.

### Before PR

https://github.com/user-attachments/assets/17f98a5a-4283-4198-8c63-c3544de960d3

### After PR

https://github.com/user-attachments/assets/8c16c464-161f-401f-9f1c-83de5630b69e

### Test project

[unresizable_size_fix.zip](https://github.com/user-attachments/files/32054377/unresizable_size_fix.zip)


## Additional information

Here the main idea is to move the "unresizable" enforcement to the Godot side, instead of the system side. But, I also tried another simpler approach: resize the window back to the original `viewport_visible_rect` after the `p_resizable` property is set. This works to some extent with the original bug, but this does not prevent the window title bar to shrink, because window type changed.

Another caveat with my approach, is that (from my understanding) sometimes the window needs to be in fact resizable, e.g. when going full screen and back, so size enforcement needs to be active only when the window is not being resized by Godot. Because of that the additional resize tracking flag needs to be added.

Also, compared to the Pre-PR approach, this time unresizable window is now not maximizable. I am not sure if this is ok, but on the other hand it makes sense, because window must not change size (and fullscreen/borderless window is not a window anymore from the user POV?).

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

