### PR TITLE
Add hypotf global math function.

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -250,6 +250,13 @@ constexpr bool is_inf(float p_val) {
 	return abs(p_val) == (float)INF;
 }
 
+_ALWAYS_INLINE_ double hypot(double p_x, double p_y) {
+	return std::hypot(p_x, p_y);
+}
+_ALWAYS_INLINE_ float hypot(float p_x, float p_y) {
+	return std::hypot(p_x, p_y);
+}
+
 // These methods assume (p_num + p_den) doesn't overflow.
 constexpr int32_t division_round_up(int32_t p_num, int32_t p_den) {
 	int32_t offset = (p_num < 0 && p_den < 0) ? 1 : -1;

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -97,6 +97,10 @@ double VariantUtilityFunctions::sqrt(double p_x) {
 	return Math::sqrt(p_x);
 }
 
+double VariantUtilityFunctions::hypotf(double p_x, double p_y) {
+	return Math::hypot(p_x, p_y);
+}
+
 double VariantUtilityFunctions::fmod(double p_b, double p_r) {
 	return Math::fmod(p_b, p_r);
 }
@@ -1649,6 +1653,7 @@ void Variant::_register_variant_utility_functions() {
 	FUNCBINDR(atanh, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDR(sqrt, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
+	FUNCBINDR(hypotf, sarray("x", "y"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(fmod, sarray("x", "y"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(fposmod, sarray("x", "y"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(posmod, sarray("x", "y"), Variant::UTILITY_FUNC_TYPE_MATH);

--- a/core/variant/variant_utility.h
+++ b/core/variant/variant_utility.h
@@ -67,6 +67,7 @@ struct VariantUtilityFunctions {
 	static double signf(double p_x);
 	static int64_t signi(int64_t p_x);
 	static double pow(double p_x, double p_y);
+	static double hypotf(double p_x, double p_y);
 	static double log(double p_x);
 	static double exp(double p_x);
 	static bool is_nan(double p_x);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -488,6 +488,22 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="hypotf">
+			<return type="float" />
+			<param index="0" name="x" type="float" />
+			<param index="1" name="y" type="float" />
+			<description>
+				Returns the square root of the sum of the squares of [param x] and [param y], without undue overflow or underflow at intermediate stages of the computation.
+				[codeblocks]
+				[gdscript]
+				print(hypotf(3.0, 4.0)) # Prints 5.0
+				[/gdscript]
+				[csharp]
+				GD.Print(Mathf.Hypot(3.0, 4.0)); // Prints 5.0
+				[/csharp]
+				[/codeblocks]
+			</description>
+		</method>
 		<method name="instance_from_id">
 			<return type="Object" />
 			<param index="0" name="instance_id" type="int" />

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Mathf.cs
@@ -960,6 +960,36 @@ namespace Godot
         }
 
         /// <summary>
+        /// Returns the square root of the sum of the squares of <paramref name="x"/> and
+        /// <paramref name="y"/>, i.e. the length of the hypotenuse of a right triangle with
+        /// the given side lengths. Unlike <c>Sqrt(x * x + y * y)</c>, this avoids overflow
+        /// and underflow at intermediate stages of the computation.
+        /// </summary>
+        /// <param name="x">The length of the first side.</param>
+        /// <param name="y">The length of the second side.</param>
+        /// <returns>The length of the hypotenuse.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static double Hypot(double x, double y)
+        {
+            return double.Hypot(x, y);
+        }
+
+        /// <summary>
+        /// Returns the square root of the sum of the squares of <paramref name="x"/> and
+        /// <paramref name="y"/>, i.e. the length of the hypotenuse of a right triangle with
+        /// the given side lengths. Unlike <c>Sqrt(x * x + y * y)</c>, this avoids overflow
+        /// and underflow at intermediate stages of the computation.
+        /// </summary>
+        /// <param name="x">The length of the first side.</param>
+        /// <param name="y">The length of the second side.</param>
+        /// <returns>The length of the hypotenuse.</returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static float Hypot(float x, float y)
+        {
+            return float.Hypot(x, y);
+        }
+
+        /// <summary>
         /// Returns a normalized value considering the given range.
         /// This is the opposite of <see cref="Lerp(float, float, float)"/>.
         /// </summary>

--- a/tests/core/math/test_math_funcs.cpp
+++ b/tests/core/math/test_math_funcs.cpp
@@ -291,6 +291,22 @@ TEST_CASE_TEMPLATE("[Math] pow/log/log2/exp/sqrt", T, float, double) {
 	CHECK(Math::sqrt((T)1.5) == doctest::Approx((T)1.224745));
 }
 
+TEST_CASE("[Math] hypot") {
+	CHECK(Math::hypot(0.0, 0.0) == doctest::Approx(0.0));
+	CHECK(Math::hypot(3.0, 4.0) == doctest::Approx(5.0));
+	CHECK(Math::hypot(-3.0, -4.0) == doctest::Approx(5.0));
+	CHECK(Math::hypot(1.0, 1.0) == doctest::Approx(1.4142135624));
+
+	CHECK(Math::is_finite(Math::hypot(3e300, 4e300)));
+	CHECK(Math::hypot(3e300, 4e300) == doctest::Approx(5e300));
+	CHECK(Math::hypot(3e-300, 4e-300) / 5e-300 == doctest::Approx(1.0));
+
+	CHECK(Math::hypot(Math::INF, 1.0) == Math::INF);
+	CHECK(Math::hypot(1.0, -Math::INF) == Math::INF);
+	CHECK(Math::hypot(Math::INF, Math::NaN) == Math::INF);
+	CHECK(Math::is_nan(Math::hypot(Math::NaN, 1.0)));
+}
+
 TEST_CASE_TEMPLATE("[Math] is_nan/is_inf/is_finite", T, float, double) {
 	static_assert(!Math::is_nan((T)0.0));
 	static_assert(!Math::is_nan((T)CMP_EPSILON));

--- a/tests/core/variant/test_variant_utility.cpp
+++ b/tests/core/variant/test_variant_utility.cpp
@@ -128,4 +128,39 @@ TEST_CASE("[VariantUtility] Type conversion") {
 	}
 }
 
+TEST_CASE("[VariantUtility] hypotf") {
+	CHECK(VariantUtilityFunctions::hypotf(0.0, 0.0) == doctest::Approx(0.0));
+	CHECK(VariantUtilityFunctions::hypotf(3.0, 4.0) == doctest::Approx(5.0));
+	CHECK(VariantUtilityFunctions::hypotf(-3.0, -4.0) == doctest::Approx(5.0));
+
+	CHECK(Variant::has_utility_function("hypotf"));
+	CHECK(Variant::get_utility_function_argument_count("hypotf") == 2);
+	CHECK(Variant::get_utility_function_argument_type("hypotf", 0) == Variant::FLOAT);
+	CHECK(Variant::get_utility_function_argument_type("hypotf", 1) == Variant::FLOAT);
+	CHECK(Variant::get_utility_function_return_type("hypotf") == Variant::FLOAT);
+	CHECK_FALSE(Variant::is_utility_function_vararg("hypotf"));
+
+	{
+		// Check that using Variant::call_utility_function also works.
+		Vector<const Variant *> args;
+		Variant x_arg = 3.0;
+		args.push_back(&x_arg);
+		Variant y_arg = 4.0;
+		args.push_back(&y_arg);
+		Callable::CallError call_error;
+		Variant result;
+		Variant::call_utility_function("hypotf", &result, (const Variant **)args.ptr(), 2, call_error);
+		CHECK(call_error.error == Callable::CallError::CALL_OK);
+		CHECK(result.get_type() == Variant::Type::FLOAT);
+		CHECK(double(result) == doctest::Approx(5.0));
+
+		x_arg = 5;
+		y_arg = 12;
+		Variant::call_utility_function("hypotf", &result, (const Variant **)args.ptr(), 2, call_error);
+		CHECK(call_error.error == Callable::CallError::CALL_OK);
+		CHECK(result.get_type() == Variant::Type::FLOAT);
+		CHECK(double(result) == doctest::Approx(13.0));
+	}
+}
+
 } // namespace TestVariantUtility


### PR DESCRIPTION
## What problem(s) does this PR solve?

- hypotf(x,y) is missing
- proposal to bring gd math in line with python math https://github.com/godotengine/godot-proposals/issues/15506

## Additional information

- i plan to add hypot (with varible arg count) latter hence why this one is called hypotf

## AI Usage

I used AI to test code.