### PR TITLE
3D Editor: Add a new `AABB`-based focusing method

### DIFF
--- a/editor/scene/3d/node_3d_editor_plugin.cpp
+++ b/editor/scene/3d/node_3d_editor_plugin.cpp
@@ -3645,6 +3645,7 @@ Node3DEditor::Node3DEditor() {
 	ED_SHORTCUT("spatial_editor/insert_anim_key", TTRC("Insert Animation Key"), Key::K);
 	ED_SHORTCUT("spatial_editor/focus_origin", TTRC("Focus Origin"), Key::O);
 	ED_SHORTCUT("spatial_editor/focus_selection", TTRC("Focus Selection"), Key::F);
+	ED_SHORTCUT("spatial_editor/focus_aabb", TTRC("Focus Center AABB"), KeyModifierMask::CMD_OR_CTRL + Key::F);
 	ED_SHORTCUT_ARRAY("spatial_editor/align_transform_with_view", TTRC("Align Transform with View"),
 			{ int32_t(KeyModifierMask::ALT | KeyModifierMask::CTRL | Key::KP_0),
 					int32_t(KeyModifierMask::ALT | KeyModifierMask::CTRL | Key::M),

--- a/editor/scene/3d/node_3d_editor_viewport.cpp
+++ b/editor/scene/3d/node_3d_editor_viewport.cpp
@@ -2915,6 +2915,9 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 			_menu_option(VIEW_CENTER_TO_SELECTION);
 			times_focused_consecutively += 1;
 		}
+		if (ED_IS_SHORTCUT("spatial_editor/focus_aabb", event_mod)) {
+			_menu_option(VIEW_FOCUS_AABB);
+		}
 		if (ED_IS_SHORTCUT("spatial_editor/align_transform_with_view", event_mod)) {
 			_menu_option(VIEW_ALIGN_TRANSFORM_WITH_VIEW);
 		}
@@ -4401,6 +4404,10 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 			focus_selection();
 
 		} break;
+		case VIEW_FOCUS_AABB: {
+			focus_aabb();
+
+		} break;
 		case VIEW_ALIGN_TRANSFORM_WITH_VIEW: {
 			if (!get_selected_count()) {
 				break;
@@ -5419,6 +5426,66 @@ void Node3DEditorViewport::focus_selection() {
 	view_3d_controller->cursor.pos_x = center.x;
 	view_3d_controller->cursor.pos_y = center.y;
 	view_3d_controller->cursor.pos_z = center.z;
+}
+
+void Node3DEditorViewport::focus_aabb() {
+	Vector3 center;
+	int count = 0;
+	AABB combined_aabb;
+	bool aabb_valid = false;
+	float required_distance = 0.0f;
+
+	const List<Node *> &selection = editor_selection->get_top_selected_node_list();
+	if (selection.is_empty()) {
+		return;
+	}
+
+	LocalVector<Node *> stack;
+	for (Node *node : selection) {
+		stack.push_back(node);
+	}
+
+	while (!stack.is_empty()) {
+		Node *node = stack[stack.size() - 1];
+		stack.resize(stack.size() - 1);
+
+		VisualInstance3D *vi = Object::cast_to<VisualInstance3D>(node);
+		if (vi) {
+			AABB local_aabb = vi->get_aabb();
+			if (local_aabb.has_volume()) {
+				AABB global_aabb = vi->get_global_transform().xform(local_aabb);
+				if (!aabb_valid) {
+					combined_aabb = global_aabb;
+					aabb_valid = true;
+				} else {
+					combined_aabb = combined_aabb.merge(global_aabb);
+				}
+			}
+		}
+
+		for (int i = 0; i < node->get_child_count(); i++) {
+			stack.push_back(node->get_child(i));
+		}
+	}
+
+	if (aabb_valid) {
+		center = combined_aabb.get_center();
+		count = 1;
+
+		float aabb_radius = combined_aabb.get_size().length() * 0.5f;
+
+		float fov_rad = Math::deg_to_rad(get_fov());
+		required_distance = aabb_radius / Math::tan(fov_rad * 0.5f);
+		required_distance *= 1.2f;
+		required_distance = CLAMP(required_distance, get_znear() * 2.0f, get_zfar() * 0.8f);
+	}
+
+	if (count > 0) {
+		view_3d_controller->cursor.pos_x = center.x;
+		view_3d_controller->cursor.pos_y = center.y;
+		view_3d_controller->cursor.pos_z = center.z;
+		view_3d_controller->cursor.distance = required_distance;
+	}
 }
 
 void Node3DEditorViewport::assign_pending_data_pointers(Node3D *p_preview_node, AABB *p_preview_bounds, AcceptDialog *p_accept) {
@@ -6920,6 +6987,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p
 	view_display_menu->get_popup()->add_separator();
 	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_origin"), VIEW_CENTER_TO_ORIGIN);
 	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_selection"), VIEW_CENTER_TO_SELECTION);
+	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/focus_aabb"), VIEW_FOCUS_AABB);
 	view_display_menu->get_popup()->set_item_tooltip(-1, TTR("Press Focus Selection twice to start following the selection as it moves. Press it yet another time to stop following the selection."));
 	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/align_transform_with_view"), VIEW_ALIGN_TRANSFORM_WITH_VIEW);
 	view_display_menu->get_popup()->add_shortcut(ED_GET_SHORTCUT("spatial_editor/align_rotation_with_view"), VIEW_ALIGN_ROTATION_WITH_VIEW);

--- a/editor/scene/3d/node_3d_editor_viewport.h
+++ b/editor/scene/3d/node_3d_editor_viewport.h
@@ -157,6 +157,7 @@ class Node3DEditorViewport : public Control {
 		VIEW_REAR,
 		VIEW_CENTER_TO_ORIGIN,
 		VIEW_CENTER_TO_SELECTION,
+		VIEW_FOCUS_AABB,
 		VIEW_ALIGN_TRANSFORM_WITH_VIEW,
 		VIEW_ALIGN_ROTATION_WITH_VIEW,
 		VIEW_PERSPECTIVE,
@@ -563,6 +564,7 @@ public:
 	Point2 point_to_screen(const Vector3 &p_point);
 
 	void focus_selection();
+	void focus_aabb();
 
 	void assign_pending_data_pointers(
 			Node3D *p_preview_node,


### PR DESCRIPTION
Adds a new focusing method to the 3D editor based on the node's `AABB` center.

Current focus (The old hotkey was **F**; in this PR, it is now **Ctrl+F**):

<video src="https://github.com/user-attachments/assets/e861b4e4-c494-4396-b251-6669291e04fb" controls width="400"></video>

This PR (Hotkey **F**):

<video src="https://github.com/user-attachments/assets/2259738d-dd0b-4114-8ed0-253d73ed642a" controls width="400"></video>

**Edited.**
Uniform zooming added:
<video src="https://github.com/user-attachments/assets/c7fbf80f-afc9-430b-99fa-aa99a74c4467" controls width="400"></video>

We focus on a specific visual component of the content, even if its anchor point is far away.

## What problem(s) does this PR solve?

- Closes [Add AABB-based node focus mode](https://github.com/godotengine/godot-proposals/issues/15507).
- Closes [Add Frame Selection functionality to the 3D editor](https://github.com/godotengine/godot-proposals/issues/13447)

## Additional information

I noticed that they have started trying to use `LocalVector` within the engine core, so I used it as well.

AI intelligence was used to locate the file specifying the hotkey (**F**).

The 3D model is taken from [here](https://sketchfab.com/3d-models/ponytail-hair-for-character-8ddc5c1c6cda49bc80c9f3a675b0a6c4).
