### PR TITLE
Remove outdated comment about closed PR in `EditorResourcePicker`

### DIFF
--- a/editor/inspector/editor_resource_picker.cpp
+++ b/editor/inspector/editor_resource_picker.cpp
@@ -790,7 +790,6 @@ String EditorResourcePicker::_get_resource_type(const Ref<Resource> &p_resource)
 		return res_type;
 	}
 
-	// TODO: Replace with EditorFileSystem when PR #60606 is merged to use cached resource type.
 	String script_type = EditorNode::get_editor_data().script_class_get_name(res_script->get_path());
 	if (!script_type.is_empty()) {
 		res_type = script_type;


### PR DESCRIPTION
## What problem(s) does this PR solve?

This PR removes a comment that expects #60606 to be merged. Said PR was superseded (twice) by something that doesn't do what the comment expected, so it's irrelevant now.