### PR TITLE
OpenXR: Fix spatial containers after multilayer camera change

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -2011,6 +2011,14 @@ void OpenXRAPI::update_head_tracking() {
 			print_line("OpenXR: Couldn't locate spatial container views [", get_error_string(result), "]");
 			return;
 		}
+
+		// Spatial container views are located in their space, but we expect the view poses in view space.
+		XrPosef inv_head_pose;
+		XrPosef_Invert(&inv_head_pose, &head_pose);
+		for (uint32_t i = 0; i < view_count; i++) {
+			XrPosef view_pose = views[i].pose;
+			XrPosef_Multiply(&views[i].pose, &inv_head_pose, &view_pose);
+		}
 	} else {
 		void *view_locate_info_next_pointer = nullptr;
 		for (OpenXRExtensionWrapper *extension : frame_info_extensions) {


### PR DESCRIPTION
PR https://github.com/godotengine/godot/pull/116424 broke spatial containers, because that PR switched to locating the views in view space, whereas we locate the views in the space of the spatial container when using spatial containers

So, this PR multiplies the poses by the inverse of the head pose to get view space

This feels a little weird, because we're multiplying by the inverse of the head pose, and then later multiplying by the head pose again. Of course, we need the data in view space for some other calculations, but I don't particularly like undoing and then redoing the head pose - we probably lose a little bit of precision doing that

I tried changing `OpenXRSpatialContainerSelfRenderingExtension::locate_spatial_container_views()` to locate the views in view space, but that doesn't work for some reason - it seems to always give the identity pose.

This should be valid because the spec says:

<img width="923" height="58" alt="Selection_537" src="https://github.com/user-attachments/assets/3ce47a60-262d-4e9d-a004-5f4bb5f9089d" />

So, maybe it could be an issue in the OpenXR runtime? I'm testing on Android XR.

I'd welcome any input! However, this PR does seem to fix the issue in my testing :-)