### PR TITLE
[XR] Remove experimental manifest meta-data

### DIFF
--- a/platform/android/java/editor/src/android/AndroidManifest.xml
+++ b/platform/android/java/editor/src/android/AndroidManifest.xml
@@ -20,9 +20,6 @@
     <uses-permission android:name="android.permission.HEAD_TRACKING" />
 
     <application>
-        <!-- Required for spatial container support on AndroidXR. -->
-        <meta-data android:name="com.android.extensions.xr.uses_experimental_openxr_feature" android:value="true" />
-
         <uses-native-library android:name="libopenxr.google.so" android:required="false" />
 
         <property


### PR DESCRIPTION
This removes the `uses_experimental_openxr_feature` meta-data from the editor manifest.

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->


<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
