### PR TITLE
Rename `ContainerType::builtin_type` and `ContainerTypeValidate::type` to `variant_type`.

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -627,7 +627,7 @@ void JSON::_bind_methods() {
 #define PROPS "props"
 
 static bool _encode_container_type(Dictionary &r_dict, const String &p_key, const ContainerType &p_type, bool p_full_objects) {
-	if (p_type.builtin_type != Variant::NIL) {
+	if (p_type.variant_type != Variant::NIL) {
 		if (p_type.script.is_valid()) {
 			ERR_FAIL_COND_V(!p_full_objects, false);
 			const String path = p_type.script->get_path();
@@ -638,7 +638,7 @@ static bool _encode_container_type(Dictionary &r_dict, const String &p_key, cons
 			r_dict[p_key] = String(p_type.class_name);
 		} else {
 			// No need to check `p_full_objects` since `class_name` should be non-empty for `builtin_type == Variant::OBJECT`.
-			r_dict[p_key] = Variant::get_type_name(p_type.builtin_type);
+			r_dict[p_key] = Variant::get_type_name(p_type.variant_type);
 		}
 	}
 	return true;
@@ -1004,14 +1004,14 @@ static bool _decode_container_type(const Dictionary &p_dict, const String &p_key
 
 	const Variant::Type builtin_type = Variant::get_type_by_name(type_name);
 	if (builtin_type < Variant::VARIANT_MAX && builtin_type != Variant::OBJECT) {
-		r_type.builtin_type = builtin_type;
+		r_type.variant_type = builtin_type;
 		return true;
 	}
 
 	if (ClassDB::class_exists(type_name)) {
 		ERR_FAIL_COND_V(!p_allow_objects, false);
 
-		r_type.builtin_type = Variant::OBJECT;
+		r_type.variant_type = Variant::OBJECT;
 		r_type.class_name = type_name;
 		return true;
 	}
@@ -1023,7 +1023,7 @@ static bool _decode_container_type(const Dictionary &p_dict, const String &p_key
 		const Ref<Script> script = ResourceLoader::load(type_name, "Script");
 		ERR_FAIL_COND_V_MSG(script.is_null(), false, vformat(R"(Can't load script at path "%s".)", type_name));
 
-		r_type.builtin_type = Variant::OBJECT;
+		r_type.variant_type = Variant::OBJECT;
 		r_type.class_name = script->get_instance_base_type();
 		r_type.script = script;
 		return true;
@@ -1288,7 +1288,7 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 
 					Dictionary ret;
 
-					if (key_type.builtin_type != Variant::NIL || value_type.builtin_type != Variant::NIL) {
+					if (key_type.variant_type != Variant::NIL || value_type.variant_type != Variant::NIL) {
 						ret.set_typed(key_type, value_type);
 					}
 
@@ -1311,7 +1311,7 @@ Variant JSON::_to_native(const Variant &p_json, bool p_allow_objects, int p_dept
 
 					Array ret;
 
-					if (elem_type.builtin_type != Variant::NIL) {
+					if (elem_type.variant_type != Variant::NIL) {
 						ret.set_typed(elem_type);
 					}
 

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -140,8 +140,8 @@ static Error _decode_container_type(const uint8_t *&p_buffer, int &r_left, int *
 			}
 
 			ERR_FAIL_INDEX_V(bt, Variant::VARIANT_MAX, ERR_INVALID_DATA);
-			r_type.builtin_type = (Variant::Type)bt;
-			if (!p_allow_objects && r_type.builtin_type == Variant::OBJECT) {
+			r_type.variant_type = (Variant::Type)bt;
+			if (!p_allow_objects && r_type.variant_type == Variant::OBJECT) {
 				r_type.class_name = EncodedObjectAsID::get_class_static();
 			}
 			return OK;
@@ -150,7 +150,7 @@ static Error _decode_container_type(const uint8_t *&p_buffer, int &r_left, int *
 			String str;
 			RETURN_IF_ERROR(_decode_string(p_buffer, r_left, r_len, str));
 
-			r_type.builtin_type = Variant::OBJECT;
+			r_type.variant_type = Variant::OBJECT;
 			if (p_allow_objects) {
 				r_type.class_name = str;
 			} else {
@@ -162,7 +162,7 @@ static Error _decode_container_type(const uint8_t *&p_buffer, int &r_left, int *
 			String path;
 			RETURN_IF_ERROR(_decode_string(p_buffer, r_left, r_len, path));
 
-			r_type.builtin_type = Variant::OBJECT;
+			r_type.variant_type = Variant::OBJECT;
 			if (p_allow_objects) {
 				ERR_FAIL_COND_V_MSG(path.is_empty() || !path.begins_with("res://") || !ResourceLoader::exists(path, "Script"), ERR_INVALID_DATA, vformat("Invalid script path \"%s\".", path));
 				r_type.script = ResourceLoader::load(path, "Script");
@@ -806,7 +806,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 			}
 
 			Dictionary dict;
-			if (key_type.builtin_type != Variant::NIL || value_type.builtin_type != Variant::NIL) {
+			if (key_type.variant_type != Variant::NIL || value_type.variant_type != Variant::NIL) {
 				dict.set_typed(key_type, value_type);
 			}
 
@@ -860,7 +860,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 			}
 
 			Array array;
-			if (type.builtin_type != Variant::NIL) {
+			if (type.variant_type != Variant::NIL) {
 				array.set_typed(type);
 			}
 
@@ -1284,7 +1284,7 @@ static void _encode_string(const String &p_string, uint8_t *&p_buffer, int &r_le
 }
 
 static void _encode_container_type_header(const ContainerType &p_type, uint32_t &r_header, uint32_t p_shift, bool p_full_objects) {
-	if (p_type.builtin_type != Variant::NIL) {
+	if (p_type.variant_type != Variant::NIL) {
 		if (p_type.script.is_valid()) {
 			r_header |= (p_full_objects ? CONTAINER_TYPE_KIND_SCRIPT : CONTAINER_TYPE_KIND_CLASS_NAME) << p_shift;
 		} else if (p_type.class_name != StringName()) {
@@ -1297,7 +1297,7 @@ static void _encode_container_type_header(const ContainerType &p_type, uint32_t 
 }
 
 static Error _encode_container_type(const ContainerType &p_type, uint8_t *&p_buffer, int &r_len, bool p_full_objects) {
-	if (p_type.builtin_type != Variant::NIL) {
+	if (p_type.variant_type != Variant::NIL) {
 		if (p_type.script.is_valid()) {
 			if (p_full_objects) {
 				String path = p_type.script->get_path();
@@ -1311,7 +1311,7 @@ static Error _encode_container_type(const ContainerType &p_type, uint8_t *&p_buf
 		} else {
 			// No need to check `p_full_objects` since `class_name` should be non-empty for `builtin_type == Variant::OBJECT`.
 			if (p_buffer) {
-				encode_uint32(p_type.builtin_type, p_buffer);
+				encode_uint32(p_type.variant_type, p_buffer);
 				p_buffer += 4;
 			}
 			r_len += 4;

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -216,7 +216,7 @@ void Array::assign(const Array &p_array) {
 	const ContainerTypeValidate &typed = _p->typed;
 	const ContainerTypeValidate &source_typed = p_array._p->typed;
 
-	if (typed == source_typed || typed.type == Variant::NIL || (source_typed.type == Variant::OBJECT && typed.can_reference(source_typed))) {
+	if (typed == source_typed || typed.variant_type == Variant::NIL || (source_typed.variant_type == Variant::OBJECT && typed.can_reference(source_typed))) {
 		// from same to same or
 		// from anything to variants or
 		// from subclasses to base classes
@@ -227,51 +227,51 @@ void Array::assign(const Array &p_array) {
 	const Variant *source = p_array._p->array.ptr();
 	int size = p_array._p->array.size();
 
-	if ((source_typed.type == Variant::NIL && typed.type == Variant::OBJECT) || (source_typed.type == Variant::OBJECT && source_typed.can_reference(typed))) {
+	if ((source_typed.variant_type == Variant::NIL && typed.variant_type == Variant::OBJECT) || (source_typed.variant_type == Variant::OBJECT && source_typed.can_reference(typed))) {
 		// from variants to objects or
 		// from base classes to subclasses
 		for (int i = 0; i < size; i++) {
 			const Variant &element = source[i];
 			if (element.get_type() != Variant::NIL && (element.get_type() != Variant::OBJECT || !typed.validate_object(element, "assign"))) {
-				ERR_FAIL_MSG(vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(element.get_type()), Variant::get_type_name(typed.type)));
+				ERR_FAIL_MSG(vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(element.get_type()), Variant::get_type_name(typed.variant_type)));
 			}
 		}
 		_p->array = p_array._p->array;
 		return;
 	}
-	if (typed.type == Variant::OBJECT || source_typed.type == Variant::OBJECT) {
-		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Array[%s]" to "Array[%s]".)", Variant::get_type_name(source_typed.type), Variant::get_type_name(typed.type)));
+	if (typed.variant_type == Variant::OBJECT || source_typed.variant_type == Variant::OBJECT) {
+		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Array[%s]" to "Array[%s]".)", Variant::get_type_name(source_typed.variant_type), Variant::get_type_name(typed.variant_type)));
 	}
 
 	Vector<Variant> array;
 	array.resize(size);
 	Variant *data = array.ptrw();
 
-	if (source_typed.type == Variant::NIL && typed.type != Variant::OBJECT) {
+	if (source_typed.variant_type == Variant::NIL && typed.variant_type != Variant::OBJECT) {
 		// from variants to primitives
 		for (int i = 0; i < size; i++) {
 			const Variant *value = source + i;
-			if (value->get_type() == typed.type) {
+			if (value->get_type() == typed.variant_type) {
 				data[i] = *value;
 				continue;
 			}
-			if (!Variant::can_convert_strict(value->get_type(), typed.type)) {
-				ERR_FAIL_MSG(vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.type)));
+			if (!Variant::can_convert_strict(value->get_type(), typed.variant_type)) {
+				ERR_FAIL_MSG(vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.variant_type)));
 			}
 			Callable::CallError ce;
-			Variant::construct(typed.type, data[i], &value, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.type)));
+			Variant::construct(typed.variant_type, data[i], &value, 1, ce);
+			ERR_FAIL_COND_MSG(ce.error, vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.variant_type)));
 		}
-	} else if (Variant::can_convert_strict(source_typed.type, typed.type)) {
+	} else if (Variant::can_convert_strict(source_typed.variant_type, typed.variant_type)) {
 		// from primitives to different convertible primitives
 		for (int i = 0; i < size; i++) {
 			const Variant *value = source + i;
 			Callable::CallError ce;
-			Variant::construct(typed.type, data[i], &value, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.type)));
+			Variant::construct(typed.variant_type, data[i], &value, 1, ce);
+			ERR_FAIL_COND_MSG(ce.error, vformat("Unable to convert array index %d from '%s' to '%s'.", i, Variant::get_type_name(value->get_type()), Variant::get_type_name(typed.variant_type)));
 		}
 	} else {
-		ERR_FAIL_MSG(vformat("Cannot assign contents of 'Array[%s]' to 'Array[%s]'.", Variant::get_type_name(source_typed.type), Variant::get_type_name(typed.type)));
+		ERR_FAIL_MSG(vformat("Cannot assign contents of 'Array[%s]' to 'Array[%s]'.", Variant::get_type_name(source_typed.variant_type), Variant::get_type_name(typed.variant_type)));
 	}
 
 	_p->array = array;
@@ -303,7 +303,7 @@ void Array::append_array(const Array &p_array) {
 
 Error Array::resize(int p_new_size) {
 	ERR_FAIL_COND_V_MSG(_p->read_only, ERR_LOCKED, "Array is in read-only state.");
-	Variant::Type &variant_type = _p->typed.type;
+	Variant::Type &variant_type = _p->typed.variant_type;
 	int old_size = _p->array.size();
 	Error err = _p->array.resize_initialized(p_new_size);
 	if (!err && variant_type != Variant::NIL && variant_type != Variant::OBJECT) {
@@ -877,26 +877,26 @@ Array::Array(const Array &p_from, uint32_t p_type, const StringName &p_class_nam
 }
 
 void Array::set_typed(const ContainerType &p_element_type) {
-	set_typed(p_element_type.builtin_type, p_element_type.class_name, p_element_type.script);
+	set_typed(p_element_type.variant_type, p_element_type.class_name, p_element_type.script);
 }
 
 void Array::set_typed(uint32_t p_type, const StringName &p_class_name, const Variant &p_script) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Array is in read-only state.");
 	ERR_FAIL_COND_MSG(_p->array.size() > 0, "Type can only be set when array is empty.");
 	ERR_FAIL_COND_MSG(_p->refcount.get() > 1, "Type can only be set when array has no more than one user.");
-	ERR_FAIL_COND_MSG(_p->typed.type != Variant::NIL, "Type can only be set once.");
+	ERR_FAIL_COND_MSG(_p->typed.variant_type != Variant::NIL, "Type can only be set once.");
 	ERR_FAIL_COND_MSG(p_class_name != StringName() && p_type != Variant::OBJECT, "Class names can only be set for type OBJECT");
 	Ref<Script> script = p_script;
 	ERR_FAIL_COND_MSG(script.is_valid() && p_class_name == StringName(), "Script class can only be set together with base class name");
 
-	_p->typed.type = Variant::Type(p_type);
+	_p->typed.variant_type = Variant::Type(p_type);
 	_p->typed.class_name = p_class_name;
 	_p->typed.script = script;
 	_p->typed.where = "TypedArray";
 }
 
 bool Array::is_typed() const {
-	return _p->typed.type != Variant::NIL;
+	return _p->typed.variant_type != Variant::NIL;
 }
 
 bool Array::is_same_typed(const Array &p_other) const {
@@ -909,14 +909,14 @@ bool Array::is_same_instance(const Array &p_other) const {
 
 ContainerType Array::get_element_type() const {
 	ContainerType type;
-	type.builtin_type = _p->typed.type;
+	type.variant_type = _p->typed.variant_type;
 	type.class_name = _p->typed.class_name;
 	type.script = _p->typed.script;
 	return type;
 }
 
 uint32_t Array::get_typed_builtin() const {
-	return _p->typed.type;
+	return _p->typed.variant_type;
 }
 
 StringName Array::get_typed_class_name() const {

--- a/core/variant/container_type_validate.h
+++ b/core/variant/container_type_validate.h
@@ -35,33 +35,33 @@
 #include "core/variant/variant.h"
 
 struct ContainerType {
-	Variant::Type builtin_type = Variant::NIL;
+	Variant::Type variant_type = Variant::NIL;
 	StringName class_name;
 	Ref<Script> script;
 };
 
 struct ContainerTypeValidate {
-	Variant::Type type = Variant::NIL;
+	Variant::Type variant_type = Variant::NIL;
 	StringName class_name;
 	Ref<Script> script;
 	const char *where = "container";
 
 private:
 	_FORCE_INLINE_ bool _internal_validate(Variant &r_inout_variant, const char *p_operation, bool p_output_errors) const {
-		if (type == Variant::NIL) {
+		if (variant_type == Variant::NIL) {
 			return true;
 		}
 
-		if (type != r_inout_variant.get_type()) {
-			if (r_inout_variant.get_type() == Variant::NIL && type == Variant::OBJECT) {
+		if (variant_type != r_inout_variant.get_type()) {
+			if (r_inout_variant.get_type() == Variant::NIL && variant_type == Variant::OBJECT) {
 				return true;
 			}
 
-			if (Variant::can_convert_strict(r_inout_variant.get_type(), type)) {
+			if (Variant::can_convert_strict(r_inout_variant.get_type(), variant_type)) {
 				Variant converted_to;
 				const Variant *converted_from = &r_inout_variant;
 				Callable::CallError call_error;
-				Variant::construct(type, converted_to, &converted_from, 1, call_error);
+				Variant::construct(variant_type, converted_to, &converted_from, 1, call_error);
 
 				if (call_error.error == Callable::CallError::CALL_OK) {
 					r_inout_variant = converted_to;
@@ -70,13 +70,13 @@ private:
 			}
 
 			if (p_output_errors) {
-				ERR_FAIL_V_MSG(false, vformat("Attempted to %s a variable of type '%s' into a %s of incompatible type '%s'.", String(p_operation), Variant::get_type_name(r_inout_variant.get_type()), where, Variant::get_type_name(type)));
+				ERR_FAIL_V_MSG(false, vformat("Attempted to %s a variable of type '%s' into a %s of incompatible type '%s'.", String(p_operation), Variant::get_type_name(r_inout_variant.get_type()), where, Variant::get_type_name(variant_type)));
 			} else {
 				return false;
 			}
 		}
 
-		if (type != Variant::OBJECT) {
+		if (variant_type != Variant::OBJECT) {
 			return true;
 		}
 
@@ -164,9 +164,9 @@ public:
 	}
 
 	_FORCE_INLINE_ bool can_reference(const ContainerTypeValidate &p_type) const {
-		if (type != p_type.type) {
+		if (variant_type != p_type.variant_type) {
 			return false;
-		} else if (type != Variant::OBJECT) {
+		} else if (variant_type != Variant::OBJECT) {
 			return true;
 		}
 
@@ -190,9 +190,9 @@ public:
 	}
 
 	_FORCE_INLINE_ bool operator==(const ContainerTypeValidate &p_type) const {
-		return type == p_type.type && class_name == p_type.class_name && script == p_type.script;
+		return variant_type == p_type.variant_type && class_name == p_type.class_name && script == p_type.script;
 	}
 	_FORCE_INLINE_ bool operator!=(const ContainerTypeValidate &p_type) const {
-		return type != p_type.type || class_name != p_type.class_name || script != p_type.script;
+		return variant_type != p_type.variant_type || class_name != p_type.class_name || script != p_type.script;
 	}
 };

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -99,20 +99,20 @@ Variant &Dictionary::operator[](const Variant &p_key) {
 		if (unlikely(!_p->typed_fallback)) {
 			_p->typed_fallback = memnew(Variant);
 		}
-		VariantInternal::initialize(_p->typed_fallback, _p->typed_value.type);
+		VariantInternal::initialize(_p->typed_fallback, _p->typed_value.variant_type);
 		return *_p->typed_fallback;
 	} else if (unlikely(_p->read_only)) {
 		if (likely(_p->variant_map.has(key))) {
 			*_p->read_only = _p->variant_map[key];
 		} else {
-			VariantInternal::initialize(_p->read_only, _p->typed_value.type);
+			VariantInternal::initialize(_p->read_only, _p->typed_value.variant_type);
 		}
 		return *_p->read_only;
 	} else {
 		const uint32_t old_size = _p->variant_map.size();
 		Variant &value = _p->variant_map[key];
 		if (_p->variant_map.size() > old_size) {
-			VariantInternal::initialize(&value, _p->typed_value.type);
+			VariantInternal::initialize(&value, _p->typed_value.variant_type);
 		}
 		return value;
 	}
@@ -124,7 +124,7 @@ const Variant &Dictionary::operator[](const Variant &p_key) const {
 		if (unlikely(!_p->typed_fallback)) {
 			_p->typed_fallback = memnew(Variant);
 		}
-		VariantInternal::initialize(_p->typed_fallback, _p->typed_value.type);
+		VariantInternal::initialize(_p->typed_fallback, _p->typed_value.variant_type);
 		return *_p->typed_fallback;
 	} else {
 		static Variant empty;
@@ -426,8 +426,8 @@ void Dictionary::assign(const Dictionary &p_dictionary) {
 	const ContainerTypeValidate &typed_value = _p->typed_value;
 	const ContainerTypeValidate &typed_value_source = p_dictionary._p->typed_value;
 
-	if ((typed_key == typed_key_source || typed_key.type == Variant::NIL || (typed_key_source.type == Variant::OBJECT && typed_key.can_reference(typed_key_source))) &&
-			(typed_value == typed_value_source || typed_value.type == Variant::NIL || (typed_value_source.type == Variant::OBJECT && typed_value.can_reference(typed_value_source)))) {
+	if ((typed_key == typed_key_source || typed_key.variant_type == Variant::NIL || (typed_key_source.variant_type == Variant::OBJECT && typed_key.can_reference(typed_key_source))) &&
+			(typed_value == typed_value_source || typed_value.variant_type == Variant::NIL || (typed_value_source.variant_type == Variant::OBJECT && typed_value.can_reference(typed_value_source)))) {
 		// From same to same or,
 		// from anything to variants or,
 		// from subclasses to base classes.
@@ -446,7 +446,7 @@ void Dictionary::assign(const Dictionary &p_dictionary) {
 	value_array.resize(size);
 	Variant *value_data = value_array.ptrw();
 
-	if (typed_key == typed_key_source || typed_key.type == Variant::NIL || (typed_key_source.type == Variant::OBJECT && typed_key.can_reference(typed_key_source))) {
+	if (typed_key == typed_key_source || typed_key.variant_type == Variant::NIL || (typed_key_source.variant_type == Variant::OBJECT && typed_key.can_reference(typed_key_source))) {
 		// From same to same or,
 		// from anything to variants or,
 		// from subclasses to base classes.
@@ -455,51 +455,51 @@ void Dictionary::assign(const Dictionary &p_dictionary) {
 			const Variant *key = &E.key;
 			key_data[i++] = *key;
 		}
-	} else if ((typed_key_source.type == Variant::NIL && typed_key.type == Variant::OBJECT) || (typed_key_source.type == Variant::OBJECT && typed_key_source.can_reference(typed_key))) {
+	} else if ((typed_key_source.variant_type == Variant::NIL && typed_key.variant_type == Variant::OBJECT) || (typed_key_source.variant_type == Variant::OBJECT && typed_key_source.can_reference(typed_key))) {
 		// From variants to objects or,
 		// from base classes to subclasses.
 		int i = 0;
 		for (const KeyValue<Variant, Variant> &E : p_dictionary._p->variant_map) {
 			const Variant *key = &E.key;
 			if (key->get_type() != Variant::NIL && (key->get_type() != Variant::OBJECT || !typed_key.validate_object(*key, "assign"))) {
-				ERR_FAIL_MSG(vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.type)));
+				ERR_FAIL_MSG(vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.variant_type)));
 			}
 			key_data[i++] = *key;
 		}
-	} else if (typed_key.type == Variant::OBJECT || typed_key_source.type == Variant::OBJECT) {
-		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s]".)", Variant::get_type_name(typed_key_source.type), Variant::get_type_name(typed_value_source.type),
-				Variant::get_type_name(typed_key.type), Variant::get_type_name(typed_value.type)));
-	} else if (typed_key_source.type == Variant::NIL && typed_key.type != Variant::OBJECT) {
+	} else if (typed_key.variant_type == Variant::OBJECT || typed_key_source.variant_type == Variant::OBJECT) {
+		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s]".)", Variant::get_type_name(typed_key_source.variant_type), Variant::get_type_name(typed_value_source.variant_type),
+				Variant::get_type_name(typed_key.variant_type), Variant::get_type_name(typed_value.variant_type)));
+	} else if (typed_key_source.variant_type == Variant::NIL && typed_key.variant_type != Variant::OBJECT) {
 		// From variants to primitives.
 		int i = 0;
 		for (const KeyValue<Variant, Variant> &E : p_dictionary._p->variant_map) {
 			const Variant *key = &E.key;
-			if (key->get_type() == typed_key.type) {
+			if (key->get_type() == typed_key.variant_type) {
 				key_data[i++] = *key;
 				continue;
 			}
-			if (!Variant::can_convert_strict(key->get_type(), typed_key.type)) {
-				ERR_FAIL_MSG(vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.type)));
+			if (!Variant::can_convert_strict(key->get_type(), typed_key.variant_type)) {
+				ERR_FAIL_MSG(vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.variant_type)));
 			}
 			Callable::CallError ce;
-			Variant::construct(typed_key.type, key_data[i++], &key, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.type)));
+			Variant::construct(typed_key.variant_type, key_data[i++], &key, 1, ce);
+			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.variant_type)));
 		}
-	} else if (Variant::can_convert_strict(typed_key_source.type, typed_key.type)) {
+	} else if (Variant::can_convert_strict(typed_key_source.variant_type, typed_key.variant_type)) {
 		// From primitives to different convertible primitives.
 		int i = 0;
 		for (const KeyValue<Variant, Variant> &E : p_dictionary._p->variant_map) {
 			const Variant *key = &E.key;
 			Callable::CallError ce;
-			Variant::construct(typed_key.type, key_data[i++], &key, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.type)));
+			Variant::construct(typed_key.variant_type, key_data[i++], &key, 1, ce);
+			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert key from "%s" to "%s".)", Variant::get_type_name(key->get_type()), Variant::get_type_name(typed_key.variant_type)));
 		}
 	} else {
-		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s].)", Variant::get_type_name(typed_key_source.type), Variant::get_type_name(typed_value_source.type),
-				Variant::get_type_name(typed_key.type), Variant::get_type_name(typed_value.type)));
+		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s].)", Variant::get_type_name(typed_key_source.variant_type), Variant::get_type_name(typed_value_source.variant_type),
+				Variant::get_type_name(typed_key.variant_type), Variant::get_type_name(typed_value.variant_type)));
 	}
 
-	if (typed_value == typed_value_source || typed_value.type == Variant::NIL || (typed_value_source.type == Variant::OBJECT && typed_value.can_reference(typed_value_source))) {
+	if (typed_value == typed_value_source || typed_value.variant_type == Variant::NIL || (typed_value_source.variant_type == Variant::OBJECT && typed_value.can_reference(typed_value_source))) {
 		// From same to same or,
 		// from anything to variants or,
 		// from subclasses to base classes.
@@ -508,48 +508,48 @@ void Dictionary::assign(const Dictionary &p_dictionary) {
 			const Variant *value = &E.value;
 			value_data[i++] = *value;
 		}
-	} else if (((typed_value_source.type == Variant::NIL && typed_value.type == Variant::OBJECT) || (typed_value_source.type == Variant::OBJECT && typed_value_source.can_reference(typed_value)))) {
+	} else if (((typed_value_source.variant_type == Variant::NIL && typed_value.variant_type == Variant::OBJECT) || (typed_value_source.variant_type == Variant::OBJECT && typed_value_source.can_reference(typed_value)))) {
 		// From variants to objects or,
 		// from base classes to subclasses.
 		int i = 0;
 		for (const KeyValue<Variant, Variant> &E : p_dictionary._p->variant_map) {
 			const Variant *value = &E.value;
 			if (value->get_type() != Variant::NIL && (value->get_type() != Variant::OBJECT || !typed_value.validate_object(*value, "assign"))) {
-				ERR_FAIL_MSG(vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.type)));
+				ERR_FAIL_MSG(vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.variant_type)));
 			}
 			value_data[i++] = *value;
 		}
-	} else if (typed_value.type == Variant::OBJECT || typed_value_source.type == Variant::OBJECT) {
-		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s]".)", Variant::get_type_name(typed_key_source.type), Variant::get_type_name(typed_value_source.type),
-				Variant::get_type_name(typed_key.type), Variant::get_type_name(typed_value.type)));
-	} else if (typed_value_source.type == Variant::NIL && typed_value.type != Variant::OBJECT) {
+	} else if (typed_value.variant_type == Variant::OBJECT || typed_value_source.variant_type == Variant::OBJECT) {
+		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s]".)", Variant::get_type_name(typed_key_source.variant_type), Variant::get_type_name(typed_value_source.variant_type),
+				Variant::get_type_name(typed_key.variant_type), Variant::get_type_name(typed_value.variant_type)));
+	} else if (typed_value_source.variant_type == Variant::NIL && typed_value.variant_type != Variant::OBJECT) {
 		// From variants to primitives.
 		int i = 0;
 		for (const KeyValue<Variant, Variant> &E : p_dictionary._p->variant_map) {
 			const Variant *value = &E.value;
-			if (value->get_type() == typed_value.type) {
+			if (value->get_type() == typed_value.variant_type) {
 				value_data[i++] = *value;
 				continue;
 			}
-			if (!Variant::can_convert_strict(value->get_type(), typed_value.type)) {
-				ERR_FAIL_MSG(vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.type)));
+			if (!Variant::can_convert_strict(value->get_type(), typed_value.variant_type)) {
+				ERR_FAIL_MSG(vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.variant_type)));
 			}
 			Callable::CallError ce;
