### PR TITLE
Prevent Scene crash during import

### DIFF
--- a/editor/scene/scene_tree_editor.cpp
+++ b/editor/scene/scene_tree_editor.cpp
@@ -1899,7 +1899,7 @@ void SceneTreeEditor::_update_selection(TreeItem *item) {
 
 	NodePath np = item->get_metadata(0);
 
-	if (!get_scene_node()->has_node(np)) {
+	if (!is_inside_tree() || !get_scene_node() || !get_scene_node()->has_node(np)) {
 		return;
 	}
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #123380

## Additional information

The crash seems to be caused by scene tree update coming from a selection changed signal emitted after resource preview's queue flush. Not sure what emits the signal exactly; the scene is empty at that point. Since manual flush is involved, maybe it was only working because normally the scene is loaded before the deferred signal is received.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
