### PR TITLE
Allow creating/removing `.gdignore` files using the FileSystem dock

### DIFF
--- a/editor/docks/filesystem_dock.cpp
+++ b/editor/docks/filesystem_dock.cpp
@@ -53,6 +53,7 @@
 #include "editor/gui/create_dialog.h"
 #include "editor/gui/directory_create_dialog.h"
 #include "editor/gui/editor_dir_dialog.h"
+#include "editor/gui/editor_icon_manager.h"
 #include "editor/import/3d/scene_import_settings.h"
 #include "editor/inspector/editor_context_menu_plugin.h"
 #include "editor/inspector/editor_resource_preview.h"
@@ -261,6 +262,16 @@ void FileSystemDock::_create_tree(TreeItem *p_parent, EditorFileSystemDirectory 
 				subdirectory_item->set_icon_modulate(0, get_theme_color(SNAME("folder_icon_color"), SNAME("FileDialog")));
 			}
 		}
+	}
+
+	if (EditorFileSystem::get_singleton()->is_folder_hidden(lpath)) {
+		const float alpha = 0.5f;
+		Color icon_modulate = subdirectory_item->get_icon_modulate(0);
+		Color text_color = tree->get_theme_color(SNAME("font_color"));
+		icon_modulate.a *= alpha;
+		text_color.a *= alpha;
+		subdirectory_item->set_icon_modulate(0, icon_modulate);
+		subdirectory_item->set_custom_color(0, text_color);
 	}
 
 	subdirectory_item->set_text(0, dname);
@@ -698,6 +709,11 @@ void FileSystemDock::_notification(int p_what) {
 				thumbnail_size_setting = new_thumbnail_size_setting;
 				thumbnail_size_slider->set_value(thumbnail_size_setting);
 				do_redraw = true;
+			}
+
+			bool new_show_hidden_files = bool(EDITOR_GET("filesystem/file_dialog/show_hidden_files"));
+			if (new_show_hidden_files != EditorFileSystem::get_singleton()->is_showing_hidden_folders()) {
+				_toggle_folders_visibility(new_show_hidden_files);
 			}
 
 			if (do_redraw) {
@@ -1185,6 +1201,16 @@ void FileSystemDock::_update_file_list(bool p_keep_selection, const Vector<Strin
 						this_folder_color *= ITEM_COLOR_SCALE;
 					}
 					files->set_item_icon_modulate(-1, this_folder_color);
+
+					if (EditorFileSystem::get_singleton()->is_folder_hidden(dpath)) {
+						const float alpha = 0.5f;
+						Color icon_modulate = files->get_item_icon_modulate(-1);
+						Color text_color = files->get_theme_color(SNAME("font_color"));
+						icon_modulate.a *= alpha;
+						text_color.a *= alpha;
+						files->set_item_icon_modulate(-1, icon_modulate);
+						files->set_item_custom_fg_color(-1, text_color);
+					}
 
 					if (previous_selection.has(dpath)) {
 						files->select(files->get_item_count() - 1, false);
@@ -2499,6 +2525,12 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			}
 		} break;
 
