### PR TITLE
Fix RenderingDevice thread ownership during shutdown

### DIFF
--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -300,6 +300,13 @@ void RenderingServerDefault::finish() {
 	} else {
 		_finish();
 	}
+#ifdef RD_ENABLED
+	// The display server destroys the main device after the render worker
+	// has stopped. Return ownership to the calling (main) thread first.
+	if (RenderingDevice *rd = RenderingDevice::get_singleton()) {
+		rd->make_current();
+	}
+#endif
 }
 
 /* STATUS INFORMATION */


### PR DESCRIPTION
## What problem(s) does this PR solve?

Fixes #119000.

With the separate rendering thread enabled, closing a project reports:

```text
ERROR: This function (finalize) can only be called from the render thread.
```

## Additional information

`_assign_mt_ids()` makes the main `RenderingDevice` current on the render worker. During shutdown, `finish()` waits for that worker to exit and resets `server_thread`, but the device still records the worker's thread ID. The display server then deletes the device on the main thread, where `finalize()` fails its thread guard.

Return the device to the calling thread after the worker has stopped, before the display server destroys it. The null check handles rendering backends without a `RenderingDevice`.

Tested with an empty `Node3D` project, separate rendering thread, and Forward+ on Windows 11 / RTX 2080 SUPER:

- Official 4.8-dev5 (`9552dfb68`): the error and a warning about two leaked ObjectDB instances occur with both Vulkan and D3D12.
- Local build from the same revision with the fix: both backends exit without those messages. The build also includes a texture-import change; the reproduction project contains no imported assets.

This PR targets `master`. The affected shutdown code is unchanged from the tested revision.
