### PR TITLE
Remove TTRGET

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -886,7 +886,7 @@ String InputEventMouseButton::_to_string() {
 		case MouseButton::WHEEL_RIGHT:
 		case MouseButton::MB_XBUTTON1:
 		case MouseButton::MB_XBUTTON2:
-			button_string += vformat(" (%s)", TTRGET(_mouse_button_descriptions[(size_t)idx - 1])); // button index starts from 1, array index starts from 0, so subtract 1
+			button_string += vformat(" (%s)", RTR(_mouse_button_descriptions[(size_t)idx - 1])); // button index starts from 1, array index starts from 0, so subtract 1
 			break;
 		default:
 			break;
@@ -1013,19 +1013,19 @@ String InputEventMouseMotion::_to_string() {
 	String button_mask_string = itos((int64_t)mouse_button_mask);
 
 	if (mouse_button_mask.has_flag(MouseButtonMask::LEFT)) {
-		button_mask_string += vformat(" (%s)", TTRGET(_mouse_button_descriptions[(size_t)MouseButton::LEFT - 1]));
+		button_mask_string += vformat(" (%s)", RTR(_mouse_button_descriptions[(size_t)MouseButton::LEFT - 1]));
 	}
 	if (mouse_button_mask.has_flag(MouseButtonMask::MIDDLE)) {
-		button_mask_string += vformat(" (%s)", TTRGET(_mouse_button_descriptions[(size_t)MouseButton::MIDDLE - 1]));
+		button_mask_string += vformat(" (%s)", RTR(_mouse_button_descriptions[(size_t)MouseButton::MIDDLE - 1]));
 	}
 	if (mouse_button_mask.has_flag(MouseButtonMask::RIGHT)) {
-		button_mask_string += vformat(" (%s)", TTRGET(_mouse_button_descriptions[(size_t)MouseButton::RIGHT - 1]));
+		button_mask_string += vformat(" (%s)", RTR(_mouse_button_descriptions[(size_t)MouseButton::RIGHT - 1]));
 	}
 	if (mouse_button_mask.has_flag(MouseButtonMask::MB_XBUTTON1)) {
-		button_mask_string += vformat(" (%s)", TTRGET(_mouse_button_descriptions[(size_t)MouseButton::MB_XBUTTON1 - 1]));
+		button_mask_string += vformat(" (%s)", RTR(_mouse_button_descriptions[(size_t)MouseButton::MB_XBUTTON1 - 1]));
 	}
 	if (mouse_button_mask.has_flag(MouseButtonMask::MB_XBUTTON2)) {
-		button_mask_string += vformat(" (%s)", TTRGET(_mouse_button_descriptions[(size_t)MouseButton::MB_XBUTTON2 - 1]));
+		button_mask_string += vformat(" (%s)", RTR(_mouse_button_descriptions[(size_t)MouseButton::MB_XBUTTON2 - 1]));
 	}
 
 	// Work around the fact vformat can only take 5 substitutions but 7 need to be passed.
@@ -1199,7 +1199,7 @@ static const char *_joy_axis_descriptions[(size_t)JoyAxis::MAX] = {
 };
 
 String InputEventJoypadMotion::as_text() const {
-	String desc = axis < JoyAxis::MAX ? TTRGET(_joy_axis_descriptions[(size_t)axis]) : RTR("Unknown Joypad Axis");
+	String desc = axis < JoyAxis::MAX ? RTR(_joy_axis_descriptions[(size_t)axis]) : RTR("Unknown Joypad Axis");
 
 	return vformat(RTR("Joypad Motion on Axis %d (%s) with Value %.2f"), axis, desc, axis_value);
 }
@@ -1313,7 +1313,7 @@ String InputEventJoypadButton::as_text() const {
 	String text = vformat(RTR("Joypad Button %d"), (int64_t)button_index);
 
 	if (button_index > JoyButton::INVALID && button_index < JoyButton::SDL_MAX) {
-		text += vformat(" (%s)", TTRGET(_joy_button_descriptions[(size_t)button_index]));
+		text += vformat(" (%s)", RTR(_joy_button_descriptions[(size_t)button_index]));
 	}
 
 	if (pressure != 0) {

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -761,15 +761,9 @@ String TTR(const String &p_text, const String &p_context = "");
 String TTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
 String DTR(const String &p_text, const String &p_context = "");
 String DTRN(const String &p_text, const String &p_text_plural, int p_n, const String &p_context = "");
+#endif
 // Use for C strings.
 #define TTRC(m_value) (m_value)
-// Use to avoid parsing (for use later with C strings).
-#define TTRGET(m_value) TTR(m_value)
-
-#else
-#define TTRC(m_value) (m_value)
-#define TTRGET(m_value) (m_value)
-#endif
 
 // Use this to mark property names for editor translation.
 // Often for dynamic properties defined in _get_property_list().

--- a/editor/doc/editor_help.cpp
+++ b/editor/doc/editor_help.cpp
@@ -764,7 +764,7 @@ void EditorHelp::_update_method_list(MethodType p_method_type, const Vector<DocD
 		TTRC("Constructors"),
 		TTRC("Operators"),
 	};
-	const String title = TTRGET(titles_by_type[p_method_type]);
+	const String title = TTR(titles_by_type[p_method_type]);
 
 	section_line.push_back(Pair<String, int>(title, class_desc->get_paragraph_count() - 2));
 	_push_title_font();
@@ -838,7 +838,7 @@ void EditorHelp::_update_method_descriptions(const DocData::ClassDoc &p_classdoc
 		TTRC("Constructor Descriptions"),
 		TTRC("Operator Descriptions"),
 	};
-	const String title = TTRGET(titles_by_type[p_method_type]);
+	const String title = TTR(titles_by_type[p_method_type]);
 
 	section_line.push_back(Pair<String, int>(title, class_desc->get_paragraph_count() - 2));
 	_push_title_font();
@@ -890,7 +890,7 @@ void EditorHelp::_update_method_descriptions(const DocData::ClassDoc &p_classdoc
 					TTRC("This constructor may be changed or removed in future versions."),
 					TTRC("This operator may be changed or removed in future versions."),
 				};
-				DEPRECATED_DOC_MSG(HANDLE_DOC(method.deprecated_message), TTRGET(messages_by_type[p_method_type]));
+				DEPRECATED_DOC_MSG(HANDLE_DOC(method.deprecated_message), TTR(messages_by_type[p_method_type]));
 			}
 
 			if (method.is_experimental) {
@@ -904,7 +904,7 @@ void EditorHelp::_update_method_descriptions(const DocData::ClassDoc &p_classdoc
 					TTRC("This constructor may be changed or removed in future versions."),
 					TTRC("This operator may be changed or removed in future versions."),
 				};
-				EXPERIMENTAL_DOC_MSG(HANDLE_DOC(method.experimental_message), TTRGET(messages_by_type[p_method_type]));
+				EXPERIMENTAL_DOC_MSG(HANDLE_DOC(method.experimental_message), TTR(messages_by_type[p_method_type]));
 			}
 
 			if (!method.errors_returned.is_empty()) {
@@ -959,14 +959,14 @@ void EditorHelp::_update_method_descriptions(const DocData::ClassDoc &p_classdoc
 						TTRC("There is currently no description for this constructor."),
 						TTRC("There is currently no description for this operator."),
 					};
-					message = TTRGET(messages_by_type[p_method_type]);
+					message = TTR(messages_by_type[p_method_type]);
 				} else {
 					static const char *messages_by_type[METHOD_TYPE_MAX] = {
 						TTRC("There is currently no description for this method. Please help us by [color=$color][url=$url]contributing one[/url][/color]!"),
 						TTRC("There is currently no description for this constructor. Please help us by [color=$color][url=$url]contributing one[/url][/color]!"),
 						TTRC("There is currently no description for this operator. Please help us by [color=$color][url=$url]contributing one[/url][/color]!"),
 					};
-					message = TTRGET(messages_by_type[p_method_type]).replace("$url", CONTRIBUTE_URL).replace("$color", link_color_text);
+					message = TTR(messages_by_type[p_method_type]).replace("$url", CONTRIBUTE_URL).replace("$color", link_color_text);
 				}
 
 				class_desc->add_image(get_editor_theme_icon(SNAME("Error")));

--- a/editor/doc/editor_help_search.cpp
+++ b/editor/doc/editor_help_search.cpp
@@ -1250,7 +1250,7 @@ TreeItem *EditorHelpSearch::Runner::_create_member_item(TreeItem *p_parent, cons
 	TreeItem *item = nullptr;
 	if (_find_or_create_item(p_parent, item_meta, item)) {
 		item->set_icon(0, ui_service->get_editor_theme_icon(p_icon));
-		item->set_text(1, TTRGET(p_type));
+		item->set_text(1, TTR(p_type));
 		item->set_tooltip_text(0, p_tooltip);
 		item->set_tooltip_text(1, p_tooltip);
 		item->set_metadata(0, item_meta);

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -93,8 +93,8 @@ private:
 			toggle_button->set_toggle_mode(true);
 			toggle_button->set_pressed(true);
 			toggle_button->set_text(itos(message_count));
-			toggle_button->set_accessibility_name(TTRGET(p_name));
-			toggle_button->set_tooltip_text(TTRGET(p_tooltip));
+			toggle_button->set_accessibility_name(p_name);
+			toggle_button->set_tooltip_text(p_tooltip);
 			toggle_button->set_focus_mode(FOCUS_ACCESSIBILITY);
 			toggle_button->set_theme_type_variation("EditorLogFilterButton");
 			// When toggled call the callback and pass the MessageType this button is for.

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -259,7 +259,7 @@ String ResourceImporterTexture::get_preset_name(int p_idx) const {
 		TTRC("3D"),
 	};
 
-	return TTRGET(preset_names[p_idx]);
+	return TTR(preset_names[p_idx]);
 }
 
 void ResourceImporterTexture::get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset) const {

--- a/editor/scene/gui/font_config_plugin.cpp
+++ b/editor/scene/gui/font_config_plugin.cpp
@@ -713,7 +713,7 @@ void EditorPropertyOTFeatures::update_property() {
 		}
 		for (int i = 0; i < FGRP_MAX; i++) {
 			if (have_sub[i]) {
-				menu->add_submenu_node_item(TTRGET(group_names[i]), menu_sub[i]);
+				menu->add_submenu_node_item(TTR(group_names[i]), menu_sub[i]);
 			}
 		}
 

--- a/editor/settings/editor_build_profile.cpp
+++ b/editor/settings/editor_build_profile.cpp
@@ -451,7 +451,7 @@ String EditorBuildProfile::get_build_option_name(BuildOption p_build_option) {
 		TTRC("SIL Graphite Fonts"),
 		TTRC("Multi-channel Signed Distance Field Font Rendering"),
 	};
-	return TTRGET(build_option_names[p_build_option]);
+	return TTR(build_option_names[p_build_option]);
 }
 
 String EditorBuildProfile::get_build_option_description(BuildOption p_build_option) {
@@ -490,7 +490,7 @@ String EditorBuildProfile::get_build_option_description(BuildOption p_build_opti
 		TTRC("Multi-channel signed distance field font rendering support using msdfgen library (pre-rendered MSDF fonts can be used even if this option is disabled)."),
 	};
 
-	return TTRGET(build_option_descriptions[p_build_option]);
+	return TTR(build_option_descriptions[p_build_option]);
 }
 
 String EditorBuildProfile::get_build_option_identifier(BuildOption p_build_option) {
@@ -528,7 +528,7 @@ String EditorBuildProfile::get_build_option_category_name(BuildOptionCategory p_
 		TTRC("Text Rendering and Font Options:"),
 	};
 
-	return TTRGET(build_option_subcategories[p_build_option_category]);
+	return TTR(build_option_subcategories[p_build_option_category]);
 }
 
 Error EditorBuildProfile::save_to_file(const String &p_path) {
@@ -1230,7 +1230,7 @@ void EditorBuildProfileManager::_class_list_item_selected() {
 		description_bit->parse_symbol("class|" + md.operator String() + "|");
 	} else if (md.get_type() == Variant::INT) {
 		String build_option_description = EditorBuildProfile::get_build_option_description(EditorBuildProfile::BuildOption((int)md));
-		description_bit->set_custom_text(TTR(item->get_text(0)), String(), TTRGET(build_option_description));
+		description_bit->set_custom_text(TTR(item->get_text(0)), String(), TTR(build_option_description));
 	}
 }
 

--- a/editor/settings/editor_feature_profile.cpp
+++ b/editor/settings/editor_feature_profile.cpp
@@ -591,7 +591,7 @@ void EditorFeatureProfileManager::_class_list_item_selected() {
 		description_bit->parse_symbol("class|" + md.operator String() + "|");
 	} else if (md.get_type() == Variant::INT) {
 		String feature_description = EditorFeatureProfile::get_feature_description(EditorFeatureProfile::Feature((int)md));
-		description_bit->set_custom_text(TTR(item->get_text(0)), String(), TTRGET(feature_description));
+		description_bit->set_custom_text(TTR(item->get_text(0)), String(), TTR(feature_description));
 		return;
 	} else {
 		return;
@@ -805,7 +805,7 @@ void EditorFeatureProfileManager::_update_selected_profile() {
 			last_feature = feature;
 		}
 		feature->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
-		feature->set_text(0, TTRGET(EditorFeatureProfile::get_feature_name(EditorFeatureProfile::Feature(i))));
+		feature->set_text(0, TTR(EditorFeatureProfile::get_feature_name(EditorFeatureProfile::Feature(i))));
 		feature->set_selectable(0, true);
 		feature->set_editable(0, true);
 		feature->set_metadata(0, i);

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
@@ -8317,7 +8317,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	// CONSTANTS
 
 	for (int i = 0; i < MAX_FLOAT_CONST_DEFS; i++) {
-		add_options.push_back(AddOption(float_constant_defs[i].name, "Scalar/Constants", "VisualShaderNodeFloatConstant", TTRGET(float_constant_defs[i].desc_key), { float_constant_defs[i].value }, VisualShaderNode::PORT_TYPE_SCALAR));
+		add_options.push_back(AddOption(float_constant_defs[i].name, "Scalar/Constants", "VisualShaderNodeFloatConstant", TTR(float_constant_defs[i].desc_key), { float_constant_defs[i].value }, VisualShaderNode::PORT_TYPE_SCALAR));
 	}
 	// FUNCTIONS
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

TTRGET is useless. The description says "Use to avoid parsing", which I assume by extraction scripts, but the scripts already ignore strings that aren't quoted. For the RegEx it does not matter if a parsed line uses a special "no-parse" method to, I don't know, return early? (it doesn't help). And if you want to avoid parsing a quoted string, just don't use any TTR macro??

Since TTRGET simply falls back to TTR, it can be completely replaced with the latter.

## Additional information

Also fixes auto-translation for EditorLog button tooltips, because their TTRGET usage was wrong.

I also moved TTRC out of `#ifdef`, because it didn't do anything.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
