### PR TITLE
Allow `_get_minimum_size()` and `_get_maximum_size()` to always be overriden.

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -129,8 +129,7 @@
 			<return type="Vector2" />
 			<description>
 				Virtual method to be implemented by the user. Returns the maximum size for this control. Alternative to [member custom_maximum_size] for controlling maximum size via code. The actual maximum size will be the max value of these two (in each axis separately).
-				If not overridden, defaults to [constant Vector2.ZERO].
-				[b]Note:[/b] This method will not be called when the script is attached to a [Control] node that already overrides its maximum size (e.g. [ScrollContainer]).
+				If not overridden, defaults to [code]Vector2(-1, -1)[/code].
 				[b]Note:[/b] It is recommended to use [method get_bound_minimum_size] instead of [method get_combined_minimum_size] when implementing this method, as the former respects maximum size limits when calculating the minimum size, while the latter does not.
 			</description>
 		</method>
@@ -139,7 +138,6 @@
 			<description>
 				Virtual method to be implemented by the user. Returns the minimum size for this control. Alternative to [member custom_minimum_size] for controlling minimum size via code. The actual minimum size will be the max value of these two (in each axis separately).
 				If not overridden, defaults to [constant Vector2.ZERO].
-				[b]Note:[/b] This method will not be called when the script is attached to a [Control] node that already overrides its minimum size (e.g. [Label], [Button], [PanelContainer] etc.). It can only be used with most basic GUI nodes, like [Control], [Container], [Panel] etc.
 			</description>
 		</method>
 		<method name="_get_tooltip" qualifiers="virtual const">

--- a/editor/animation/animation_bezier_editor.cpp
+++ b/editor/animation/animation_bezier_editor.cpp
@@ -920,7 +920,7 @@ void AnimationBezierTrackEdit::set_animation_and_track(const Ref<Animation> &p_a
 	queue_redraw();
 }
 
-Size2 AnimationBezierTrackEdit::get_minimum_size() const {
+Size2 AnimationBezierTrackEdit::_get_minimum_size() const {
 	return Vector2(1, 1);
 }
 

--- a/editor/animation/animation_bezier_editor.h
+++ b/editor/animation/animation_bezier_editor.h
@@ -207,6 +207,8 @@ protected:
 	static void _bind_methods();
 	void _notification(int p_what);
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
 	static float get_bezier_key_value(Array p_bezier_key_array);
 
@@ -215,7 +217,6 @@ public:
 	Ref<Animation> get_animation() const;
 
 	void set_animation_and_track(const Ref<Animation> &p_animation, int p_track, bool p_read_only);
-	virtual Size2 get_minimum_size() const override;
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 
 	void set_timeline(AnimationTimelineEdit *p_timeline);

--- a/editor/animation/animation_blend_tree_editor_plugin.cpp
+++ b/editor/animation/animation_blend_tree_editor_plugin.cpp
@@ -98,7 +98,7 @@ void AnimationNodeBlendTreeEditor::_update_options_menu(bool p_has_input_ports) 
 	use_position_from_popup_menu = false;
 }
 
-Size2 AnimationNodeBlendTreeEditor::get_minimum_size() const {
+Size2 AnimationNodeBlendTreeEditor::_get_minimum_size() const {
 	return Size2(10, 200);
 }
 

--- a/editor/animation/animation_blend_tree_editor_plugin.h
+++ b/editor/animation/animation_blend_tree_editor_plugin.h
@@ -155,13 +155,13 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
 	static AnimationNodeBlendTreeEditor *get_singleton() { return singleton; }
 
 	void add_custom_type(const String &p_name, const Ref<Script> &p_script);
 	void remove_custom_type(const Ref<Script> &p_script);
-
-	virtual Size2 get_minimum_size() const override;
 
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) override;
 	virtual void edit(const Ref<AnimationNode> &p_node) override;

--- a/editor/animation/animation_track_editor.cpp
+++ b/editor/animation/animation_track_editor.cpp
@@ -1742,7 +1742,7 @@ void AnimationTimelineEdit::set_animation(const Ref<Animation> &p_animation, boo
 	queue_redraw();
 }
 