-			Variant::construct(typed_value.type, value_data[i++], &value, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i - 1], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.type)));
+			Variant::construct(typed_value.variant_type, value_data[i++], &value, 1, ce);
+			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i - 1], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.variant_type)));
 		}
-	} else if (Variant::can_convert_strict(typed_value_source.type, typed_value.type)) {
+	} else if (Variant::can_convert_strict(typed_value_source.variant_type, typed_value.variant_type)) {
 		// From primitives to different convertible primitives.
 		int i = 0;
 		for (const KeyValue<Variant, Variant> &E : p_dictionary._p->variant_map) {
 			const Variant *value = &E.value;
 			Callable::CallError ce;
-			Variant::construct(typed_value.type, value_data[i++], &value, 1, ce);
-			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i - 1], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.type)));
+			Variant::construct(typed_value.variant_type, value_data[i++], &value, 1, ce);
+			ERR_FAIL_COND_MSG(ce.error, vformat(R"(Unable to convert value at key "%s" from "%s" to "%s".)", key_data[i - 1], Variant::get_type_name(value->get_type()), Variant::get_type_name(typed_value.variant_type)));
 		}
 	} else {
-		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s].)", Variant::get_type_name(typed_key_source.type), Variant::get_type_name(typed_value_source.type),
-				Variant::get_type_name(typed_key.type), Variant::get_type_name(typed_value.type)));
+		ERR_FAIL_MSG(vformat(R"(Cannot assign contents of "Dictionary[%s, %s]" to "Dictionary[%s, %s].)", Variant::get_type_name(typed_key_source.variant_type), Variant::get_type_name(typed_value_source.variant_type),
+				Variant::get_type_name(typed_key.variant_type), Variant::get_type_name(typed_value.variant_type)));
 	}
 
 	for (int i = 0; i < size; i++) {
@@ -634,26 +634,26 @@ Dictionary Dictionary::recursive_duplicate(bool p_deep, ResourceDeepDuplicateMod
 }
 
 void Dictionary::set_typed(const ContainerType &p_key_type, const ContainerType &p_value_type) {
-	set_typed(p_key_type.builtin_type, p_key_type.class_name, p_key_type.script, p_value_type.builtin_type, p_value_type.class_name, p_value_type.script);
+	set_typed(p_key_type.variant_type, p_key_type.class_name, p_key_type.script, p_value_type.variant_type, p_value_type.class_name, p_value_type.script);
 }
 
 void Dictionary::set_typed(uint32_t p_key_type, const StringName &p_key_class_name, const Variant &p_key_script, uint32_t p_value_type, const StringName &p_value_class_name, const Variant &p_value_script) {
 	ERR_FAIL_COND_MSG(_p->read_only, "Dictionary is in read-only state.");
 	ERR_FAIL_COND_MSG(_p->variant_map.size() > 0, "Type can only be set when dictionary is empty.");
 	ERR_FAIL_COND_MSG(_p->refcount.get() > 1, "Type can only be set when dictionary has no more than one user.");
-	ERR_FAIL_COND_MSG(_p->typed_key.type != Variant::NIL || _p->typed_value.type != Variant::NIL, "Type can only be set once.");
+	ERR_FAIL_COND_MSG(_p->typed_key.variant_type != Variant::NIL || _p->typed_value.variant_type != Variant::NIL, "Type can only be set once.");
 	ERR_FAIL_COND_MSG((p_key_class_name != StringName() && p_key_type != Variant::OBJECT) || (p_value_class_name != StringName() && p_value_type != Variant::OBJECT), "Class names can only be set for type OBJECT.");
 	Ref<Script> key_script = p_key_script;
 	ERR_FAIL_COND_MSG(key_script.is_valid() && p_key_class_name == StringName(), "Script class can only be set together with base class name.");
 	Ref<Script> value_script = p_value_script;
 	ERR_FAIL_COND_MSG(value_script.is_valid() && p_value_class_name == StringName(), "Script class can only be set together with base class name.");
 
-	_p->typed_key.type = Variant::Type(p_key_type);
+	_p->typed_key.variant_type = Variant::Type(p_key_type);
 	_p->typed_key.class_name = p_key_class_name;
 	_p->typed_key.script = key_script;
 	_p->typed_key.where = "TypedDictionary.Key";
 
-	_p->typed_value.type = Variant::Type(p_value_type);
+	_p->typed_value.variant_type = Variant::Type(p_value_type);
 	_p->typed_value.class_name = p_value_class_name;
 	_p->typed_value.script = value_script;
 	_p->typed_value.where = "TypedDictionary.Value";
@@ -664,11 +664,11 @@ bool Dictionary::is_typed() const {
 }
 
 bool Dictionary::is_typed_key() const {
-	return _p->typed_key.type != Variant::NIL;
+	return _p->typed_key.variant_type != Variant::NIL;
 }
 
 bool Dictionary::is_typed_value() const {
-	return _p->typed_value.type != Variant::NIL;
+	return _p->typed_value.variant_type != Variant::NIL;
 }
 
 bool Dictionary::is_same_instance(const Dictionary &p_other) const {
@@ -689,7 +689,7 @@ bool Dictionary::is_same_typed_value(const Dictionary &p_other) const {
 
 ContainerType Dictionary::get_key_type() const {
 	ContainerType type;
-	type.builtin_type = _p->typed_key.type;
+	type.variant_type = _p->typed_key.variant_type;
 	type.class_name = _p->typed_key.class_name;
 	type.script = _p->typed_key.script;
 	return type;
@@ -697,18 +697,18 @@ ContainerType Dictionary::get_key_type() const {
 
 ContainerType Dictionary::get_value_type() const {
 	ContainerType type;
-	type.builtin_type = _p->typed_value.type;
+	type.variant_type = _p->typed_value.variant_type;
 	type.class_name = _p->typed_value.class_name;
 	type.script = _p->typed_value.script;
 	return type;
 }
 
 uint32_t Dictionary::get_typed_key_builtin() const {
-	return _p->typed_key.type;
+	return _p->typed_key.variant_type;
 }
 
 uint32_t Dictionary::get_typed_value_builtin() const {
-	return _p->typed_value.type;
+	return _p->typed_value.variant_type;
 }
 
 StringName Dictionary::get_typed_key_class_name() const {

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -107,7 +107,7 @@ Variant SceneState::_duplicate_recursive(const Variant &p_variant, HashMap<Node 
 				if (fallback.is_typed()) {
 					const ContainerType &fallback_type = fallback.get_element_type();
 					has_fallback =
-							scr_type.builtin_type == fallback_type.builtin_type &&
+							scr_type.variant_type == fallback_type.variant_type &&
 							scr_type.class_name == fallback_type.class_name &&
 							scr_type.script == fallback_type.script;
 				}


### PR DESCRIPTION
## What problem(s) does this PR solve?

I wanted to start looking at the deep `ContainerType` and this was more of a blocker than I expected.

Mainly `ContainerType` is unified with `ContainerTypeValidate` here, using the same name to refer to the same thing. `builtin_type` is not a fitting name and `type` is ambiguous.

## Additional information

`ContainerType` is supposed to be the same as `ContainerTypeValidate`, but without `where` because `where` is contextual by owner, and whoever exchanges types shouldn't override it. Odd design choice, but fair enough.

I expect any smart refactor will merge the two, or at least subclass, so a uniform name is needed. This will simplify https://github.com/godotengine/godot/pull/122723, for example.