### PR TITLE
Properly conserve energy when calculating ambient lighting.

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -2775,7 +2775,9 @@ void main() {
 
 		float a004 = min(r.x * r.x, exp2(-9.28 * ndotv)) * r.x + r.y;
 		vec2 env = vec2(-1.04, 1.04) * a004 + r.zw;
-		specular_light *= env.x * f0 + env.y * clamp(50.0 * f0.g, metallic, 1.0);
+		vec3 E = env.x * f0 + env.y * clamp(50.0 * f0.g, metallic, 1.0);
+		specular_light *= E;
+		ambient_light *= 1.0 - E;
 #endif
 	}
 #endif // !AMBIENT_LIGHT_DISABLED

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -2338,7 +2338,9 @@ void fragment_shader(in SceneData scene_data) {
 
 		// cheap luminance approximation
 		float f90 = clamp(50.0 * f0.g, metallic, 1.0);
-		indirect_specular_light *= energy_compensation * ((f90 - f0) * envBRDF.x + f0 * envBRDF.y);
+		vec3 E = energy_compensation * ((f90 - f0) * envBRDF.x + f0 * envBRDF.y);
+		indirect_specular_light *= E;
+		ambient_light *= 1.0 - E;
 
 #ifdef LIGHT_CLEARCOAT_USED
 		float geo_NdotV = max(dot(geo_normal, view), 0.0001); // We want to use geometric normal, not normal_map

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1964,7 +1964,9 @@ void main() {
 		half a004 = min(r.x * r.x, exp2(half(-9.28) * ndotv)) * r.x + r.y;
 		hvec2 env = hvec2(-1.04, 1.04) * a004 + r.zw;
 
-		indirect_specular_light *= env.x * f0 + env.y * clamp(half(50.0) * f0.g, metallic, half(1.0));
+		hvec3 E = env.x * f0 + env.y * clamp(half(50.0) * f0.g, metallic, half(1.0));
+		indirect_specular_light *= E;
+		ambient_light *= hvec3(1.0) - E;
 
 #ifdef LIGHT_CLEARCOAT_USED
 		half geo_NdotV = max(dot(geo_normal, view), half(0.0001)); // We want to use geometric normal, not normal_map


### PR DESCRIPTION
_Edit: I'm not sure if this is worth doing at all. This PR matches the behaviour of UE5, but only when the "enable energy conservation on material” rendering setting is on (its off by default). The setting isn't even documented and isn't discussed much online, so it seems people really don't care. So probably not worth adding a slight cost for this and changing behaviour slightly_

_Edit2: It looks like Unity HDRP matches the behaviour of Godot Master. So this change probably isn't worth doing. It seems like no one cares about energy conservation in practice_

Previously (in all Godot versions) we forgot to scale the ambient light diffuse term. This resulted in adding energy twice.

The impact can easily be seen in a gray furnace test

_Metallic increases from top to bottom. Roughness increases from left to right_
_Note how dialectrics get a white halo. This is the area where the energy is being added twice_
<img width="1048" height="1017" alt="Screenshot from 2026-09-11 09-47-35" src="https://github.com/user-attachments/assets/79a70417-e19d-478d-9ba5-ae5e0f95f43a" />

_With this change no halo. And fully dielectric and fully metallic objects disappear as they should_
<img width="1048" height="1017" alt="Screenshot from 2026-09-11 09-47-13" src="https://github.com/user-attachments/assets/c8c7a9c5-0d64-445a-a39c-d06e0a2fd6ca" />

Some energy loss is still expected in the transition. However, this appears to be more than I would expect. So opening as draft for now while I investigate

Here is an example of what it should look like (source: https://github.com/google/filament/pull/1563)

![](https://user-images.githubusercontent.com/869684/63814740-be2a7e80-c8e6-11e9-8dba-2f0ed0c885ce.png)

_White furnace with this PR to compare to Filament_
<img width="1172" height="1146" alt="Screenshot from 2026-09-11 11-30-20" src="https://github.com/user-attachments/assets/f88ac8de-5209-4ad9-83c4-18ea5984d1c7" />


