### PR TITLE
Use popup_file_dialog() in ColorPicker

### DIFF
--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -933,7 +933,7 @@ void ColorPicker::_load_palette() {
 
 	file_dialog->set_file_mode(FileDialog::FILE_MODE_OPEN_FILE);
 	file_dialog->set_current_file("");
-	file_dialog->popup_centered_ratio();
+	file_dialog->popup_file_dialog();
 }
 
 void ColorPicker::_save_palette(bool p_is_save_as) {
@@ -953,7 +953,7 @@ void ColorPicker::_save_palette(bool p_is_save_as) {
 
 		file_dialog->set_file_mode(FileDialog::FILE_MODE_SAVE_FILE);
 		file_dialog->set_current_file("new_palette.tres");
-		file_dialog->popup_centered_ratio();
+		file_dialog->popup_file_dialog();
 	}
 }
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

ColorPicker was using `popup_centered_ratio()` for its FileDialog. `popup_file_dialog()` should always be used for file dialogs, because it ensures correct size (`popup_centered_ratio()` is too big).

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
