### PR TITLE
Fix `TextEdit` add caret at carets reselecting

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5941,6 +5941,39 @@ void TextEdit::add_caret_at_carets(bool p_below) {
 
 	set_selection_mode(SELECTION_MODE_NONE);
 
+	HashSet<int> carets_to_select;
+	int carets_to_select_offset = 0;
+	if (has_selection()) {
+		// Get all carets that are connected to another caret that selects.
+		// A caret is considered connected if the `last_fit_x` matches and there are connecting carets on every line between.
+		// This lets selections continue after lines that are too small to select.
+		const PackedInt32Array sorted_carets = get_sorted_carets();
+		const int start_index = p_below ? 0 : (sorted_carets.size() - 1);
+		const int inc = p_below ? 1 : -1;
+		for (int i = start_index; i >= 0 && i < sorted_carets.size(); i += inc) {
+			int c = sorted_carets[i];
+			if (has_selection(c)) {
+				carets_to_select.insert(c);
+				continue;
+			}
+			// When adding carets below, search above for connected carets and vice versa.
+			for (int j = i - inc; j >= 0 && j < sorted_carets.size(); j -= inc) {
+				if (get_caret_line(sorted_carets[j]) == get_caret_line(c)) {
+					continue;
+				}
+				if (get_caret_line(sorted_carets[j]) != get_caret_line(c) - inc) {
+					break;
+				}
+				if (carets[sorted_carets[j]].last_fit_x == carets[c].last_fit_x && carets[sorted_carets[j]].selection.origin_last_fit_x == carets[c].selection.origin_last_fit_x) {
+					if (carets_to_select.has(sorted_carets[j])) {
+						carets_to_select.insert(c);
+					}
+					break;
+				}
+			}
+		}
+	}
+
 	begin_multicaret_edit();
 	int view_target_caret = -1;
 	int view_line = p_below ? -1 : INT_MAX;
@@ -5948,10 +5981,10 @@ void TextEdit::add_caret_at_carets(bool p_below) {
 	for (int i = 0; i < num_carets; i++) {
 		const int caret_line = get_caret_line(i);
 		const int caret_column = get_caret_column(i);
-		bool is_selected = has_selection(i) || carets[i].last_fit_x != carets[i].selection.origin_last_fit_x;
 		const int selection_origin_line = get_selection_origin_line(i);
 		const int selection_origin_column = get_selection_origin_column(i);
 		const int caret_wrap_index = get_caret_wrap_index(i);
+		const bool is_selected = carets_to_select.has(i - carets_to_select_offset);
 		const int selection_origin_wrap_index = !is_selected ? -1 : get_line_wrap_index_at_column(selection_origin_line, selection_origin_column);
 
 		if (caret_line == 0 && !p_below && (caret_wrap_index == 0 || selection_origin_wrap_index == 0)) {
@@ -6041,6 +6074,7 @@ void TextEdit::add_caret_at_carets(bool p_below) {
 			carets.insert(0, new_caret);
 			i++;
 			num_carets += 1;
+			carets_to_select_offset += 1;
 		}
 	}
 

--- a/tests/scene/test_text_edit.cpp
+++ b/tests/scene/test_text_edit.cpp
@@ -7258,6 +7258,19 @@ TEST_CASE("[SceneTree][TextEdit] multicaret") {
 		CHECK(text_edit->get_caret_line(2) == 2);
 		CHECK(text_edit->get_caret_column(2) == 4);
 
+		// Does not select after caret deselection.
+		text_edit->remove_secondary_carets();
+		text_edit->deselect();
+		text_edit->select(0, 0, 0, 1);
+		text_edit->deselect();
+		text_edit->add_caret_at_carets(true);
+		CHECK(text_edit->get_caret_count() == 2);
+		CHECK_FALSE(text_edit->has_selection());
+		CHECK(text_edit->get_caret_line(0) == 0);
+		CHECK(text_edit->get_caret_column(0) == 1);
+		CHECK(text_edit->get_caret_line(1) == 1);
+		CHECK(text_edit->get_caret_column(1) == 1);
+
 		text_edit->set_text("\tthis is\nsome\n\ttest text");
 		MessageQueue::get_singleton()->flush();
 


### PR DESCRIPTION

## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot/issues/123355

## Additional information

Added logic to properly detect which carets need to select when adding carets. Previously it was just checking if the selection origin last fit is different.
This checks carets above/below to see if it has a selection to know if each new caret should have a selection.
A simpler solution would be to just check if there is any selection, but there are some edge cases with that when you have multiple carets, some selected and some not.

Added a test.