+		case FILE_MENU_TOGGLE_FOLDER: {
+			String path = p_selected[0];
+			bool is_hidden = EditorFileSystem::get_singleton()->is_folder_hidden(path);
+			EditorFileSystem::get_singleton()->mark_folder_hidden(path, !is_hidden, true);
+		} break;
+
 		case FILE_MENU_INHERIT: {
 			// Create a new scene inherited from the selected one.
 			if (p_selected.size() == 1) {
@@ -3513,6 +3545,14 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, const Vect
 		p_popup->add_icon_item(get_editor_theme_icon(SNAME("Load")), TTRC("Expand Folder"), FILE_MENU_OPEN);
 
 		if (foldernames.size() == 1) {
+			if (root_path_not_selected) {
+				bool is_hidden = EditorFileSystem::get_singleton()->is_folder_hidden(foldernames[0]);
+				bool is_read_only = foldernames[0].begins_with(".");
+				p_popup->add_check_item(TTRC("Hidden Folder"), FILE_MENU_TOGGLE_FOLDER);
+				p_popup->set_item_checked(-1, is_hidden);
+				p_popup->set_item_disabled(-1, is_read_only);
+			}
+
 			p_popup->add_icon_item(get_editor_theme_icon(SNAME("GuiTreeArrowDown")), TTRC("Expand Hierarchy"), FILE_MENU_EXPAND_ALL);
 			p_popup->add_icon_item(get_editor_theme_icon(SNAME("GuiTreeArrowRight")), TTRC("Collapse Hierarchy"), FILE_MENU_COLLAPSE_ALL);
 		}
@@ -4469,6 +4509,16 @@ void FileSystemDock::_on_open_editor_settings_file_exts() {
 	ed_settings->set_current_section("docks/filesystem");
 }
 
+void FileSystemDock::_toggle_folders_visibility(bool p_toggled) {
+	tree_button_toggle_folders->set_disabled(true);
+	file_list_button_toggle_folders->set_disabled(true);
+	tree_button_toggle_folders->set_pressed_no_signal(p_toggled);
+	file_list_button_toggle_folders->set_pressed_no_signal(p_toggled);
+	EditorFileSystem::get_singleton()->set_show_hidden_folders(p_toggled);
+	tree_button_toggle_folders->set_disabled(false);
+	file_list_button_toggle_folders->set_disabled(false);
+}
+
 void FileSystemDock::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("navigate_to_path", "path"), &FileSystemDock::navigate_to_path);
 
@@ -4590,6 +4640,15 @@ FileSystemDock::FileSystemDock() {
 	tree_search_box->connect(SceneStringName(text_changed), callable_mp(this, &FileSystemDock::_search_changed).bind(tree_search_box));
 	toolbar2_hbc->add_child(tree_search_box);
 
+	tree_button_toggle_folders = memnew(Button);
+	tree_button_toggle_folders->set_flat(true);
+	tree_button_toggle_folders->set_toggle_mode(true);
+	tree_button_toggle_folders->set_button_icon(EditorIconManager::get_icon(SNAME("GuiVisibilityVisible")));
+	tree_button_toggle_folders->set_pressed_no_signal(EDITOR_GET("filesystem/file_dialog/show_hidden_files"));
+	tree_button_toggle_folders->set_tooltip_text(TTRC("Toggle the visibility of hidden folders."));
+	tree_button_toggle_folders->connect(SceneStringName(toggled), callable_mp(this, &FileSystemDock::_toggle_folders_visibility));
+	toolbar2_hbc->add_child(tree_button_toggle_folders);
+
 	tree_button_sort = _create_file_menu_button();
 	toolbar2_hbc->add_child(tree_button_sort);
 
@@ -4649,6 +4708,15 @@ FileSystemDock::FileSystemDock() {
 	file_list_search_box->set_clear_button_enabled(true);
 	file_list_search_box->connect(SceneStringName(text_changed), callable_mp(this, &FileSystemDock::_search_changed).bind(file_list_search_box));
 	path_hb->add_child(file_list_search_box);
+
+	file_list_button_toggle_folders = memnew(Button);
+	file_list_button_toggle_folders->set_flat(true);
+	file_list_button_toggle_folders->set_toggle_mode(true);
+	file_list_button_toggle_folders->set_button_icon(EditorIconManager::get_icon(SNAME("GuiVisibilityVisible")));
+	file_list_button_toggle_folders->set_pressed_no_signal(EDITOR_GET("filesystem/file_dialog/show_hidden_files"));
+	file_list_button_toggle_folders->set_tooltip_text(TTRC("Toggle the visibility of hidden folders."));
+	file_list_button_toggle_folders->connect(SceneStringName(toggled), callable_mp(this, &FileSystemDock::_toggle_folders_visibility));
+	path_hb->add_child(file_list_button_toggle_folders);
 
 	file_list_button_sort = _create_file_menu_button();
 	path_hb->add_child(file_list_button_sort);

--- a/editor/docks/filesystem_dock.h
+++ b/editor/docks/filesystem_dock.h
@@ -130,6 +130,7 @@ private:
 		FILE_MENU_COPY_PATH,
 		FILE_MENU_COPY_ABSOLUTE_PATH,
 		FILE_MENU_COPY_UID,
+		FILE_MENU_TOGGLE_FOLDER,
 		FILE_MENU_EXPAND_ALL,
 		FILE_MENU_COLLAPSE_ALL,
 		FILE_MENU_NEW_RESOURCE,
@@ -175,12 +176,14 @@ private:
 	HBoxContainer *toolbar2_hbc = nullptr;
 	LineEdit *tree_search_box = nullptr;
 	MenuButton *tree_button_sort = nullptr;
+	Button *tree_button_toggle_folders = nullptr;
 
 	HBoxContainer *bottom_toolbar_hbc = nullptr;
 	HSlider *thumbnail_size_slider = nullptr;
 
 	LineEdit *file_list_search_box = nullptr;
 	MenuButton *file_list_button_sort = nullptr;
+	Button *file_list_button_toggle_folders = nullptr;
 
 	PackedStringArray searched_tokens;
 	Vector<String> uncollapsed_paths_before_search;
@@ -399,6 +402,8 @@ private:
 	static Vector<String> _remove_self_included_paths(Vector<String> selected_strings);
 
 	void _on_open_editor_settings_file_exts();
+
+	void _toggle_folders_visibility(bool p_toggled);
 
 private:
 	inline static FileSystemDock *singleton = nullptr;

--- a/editor/file_system/editor_file_system.cpp
+++ b/editor/file_system/editor_file_system.cpp
@@ -1167,8 +1167,15 @@ int EditorFileSystem::_scan_new_dir(ScannedDirectory *p_dir, Ref<DirAccess> &da)
 		}
 
 		if (da->current_is_dir()) {
-			if (f.begins_with(".")) { // Ignore special and . / ..
+			if (f == "." || f == "..") { // Ignore . / ..
 				continue;
+			}
+
+			if (f.begins_with(".")) { // Ignore special
+				singleton->mark_folder_hidden(cd.path_join(f), true);
+				if (!singleton->is_showing_hidden_folders()) {
+					continue;
+				}
 			}
 
 			if (_should_skip_directory(cd.path_join(f))) {
@@ -1463,8 +1470,15 @@ void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, ScanPr
 			}
 
 			if (da->current_is_dir()) {
-				if (f.begins_with(".")) { // Ignore special and . / ..
+				if (f == "." || f == "..") { // Ignore . / ..
 					continue;
+				}
+
+				if (f.begins_with(".")) { // Ignore special
+					singleton->mark_folder_hidden(cd.path_join(f), true);
+					if (!singleton->is_showing_hidden_folders()) {
+						continue;
+					}
 				}
 
 				int idx = p_dir->find_dir_index(f);
@@ -1896,9 +1910,17 @@ bool EditorFileSystem::_find_file(const String &p_file, EditorFileSystemDirector
 	EditorFileSystemDirectory *fs = filesystem;
 
 	for (const String &path_bit : path) {
-		if (path_bit.begins_with(".")) {
-			return false;
+		if (path_bit == "." || path_bit == "..") {
+			continue;
 		}
+
+		if (path_bit.begins_with(".")) {
+			singleton->mark_folder_hidden(fs->get_path().path_join(path_bit), true);
+			if (!singleton->is_showing_hidden_folders()) {
+				return false;
+			}
+		}
+
 		const String path_bit_lower = path_bit.to_lower();
 
 		int idx = -1;
@@ -3481,7 +3503,8 @@ bool EditorFileSystem::_should_skip_directory(const String &p_path) {
 
 	if (FileAccess::exists(p_path.path_join(".gdignore"))) {
 		// Skip if a `.gdignore` file is inside this.
-		return true;
+		singleton->mark_folder_hidden(p_path, true);
+		return !singleton->is_showing_hidden_folders();
 	}
 
 	return false;
@@ -3646,6 +3669,66 @@ Error EditorFileSystem::copy_directory(const String &p_from, const String &p_to)
 	return success ? OK : FAILED;
 }
 
+void EditorFileSystem::mark_folder_hidden(const String &p_path, bool p_hidden, bool p_update) {
+	MutexLock hidden_folders_lock(hidden_folders_mutex);
+	const String path = p_path.trim_suffix("/");
+	const String gdignore = path.path_join(".gdignore");
+	bool is_hidden = FileAccess::exists(gdignore);
+	bool is_marked_hidden = hidden_folders.has(path);
+	bool is_read_only = p_path.begins_with(".");
+	if (!is_read_only) {
+		if (is_hidden && !p_hidden) {
+			DirAccess::remove_absolute(gdignore);
+		} else if (!is_hidden && p_hidden) {
+			FileAccess::open(gdignore, FileAccess::WRITE);
+		}
+	}
+
+	if (p_hidden && !is_marked_hidden) {
+		hidden_folders.insert(path);
+	} else if (!p_hidden && is_marked_hidden) {
+		hidden_folders.erase(path);
+	}
+
+	if (p_update) {
+		ScanProgress sp;
+		EditorFileSystemDirectory *parent = get_filesystem_path(path.get_base_dir());
+		if (parent) {
+			parent->force_update();
+			_scan_fs_changes(parent, sp, false);
+		}
+
+		_update_scan_actions();
+		_queue_refresh_filesystem();
+	}
+}
+
+void EditorFileSystem::set_show_hidden_folders(bool p_show) {
+	show_hidden_folders = p_show;
+	ScanProgress sp;
+	HashSet<ObjectID> scanned;
+	for (const String &path : hidden_folders) {
+		EditorFileSystemDirectory *parent = get_filesystem_path(path.get_base_dir());
+		if (parent && !scanned.has(parent->get_instance_id())) {
+			parent->force_update();
+			_scan_fs_changes(parent, sp, false);
+			scanned.insert(parent->get_instance_id());
+		}
+	}
+
+	_update_scan_actions();
+	_queue_refresh_filesystem();
+}
+
+bool EditorFileSystem::is_showing_hidden_folders() const {
+	return show_hidden_folders;
+}
+
+bool EditorFileSystem::is_folder_hidden(const String &p_path) const {
+	MutexLock hidden_folders_lock(hidden_folders_mutex);
+	return hidden_folders.has(p_path.trim_suffix("/"));
+}
+
 ResourceUID::ID EditorFileSystem::_resource_saver_get_resource_id_for_path(const String &p_path, bool p_generate) {
 	if (!p_path.is_resource_file() || p_path.begins_with(ProjectSettings::get_singleton()->get_project_data_path())) {
 		// Saved externally (configuration file) or internal file, do not assign an ID.
@@ -3777,6 +3860,7 @@ EditorFileSystem::EditorFileSystem() {
 	// See GH-112072 for details.
 	use_threads = true;
 #endif
+	show_hidden_folders = EDITOR_GET("filesystem/file_dialog/show_hidden_files");
 
 	ResourceLoader::import = _resource_import;
 	reimport_on_missing_imported_files = GLOBAL_GET("editor/import/reimport_missing_imported_files");

--- a/editor/file_system/editor_file_system.h
+++ b/editor/file_system/editor_file_system.h
@@ -346,6 +346,10 @@ class EditorFileSystem : public Node {
 	bool refresh_queued = false;
 	HashSet<ObjectID> folders_to_sort;
 
+	bool show_hidden_folders = false;
+	Mutex hidden_folders_mutex;
+	HashSet<String> hidden_folders;
+
 	Error _copy_file(const String &p_from, const String &p_to);
 	bool _copy_directory(const String &p_from, const String &p_to, HashMap<String, String> *p_files);
 	void _queue_refresh_filesystem();
@@ -413,6 +417,11 @@ public:
 	Error make_dir_recursive(const String &p_path, const String &p_base_path = String());
 	Error copy_file(const String &p_from, const String &p_to);
 	Error copy_directory(const String &p_from, const String &p_to);
+
+	void mark_folder_hidden(const String &p_path, bool p_hidden, bool p_update = false);
+	void set_show_hidden_folders(bool p_show);
+	bool is_showing_hidden_folders() const;
+	bool is_folder_hidden(const String &p_path) const;
 
 	static bool _should_skip_directory(const String &p_path);
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes https://github.com/godotengine/godot-proposals/issues/1809
- Closes https://github.com/godotengine/godot-proposals/issues/13119

## Additional information
<img width="238" height="232" alt="GIF 9-11-2026 10-14-36 PM" src="https://github.com/user-attachments/assets/fd7cc355-42ca-4e1b-96da-715e260cb5e2" />

May need some UI/UX adjustments
N/AI
