### PR TITLE
Fix editor's bottom panel top margin when switching to a RTL language

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -202,7 +202,9 @@ void TabContainer::_notification(int p_what) {
 				popup_button->set_button_icon(theme_cache.menu_icon);
 				internal_container->move_child(popup_button, is_layout_rtl() ? 0 : 1);
 			}
+
 			_update_margins();
+			callable_mp(this, &TabContainer::_repaint).call_deferred();
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Regression from #114283.

## Additional information

When switching to any language that uses a right-to-left layout, the inner container of `TabContainer` wasn't being properly adjusted, resulting into the top margin being larger than it should:

<img width="401" height="56" alt="image" src="https://github.com/user-attachments/assets/d32fc0fd-5354-42bc-999f-fe235a7f82be" />