### PR TITLE
Fix D3D12 freeze/crash from abrupt Play-session termination on Windows

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -180,6 +180,12 @@ String OS::get_executable_path() const {
 	return _execpath;
 }
 
+void OS::kill_multiple(const List<ProcessID> &p_pids, const List<ProcessID> &p_skip_graceful) {
+	for (const ProcessID &pid : p_pids) {
+		kill(pid);
+	}
+}
+
 int OS::get_process_id() const {
 	return -1;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -218,6 +218,16 @@ public:
 	virtual Error create_instance(const List<String> &p_arguments, ProcessID *r_child_id = nullptr) { return create_process(get_executable_path(), p_arguments, r_child_id); }
 	virtual Error open_with_program(const String &p_program_path, const List<String> &p_paths) { return create_process(p_program_path, p_paths); }
 	virtual Error kill(const ProcessID &p_pid) = 0;
+	// Kills multiple processes at once. On platforms that support it, this may attempt a
+	// graceful shutdown first (asking each process to quit on its own), sharing a single
+	// timeout budget across all of them, before falling back to killing any stragglers
+	// outright -- which is different from, and can be cheaper than, calling kill() on each
+	// PID in a loop with its own separate timeout. p_skip_graceful lists PIDs that should be
+	// killed immediately without attempting a graceful shutdown at all (e.g. a process the
+	// caller knows can't respond right now, such as one paused at a debugger breakpoint).
+	// The default implementation has no batching/grace support and simply calls kill() on
+	// each PID in turn, which preserves prior behavior on any platform that doesn't override it.
+	virtual void kill_multiple(const List<ProcessID> &p_pids, const List<ProcessID> &p_skip_graceful = List<ProcessID>());
 	virtual int get_process_id() const;
 	virtual bool is_process_running(const ProcessID &p_pid) const = 0;
 	virtual int get_process_exit_code(const ProcessID &p_pid) const = 0;

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -266,6 +266,16 @@ int EditorDebuggerNode::get_debugger_id(const ScriptEditorDebugger *p_debugger) 
 	ERR_FAIL_V(-1);
 }
 
+bool EditorDebuggerNode::is_process_paused(ProcessID p_pid) const {
+	for (int i = 0; i < tabs->get_tab_count(); i++) {
+		const ScriptEditorDebugger *debugger = Object::cast_to<ScriptEditorDebugger>(tabs->get_tab_control(i));
+		if (debugger && debugger->get_remote_pid() == p_pid && debugger->is_breaked()) {
+			return true;
+		}
+	}
+	return false;
+}
+
 ScriptEditorDebugger *EditorDebuggerNode::get_previous_debugger() const {
 	return Object::cast_to<ScriptEditorDebugger>(tabs->get_tab_control(tabs->get_previous_tab()));
 }

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "core/object/script_language.h"
+#include "core/os/process_id.h"
 #include "editor/debugger/editor_debugger_server.h"
 #include "editor/docks/editor_dock.h"
 
@@ -175,6 +176,7 @@ public:
 	ScriptEditorDebugger *get_default_debugger() const;
 	ScriptEditorDebugger *get_debugger(int p_debugger) const;
 	int get_debugger_id(const ScriptEditorDebugger *p_debugger);
+	bool is_process_paused(ProcessID p_pid) const;
 
 	void debug_next();
 	void debug_step();

