### PR TITLE
Remove `ScriptServer` fallbacks from `ClassDB`

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -31,8 +31,7 @@
 #include "class_db.h"
 
 #include "core/config/engine.h"
-#include "core/io/resource_loader.h"
-#include "core/object/script_language.h"
+#include "core/object/ref_counted.h"
 #include "core/templates/sort_array.h"
 #include "core/version.h"
 
@@ -829,87 +828,49 @@ void ClassDB::set_object_extension_instance(Object *p_object, const StringName &
 }
 
 bool ClassDB::can_instantiate(const StringName &p_class) {
-	String script_path;
-	{
-		Locker::Lock lock(Locker::STATE_READ);
+	Locker::Lock lock(Locker::STATE_READ);
 
-		ClassInfo *ti = classes.getptr(p_class);
-		if (!ti) {
-			if (!ScriptServer::is_global_class(p_class)) {
-				ERR_FAIL_V_MSG(false, vformat("Cannot get class '%s'.", String(p_class)));
-			}
-			script_path = ScriptServer::get_global_class_path(p_class);
-			goto use_script; // Open the lock for resource loading.
-		}
+	ClassInfo *ti = classes.getptr(p_class);
+	ERR_FAIL_NULL_V_MSG(ti, false, vformat("Cannot get class '%s'.", String(p_class)));
 #ifdef TOOLS_ENABLED
-		if ((ti->api == API_EDITOR || ti->api == API_EDITOR_EXTENSION) && !Engine::get_singleton()->is_editor_hint()) {
-			return false;
-		}
-#endif
-		return _can_instantiate(ti);
+	if ((ti->api == API_EDITOR || ti->api == API_EDITOR_EXTENSION) && !Engine::get_singleton()->is_editor_hint()) {
+		return false;
 	}
-
-use_script:
-	Ref<Script> scr = ResourceLoader::load(script_path);
-	return scr.is_valid() && scr->is_script_valid() && !scr->is_abstract();
+#endif
+	return _can_instantiate(ti);
 }
 
 bool ClassDB::is_abstract(const StringName &p_class) {
-	String script_path;
-	{
-		Locker::Lock lock(Locker::STATE_READ);
+	Locker::Lock lock(Locker::STATE_READ);
 
-		ClassInfo *ti = classes.getptr(p_class);
-		if (!ti) {
-			if (!ScriptServer::is_global_class(p_class)) {
-				ERR_FAIL_V_MSG(false, vformat("Cannot get class '%s'.", String(p_class)));
-			}
-			script_path = ScriptServer::get_global_class_path(p_class);
-			goto use_script; // Open the lock for resource loading.
-		}
+	ClassInfo *ti = classes.getptr(p_class);
+	ERR_FAIL_NULL_V_MSG(ti, false, vformat("Cannot get class '%s'.", String(p_class)));
 
-		if (ti->creation_func != nullptr) {
-			return false;
-		}
-		if (!ti->gdextension) {
-			return true;
-		}
-#ifndef DISABLE_DEPRECATED
-		return ti->gdextension->create_instance3 == nullptr && ti->gdextension->create_instance2 == nullptr && ti->gdextension->create_instance == nullptr;
-#else
-		return ti->gdextension->create_instance3 == nullptr;
-#endif //  DISABLE_DEPRECATED
+	if (ti->creation_func != nullptr) {
+		return false;
 	}
-
-use_script:
-	Ref<Script> scr = ResourceLoader::load(script_path);
-	return scr.is_valid() && scr->is_script_valid() && scr->is_abstract();
+	if (!ti->gdextension) {
+		return true;
+	}
+#ifndef DISABLE_DEPRECATED
+	return ti->gdextension->create_instance3 == nullptr && ti->gdextension->create_instance2 == nullptr && ti->gdextension->create_instance == nullptr;
+#else
+	return ti->gdextension->create_instance3 == nullptr;
+#endif //  DISABLE_DEPRECATED
 }
 
 bool ClassDB::is_virtual(const StringName &p_class) {
-	String script_path;
-	{
-		Locker::Lock lock(Locker::STATE_READ);
+	Locker::Lock lock(Locker::STATE_READ);
 
-		ClassInfo *ti = classes.getptr(p_class);
-		if (!ti) {
-			if (!ScriptServer::is_global_class(p_class)) {
-				ERR_FAIL_V_MSG(false, vformat("Cannot get class '%s'.", String(p_class)));
-			}
-			script_path = ScriptServer::get_global_class_path(p_class);
-			goto use_script; // Open the lock for resource loading.
-		}
+	ClassInfo *ti = classes.getptr(p_class);
+	ERR_FAIL_NULL_V_MSG(ti, false, vformat("Cannot get class '%s'.", String(p_class)));
+
 #ifdef TOOLS_ENABLED
-		if ((ti->api == API_EDITOR || ti->api == API_EDITOR_EXTENSION) && !Engine::get_singleton()->is_editor_hint()) {
-			return false;
-		}
-#endif
-		return (_can_instantiate(ti) && ti->is_virtual);
+	if ((ti->api == API_EDITOR || ti->api == API_EDITOR_EXTENSION) && !Engine::get_singleton()->is_editor_hint()) {
+		return false;
 	}
-
-use_script:
-	Ref<Script> scr = ResourceLoader::load(script_path);
-	return scr.is_valid() && scr->is_script_valid() && scr->is_abstract();
+#endif
+	return (_can_instantiate(ti) && ti->is_virtual);
 }
 
 bool ClassDB::is_gdextension(const StringName &p_class) {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5866,8 +5866,10 @@ Ref<Texture2D> EditorNode::_get_class_or_script_icon(const String &p_class, cons
 				bool instantiable = false;
 
 				// If the class doesn't exist or isn't global, then it's not instantiable
-				if (ClassDB::class_exists(p_class) || ScriptServer::is_global_class(p_class)) {
+				if (ClassDB::class_exists(p_class)) {
 					instantiable = !ClassDB::is_virtual(p_class) && ClassDB::can_instantiate(p_class);
+				} else if (ScriptServer::is_global_class(p_class)) {
+					instantiable = !ScriptServer::is_global_class_abstract(p_class);
 				}
 
 				return _get_class_or_script_icon(base_type, "", "", false, p_skip_fallback_virtual || instantiable);

--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -672,8 +672,17 @@ void EditorResourcePicker::set_create_options(Object *p_menu_node) {
 		for (const StringName &E : allowed_types) {
 			const String &t = E;
 
-			if (!ClassDB::can_instantiate(t)) {
-				continue;
+			if (ClassDB::class_exists(t)) {
+				if (!ClassDB::can_instantiate(t)) {
+					continue;
+				}
+			} else if (ScriptServer::is_global_class(t)) {
+				Ref<Script> scr = ResourceLoader::load(ScriptServer::get_global_class_path(t));
+				if (!scr.is_valid() || !scr->is_script_valid() || scr->is_abstract()) {
+					continue;
+				}
+			} else {
+				ERR_CONTINUE_MSG(true, vformat(R"(Invalid class "%s")", t));
 			}
 
 			inheritors_array.push_back(t);
@@ -799,8 +808,12 @@ String EditorResourcePicker::_get_resource_type(const Ref<Resource> &p_resource)
 }
 
 static bool _should_hide_type(const StringName &p_type) {
-	if (ClassDB::is_virtual(p_type)) {
+	if (ClassDB::class_exists(p_type) && ClassDB::is_virtual(p_type)) {
 		return true;
+	}
+	if (ScriptServer::is_global_class(p_type)) {
+		Ref<Script> scr = ResourceLoader::load(ScriptServer::get_global_class_path(p_type));
+		return scr.is_null() || !scr->is_script_valid() || scr->is_abstract();
 	}
 
 	if (p_type == SNAME("MissingResource")) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

At the moment some methods in `ClassDB` also check against `ScriptServer`. This violates our architecture, since `ClassDB` has nothing to do with the scripting layer.

This PR removes those script paths and instead adds `ScriptServer` checks to the few places in the editor were global class names could occur.

## Additional information

I'm marking this as compat breaking for discoverability, because `ClassDB::can_instantiate` is exposed. I don't think this is an issue though because while `ClassDB::can_instantiate` was consulting `ScriptServer`, `ClassDB::instantiate` never was able to instantiate scripts. So I'd consider this a bug fix and not a compat break.