### PR TITLE
Fix continuation lines processing when convering the project from Godot 3 to 4

### DIFF
--- a/editor/project_upgrade/project_converter_3_to_4.cpp
+++ b/editor/project_upgrade/project_converter_3_to_4.cpp
@@ -1563,6 +1563,7 @@ Vector<String> ProjectConverter3To4::check_for_rename_classes(Vector<String> &li
 }
 
 void ProjectConverter3To4::rename_gdscript_functions(Vector<SourceLine> &source_lines, const RegExContainer &reg_container, bool builtin) {
+	bool previous_line_is_continuation = false;
 	for (SourceLine &source_line : source_lines) {
 		if (source_line.is_comment) {
 			continue;
@@ -1570,8 +1571,10 @@ void ProjectConverter3To4::rename_gdscript_functions(Vector<SourceLine> &source_
 
 		String &line = source_line.line;
 		if (uint64_t(line.length()) <= maximum_line_length) {
-			process_gdscript_line(line, reg_container, builtin);
+			process_gdscript_line(line, reg_container, builtin, previous_line_is_continuation);
 		}
+
+		previous_line_is_continuation = line.strip_edges(false, true).ends_with("\\");
 	}
 }
 
@@ -1580,14 +1583,17 @@ Vector<String> ProjectConverter3To4::check_for_rename_gdscript_functions(Vector<
 
 	Vector<String> found_renames;
 
+	bool previous_line_is_continuation = false;
 	for (String &line : lines) {
 		if (uint64_t(line.length()) <= maximum_line_length) {
 			String old_line = line;
-			process_gdscript_line(line, reg_container, builtin);
+			process_gdscript_line(line, reg_container, builtin, previous_line_is_continuation);
 			if (old_line != line) {
 				found_renames.append(simple_line_formatter(current_line, old_line, line));
 			}
 		}
+
+		previous_line_is_continuation = line.strip_edges(false, true).ends_with("\\");
 	}
 
 	return found_renames;
@@ -1610,7 +1616,7 @@ bool ProjectConverter3To4::contains_function_call(const String &line, const Stri
 }
 
 // TODO, this function should run only on all ".gd" files and also on lines in ".tscn" files which are parts of built-in Scripts.
-void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContainer &reg_container, bool builtin) {
+void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContainer &reg_container, bool builtin, bool is_continuation_line) {
 	// In this and other functions, reg.sub() is used only after checking lines with str.contains().
 	// With longer lines, doing so can sometimes be significantly faster.
 
@@ -1630,7 +1636,7 @@ void ProjectConverter3To4::process_gdscript_line(String &line, const RegExContai
 	}
 
 	// -- \t.func() -> \tsuper.func()       Object
-	if (line.contains_char('(') && line.contains_char('.')) {
+	if (!is_continuation_line && line.contains_char('(') && line.contains_char('.')) {
 		line = reg_container.reg_super.sub(line, "$1super.$2", true); // TODO, not sure if possible, but for now this broke String text e.g. "Chosen .gitignore" -> "Chosen super.gitignore"
 	}
 

--- a/editor/project_upgrade/project_converter_3_to_4.h
+++ b/editor/project_upgrade/project_converter_3_to_4.h
@@ -63,7 +63,7 @@ class ProjectConverter3To4 {
 
 	void rename_gdscript_functions(Vector<SourceLine> &source_lines, const RegExContainer &reg_container, bool builtin);
 	Vector<String> check_for_rename_gdscript_functions(Vector<String> &lines, const RegExContainer &reg_container, bool builtin);
-	void process_gdscript_line(String &line, const RegExContainer &reg_container, bool builtin);
+	void process_gdscript_line(String &line, const RegExContainer &reg_container, bool builtin, bool is_continuation_line = false);
 
 	void rename_csharp_functions(Vector<SourceLine> &source_lines, const RegExContainer &reg_container);
 	Vector<String> check_for_rename_csharp_functions(Vector<String> &lines, const RegExContainer &reg_container);


### PR DESCRIPTION
This fixes the bug, when the lines started with dot were incorrectly assumed to be super calls, when in reality they were chained call with the previous lines ended with "\"

<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #68719

## Additional information

### How to test

1. Open the project from the issue and convert it to Godot 4
2. Open .gd file, the `._add_one()` lines should be untouched (no `super` keyword is added)

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
