### PR TITLE
Remove `Container` level `get_minimum_size` override

### DIFF
--- a/scene/gui/aspect_ratio_container.cpp
+++ b/scene/gui/aspect_ratio_container.cpp
@@ -33,6 +33,10 @@
 #include "core/object/class_db.h"
 #include "scene/gui/texture_rect.h"
 
+Size2 AspectRatioContainer::get_minimum_size() const {
+	return Container::_get_minimum_size();
+}
+
 void AspectRatioContainer::set_ratio(float p_ratio) {
 	if (ratio == p_ratio) {
 		return;

--- a/scene/gui/aspect_ratio_container.h
+++ b/scene/gui/aspect_ratio_container.h
@@ -38,6 +38,7 @@ class AspectRatioContainer : public Container {
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+	virtual Size2 get_minimum_size() const override;
 
 public:
 	enum StretchMode {

--- a/scene/gui/center_container.cpp
+++ b/scene/gui/center_container.cpp
@@ -36,7 +36,7 @@ Size2 CenterContainer::get_minimum_size() const {
 	if (use_top_left) {
 		return Size2();
 	}
-	return Container::get_minimum_size();
+	return Container::_get_minimum_size();
 }
 
 Size2 CenterContainer::get_desired_size() const {

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -91,7 +91,7 @@ void Container::remove_child_notify(Node *p_child) {
 	queue_sort();
 }
 
-Size2 Container::get_minimum_size() const {
+Size2 Container::_get_minimum_size() const {
 	Size2 min_size;
 
 	for (Node *child : iterate_children()) {

--- a/scene/gui/container.h
+++ b/scene/gui/container.h
@@ -55,7 +55,7 @@ protected:
 	virtual void move_child_notify(Node *p_child) override;
 	virtual void remove_child_notify(Node *p_child) override;
 
-	virtual Size2 get_minimum_size() const override;
+	Size2 _get_minimum_size() const;
 
 	GDVIRTUAL0RC(Vector<int>, _get_allowed_size_flags_horizontal)
 	GDVIRTUAL0RC(Vector<int>, _get_allowed_size_flags_vertical)

--- a/scene/gui/foldable_container.cpp
+++ b/scene/gui/foldable_container.cpp
@@ -40,7 +40,7 @@ Size2 FoldableContainer::get_minimum_size() const {
 	if (folded) {
 		return title_minimum_size;
 	}
-	Size2 ms = Container::get_minimum_size();
+	Size2 ms = Container::_get_minimum_size();
 	ms += theme_cache.panel_style->get_minimum_size();
 
 	return Size2(MAX(ms.width, title_minimum_size.width), ms.height + title_minimum_size.height);

--- a/scene/gui/graph_element.cpp
+++ b/scene/gui/graph_element.cpp
@@ -46,6 +46,10 @@ void GraphElement::_edit_set_position(const Point2 &p_position) {
 }
 #endif
 
+Size2 GraphElement::get_minimum_size() const {
+	return Container::_get_minimum_size();
+}
+
 void GraphElement::_resort() {
 	Size2 size = get_size();
 

--- a/scene/gui/graph_element.h
+++ b/scene/gui/graph_element.h
@@ -65,6 +65,8 @@ protected:
 
 	virtual void _resort();
 
+	virtual Size2 get_minimum_size() const override;
+
 	void _validate_property(PropertyInfo &p_property) const;
 
 public:

--- a/scene/gui/margin_container.cpp
+++ b/scene/gui/margin_container.cpp
@@ -33,7 +33,7 @@
 #include "scene/theme/theme_db.h"
 
 Size2 MarginContainer::get_minimum_size() const {
-	Size2 max = Container::get_minimum_size();
+	Size2 max = Container::_get_minimum_size();
 
 	max.width += (theme_cache.margin_left + theme_cache.margin_right);
 	max.height += (theme_cache.margin_top + theme_cache.margin_bottom);

--- a/scene/gui/panel_container.cpp
+++ b/scene/gui/panel_container.cpp
@@ -33,7 +33,7 @@
 #include "scene/theme/theme_db.h"
 
 Size2 PanelContainer::get_minimum_size() const {
-	Size2 ms = Container::get_minimum_size();
+	Size2 ms = Container::_get_minimum_size();
 
 	if (theme_cache.panel_style.is_valid()) {
 		ms += theme_cache.panel_style->get_minimum_size();

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -38,7 +38,7 @@ Size2 SubViewportContainer::get_minimum_size() const {
 	if (stretch) {
 		return Size2();
 	}
-	return Container::get_minimum_size();
+	return Container::_get_minimum_size();
 }
 
 void SubViewportContainer::set_stretch(bool p_enable) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #123392

In #118309, I standardized the `get_minimum_size` implementation for "basic" `Container` types, but in doing so, I overrode the GDVirtual caller method, thereby killing all user-defined custom `Container` classes' implementations of `_get_minimum_size()`...

This fix moves it from overriding the GDVirtual caller method to creating a new method (`virtual Size2 get_minimum_size() const override` -> `Size2 _get_minimum_size() const`), and changes all caller sites to match. 
`AspectRatioContainer` and `GraphElement` had had theirs fully removed; they are added back as basic indirections. 

## Additional information

Ideally, the `Control::get_minimum_size` and `Control::get_maximum_size` systems should be migrated to use the more standard GDVirtual implementation style, namely:
```cpp
Size2 Control::get_minimum_size() {
  ERR_READ_THREAD_GUARD_V(Size2());
  Size2 ms;
  if (!GDVIRTUAL_CALL(_get_minimum_size, ms)) {
    ms = _get_minimum_size();
  }
  return ms;
}
```
instead of the existing
```cpp
Size2 Control::get_minimum_size() const {
  ERR_READ_THREAD_GUARD_V(Size2());
  Vector2 ms;
  GDVIRTUAL_CALL(_get_minimum_size, ms);
  return ms;
}
```
such that all engine subclasses would override a `virtual Size2 _get_minimum_size()` instead of the current `virtual Size2 get_minimum_size()` (which is our GDVirtual caller method). This would let all custom `Control` subclasses override their parent's implementation instead of only a few, and it would prevent this kind of breakage in the future. This is not in scope for this bug fix, and I will open a follow-up PR for it. 