-Size2 AnimationTimelineEdit::get_minimum_size() const {
+Size2 AnimationTimelineEdit::_get_minimum_size() const {
 	Size2 ms = filter_track->get_minimum_size();
 	const Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 	const int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
@@ -2769,7 +2769,7 @@ NodePath AnimationTrackEdit::get_path() const {
 	return node_path;
 }
 
-Size2 AnimationTrackEdit::get_minimum_size() const {
+Size2 AnimationTrackEdit::_get_minimum_size() const {
 	Ref<Texture2D> texture = get_editor_theme_icon(SNAME("Object"));
 	const Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 	const int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
@@ -4021,7 +4021,7 @@ void AnimationTrackEditGroup::set_type_and_name(const Ref<Texture2D> &p_type, co
 	update_minimum_size();
 }
 
-Size2 AnimationTrackEditGroup::get_minimum_size() const {
+Size2 AnimationTrackEditGroup::_get_minimum_size() const {
 	const Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 	const int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
 	const int separation = get_theme_constant(SNAME("v_separation"), SNAME("ItemList"));
@@ -9521,7 +9521,7 @@ void AnimationMarkerEdit::set_animation(const Ref<Animation> &p_animation, bool 
 	queue_redraw();
 }
 
-Size2 AnimationMarkerEdit::get_minimum_size() const {
+Size2 AnimationMarkerEdit::_get_minimum_size() const {
 	Ref<Texture2D> texture = get_editor_theme_icon(SNAME("Object"));
 	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));

--- a/editor/animation/animation_track_editor.h
+++ b/editor/animation/animation_track_editor.h
@@ -256,6 +256,7 @@ class AnimationTimelineEdit : public Range {
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
+	virtual Size2 _get_minimum_size() const override;
 
 public:
 	int get_name_limit() const;
@@ -263,7 +264,6 @@ public:
 
 	float get_zoom_scale() const;
 
-	virtual Size2 get_minimum_size() const override;
 	void set_animation(const Ref<Animation> &p_animation, bool p_read_only);
 	void set_track_edit(AnimationTrackEdit *p_track_edit);
 	void set_editor(AnimationTrackEditor *p_editor);
@@ -384,6 +384,8 @@ protected:
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 
@@ -401,7 +403,6 @@ public:
 	bool is_moving_selection() const { return moving_selection; }
 	float get_moving_selection_offset() const { return moving_selection_offset; }
 	void set_animation(const Ref<Animation> &p_animation, bool p_read_only);
-	virtual Size2 get_minimum_size() const override;
 
 	void set_timeline(AnimationTimelineEdit *p_timeline);
 	void set_editor(AnimationTrackEditor *p_editor);
@@ -515,6 +516,8 @@ protected:
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
 	virtual Variant get_drag_data(const Point2 &p_point) override;
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
@@ -542,7 +545,6 @@ public:
 	AnimationTrackEditor *get_editor() const { return editor; }
 	NodePath get_path() const;
 	void set_animation_and_track(const Ref<Animation> &p_animation, int p_track, bool p_read_only);
-	virtual Size2 get_minimum_size() const override;
 
 	void set_timeline(AnimationTimelineEdit *p_timeline);
 	void set_editor(AnimationTrackEditor *p_editor);
@@ -592,9 +594,10 @@ protected:
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
 	void set_type_and_name(const Ref<Texture2D> &p_type, const String &p_name, const NodePath &p_node);
-	virtual Size2 get_minimum_size() const override;
 	void set_timeline(AnimationTimelineEdit *p_timeline);
 	void set_root(Node *p_root);
 	void set_editor(AnimationTrackEditor *p_editor);

--- a/editor/audio/editor_audio_buses.cpp
+++ b/editor/audio/editor_audio_buses.cpp
@@ -1682,7 +1682,7 @@ void EditorAudioMeterNotches::add_notch(float p_normalized_offset, float p_db_va
 	notches.push_back(AudioNotch(p_normalized_offset, p_db_value, p_render_value));
 }
 
-Size2 EditorAudioMeterNotches::get_minimum_size() const {
+Size2 EditorAudioMeterNotches::_get_minimum_size() const {
 	Ref<Font> font = get_theme_font(SceneStringName(font), SNAME("Label"));
 	int font_size = get_theme_font_size(SceneStringName(font_size), SNAME("Label"));
 	float font_height = font->get_height(font_size);

--- a/editor/audio/editor_audio_buses.h
+++ b/editor/audio/editor_audio_buses.h
@@ -287,12 +287,14 @@ private:
 		int font_size = 0;
 	} theme_cache;
 
+protected:
+	virtual Size2 _get_minimum_size() const override;
+
 public:
 	const float line_length = 5.0f;
 	const float label_space = 2.0f;
 
 	void add_notch(float p_normalized_offset, float p_db_value, bool p_render_value = false);
-	Size2 get_minimum_size() const override;
 
 private:
 	virtual void _update_theme_item_cache() override;

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -336,8 +336,8 @@ void ScriptEditorDebugger::_video_mem_export() {
 	file_dialog->popup_file_dialog();
 }
 
-Size2 ScriptEditorDebugger::get_minimum_size() const {
-	Size2 ms = MarginContainer::get_minimum_size();
+Size2 ScriptEditorDebugger::_get_minimum_size() const {
+	Size2 ms = MarginContainer::_get_minimum_size();
 	ms.y = MAX(ms.y, 250 * EDSCALE);
 	return ms;
 }

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -305,6 +305,8 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
 	enum EmbedShortcutAction {
 		EMBED_SUSPEND_TOGGLE,
@@ -384,8 +386,6 @@ public:
 
 	bool is_skip_breakpoints() const;
 	bool is_ignore_error_breaks() const;
-
-	virtual Size2 get_minimum_size() const override;
 
 	void add_debugger_tab(Control *p_control);
 	void remove_debugger_tab(Control *p_control);

--- a/editor/docks/editor_dock_manager.cpp
+++ b/editor/docks/editor_dock_manager.cpp
@@ -1178,6 +1178,6 @@ void DockSlotGrid::gui_input(const Ref<InputEvent> &p_event) {
 	}
 }
 
-Size2 DockSlotGrid::get_minimum_size() const {
+Size2 DockSlotGrid::_get_minimum_size() const {
 	return GRID_SIZE * CELL_SIZE * EDSCALE + (GRID_SIZE - Vector2i(1, 0)) * MARGINS * EDSCALE;
 }

--- a/editor/docks/editor_dock_manager.h
+++ b/editor/docks/editor_dock_manager.h
@@ -187,7 +187,7 @@ protected:
 	void _notification(int p_what);
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
-	virtual Size2 get_minimum_size() const override;
+	virtual Size2 _get_minimum_size() const override;
 
 public:
 	EditorDock *context_dock = nullptr;

--- a/editor/gui/editor_object_selector.cpp
+++ b/editor/gui/editor_object_selector.cpp
@@ -38,7 +38,7 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/margin_container.h"
 
-Size2 EditorObjectSelector::get_minimum_size() const {
+Size2 EditorObjectSelector::_get_minimum_size() const {
 	return main_mc->get_minimum_size();
 }
 

--- a/editor/gui/editor_object_selector.h
+++ b/editor/gui/editor_object_selector.h
@@ -59,9 +59,9 @@ class EditorObjectSelector : public Button {
 protected:
 	void _notification(int p_what);
 
-public:
-	virtual Size2 get_minimum_size() const override;
+	virtual Size2 _get_minimum_size() const override;
 
+public:
 	void update_path();
 	void clear_path();
 	void enable_path();

--- a/editor/gui/editor_spin_slider.cpp
+++ b/editor/gui/editor_spin_slider.cpp
@@ -60,7 +60,7 @@ String EditorSpinSlider::get_tooltip(const Point2 &p_pos) const {
 	return value;
 }
 
-Size2 EditorSpinSlider::get_minimum_size() const {
+Size2 EditorSpinSlider::_get_minimum_size() const {
 	Size2 ms = theme_cache.normal->get_minimum_size();
 	Ref<Texture2D> updown = read_only ? theme_cache.updown_disabled_icon : theme_cache.updown_icon;
 	ms.width += updown->get_width();

--- a/editor/gui/editor_spin_slider.h
+++ b/editor/gui/editor_spin_slider.h
@@ -127,10 +127,10 @@ protected:
 	void _grabber_mouse_exited();
 	void _focus_entered(bool p_hide_focus = false);
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
 	String get_tooltip(const Point2 &p_pos) const override;
-
-	virtual Size2 get_minimum_size() const override;
 
 	String get_text_value() const;
 	void set_label(const String &p_label);

--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -223,7 +223,7 @@ String EditorProperty::get_tooltip_string(const String &p_string) const {
 	return p_string.left(TOOLTIP_MAX_LENGTH).strip_edges() + String((p_string.length() > TOOLTIP_MAX_LENGTH) ? "..." : "");
 }
 
-Size2 EditorProperty::get_minimum_size() const {
+Size2 EditorProperty::_get_minimum_size() const {
 	if (theme_cache.font.is_null()) {
 		// Too early.
 		return Vector2();
@@ -2049,7 +2049,7 @@ void EditorInspectorCategory::set_color_level(int p_color_level) {
 	queue_redraw();
 }
 
-Size2 EditorInspectorCategory::get_minimum_size() const {
+Size2 EditorInspectorCategory::_get_minimum_size() const {
 	Size2 ms;
 	if (theme_cache.bold_font.is_valid()) {
 		ms.height = theme_cache.bold_font->get_height(theme_cache.bold_font_size);
@@ -2551,7 +2551,7 @@ void EditorInspectorSection::_notification(int p_what) {
 	}
 }
 
-Size2 EditorInspectorSection::get_minimum_size() const {
+Size2 EditorInspectorSection::_get_minimum_size() const {
 	Size2 ms;
 	for (int i = 0; i < get_child_count(); i++) {
 		Control *c = as_sortable_control(get_child(i));

--- a/editor/inspector/editor_inspector.h
+++ b/editor/inspector/editor_inspector.h
@@ -238,14 +238,14 @@ protected:
 	void _accessibility_action_menu(const Variant &p_data);
 	void _accessibility_action_click(const Variant &p_data);
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
 	static String get_property_warning(Object *p_object, const StringName &p_property);
 
 	void emit_changed(const StringName &p_property, const Variant &p_value, const StringName &p_field = StringName(), bool p_changing = false);
 
 	String get_tooltip_string(const String &p_string) const;
-
-	virtual Size2 get_minimum_size() const override;
 
 	void set_label(const String &p_label);
 	String get_label() const;
@@ -445,6 +445,8 @@ protected:
 	void _notification(int p_what);
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
+	virtual Size2 _get_minimum_size() const override;
+
 	void _accessibility_action_menu(const Variant &p_data);
 
 public:
@@ -455,7 +457,6 @@ public:
 
 	void register_property(EditorProperty *p_property) { category_properties.push_back(p_property); }
 
-	virtual Size2 get_minimum_size() const override;
 	virtual Control *make_custom_tooltip(const String &p_text) const override;
 
 	EditorInspectorCategory();
@@ -564,11 +565,12 @@ protected:
 	static void _bind_methods();
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
+	virtual Size2 _get_minimum_size() const override;
+
 	void _accessibility_action_collapse(const Variant &p_data);
 	void _accessibility_action_expand(const Variant &p_data);
 
 public:
-	virtual Size2 get_minimum_size() const override;
 	virtual Control *make_custom_tooltip(const String &p_text) const override;
 
 	void setup(const String &p_section, const String &p_label, Object *p_object, const Color &p_bg_color, bool p_foldable, int p_indent_depth = 0, int p_level = 1);

--- a/editor/inspector/editor_properties.cpp
+++ b/editor/inspector/editor_properties.cpp
@@ -1143,7 +1143,7 @@ void EditorPropertyLayersGrid::set_read_only(bool p_read_only) {
 	read_only = p_read_only;
 }
 
-Size2 EditorPropertyLayersGrid::get_minimum_size() const {
+Size2 EditorPropertyLayersGrid::_get_minimum_size() const {
 	Size2 min_size = get_grid_size();
 
 	// Add extra rows when expanded.

--- a/editor/inspector/editor_properties.h
+++ b/editor/inspector/editor_properties.h
@@ -341,6 +341,7 @@ private:
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+	virtual Size2 _get_minimum_size() const override;
 
 public:
 	uint32_t value = 0;
@@ -350,7 +351,6 @@ public:
 	Vector<String> tooltips;
 
 	void set_read_only(bool p_read_only);
-	virtual Size2 get_minimum_size() const override;
 	virtual String get_tooltip(const Point2 &p_pos) const override;
 	void gui_input(const Ref<InputEvent> &p_ev) override;
 	void set_flag(uint32_t p_flag);

--- a/editor/scene/curve_editor_plugin.cpp
+++ b/editor/scene/curve_editor_plugin.cpp
@@ -109,7 +109,7 @@ void CurveEdit::set_snap_count(int p_snap_count) {
 	}
 }
 
-Size2 CurveEdit::get_minimum_size() const {
+Size2 CurveEdit::_get_minimum_size() const {
 	return Vector2(64, MAX(135, get_size().x * ASPECT_RATIO)) * EDSCALE;
 }
 

--- a/editor/scene/curve_editor_plugin.h
+++ b/editor/scene/curve_editor_plugin.h
@@ -52,8 +52,6 @@ public:
 	void set_curve(Ref<Curve> p_curve);
 	Ref<Curve> get_curve();
 
-	Size2 get_minimum_size() const override;
-
 	enum PresetID {
 		PRESET_CONSTANT = 0,
 		PRESET_LINEAR,
@@ -72,6 +70,7 @@ public:
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+	virtual Size2 _get_minimum_size() const override;
 
 private:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;

--- a/editor/scene/gui/control_editor_plugin.cpp
+++ b/editor/scene/gui/control_editor_plugin.cpp
@@ -531,7 +531,7 @@ bool EditorInspectorPluginControl::parse_property(Object *p_object, const Varian
 
 // Toolbars controls.
 
-Size2 ControlEditorPopupButton::get_minimum_size() const {
+Size2 ControlEditorPopupButton::_get_minimum_size() const {
 	Vector2 base_size = Vector2(26, 26) * EDSCALE;
 
 	if (arrow_icon.is_null()) {

--- a/editor/scene/gui/control_editor_plugin.h
+++ b/editor/scene/gui/control_editor_plugin.h
@@ -151,9 +151,9 @@ class ControlEditorPopupButton : public Button {
 
 protected:
 	void _notification(int p_what);
+	virtual Size2 _get_minimum_size() const override;
 
 public:
-	virtual Size2 get_minimum_size() const override;
 	virtual void toggled(bool p_pressed) override;
 
 	VBoxContainer *get_popup_hbox() const { return popup_vbox; }

--- a/editor/scene/gui/font_config_plugin.cpp
+++ b/editor/scene/gui/font_config_plugin.cpp
@@ -948,7 +948,7 @@ void FontPreview::_notification(int p_what) {
 	}
 }
 
-Size2 FontPreview::get_minimum_size() const {
+Size2 FontPreview::_get_minimum_size() const {
 	return Vector2(64, 64) * EDSCALE;
 }
 

--- a/editor/scene/gui/font_config_plugin.h
+++ b/editor/scene/gui/font_config_plugin.h
@@ -205,13 +205,13 @@ class FontPreview : public Control {
 protected:
 	void _notification(int p_what);
 
+	virtual Size2 _get_minimum_size() const override;
+
 	Ref<Font> prev_font;
 
 	void _preview_changed();
 
 public:
-	virtual Size2 get_minimum_size() const override;
-
 	void set_data(const Ref<Font> &p_f);
 };
 

--- a/editor/scene/gui/theme_editor_preview.cpp
+++ b/editor/scene/gui/theme_editor_preview.cpp
@@ -74,8 +74,8 @@ void ScalableContainer::_notification(int p_what) {
 	}
 }
 
-Size2 ScalableContainer::get_minimum_size() const {
-	return MarginContainer::get_minimum_size() * EDSCALE;
+Size2 ScalableContainer::_get_minimum_size() const {
+	return MarginContainer::_get_minimum_size() * EDSCALE;
 }
 
 ScalableContainer::ScalableContainer() {

--- a/editor/scene/gui/theme_editor_preview.h
+++ b/editor/scene/gui/theme_editor_preview.h
@@ -46,9 +46,9 @@ class ScalableContainer : public MarginContainer {
 protected:
 	void _notification(int p_what);
 
-public:
-	virtual Size2 get_minimum_size() const override;
+	virtual Size2 _get_minimum_size() const override;
 
+public:
 	ScalableContainer();
 };
 

--- a/editor/shader/shader_text_editor.cpp
+++ b/editor/shader/shader_text_editor.cpp
@@ -127,9 +127,9 @@ TextShaderPreviewLineLayer::TextShaderPreviewLineLayer() {
 /***  SHADER PREVIEW ****/
 
 class SquareMarginContainer : public MarginContainer {
-public:
-	Size2 get_minimum_size() const override {
-		Size2 ms = MarginContainer::get_minimum_size();
+protected:
+	virtual Size2 _get_minimum_size() const override {
+		Size2 ms = MarginContainer::_get_minimum_size();
 		float side = MAX(get_size().x, ms.y);
 		return Size2(ms.x, side);
 	}

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.cpp
@@ -9336,7 +9336,7 @@ void VisualShaderNodePortPreview::setup(const Ref<ShaderGraph> &p_shader_graph, 
 	_shader_changed();
 }
 
-Size2 VisualShaderNodePortPreview::get_minimum_size() const {
+Size2 VisualShaderNodePortPreview::_get_minimum_size() const {
 	int port_preview_size = EDITOR_GET("editors/visual_editors/visual_shader/port_preview_size");
 	return Size2(port_preview_size, port_preview_size) * EDSCALE;
 }

--- a/modules/visual_shader/editor/visual_shader_editor_plugin.h
+++ b/modules/visual_shader/editor/visual_shader_editor_plugin.h
@@ -830,9 +830,9 @@ class VisualShaderNodePortPreview : public Control {
 	void _shader_changed(); //must regen
 protected:
 	void _notification(int p_what);
+	virtual Size2 _get_minimum_size() const override;
 
 public:
-	virtual Size2 get_minimum_size() const override;
 	void setup(const Ref<ShaderGraph> &p_shader_graph, Ref<ShaderMaterial> &p_preview_material, bool p_has_transparency, int p_node, int p_port, bool p_is_valid);
 };
 

--- a/scene/gui/aspect_ratio_container.cpp
+++ b/scene/gui/aspect_ratio_container.cpp
@@ -33,10 +33,6 @@
 #include "core/object/class_db.h"
 #include "scene/gui/texture_rect.h"
 
-Size2 AspectRatioContainer::get_minimum_size() const {
-	return Container::_get_minimum_size();
-}
-
 void AspectRatioContainer::set_ratio(float p_ratio) {
 	if (ratio == p_ratio) {
 		return;

--- a/scene/gui/aspect_ratio_container.h
+++ b/scene/gui/aspect_ratio_container.h
@@ -38,7 +38,6 @@ class AspectRatioContainer : public Container {
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
-	virtual Size2 get_minimum_size() const override;
 
 public:
 	enum StretchMode {

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -357,7 +357,7 @@ Size2 BoxContainer::_get_minimum_size(bool p_use_desired_sizes) const {
 	return minimum;
 }
 
-Size2 BoxContainer::get_minimum_size() const {
+Size2 BoxContainer::_get_minimum_size() const {
 	return _get_minimum_size(false);
 }
 

--- a/scene/gui/box_container.h
+++ b/scene/gui/box_container.h
@@ -62,6 +62,8 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
 	Control *add_spacer(bool p_begin = false);
 
@@ -74,7 +76,6 @@ public:
 	void set_reverse_sort(bool p_reverse_sort);
 	bool is_reverse_sort() const;
 
-	virtual Size2 get_minimum_size() const override;
 	virtual Size2 get_desired_size() const override;
 
 	virtual Vector<int> get_allowed_size_flags_horizontal() const override;

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -36,7 +36,7 @@
 #include "scene/theme/theme_db.h"
 #include "servers/display/accessibility_server.h"
 
-Size2 Button::get_minimum_size() const {
+Size2 Button::_get_minimum_size() const {
 	Ref<Texture2D> _icon = icon;
 	if (_icon.is_null() && has_theme_icon(SNAME("icon"))) {
 		_icon = theme_cache.icon;

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -122,9 +122,9 @@ protected:
 
 	virtual String _get_accessibility_name() const override;
 
-public:
-	virtual Size2 get_minimum_size() const override;
+	virtual Size2 _get_minimum_size() const override;
 
+public:
 	Size2 get_minimum_size_for_text_and_icon(const String &p_text, Ref<Texture2D> p_icon) const;
 
 	void set_text(const String &p_text);

--- a/scene/gui/center_container.cpp
+++ b/scene/gui/center_container.cpp
@@ -32,7 +32,7 @@
 
 #include "core/object/class_db.h"
 
-Size2 CenterContainer::get_minimum_size() const {
+Size2 CenterContainer::_get_minimum_size() const {
 	if (use_top_left) {
 		return Size2();
 	}

--- a/scene/gui/center_container.h
+++ b/scene/gui/center_container.h
@@ -41,11 +41,12 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
 	void set_use_top_left(bool p_enable);
 	bool is_using_top_left() const;
 
-	virtual Size2 get_minimum_size() const override;
 	virtual Size2 get_desired_size() const override;
 
 	virtual Vector<int> get_allowed_size_flags_horizontal() const override;

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -62,8 +62,8 @@ Size2 CheckBox::get_icon_size() const {
 	return _fit_icon_size(tex_size);
 }
 
-Size2 CheckBox::get_minimum_size() const {
-	Size2 minsize = Button::get_minimum_size();
+Size2 CheckBox::_get_minimum_size() const {
+	Size2 minsize = Button::_get_minimum_size();
 	const Size2 tex_size = get_icon_size();
 	if (tex_size.width > 0 || tex_size.height > 0) {
 		const Size2 padding = _get_largest_stylebox_size();

--- a/scene/gui/check_box.h
+++ b/scene/gui/check_box.h
@@ -55,7 +55,7 @@ class CheckBox : public Button {
 
 protected:
 	Size2 get_icon_size() const;
-	Size2 get_minimum_size() const override;
+	virtual Size2 _get_minimum_size() const override;
 
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -66,8 +66,8 @@ Size2 CheckButton::get_icon_size() const {
 	return _fit_icon_size(tex_size);
 }
 
-Size2 CheckButton::get_minimum_size() const {
-	Size2 minsize = Button::get_minimum_size();
+Size2 CheckButton::_get_minimum_size() const {
+	Size2 minsize = Button::_get_minimum_size();
 	const Size2 tex_size = get_icon_size();
 	if (tex_size.width > 0 || tex_size.height > 0) {
 		const Size2 padding = _get_largest_stylebox_size();

--- a/scene/gui/check_button.h
+++ b/scene/gui/check_button.h
@@ -55,7 +55,7 @@ class CheckButton : public Button {
 
 protected:
 	Size2 get_icon_size() const;
-	virtual Size2 get_minimum_size() const override;
+	virtual Size2 _get_minimum_size() const override;
 
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/scene/gui/container.h
+++ b/scene/gui/container.h
@@ -55,7 +55,7 @@ protected:
 	virtual void move_child_notify(Node *p_child) override;
 	virtual void remove_child_notify(Node *p_child) override;
 
-	Size2 _get_minimum_size() const;
+	virtual Size2 _get_minimum_size() const override;
 
 	GDVIRTUAL0RC(Vector<int>, _get_allowed_size_flags_horizontal)
 	GDVIRTUAL0RC(Vector<int>, _get_allowed_size_flags_vertical)

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1859,7 +1859,9 @@ Size2 Control::get_custom_maximum_size() const {
 Size2 Control::get_maximum_size() const {
 	ERR_READ_THREAD_GUARD_V(Size2());
 	Vector2 ms = Vector2(-1, -1);
-	GDVIRTUAL_CALL(_get_maximum_size, ms);
+	if (!GDVIRTUAL_CALL(_get_maximum_size, ms)) {
+		ms = _get_maximum_size();
+	}
 	return ms;
 }
 
@@ -1981,7 +1983,9 @@ void Control::set_block_minimum_size_adjust(bool p_block) {
 Size2 Control::get_minimum_size() const {
 	ERR_READ_THREAD_GUARD_V(Size2());
 	Vector2 ms;
-	GDVIRTUAL_CALL(_get_minimum_size, ms);
+	if (!GDVIRTUAL_CALL(_get_minimum_size, ms)) {
+		ms = _get_minimum_size();
+	}
 	return ms;
 }
 

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -444,6 +444,11 @@ protected:
 
 	virtual StringName _get_translation_context_with_override(const StringName &p_context) const override;
 
+	// Sizing.
+
+	virtual Size2 _get_minimum_size() const { return Size2(); }
+	virtual Size2 _get_maximum_size() const { return Size2(-1, -1); }
+
 	// Theming.
 
 	virtual void _update_theme_item_cache();
@@ -634,7 +639,7 @@ public:
 	void set_block_maximum_size_adjust(bool p_block);
 	void set_block_minimum_size_adjust(bool p_block);
 
-	virtual Size2 get_maximum_size() const;
+	Size2 get_maximum_size() const;
 	virtual Size2 get_combined_maximum_size() const;
 	virtual Size2 get_inner_combined_maximum_size() const;
 
@@ -643,7 +648,7 @@ public:
 
 	void set_parent_maximum_size_cache(const Size2 &p_size);
 
-	virtual Size2 get_minimum_size() const;
+	Size2 get_minimum_size() const;
 	virtual Size2 get_combined_minimum_size() const;
 
 	void set_custom_minimum_size(const Size2 &p_custom);

--- a/scene/gui/flow_container.cpp
+++ b/scene/gui/flow_container.cpp
@@ -412,7 +412,7 @@ Size2 FlowContainer::_get_minimum_size(bool p_use_desired_sizes) const {
 	return minimum;
 }
 
-Size2 FlowContainer::get_minimum_size() const {
+Size2 FlowContainer::_get_minimum_size() const {
 	return _get_minimum_size(false);
 }
 

--- a/scene/gui/flow_container.h
+++ b/scene/gui/flow_container.h
@@ -73,6 +73,8 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
 	int get_line_count() const;
 	int get_line_max_child_count() const;
@@ -89,7 +91,6 @@ public:
 	void set_reverse_fill(bool p_reverse_fill);
 	bool is_reverse_fill() const;
 
-	virtual Size2 get_minimum_size() const override;
 	virtual Size2 get_desired_size() const override;
 
 	virtual Vector<int> get_allowed_size_flags_horizontal() const override;

--- a/scene/gui/foldable_container.cpp
+++ b/scene/gui/foldable_container.cpp
@@ -34,7 +34,7 @@
 #include "scene/resources/text_line.h"
 #include "scene/theme/theme_db.h"
 
-Size2 FoldableContainer::get_minimum_size() const {
+Size2 FoldableContainer::_get_minimum_size() const {
 	_update_title_min_size();
 
 	if (folded) {

--- a/scene/gui/foldable_container.h
+++ b/scene/gui/foldable_container.h
@@ -106,6 +106,8 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
 	void fold();
 	void expand();
@@ -137,7 +139,6 @@ public:
 	void add_title_bar_control(Control *p_control);
 	void remove_title_bar_control(Control *p_control);
 
-	virtual Size2 get_minimum_size() const override;
 	virtual Size2 get_desired_size() const override;
 	virtual Size2 get_inner_combined_maximum_size() const override;
 

--- a/scene/gui/graph_element.cpp
+++ b/scene/gui/graph_element.cpp
@@ -46,10 +46,6 @@ void GraphElement::_edit_set_position(const Point2 &p_position) {
 }
 #endif
 
-Size2 GraphElement::get_minimum_size() const {
-	return Container::_get_minimum_size();
-}
-
 void GraphElement::_resort() {
 	Size2 size = get_size();
 

--- a/scene/gui/graph_element.h
+++ b/scene/gui/graph_element.h
@@ -65,8 +65,6 @@ protected:
 
 	virtual void _resort();
 
-	virtual Size2 get_minimum_size() const override;
-
 	void _validate_property(PropertyInfo &p_property) const;
 
 public:

--- a/scene/gui/graph_frame.cpp
+++ b/scene/gui/graph_frame.cpp
@@ -352,7 +352,7 @@ Size2 GraphFrame::_get_minimum_size(bool p_use_desired_sizes) const {
 	return minsize;
 }
 
-Size2 GraphFrame::get_minimum_size() const {
+Size2 GraphFrame::_get_minimum_size() const {
 	return _get_minimum_size(false);
 }
 

--- a/scene/gui/graph_frame.h
+++ b/scene/gui/graph_frame.h
@@ -73,6 +73,8 @@ protected:
 
 	virtual void _resort() override;
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
 	void set_title(const String &p_title);
 	String get_title() const;
@@ -96,7 +98,6 @@ public:
 	Color get_tint_color() const;
 
 	virtual bool has_point(const Point2 &p_point) const override;
-	virtual Size2 get_minimum_size() const override;
 	virtual Size2 get_desired_size() const override;
 
 	GraphFrame();

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -1039,7 +1039,7 @@ Size2 GraphNode::_get_minimum_size(bool p_use_desired_sizes) const {
 	return minsize;
 }
 
-Size2 GraphNode::get_minimum_size() const {
+Size2 GraphNode::_get_minimum_size() const {
 	return _get_minimum_size(false);
 }
 

--- a/scene/gui/graph_node.h
+++ b/scene/gui/graph_node.h
@@ -133,6 +133,8 @@ protected:
 
 	virtual String _get_accessibility_name() const override;
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
 	virtual String get_accessibility_container_name(const Node *p_node) const override;
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
@@ -197,7 +199,6 @@ public:
 	void set_slots_focus_mode(Control::FocusMode p_focus_mode);
 	Control::FocusMode get_slots_focus_mode() const;
 
-	virtual Size2 get_minimum_size() const override;
 	virtual Size2 get_desired_size() const override;
 
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -493,7 +493,7 @@ Size2 GridContainer::_get_minimum_size(bool p_use_desired_sizes) const {
 	return ms;
 }
 
-Size2 GridContainer::get_minimum_size() const {
+Size2 GridContainer::_get_minimum_size() const {
 	return _get_minimum_size(false);
 }
 

--- a/scene/gui/grid_container.h
+++ b/scene/gui/grid_container.h
@@ -45,6 +45,7 @@ class GridContainer : public Container {
 private:
 	void _resort();
 	Size2 _get_minimum_size(bool p_use_desired_sizes) const;
+	virtual Size2 _get_minimum_size() const override;
 
 protected:
 	void _notification(int p_what);
@@ -53,7 +54,6 @@ protected:
 public:
 	void set_columns(int p_columns);
 	int get_columns() const;
-	virtual Size2 get_minimum_size() const override;
 	virtual Size2 get_desired_size() const override;
 
 	int get_h_separation() const;

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -2190,7 +2190,7 @@ bool ItemList::is_anything_selected() {
 	return false;
 }
 
-Size2 ItemList::get_minimum_size() const {
+Size2 ItemList::_get_minimum_size() const {
 	Size2 min_size;
 	if (auto_width) {
 		min_size.x = auto_width_value;

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -204,6 +204,8 @@ protected:
 	bool _property_get_revert(const StringName &p_name, Variant &r_property) const { return property_helper.property_get_revert(p_name, r_property); }
 	static void _bind_methods();
 
+	virtual Size2 _get_minimum_size() const override;
+
 	void _accessibility_action_scroll_set(const Variant &p_data);
 	void _accessibility_action_scroll_up(const Variant &p_data);
 	void _accessibility_action_scroll_down(const Variant &p_data);
@@ -345,8 +347,6 @@ public:
 
 	void set_wraparound_items(bool p_enable);
 	bool has_wraparound_items() const;
-
-	Size2 get_minimum_size() const override;
 
 	void set_autoscroll_to_bottom(const bool p_enable);
 

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -1055,7 +1055,7 @@ Rect2 Label::get_character_bounds(int p_pos) const {
 	return Rect2();
 }
 
-Size2 Label::get_minimum_size() const {
+Size2 Label::_get_minimum_size() const {
 	_ensure_shaped();
 
 	Size2 min_size = minsize;

--- a/scene/gui/label.h
+++ b/scene/gui/label.h
@@ -121,8 +121,9 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 #endif
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
-	virtual Size2 get_minimum_size() const override;
 	virtual Size2 get_desired_size() const override;
 	virtual PackedStringArray get_configuration_warnings() const override;
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2461,7 +2461,7 @@ void LineEdit::clear_internal() {
 	queue_redraw();
 }
 
-Size2 LineEdit::get_minimum_size() const {
+Size2 LineEdit::_get_minimum_size() const {
 	Ref<Font> font = theme_cache.font;
 	int font_size = theme_cache.font_size;
 

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -284,6 +284,8 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	static void _bind_methods();
 
+	virtual Size2 _get_minimum_size() const override;
+
 #ifndef DISABLE_DEPRECATED
 	void _edit_bind_compat_111117();
 	static void _bind_compatibility_methods();
@@ -407,8 +409,6 @@ public:
 
 	void set_secret_character(const String &p_string);
 	String get_secret_character() const;
-
-	virtual Size2 get_minimum_size() const override;
 
 	void set_expand_to_text_length_enabled(bool p_enabled);
 	bool is_expand_to_text_length_enabled() const;

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -198,7 +198,7 @@ void LinkButton::pressed() {
 	OS::get_singleton()->shell_open(uri);
 }
 
-Size2 LinkButton::get_minimum_size() const {
+Size2 LinkButton::_get_minimum_size() const {
 	Size2 minsize = text_buf->get_size();
 	if (overrun_behavior != TextServer::OVERRUN_NO_TRIMMING) {
 		minsize.width = 0;

--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -83,10 +83,11 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	virtual Size2 _get_minimum_size() const override;
+
 	virtual String _get_accessibility_name() const override;
 
 public:
-	virtual Size2 get_minimum_size() const override;
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 
 	void set_text(const String &p_text);

--- a/scene/gui/margin_container.cpp
+++ b/scene/gui/margin_container.cpp
@@ -32,7 +32,7 @@
 
 #include "scene/theme/theme_db.h"
 
-Size2 MarginContainer::get_minimum_size() const {
+Size2 MarginContainer::_get_minimum_size() const {
 	Size2 max = Container::_get_minimum_size();
 
 	max.width += (theme_cache.margin_left + theme_cache.margin_right);

--- a/scene/gui/margin_container.h
+++ b/scene/gui/margin_container.h
@@ -46,8 +46,9 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
-	virtual Size2 get_minimum_size() const override;
 	virtual Size2 get_desired_size() const override;
 	virtual Size2 get_inner_combined_maximum_size() const override;
 

--- a/scene/gui/menu_bar.cpp
+++ b/scene/gui/menu_bar.cpp
@@ -872,7 +872,7 @@ bool MenuBar::is_prefer_global_menu() const {
 	return prefer_native;
 }
 
-Size2 MenuBar::get_minimum_size() const {
+Size2 MenuBar::_get_minimum_size() const {
 	if (is_native_menu()) {
 		return Size2();
 	}

--- a/scene/gui/menu_bar.h
+++ b/scene/gui/menu_bar.h
@@ -147,6 +147,8 @@ protected:
 	virtual void remove_child_notify(Node *p_child) override;
 	static void _bind_methods();
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
@@ -158,8 +160,6 @@ public:
 	bool is_prefer_global_menu() const;
 
 	bool is_native_menu() const;
-
-	virtual Size2 get_minimum_size() const override;
 
 	int get_menu_count() const;
 

--- a/scene/gui/nine_patch_rect.cpp
+++ b/scene/gui/nine_patch_rect.cpp
@@ -52,7 +52,7 @@ void NinePatchRect::_notification(int p_what) {
 	}
 }
 
-Size2 NinePatchRect::get_minimum_size() const {
+Size2 NinePatchRect::_get_minimum_size() const {
 	return Size2(margin[SIDE_LEFT] + margin[SIDE_RIGHT], margin[SIDE_TOP] + margin[SIDE_BOTTOM]);
 }
 

--- a/scene/gui/nine_patch_rect.h
+++ b/scene/gui/nine_patch_rect.h
@@ -56,9 +56,9 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-public:
-	virtual Size2 get_minimum_size() const override;
+	virtual Size2 _get_minimum_size() const override;
 
+public:
 	void set_texture(const Ref<Texture2D> &p_tex);
 	Ref<Texture2D> get_texture() const;
 

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -52,12 +52,12 @@ void OptionButton::shortcut_input(const Ref<InputEvent> &p_event) {
 	Button::shortcut_input(p_event);
 }
 
-Size2 OptionButton::get_minimum_size() const {
+Size2 OptionButton::_get_minimum_size() const {
 	Size2 minsize;
 	if (fit_to_longest_item) {
 		minsize = _cached_size;
 	} else {
-		minsize = Button::get_minimum_size();
+		minsize = Button::_get_minimum_size();
 	}
 
 	if (has_theme_icon(SNAME("arrow"))) {

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -77,7 +77,7 @@ class OptionButton : public Button {
 	virtual void pressed() override;
 
 protected:
-	Size2 get_minimum_size() const override;
+	virtual Size2 _get_minimum_size() const override;
 	virtual void _queue_update_size_cache() override;
 	virtual String _get_translated_text(const String &p_text) const override;
 

--- a/scene/gui/panel_container.cpp
+++ b/scene/gui/panel_container.cpp
@@ -32,7 +32,7 @@
 
 #include "scene/theme/theme_db.h"
 
-Size2 PanelContainer::get_minimum_size() const {
+Size2 PanelContainer::_get_minimum_size() const {
 	Size2 ms = Container::_get_minimum_size();
 
 	if (theme_cache.panel_style.is_valid()) {

--- a/scene/gui/panel_container.h
+++ b/scene/gui/panel_container.h
@@ -42,9 +42,9 @@ class PanelContainer : public Container {
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+	virtual Size2 _get_minimum_size() const override;
 
 public:
-	virtual Size2 get_minimum_size() const override;
 	virtual Size2 get_desired_size() const override;
 	virtual Size2 get_inner_combined_maximum_size() const override;
 

--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -37,7 +37,7 @@
 #include "scene/theme/theme_db.h"
 #include "servers/display/accessibility_server.h"
 
-Size2 ProgressBar::get_minimum_size() const {
+Size2 ProgressBar::_get_minimum_size() const {
 	Size2 minimum_size = theme_cache.background_style->get_minimum_size();
 	minimum_size = minimum_size.max(theme_cache.fill_style->get_minimum_size());
 	if (show_percentage) {

--- a/scene/gui/progress_bar.h
+++ b/scene/gui/progress_bar.h
@@ -56,6 +56,8 @@ protected:
 
 	static void _bind_methods();
 
+	virtual Size2 _get_minimum_size() const override;
+
 	double indeterminate_min_speed = 200.0;
 
 public:
@@ -79,7 +81,6 @@ public:
 	void set_editor_preview_indeterminate(bool p_indeterminate_preview);
 	bool is_editor_preview_indeterminate_enabled() const;
 
-	Size2 get_minimum_size() const override;
 	ProgressBar();
 
 private:

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -8456,7 +8456,7 @@ int RichTextLabel::get_total_glyph_count() const {
 	return tg;
 }
 
-Size2 RichTextLabel::get_minimum_size() const {
+Size2 RichTextLabel::_get_minimum_size() const {
 	Size2 sb_min_size = theme_cache.normal_style->get_minimum_size();
 	Size2 min_size;
 	bool wrap_with_max_width = autowrap_mode != TextServer::AUTOWRAP_OFF && get_combined_maximum_size().x > 0.0;

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -145,6 +145,8 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	virtual Size2 _get_minimum_size() const override;
+
 #ifndef DISABLE_DEPRECATED
 	void _push_font_bind_compat_79053(const Ref<Font> &p_font, int p_size);
 	void _set_table_column_expand_bind_compat_79053(int p_column, bool p_expand, int p_ratio);
@@ -1041,8 +1043,6 @@ public:
 
 	void install_effect(const Variant effect);
 	void reload_effects();
-
-	virtual Size2 get_minimum_size() const override;
 
 	RichTextLabel(const String &p_text = String());
 	~RichTextLabel();

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -520,7 +520,7 @@ double ScrollBar::get_grabber_offset() const {
 	return get_area_size() * get_as_ratio();
 }
 
-Size2 ScrollBar::get_minimum_size() const {
+Size2 ScrollBar::_get_minimum_size() const {
 	Ref<Texture2D> incr = theme_cache.increment_icon;
 	Ref<Texture2D> decr = theme_cache.decrement_icon;
 	Ref<StyleBox> bg = theme_cache.scroll_style;

--- a/scene/gui/scroll_bar.h
+++ b/scene/gui/scroll_bar.h
@@ -112,6 +112,8 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
 	static inline const int PAGE_DIVISOR = 8;
 
@@ -128,7 +130,6 @@ public:
 	void set_smooth_scroll_enabled(bool p_enable);
 	bool is_smooth_scroll_enabled() const;
 
-	virtual Size2 get_minimum_size() const override;
 	ScrollBar(Orientation p_orientation = VERTICAL);
 	~ScrollBar();
 };

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -98,7 +98,7 @@ Size2 ScrollContainer::_get_minimum_size(bool p_use_desired_sizes) const {
 	return min_size;
 }
 
-Size2 ScrollContainer::get_minimum_size() const {
+Size2 ScrollContainer::_get_minimum_size() const {
 	return _get_minimum_size(false);
 }
 

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -121,11 +121,11 @@ private:
 	bool child_has_focus();
 
 	Size2 _get_minimum_size(bool p_use_desired_sizes) const;
+	virtual Size2 _get_minimum_size() const override;
 
 	Rect2 _get_local_visible_rect() const;
 
 protected:
-	Size2 get_minimum_size() const override;
 	Size2 get_desired_size() const override;
 	Size2 get_inner_combined_maximum_size() const override;
 

--- a/scene/gui/separator.cpp
+++ b/scene/gui/separator.cpp
@@ -32,7 +32,7 @@
 
 #include "scene/theme/theme_db.h"
 
-Size2 Separator::get_minimum_size() const {
+Size2 Separator::_get_minimum_size() const {
 	Size2 ms(3, 3);
 	if (orientation == VERTICAL) {
 		ms.x = theme_cache.separation;

--- a/scene/gui/separator.h
+++ b/scene/gui/separator.h
@@ -44,10 +44,9 @@ protected:
 
 	void _notification(int p_what);
 	static void _bind_methods();
+	virtual Size2 _get_minimum_size() const override;
 
 public:
-	virtual Size2 get_minimum_size() const override;
-
 	Separator();
 	~Separator();
 };

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -36,7 +36,7 @@
 #include "scene/theme/theme_db.h"
 #include "servers/display/accessibility_server.h"
 
-Size2 Slider::get_minimum_size() const {
+Size2 Slider::_get_minimum_size() const {
 	Size2i ss = theme_cache.slider_style->get_minimum_size();
 	Size2i rs = theme_cache.grabber_icon->get_size();
 

--- a/scene/gui/slider.h
+++ b/scene/gui/slider.h
@@ -89,10 +89,9 @@ protected:
 	void _validate_property(PropertyInfo &p_property) const;
 	Size2 _fit_icon_size(const Size2 &p_size, int p_max_size) const;
 	static void _bind_methods();
+	virtual Size2 _get_minimum_size() const override;
 
 public:
-	virtual Size2 get_minimum_size() const override;
-
 	void set_custom_step(double p_custom_step);
 	double get_custom_step() const;
 

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -90,7 +90,7 @@ void SpinBoxLineEdit::_notification(int p_what) {
 	}
 }
 
-Size2 SpinBox::get_minimum_size() const {
+Size2 SpinBox::_get_minimum_size() const {
 	Size2 ms = line_edit->get_bound_minimum_size();
 	ms.width += sizing_cache.buttons_block_width;
 	return ms;

--- a/scene/gui/spin_box.h
+++ b/scene/gui/spin_box.h
@@ -168,11 +168,10 @@ protected:
 	void _notification(int p_what);
 	Size2 _fit_icon_size(const Size2 &p_size) const;
 	static void _bind_methods();
+	virtual Size2 _get_minimum_size() const override;
 
 public:
 	LineEdit *get_line_edit();
-
-	virtual Size2 get_minimum_size() const override;
 
 	void set_horizontal_alignment(HorizontalAlignment p_alignment);
 	HorizontalAlignment get_horizontal_alignment() const;

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -1107,7 +1107,7 @@ Size2 SplitContainer::_get_minimum_size(bool p_use_desired_sizes) const {
 	return minimum;
 }
 
-Size2 SplitContainer::get_minimum_size() const {
+Size2 SplitContainer::_get_minimum_size() const {
 	return _get_minimum_size(false);
 }
 

--- a/scene/gui/split_container.h
+++ b/scene/gui/split_container.h
@@ -170,6 +170,7 @@ private:
 	void _update_all_nested_descendents(Control *p_control, Control *p_first_child = nullptr);
 
 	Size2 _get_minimum_size(bool p_use_desired_sizes) const;
+	virtual Size2 _get_minimum_size() const override;
 
 protected:
 	bool is_fixed = false;
@@ -208,7 +209,6 @@ public:
 	void set_dragging_enabled(bool p_enabled);
 	bool is_dragging_enabled() const;
 
-	virtual Size2 get_minimum_size() const override;
 	virtual Size2 get_desired_size() const override;
 
 	virtual Vector<int> get_allowed_size_flags_horizontal() const override;

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -34,7 +34,7 @@
 #include "core/object/class_db.h"
 #include "scene/main/viewport.h"
 
-Size2 SubViewportContainer::get_minimum_size() const {
+Size2 SubViewportContainer::_get_minimum_size() const {
 	if (stretch) {
 		return Size2();
 	}

--- a/scene/gui/subviewport_container.h
+++ b/scene/gui/subviewport_container.h
@@ -47,6 +47,7 @@ class SubViewportContainer : public Container {
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+	virtual Size2 _get_minimum_size() const override;
 
 	virtual void add_child_notify(Node *p_child) override;
 	virtual void remove_child_notify(Node *p_child) override;
@@ -66,8 +67,6 @@ public:
 
 	void set_mouse_target(bool p_enable);
 	bool is_mouse_target_enabled();
-
-	virtual Size2 get_minimum_size() const override;
 
 	virtual Vector<int> get_allowed_size_flags_horizontal() const override;
 	virtual Vector<int> get_allowed_size_flags_vertical() const override;

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -47,7 +47,7 @@ static inline Color _select_color(const Color &p_override_color, const Color &p_
 	return p_override_color.a > 0 ? p_override_color : p_default_color;
 }
 
-Size2 TabBar::get_minimum_size() const {
+Size2 TabBar::_get_minimum_size() const {
 	Size2 ms;
 	Size2 combined_max = get_combined_maximum_size();
 

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -227,6 +227,8 @@ protected:
 	void drop_data(const Point2 &p_point, const Variant &p_data) override;
 	void _move_tab_from(TabBar *p_from_tabbar, int p_from_index, int p_to_index);
 
+	virtual Size2 _get_minimum_size() const override;
+
 public:
 	RID get_tab_accessibility_element(int p_tab) const;
 	virtual RID get_focused_accessibility_element() const override;
@@ -345,7 +347,6 @@ public:
 	void set_switch_on_release(bool p_switch) { switch_on_release = p_switch; }
 
 	Rect2 get_tab_rect(int p_tab) const;
-	Size2 get_minimum_size() const override;
 	Size2 get_desired_size() const override;
 
 	TabBar();

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -1067,7 +1067,7 @@ Size2 TabContainer::_get_minimum_size(bool p_use_desired_sizes) const {
 	return ms;
 }
 
-Size2 TabContainer::get_minimum_size() const {
+Size2 TabContainer::_get_minimum_size() const {
 	return _get_minimum_size(false);
 }
 

--- a/scene/gui/tab_container.h
+++ b/scene/gui/tab_container.h
@@ -153,6 +153,7 @@ private:
 	void _popup_button_pressed();
 
 	Size2 _get_minimum_size(bool p_use_desired_sizes) const;
+	virtual Size2 _get_minimum_size() const override;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value) { return property_helper.property_set_value(p_name, p_value); }
@@ -241,7 +242,6 @@ public:
 	Control *get_tab_control(int p_idx) const;
 	Control *get_current_tab_control() const;
 
-	virtual Size2 get_minimum_size() const override;
 	virtual Size2 get_inner_combined_maximum_size() const override;
 	virtual Size2 get_desired_size() const override;
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4002,7 +4002,7 @@ void TextEdit::_show_virtual_keyboard() {
 }
 
 /* General overrides. */
-Size2 TextEdit::get_minimum_size() const {
+Size2 TextEdit::_get_minimum_size() const {
 	Size2 ms = _get_current_stylebox()->get_minimum_size();
 	if (fit_content_height) {
 		ms.height += content_size_cache.height;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -747,6 +747,8 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	virtual Size2 _get_minimum_size() const override;
+
 #ifndef DISABLE_DEPRECATED
 	void _set_selection_mode_bind_compat_86978(SelectionMode p_mode, int p_line = -1, int p_column = -1, int p_caret = 0);
 	Point2i _get_line_column_at_pos_bind_compat_100913(const Point2i &p_pos, bool p_allow_out_of_bounds = true) const;
@@ -849,7 +851,6 @@ public:
 	virtual void unhandled_key_input(const Ref<InputEvent> &p_event) override;
 	virtual void gui_input(const Ref<InputEvent> &p_gui_input) override;
 	bool alt_input(const Ref<InputEvent> &p_gui_input);
-	virtual Size2 get_minimum_size() const override;
 	virtual bool is_text_field() const override;
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;
 	virtual Variant get_drag_data(const Point2 &p_point) override;

--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -34,8 +34,8 @@
 #include "core/object/class_db.h"
 #include "core/typedefs.h"
 
-Size2 TextureButton::get_minimum_size() const {
-	Size2 rscale = Control::get_minimum_size();
+Size2 TextureButton::_get_minimum_size() const {
+	Size2 rscale;
 
 	if (!ignore_texture_size) {
 		if (normal.is_null()) {

--- a/scene/gui/texture_button.h
+++ b/scene/gui/texture_button.h
@@ -70,10 +70,9 @@ protected:
 	virtual bool has_point(const Point2 &p_point) const override;
 	void _notification(int p_what);
 	static void _bind_methods();
+	virtual Size2 _get_minimum_size() const override;
 
 public:
-	virtual Size2 get_minimum_size() const override;
-
 	void set_texture_normal(const Ref<Texture2D> &p_normal);
 	void set_texture_pressed(const Ref<Texture2D> &p_pressed);
 	void set_texture_hover(const Ref<Texture2D> &p_hover);

--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -84,7 +84,7 @@ bool TextureProgressBar::get_nine_patch_stretch() const {
 	return nine_patch_stretch;
 }
 
-Size2 TextureProgressBar::get_minimum_size() const {
+Size2 TextureProgressBar::_get_minimum_size() const {
 	if (nine_patch_stretch) {
 		return Size2(stretch_margin[SIDE_LEFT] + stretch_margin[SIDE_RIGHT], stretch_margin[SIDE_TOP] + stretch_margin[SIDE_BOTTOM]);
 	}

--- a/scene/gui/texture_progress_bar.h
+++ b/scene/gui/texture_progress_bar.h
@@ -43,6 +43,7 @@ protected:
 	static void _bind_methods();
 	void _notification(int p_what);
 	void _validate_property(PropertyInfo &p_property) const;
+	virtual Size2 _get_minimum_size() const override;
 
 public:
 	enum FillMode {
@@ -96,8 +97,6 @@ public:
 
 	void set_tint_over(const Color &p_tint);
 	Color get_tint_over() const;
-
-	Size2 get_minimum_size() const override;
 
 	TextureProgressBar();
 

--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -125,7 +125,7 @@ void TextureRect::_notification(int p_what) {
 	}
 }
 
-Size2 TextureRect::get_minimum_size() const {
+Size2 TextureRect::_get_minimum_size() const {
 	if (texture.is_valid()) {
 		switch (expand_mode) {
 			case EXPAND_KEEP_SIZE: {

--- a/scene/gui/texture_rect.h
+++ b/scene/gui/texture_rect.h
@@ -67,13 +67,12 @@ private:
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+	virtual Size2 _get_minimum_size() const override;
 #ifndef DISABLE_DEPRECATED
 	bool _set(const StringName &p_name, const Variant &p_value);
 #endif
 
 public:
-	virtual Size2 get_minimum_size() const override;
-
 	void set_texture(const Ref<Texture2D> &p_tex);
 	Ref<Texture2D> get_texture() const;
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -5771,7 +5771,7 @@ void Tree::_update_all() {
 	}
 }
 
-Size2 Tree::get_minimum_size() const {
+Size2 Tree::_get_minimum_size() const {
 	Vector2 min_size = Vector2(0, _get_title_button_height());
 
 	if (theme_cache.panel_style.is_valid()) {

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -837,6 +837,8 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	virtual Size2 _get_minimum_size() const override;
+
 	void _accessibility_action_scroll_down(const Variant &p_data);
 	void _accessibility_action_scroll_left(const Variant &p_data);
 	void _accessibility_action_scroll_right(const Variant &p_data);
@@ -987,8 +989,6 @@ public:
 
 	void set_auto_tooltip(bool p_enable);
 	bool is_auto_tooltip_enabled() const;
-
-	Size2 get_minimum_size() const override;
 
 	Tree();
 	~Tree();

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -233,7 +233,7 @@ void VideoStreamPlayer::texture_changed(const Ref<Texture2D> &p_texture) {
 	}
 }
 
-Size2 VideoStreamPlayer::get_minimum_size() const {
+Size2 VideoStreamPlayer::_get_minimum_size() const {
 	if (!expand && texture.is_valid()) {
 		return texture_size;
 	} else {

--- a/scene/gui/video_stream_player.h
+++ b/scene/gui/video_stream_player.h
@@ -73,9 +73,9 @@ class VideoStreamPlayer : public Control {
 protected:
 	static void _bind_methods();
 	void _notification(int p_notification);
+	virtual Size2 _get_minimum_size() const override;
 
 public:
-	Size2 get_minimum_size() const override;
 	void set_expand(bool p_expand);
 	bool has_expand() const;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

Currently, custom `Control` classes cannot always define a custom `_get_minimum_size()` or `_get_maximum_size()` that will be called, as outlined in the docs: https://docs.godotengine.org/en/stable/classes/class_control.html#class-control-private-method-get-minimum-size.

This is a completely artificial limitation due to the engine classes overriding the GDVirtual caller instead of using the more standard pattern of
```cpp
Class::method() {
  if (!GDVIRTUAL_CALL(_method) {
    _method();
  }
}
```
with the subclasses overriding `_method()` instead of `method()`.

By changing engine classes to use the standard pattern, users can now override those methods for any custom `Control` subclass. 

This also prevents issues like the one fixed in #123415, since the virtual caller is no longer overridable. 

## Additional information

All engine methods are also now strictly `virtual` on top of `override`, so the virtual chain is always extendable. 
Also fixes a doc issue with regard to `_get_maximum_size()`'s default return value. 

In the future, once #123141 (or equivalent) is added to the engine, we can also fully allow users to use engine-defined classes' implementations in their own derived implementations thanks to these changes. 