--- a/editor/run/editor_run.cpp
+++ b/editor/run/editor_run.cpp
@@ -223,21 +223,34 @@ bool EditorRun::has_child_process(ProcessID p_pid) const {
 
 void EditorRun::stop_child_process(ProcessID p_pid) {
 	if (has_child_process(p_pid)) {
-		OS::get_singleton()->kill(p_pid);
+		List<ProcessID> pids_to_kill;
+		pids_to_kill.push_back(p_pid);
+		OS::get_singleton()->kill_multiple(pids_to_kill, _get_paused_pids(pids_to_kill));
 		pids.erase(p_pid);
 	}
 }
 
 void EditorRun::stop() {
 	if (status != STATUS_STOP && pids.size() > 0) {
-		for (const ProcessID &E : pids) {
-			OS::get_singleton()->kill(E);
-		}
+		OS::get_singleton()->kill_multiple(pids, _get_paused_pids(pids));
 		pids.clear();
 	}
 
 	status = STATUS_STOP;
 	running_scene = "";
+}
+
+List<ProcessID> EditorRun::_get_paused_pids(const List<ProcessID> &p_pids) {
+	// A process paused at a debugger breakpoint can't respond to a graceful shutdown request
+	// (its main loop isn't running to receive it), so don't waste any part of the shared
+	// shutdown timeout waiting on one -- go straight to killing it outright.
+	List<ProcessID> paused_pids;
+	for (const ProcessID &pid : p_pids) {
+		if (EditorDebuggerNode::get_singleton()->is_process_paused(pid)) {
+			paused_pids.push_back(pid);
+		}
+	}
+	return paused_pids;
 }
 
 ProcessID EditorRun::get_current_process() const {

--- a/editor/run/editor_run.h
+++ b/editor/run/editor_run.h
@@ -63,6 +63,8 @@ private:
 	Status status;
 	String running_scene;
 
+	static List<ProcessID> _get_paused_pids(const List<ProcessID> &p_pids);
+
 public:
 	inline static EditorRunInstanceStarting instance_starting_callback = nullptr;
 	inline static EditorRunInstanceRequestScreenshot instance_rq_screenshot_callback = nullptr;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1620,6 +1620,158 @@ Error OS_Windows::kill(const ProcessID &p_pid) {
 	return ret != 0 ? OK : FAILED;
 }
 
+namespace {
+struct GracefulCloseData {
+	DWORD pid = 0;
+	bool found_window = false;
+};
+
+BOOL CALLBACK _graceful_close_enum_proc(HWND hwnd, LPARAM lParam) {
+	GracefulCloseData *data = (GracefulCloseData *)lParam;
+	DWORD window_pid = 0;
+	GetWindowThreadProcessId(hwnd, &window_pid);
+	if (window_pid == data->pid && IsWindowVisible(hwnd)) {
+		data->found_window = true;
+		PostMessageW(hwnd, WM_CLOSE, 0, 0);
+	}
+	return TRUE; // Keep enumerating; a process may own more than one top-level window.
+}
+
+// Finds the target process's visible top-level window(s), if any, and posts WM_CLOSE to
+// each. Returns whether any such window was found (i.e. whether it's worth waiting for this
+// process to exit on its own at all). Does not wait for anything itself -- see kill_multiple().
+bool _post_close_to_windows(DWORD p_pid) {
+	GracefulCloseData data;
+	data.pid = p_pid;
+	EnumWindows(_graceful_close_enum_proc, (LPARAM)&data);
+	return data.found_window;
+}
+
+struct PendingKill {
+	ProcessID pid = 0;
+	HANDLE handle = nullptr;
+	PROCESS_INFORMATION pi = {};
+	bool from_process_map = false;
+	bool graceful_requested = false; // We posted WM_CLOSE and are waiting to see if it exits on its own.
+	bool exited = false; // Confirmed exited on its own; must NOT be hard-killed in phase 3.
+};
+} // namespace
+
+// TerminateProcess() gives a process's cleanup code zero chance to run: no destructors, no
+// RenderingDevice teardown, no swap chain release. For a process holding a D3D12 fullscreen
+// flip-model swap chain, an abrupt kill can leave the GPU driver with teardown work to reclaim
+// asynchronously; doing this repeatedly in quick succession -- which is exactly what the
+// editor's Play/Stop/Reload workflow does every time -- has been observed to race with that
+// reclaim on some AMD drivers, producing multi-second Present()/fence stalls or a device-removed
+// crash on a later relaunch. Asking each process to close itself first (WM_CLOSE, which runs
+// Godot's normal SceneTree::quit() -> RenderingDevice destruction -> swap chain release path)
+// avoids the race, at the cost of a bounded wait for processes that don't cooperate.
+//
+// This is batched (rather than being folded into kill() and called once per PID) so that
+// closing N processes at once -- e.g. the editor's multi-instance play/test feature -- shares
+// one timeout budget instead of paying it N times over serially.
+void OS_Windows::kill_multiple(const List<ProcessID> &p_pids, const List<ProcessID> &p_skip_graceful) {
+	if (p_pids.is_empty()) {
+		return;
+	}
+
+	// Note: process_map entries are intentionally NOT erased here yet, only looked up. Erasing
+	// early would make is_process_running()/get_process_exit_code() report "not running" for a
+	// pid the instant this function is called, even though the process may still legitimately
+	// be alive and running for most of the shared wait below -- they're only erased once each
+	// pid's actual fate (exited on its own, or hard-killed) is known, at the end of phase 3.
+	Vector<PendingKill> pending;
+	pending.resize(p_pids.size());
+	{
+		MutexLock lock(process_map_mutex);
+		int i = 0;
+		for (const ProcessID &pid : p_pids) {
+			PendingKill &pk = pending.write[i++];
+			pk.pid = pid;
+			if (process_map->has(pid)) {
+				pk.pi = (*process_map)[pid].pi;
+				pk.handle = pk.pi.hProcess;
+				pk.from_process_map = true;
+			} else {
+				pk.handle = OpenProcess(PROCESS_TERMINATE | SYNCHRONIZE, false, (DWORD)pid);
+			}
+		}
+	}
+
+	// Phase 1: ask everyone eligible to close, without waiting for any of them yet. Everyone
+	// else (skip-listed, or no window found to close) is simply left to be hard-killed in
+	// phase 3 below -- graceful_requested only ever narrows who phase 2 waits on, it must
+	// never be read as "does this still need killing" (that's what `exited` is for).
+	for (PendingKill &pk : pending) {
+		if (pk.handle == nullptr || p_skip_graceful.find(pk.pid) != nullptr) {
+			continue;
+		}
+		pk.graceful_requested = _post_close_to_windows((DWORD)pk.pid);
+	}
+
+	// Phase 2: wait once, against a single shared deadline, for everyone we just asked nicely.
+	// 400ms is a ceiling for the worst case (a target that doesn't cooperate), not a typical
+	// wait -- a normal clean quit finishes in tens of milliseconds, and WaitForMultipleObjects
+	// below returns as soon as each one actually exits rather than sitting out the full budget.
+	const uint64_t timeout_usec = 400 * 1000;
+	Vector<HANDLE> wait_handles;
+	Vector<int> wait_pending_indices;
+	for (int i = 0; i < pending.size(); i++) {
+		if (pending[i].graceful_requested) {
+			wait_handles.push_back(pending[i].handle);
+			wait_pending_indices.push_back(i);
+		}
+	}
+
+	if (!wait_handles.is_empty()) {
+		const uint64_t deadline_usec = OS::get_singleton()->get_ticks_usec() + timeout_usec;
+		while (!wait_handles.is_empty()) {
+			const uint64_t now_usec = OS::get_singleton()->get_ticks_usec();
+			if (now_usec >= deadline_usec) {
+				break;
+			}
+			const DWORD remaining_ms = (DWORD)MAX((uint64_t)1, (deadline_usec - now_usec) / 1000);
+			const DWORD result = WaitForMultipleObjects((DWORD)wait_handles.size(), wait_handles.ptr(), FALSE, remaining_ms);
+			const DWORD signaled_index = result - WAIT_OBJECT_0;
+			if (result == WAIT_TIMEOUT || result == WAIT_FAILED || signaled_index >= (DWORD)wait_handles.size()) {
+				break;
+			}
+			// This one exited on its own -- and ONLY this marks it as not needing phase 3.
+			pending.write[wait_pending_indices[signaled_index]].exited = true;
+			wait_handles.remove_at(signaled_index);
+			wait_pending_indices.remove_at(signaled_index);
+		}
+	}
+
+	// Phase 3: hard-kill anything not already confirmed exited above -- this covers targets
+	// that never got a graceful request at all (skip-listed or windowless) just as much as
+	// ones that were asked and didn't make the deadline. Each pid's fate is settled by the
+	// time its map entry is erased below, so is_process_running()/get_process_exit_code()
+	// never report a pid as gone before it actually is.
+	{
+		MutexLock lock(process_map_mutex);
+		for (const PendingKill &pk : pending) {
+			if (pk.from_process_map) {
+				process_map->erase(pk.pid);
+			}
+		}
+	}
+	for (PendingKill &pk : pending) {
+		if (pk.handle == nullptr) {
+			continue;
+		}
+		if (!pk.exited) {
+			TerminateProcess(pk.handle, 0);
+		}
+		if (pk.from_process_map) {
+			CloseHandle(pk.pi.hProcess);
+			CloseHandle(pk.pi.hThread);
+		} else {
+			CloseHandle(pk.handle);
+		}
+	}
+}
+
 int OS_Windows::get_process_id() const {
 	return _getpid();
 }

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -204,6 +204,7 @@ public:
 	virtual Dictionary execute_with_pipe(const String &p_path, const List<String> &p_arguments, bool p_blocking = true) override;
 	virtual Error create_process(const String &p_path, const List<String> &p_arguments, ProcessID *r_child_id = nullptr, bool p_open_console = false) override;
 	virtual Error kill(const ProcessID &p_pid) override;
+	virtual void kill_multiple(const List<ProcessID> &p_pids, const List<ProcessID> &p_skip_graceful = List<ProcessID>()) override;
 	virtual int get_process_id() const override;
 	virtual bool is_process_running(const ProcessID &p_pid) const override;
 	virtual int get_process_exit_code(const ProcessID &p_pid) const override;


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR fixes an issue with the D3D12 causing inconsistent freezes when running a project as well as semi-frequently causing graphics device timeouts on AMD GPUs. This issue was caused by the Play/Stop/Reload workflow abruptly `TerminateProcess()`ing game instances that hold a full screen D3D12 swap chain, racing with the driver's asynchronous swap-chain tear down.

## Additional information

This fix was tested on a device with an AMD RX 6600 XT graphics card running Windows 11. Numerous play / reload cycles were repeated with zero freezes or graphics device timeouts after building Godot with these changes. Also specifically tested multi-instance playing and stopping, stopping while paused at a debugger break point, and verifying that there were no orphaned processes.

I would like to make reviewers aware that I am not a seasoned C++ developer and the code in this PR is at their discretion to improve upon or rewrite. I hope that if anything, that the reviewers will become aware of what this PR highlights as an issue and that they might use this fix as a foundation for a more refined solution.

## AI Disclosure

Claude Code was used substantially to diagnose the root cause of this issue by analyzing crash logs and driver/GPU traces, as well as writing the implementation.
