### PR TITLE
Fix uri decoding with lower case digits

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4427,9 +4427,9 @@ String String::uri_decode() const {
 	for (int i = 0; i < src.length(); ++i) {
 		if (src[i] == '%' && i + 2 < src.length()) {
 			char ord1 = src[i + 1];
-			if (is_digit(ord1) || is_ascii_upper_case(ord1)) {
+			if (is_hex_digit(ord1)) {
 				char ord2 = src[i + 2];
-				if (is_digit(ord2) || is_ascii_upper_case(ord2)) {
+				if (is_hex_digit(ord2)) {
 					char bytes[3] = { (char)ord1, (char)ord2, 0 };
 					res += (char)strtol(bytes, nullptr, 16);
 					i += 2;
@@ -4452,9 +4452,9 @@ String String::uri_file_decode() const {
 	for (int i = 0; i < src.length(); ++i) {
 		if (src[i] == '%' && i + 2 < src.length()) {
 			char ord1 = src[i + 1];
-			if (is_digit(ord1) || is_ascii_upper_case(ord1)) {
+			if (is_hex_digit(ord1)) {
 				char ord2 = src[i + 2];
-				if (is_digit(ord2) || is_ascii_upper_case(ord2)) {
+				if (is_hex_digit(ord2)) {
 					char bytes[3] = { (char)ord1, (char)ord2, 0 };
 					res += (char)strtol(bytes, nullptr, 16);
 					i += 2;

--- a/tests/core/string/test_string.cpp
+++ b/tests/core/string/test_string.cpp
@@ -1901,6 +1901,7 @@ TEST_CASE("[String] uri_encode/unescape") {
 	String x2 = String::utf8((const char *)u8str);
 	String x3 = U"Tēšt";
 	String x4 = U"file+name";
+	String x5 = U"%5B%5b+%5d%5D";
 
 	CHECK(x1.uri_decode() == x2);
 	CHECK(x1.uri_decode() == x3);
@@ -1912,6 +1913,8 @@ TEST_CASE("[String] uri_encode/unescape") {
 	CHECK(t.uri_decode() == s);
 	CHECK(x4.uri_file_decode() == x4);
 	CHECK(x4.uri_decode() == U"file name");
+	CHECK(x5.uri_file_decode() == U"[[+]]");
+	CHECK(x5.uri_decode() == U"[[ ]]");
 }
 
 TEST_CASE("[String] xml_escape/unescape") {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Should fix https://github.com/godotengine/godot/issues/123427

`String::uri_file_decode` does currently only accept upper case hex digits:

```gdscript
print("%5B".uri_file_decode()) # prints [
print("%5b".uri_file_decode()) # prints %5b
```

However as per [RFC 3986](https://www.rfc-editor.org/info/rfc3986/#section-2.1) percent encoding is case insensitive:

> The uppercase hexadecimal digits 'A' through 'F' are equivalent to the lowercase digits 'a' through 'f', respectively.

In the linked issue the external editor uses lowercase hex digits which currently breaks our decoding.

This PR fixes our decoding to allow for lower case hex digits.

## Additional information

- `strtol` is case insensitive as per https://en.cppreference.com/cpp/string/byte/strtol

> The case of the characters is ignored.

- I adopted `is_hex_digit` which in theory does omit certain chars we previously considered valid since we used `is_ascii_upper_case`. Only allowing "a" through "f" seems more correct to me anyway, since percent encoding uses hex numbers.
