### PR TITLE
[3.x] Fix GLES3 vertex-lighting shadows removing indirect specular in mobile

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -2195,6 +2195,7 @@ FRAGMENT_SHADER_CODE
 	vec3 diffuse_light;
 #ifdef USE_VERTEX_LIGHTING //ubershader-runtime
 
+	vec3 vertex_specular_light = specular_light_interp.rgb;
 	specular_light = specular_light_interp.rgb;
 	diffuse_light = diffuse_light_interp.rgb;
 #else //ubershader-runtime
@@ -2345,6 +2346,9 @@ FRAGMENT_SHADER_CODE
 #if defined(DIFFUSE_TOON)
 		//simplify for toon, as
 		specular_light *= specular * metallic * albedo * 2.0;
+#ifdef USE_VERTEX_LIGHTING //ubershader-runtime
+		vertex_specular_light *= specular * metallic * albedo * 2.0;
+#endif
 #else
 
 		// scales the specular reflections, needs to be be computed before lighting happens,
@@ -2357,6 +2361,9 @@ FRAGMENT_SHADER_CODE
 		float a004 = min(r.x * r.x, exp2(-9.28 * ndotv)) * r.x + r.y;
 		vec2 env = vec2(-1.04, 1.04) * a004 + r.zw;
 		specular_light *= env.x * F + env.y;
+#ifdef USE_VERTEX_LIGHTING //ubershader-runtime
+		vertex_specular_light *= env.x * F + env.y;
+#endif
 #endif
 	}
 
@@ -2535,7 +2542,7 @@ FRAGMENT_SHADER_CODE
 
 #ifdef USE_VERTEX_LIGHTING //ubershader-runtime
 	diffuse_light *= mix(vec3(1.0), light_attenuation, diffuse_light_interp.a);
-	specular_light *= mix(vec3(1.0), light_attenuation, specular_light_interp.a);
+	specular_light = specular_light - vertex_specular_light + vertex_specular_light * mix(vec3(1.0), light_attenuation, specular_light_interp.a);
 #else //ubershader-runtime
 	light_compute(normal, -light_direction_attenuation.xyz, eye_vec, binormal, tangent, light_color_energy.rgb, light_attenuation, albedo, transmission, light_params.z * specular_blob_intensity, roughness, metallic, specular, rim, rim_tint, clearcoat, clearcoat_gloss, anisotropy, diffuse_light, specular_light, alpha);
 #endif //ubershader-runtime


### PR DESCRIPTION
## Problem
Direct shadows erroneously remove indirect specular hightlights in Godot 3 GLES3 in vertex shading mode, which is the global default mode for mobile exports (Android, iOS or in my case my TV). Bug was introduced in cc2d862733f402bb2147367ff4dc955dac4d9e1f and exists since Godot 3.2.

### Without fix: (its just flat ambient color, the little bit of shading are reflections on my TV)
<img width="1346" height="757" alt="gles3_bug" src="https://github.com/user-attachments/assets/f0584292-2e66-4f28-b747-74370398423c" />

### After fix:
<img width="1346" height="757" alt="gles3_bug_fixed" src="https://github.com/user-attachments/assets/bdaa08bd-8f94-40f6-8d84-68908ac6d7d3" />

## Description
AI found this and this is the [second attempt](https://github.com/godotengine/godot/pull/123351). A reviewer requested to make this a one line fix, which [I think is not possible](https://github.com/godotengine/godot/pull/123351#issuecomment-5630713962). An [AI golfed a three-liner](https://github.com/jejay/godot/commit/538be8c34304ae7b58c5450b0edfdff74b733adc), but I am not proposing this seriously.

Because direct and indirect specuar are accumulated in the same variable, there needs to be some seperated bookkeeping. I compacted the code down to 8 lines and removed the comments.

I also [prompted AI to do it in another way](https://github.com/jejay/godot/commit/5c8dd573dd0da069873c0de0268307bcdb2250ed), instead directly seperating direct/indirect specular. It said this variant might have a bigger performane hit on non-vertex-lighting mode (Dekstop). I don't know, your call.

The pictures above are freshly taken with the new compact branch (and without for the before one). Did not test it for the toon shader yet.