### PR TITLE
[Editor] Fix system theme update.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4141,10 +4141,17 @@ void EditorNode::_check_system_theme_changed() {
 	}
 
 	if (system_theme_changed) {
-		class_icon_cache.clear();
-		_update_theme();
-		_build_icon_type_cache();
-		recent_scenes->reset_size();
+		EditorThemeManager::set_theme_outdated();
+
+		SceneTree *sml = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
+		if (!sml) {
+			return;
+		}
+		Node *root = sml->get_root()->get_child(0);
+		if (!root) {
+			return;
+		}
+		root->propagate_notification(EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED);
 	} else if (menu_type == MENU_TYPE_GLOBAL && display_server->is_dark_mode_supported() && display_server->is_dark_mode() != last_dark_mode_state) {
 		last_dark_mode_state = display_server->is_dark_mode();
 

--- a/editor/themes/editor_theme_manager.cpp
+++ b/editor/themes/editor_theme_manager.cpp
@@ -735,6 +735,12 @@ bool EditorThemeManager::is_generated_theme_outdated() {
 	return outdated_cache;
 }
 
+void EditorThemeManager::set_theme_outdated() {
+	callable_mp_static(&EditorThemeManager::_reset_dirty_flag).call_deferred();
+	outdated_cache_dirty = false;
+	outdated_cache = true;
+}
+
 bool EditorThemeManager::is_dark_theme() {
 	Color base_color = EDITOR_GET("interface/theme/base_color");
 	return base_color.get_luminance() < 0.5;

--- a/editor/themes/editor_theme_manager.h
+++ b/editor/themes/editor_theme_manager.h
@@ -227,6 +227,7 @@ public:
 
 	static Ref<EditorTheme> generate_theme(const Ref<EditorTheme> &p_old_theme = nullptr);
 	static bool is_generated_theme_outdated();
+	static void set_theme_outdated();
 
 	static bool is_dark_theme();
 	static bool is_dark_icon_and_font();


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/123363

## Additional information

Instead of directly regenerating theme, mark it as outdated and simulate editor setting change, since a bunch of editor parts are updating icon cache only in the `NOTIFICATION_EDITOR_SETTINGS_CHANGED` handler.