### PR TITLE
[2D Editor] Fix some incorrect bind/unbind cases

### DIFF
--- a/editor/scene/2d/polygon_2d_editor_plugin.cpp
+++ b/editor/scene/2d/polygon_2d_editor_plugin.cpp
@@ -1564,17 +1564,17 @@ Polygon2DEditor::Polygon2DEditor() {
 	zoom_widget = memnew(EditorZoomWidget);
 	canvas->add_child(zoom_widget);
 	zoom_widget->set_anchors_and_offsets_preset(Control::PRESET_TOP_LEFT, Control::PRESET_MODE_MINSIZE, 2 * EDSCALE);
-	zoom_widget->connect("zoom_changed", callable_mp(this, &Polygon2DEditor::_update_zoom_and_pan).unbind(1).bind(true));
+	zoom_widget->connect("zoom_changed", callable_mp(this, &Polygon2DEditor::_update_zoom_and_pan).bind(true).unbind(1));
 	zoom_widget->set_shortcut_context(nullptr);
 
 	vscroll = memnew(VScrollBar);
 	vscroll->set_step(0.001);
 	canvas->add_child(vscroll);
-	vscroll->connect(SceneStringName(value_changed), callable_mp(this, &Polygon2DEditor::_update_zoom_and_pan).unbind(1).bind(false));
+	vscroll->connect(SceneStringName(value_changed), callable_mp(this, &Polygon2DEditor::_update_zoom_and_pan).bind(false).unbind(1));
 	hscroll = memnew(HScrollBar);
 	hscroll->set_step(0.001);
 	canvas->add_child(hscroll);
-	hscroll->connect(SceneStringName(value_changed), callable_mp(this, &Polygon2DEditor::_update_zoom_and_pan).unbind(1).bind(false));
+	hscroll->connect(SceneStringName(value_changed), callable_mp(this, &Polygon2DEditor::_update_zoom_and_pan).bind(false).unbind(1));
 
 	bone_scroll_main_vb = memnew(VBoxContainer);
 	bone_scroll_main_vb->set_custom_minimum_size(Size2(150 * EDSCALE, 0));

--- a/editor/scene/2d/sprite_2d_editor_plugin.cpp
+++ b/editor/scene/2d/sprite_2d_editor_plugin.cpp
@@ -671,15 +671,15 @@ Sprite2DEditor::Sprite2DEditor() {
 	zoom_widget = memnew(EditorZoomWidget);
 	debug_uv->add_child(zoom_widget);
 	zoom_widget->set_anchors_and_offsets_preset(Control::PRESET_TOP_LEFT, Control::PRESET_MODE_MINSIZE, 2 * EDSCALE);
-	zoom_widget->connect("zoom_changed", callable_mp(this, &Sprite2DEditor::_update_zoom_and_pan).unbind(1).bind(true));
+	zoom_widget->connect("zoom_changed", callable_mp(this, &Sprite2DEditor::_update_zoom_and_pan).bind(true).unbind(1));
 	zoom_widget->set_shortcut_context(nullptr);
 
 	v_scroll = memnew(VScrollBar);
 	debug_uv->add_child(v_scroll);
-	v_scroll->connect(SceneStringName(value_changed), callable_mp(this, &Sprite2DEditor::_update_zoom_and_pan).unbind(1).bind(false));
+	v_scroll->connect(SceneStringName(value_changed), callable_mp(this, &Sprite2DEditor::_update_zoom_and_pan).bind(false).unbind(1));
 	h_scroll = memnew(HScrollBar);
 	debug_uv->add_child(h_scroll);
-	h_scroll->connect(SceneStringName(value_changed), callable_mp(this, &Sprite2DEditor::_update_zoom_and_pan).unbind(1).bind(false));
+	h_scroll->connect(SceneStringName(value_changed), callable_mp(this, &Sprite2DEditor::_update_zoom_and_pan).bind(false).unbind(1));
 
 	debug_uv_dialog->connect(SceneStringName(confirmed), callable_mp(this, &Sprite2DEditor::_create_node));
 


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

The order of bind/unbind here is incorrect, see the following example for reference:
```gdscript
print.unbind(1).bind("Foo").call("Bar") # Prints "Bar", incorrect.
print.bind("Foo").unbind(1).call("Bar") # Prints "Foo", correct.
```

## Additional information

Couldn't tell any real difference in the behavior when testing the changes, not sure what to look for, so this might be more of a technically correctness issue

No AI used in making this PR.

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
