### PR TITLE
Auto-reimport translation csv files after saving in the editor

### DIFF
--- a/editor/script/script_editor_plugin.cpp
+++ b/editor/script/script_editor_plugin.cpp
@@ -34,6 +34,7 @@
 #include "core/io/config_file.h"
 #include "core/io/file_access.h"
 #include "core/io/json.h"
+#include "core/io/resource_importer.h"
 #include "core/io/resource_loader.h"
 #include "core/io/resource_saver.h"
 #include "core/object/callable_mp.h"
@@ -2500,8 +2501,22 @@ Error ScriptEditor::_save_text_file(Ref<TextFile> p_text_file, const String &p_p
 
 	EditorFileSystem::get_singleton()->update_file(p_path);
 
+	_saved_reimport(p_path);
 	_res_saved_callback(sqscr);
 	return OK;
+}
+
+void ScriptEditor::_saved_reimport(const String &p_path) {
+	int order;
+	bool can_threads;
+	String importer;
+	Error err;
+
+	err = ResourceFormatImporter::get_singleton()->get_import_order_threads_and_importer(p_path, order, can_threads, importer);
+
+	if (err == OK && importer == "csv_translation") {
+		EditorFileSystem::get_singleton()->reimport_files({ p_path });
+	}
 }
 
 bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, bool p_grab_focus) {

--- a/editor/script/script_editor_plugin.h
+++ b/editor/script/script_editor_plugin.h
@@ -434,6 +434,7 @@ class ScriptEditor : public EditorDock {
 	HashSet<String> textfile_extensions;
 	Ref<TextFile> _load_text_file(const String &p_path, Error *r_error) const;
 	Error _save_text_file(Ref<TextFile> p_text_file, const String &p_path);
+	void _saved_reimport(const String &p_path);
 
 	void _on_find_in_files_result_selected(const String &p_path, int p_line_number, int p_begin, int p_end);
 	void _on_find_in_files_modified_files();


### PR DESCRIPTION
For short strings and only one or two languages (e.g. early dev) it's pretty easy to edit the csv files directly within the editor.

After editing you always then need to re-import the CSV file to regenerate the translations. Instead, we can auto-reimport to greatly improve turnaround time.

AI was used as a search engine to help find suitable methods `get_import_order_threads_and_importer` and `reimport_files`. All other work is my own.

## What problem(s) does this PR solve?

Speeds up iteration of translations especially small tweaks to strings, adding additional string codes, and smaller projects where the spreadsheets are not too large.

## Testing

I created a small project with a label and a few strings in a strings file. I've set the preview to [en] and the label to one of my strings. Then edited the strings file and saved using CTRL+S, saw a reimport popup, and also saw that my label had changed.

Added a gdscript file, edited this in the editor, saved the file, there wasn't a reimport popup.