### PR TITLE
GDScript error for autoload typed variables that can't be resolved

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -836,6 +836,7 @@ GDScriptParser::DataType GDScriptAnalyzer::resolve_datatype(GDScriptParser::Type
 				script_path = autoload.path;
 			}
 			if (script_path.is_empty()) {
+				push_error(vformat(R"(Could not resolve script type from autoload "%s".)", first), first_id);
 				return bad_type;
 			}
 			Ref<GDScriptParserRef> ref = parser->get_depended_parser_for(script_path);


### PR DESCRIPTION
## What problem(s) does this PR solve?

In GDScript we allow to use autoload names as type declaration. If the autoload is a GDScript we use that script as type of the variable. If it is a scene we try to obtain the script attached to the root node and use that.

Until now if none of those cases occurs (e.g. scene autoload without a script, or maybe a CSharp script) we did just silently use a `Variant` type. That's misleading for users, so this PR does instead emit an error if we can't determine a script from the autoload.

## Additional information

- I don't think the test suite supports autoloads, so no test case. However here is an MRP with an autoload typed var that now produces an error: [plain-autoload-type.zip](https://github.com/user-attachments/files/32072177/plain-autoload-type.zip)

- Labeling this as bug, since `return bad_type;` to me heavily implies that not emitting an error was just an oversight in https://github.com/godotengine/godot/pull/90498.