### PR TITLE
Script Editor: Improve diagnostic list display (WIP)

### DIFF
--- a/editor/script/script_editor_base.cpp
+++ b/editor/script/script_editor_base.cpp
@@ -826,12 +826,19 @@ void CodeEditorBase::set_breakpoint(int p_line, bool p_enabled) {
 
 void CodeEditorBase::_show_warnings_panel(bool p_show) {
 	warnings_panel->set_visible(p_show);
+	warnings_panel_tree->set_visible(p_show);
 }
 
 bool CodeEditorBase::_warning_clicked(const Variant &p_line) {
 	if (p_line.get_type() == Variant::INT) {
 		goto_line_centered(p_line.operator int64_t());
 		return true;
+	} else if (p_line.get_type() == Variant::DICTIONARY) {
+		Dictionary as_dict = p_line;
+		if (as_dict.get("operation", "goto") == "goto") {
+			goto_line_centered(as_dict.get("line", 0), as_dict.get("column", 0));
+			return true;
+		}
 	}
 	return false;
 }
@@ -962,6 +969,13 @@ CodeEditorBase::CodeEditorBase() {
 	warnings_panel->set_focus_mode(FOCUS_CLICK);
 	warnings_panel->hide();
 	warnings_panel->connect("meta_clicked", callable_mp(this, &CodeEditorBase::_warning_clicked));
+
+	warnings_panel_tree = memnew(ScriptEditorDiagnosticPanel);
+	warnings_panel_tree->set_custom_minimum_size(Size2(0, 100 * EDSCALE));
+	warnings_panel_tree->set_h_size_flags(SIZE_EXPAND_FILL);
+	warnings_panel_tree->set_focus_mode(FOCUS_CLICK);
+	warnings_panel_tree->hide();
+	warnings_panel_tree->connect("action_requested", callable_mp(this, &CodeEditorBase::_warning_clicked));
 
 	editor_box = memnew(VSplitContainer);
 	add_child(editor_box);

--- a/editor/script/script_editor_base.h
+++ b/editor/script/script_editor_base.h
@@ -32,11 +32,40 @@
 
 #include "editor/gui/code_editor.h"
 #include "scene/gui/box_container.h"
+#include "scene/gui/tree.h"
 
 class EditorSyntaxHighlighter;
 class MenuButton;
 class VSplitContainer;
 class ScriptEditor;
+
+class ScriptEditorDiagnosticPanel : public Tree {
+	GDCLASS(ScriptEditorDiagnosticPanel, Tree);
+
+	static void _bind_methods();
+
+	void _on_button_clicked(TreeItem *p_item, int p_column, int p_id, int p_mouse_button_index);
+	void _on_item_activated();
+
+protected:
+	void _notification(int p_what);
+
+public:
+	enum DiagnosticAction {
+		ACTION_IGNORE_WARNING,
+		ACTION_COPY
+	};
+
+	TreeItem *add_warning(const String &p_message);
+	TreeItem *add_warning(const EditorLanguage::Warning &p_warning);
+
+	TreeItem *add_error(const String &p_message);
+	TreeItem *add_error(const EditorLanguage::ScriptError &p_error);
+
+	TreeItem *add_suberror(TreeItem *p_parent_item, const EditorLanguage::ScriptError &p_error);
+
+	ScriptEditorDiagnosticPanel();
+};
 
 class ScriptEditorBase : public VBoxContainer {
 	GDCLASS(ScriptEditorBase, VBoxContainer);
@@ -285,6 +314,7 @@ protected:
 
 	VSplitContainer *editor_box = nullptr;
 	RichTextLabel *warnings_panel = nullptr;
+	ScriptEditorDiagnosticPanel *warnings_panel_tree = nullptr;
 
 	static void _code_complete_scripts(void *p_ud, const String &p_code, List<EditorLanguage::CompletionOption> *r_options, bool &r_force);
 	virtual void _code_complete_script(const String &p_code, List<EditorLanguage::CompletionOption> *r_options, bool &r_force) = 0;

--- a/editor/script/script_text_editor.cpp
+++ b/editor/script/script_text_editor.cpp
@@ -63,6 +63,117 @@
 #include "scene/resources/style_box_flat.h"
 #include "servers/rendering/rendering_server.h"
 
+TreeItem *ScriptEditorDiagnosticPanel::add_warning(const String &p_message) {
+	TreeItem *item = create_item();
+	item->set_text(0, p_message);
+	item->set_icon(0, get_editor_theme_icon(SNAME("NodeWarning")));
+	item->set_custom_color(0, get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+	item->add_button(0, get_editor_theme_icon(SNAME("ActionCopy")), ACTION_COPY, false, TTR("Copy this diagnostic."));
+	return item;
+}
+
+TreeItem *ScriptEditorDiagnosticPanel::add_warning(const EditorLanguage::Warning &p_warning) {
+	TreeItem *item = create_item();
+	item->set_text(0, vformat("%s: %s [Line %s, Col %s]", p_warning.string_code, p_warning.message, p_warning.start_line, p_warning.start_column));
+	item->set_icon(0, get_editor_theme_icon(SNAME("NodeWarning")));
+	item->set_custom_color(0, get_theme_color(SNAME("warning_color"), EditorStringName(Editor)));
+	item->add_button(0, get_editor_theme_icon(SNAME("Close")), ACTION_IGNORE_WARNING, false, "Ignore this warning.");
+	item->add_button(0, get_editor_theme_icon(SNAME("ActionCopy")), ACTION_COPY, false, TTR("Copy this diagnostic."));
+
+	Dictionary location_data;
+	location_data["line"] = p_warning.start_line - 1;
+	location_data["column"] = p_warning.start_column - 1;
+	item->set_meta(SNAME("location"), location_data);
+	item->set_meta(SNAME("diagnostic_code"), p_warning.string_code);
+
+	return item;
+}
+
+TreeItem *ScriptEditorDiagnosticPanel::add_error(const String &p_message) {
+	TreeItem *item = create_item();
+	item->set_text(0, p_message);
+	item->set_icon(0, get_editor_theme_icon(SNAME("StatusError")));
+	item->set_custom_color(0, get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+	item->add_button(0, get_editor_theme_icon(SNAME("ActionCopy")), ACTION_COPY, false, TTR("Copy this diagnostic."));
+	return item;
+}
+
+TreeItem *ScriptEditorDiagnosticPanel::add_error(const EditorLanguage::ScriptError &p_error) {
+	TreeItem *item = create_item();
+	item->set_text(0, vformat("%s [Line %s, Col %s]", p_error.message, p_error.start_line, p_error.start_column));
+	item->set_icon(0, get_editor_theme_icon(SNAME("StatusError")));
+	item->set_custom_color(0, get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+	item->add_button(0, get_editor_theme_icon(SNAME("ActionCopy")), ACTION_COPY, false, TTR("Copy this diagnostic."));
+
+	Dictionary location_data;
+	location_data["line"] = p_error.start_line - 1;
+	location_data["column"] = p_error.start_column - 1;
+	item->set_meta(SNAME("location"), location_data);
+
+	return item;
+}
+
+TreeItem *ScriptEditorDiagnosticPanel::add_suberror(TreeItem *p_parent_item, const EditorLanguage::ScriptError &p_error) {
+	TreeItem *new_subitem = p_parent_item->create_child();
+	new_subitem->set_text(0, vformat("%s [Line %s, Col %s]", p_error.message, p_error.start_line, p_error.start_column));
+	new_subitem->set_custom_color(0, get_theme_color(SNAME("error_color"), EditorStringName(Editor)));
+	new_subitem->add_button(0, get_editor_theme_icon(SNAME("ActionCopy")), -1, false, "Copy this error.");
+
+	// TODO: Error location data.
+
+	return new_subitem;
+}
+
+void ScriptEditorDiagnosticPanel::_on_button_clicked(TreeItem *p_item, int p_column, int p_id, int p_mouse_button_index) {
+	switch (p_id) {
+		case ACTION_IGNORE_WARNING: {
+			if (!p_item->has_meta(SNAME("location")) || !p_item->has_meta(SNAME("diagnostic_code"))) {
+				return;
+			}
+			Dictionary data = p_item->get_meta(SNAME("location"));
+			data["operation"] = "ignore";
+			data["code"] = p_item->get_meta(SNAME("diagnostic_code"));
+			emit_signal(SNAME("action_requested"), data);
+			break;
+		}
+		case ACTION_COPY: {
+			DisplayServer::get_singleton()->clipboard_set(p_item->get_text(0));
+			break;
+		}
+	}
+}
+
+void ScriptEditorDiagnosticPanel::_on_item_activated() {
+	TreeItem *current_item = get_selected();
+	if (!current_item->has_meta(SNAME("location"))) {
+		return;
+	}
+
+	Dictionary data = current_item->get_meta(SNAME("location"));
+	data["operation"] = "goto";
+	emit_signal(SNAME("action_requested"), data);
+}
+
+void ScriptEditorDiagnosticPanel::_bind_methods() {
+	ADD_SIGNAL(MethodInfo("action_requested", PropertyInfo(Variant::DICTIONARY, "location")));
+}
+
+void ScriptEditorDiagnosticPanel::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_READY:
+			connect("button_clicked", callable_mp(this, &ScriptEditorDiagnosticPanel::_on_button_clicked));
+			connect("item_activated", callable_mp(this, &ScriptEditorDiagnosticPanel::_on_item_activated));
+			break;
+		default:
+			break;
+	}
+}
+
+ScriptEditorDiagnosticPanel::ScriptEditorDiagnosticPanel() {
+	set_hide_root(true);
+	create_item();
+}
+
 void ConnectionInfoDialog::ok_pressed() {
 }
 
@@ -359,6 +470,8 @@ void ScriptTextEditor::_show_errors_panel(bool p_show) {
 
 bool ScriptTextEditor::_warning_clicked(const Variant &p_line) {
 	if (CodeEditorBase::_warning_clicked(p_line)) {
+		CodeEdit *text_edit = code_editor->get_text_editor();
+		text_edit->grab_focus();
 		return true;
 	} else if (p_line.get_type() == Variant::DICTIONARY) {
 		Dictionary meta = p_line.operator Dictionary();
@@ -962,6 +1075,7 @@ void ScriptTextEditor::_validate_script() {
 void ScriptTextEditor::_update_warnings() {
 	int warning_nb = warnings.size();
 	warnings_panel->clear();
+	warnings_panel_tree->clear();
 
 	bool has_connections_table = false;
 	// Add missing connections.
@@ -980,6 +1094,8 @@ void ScriptTextEditor::_update_warnings() {
 				warnings_panel->add_text(vformat(TTR("Missing connected method '%s' for signal '%s' from node '%s' to node '%s'."), connection.callable.get_method(), connection.signal.get_name(), source_path, target_path));
 				warnings_panel->pop(); // Color.
 				warnings_panel->pop(); // Cell.
+
+				warnings_panel_tree->add_warning(vformat(TTR("Missing connected method '%s' for signal '%s' from node '%s' to node '%s'."), connection.callable.get_method(), connection.signal.get_name(), source_path, target_path));
 			}
 			warnings_panel->pop(); // Table.
 
@@ -1020,6 +1136,9 @@ void ScriptTextEditor::_update_warnings() {
 		warnings_panel->add_text(w.message);
 		warnings_panel->add_newline();
 		warnings_panel->pop(); // Cell.
+
+		warnings_panel_tree->add_warning(w);
+		// warnings_panel_tree->add_diagnostic(vformat("%s [Line %s, Col %s]", w.message, w.start_line, w.start_column));
 	}
 	warnings_panel->pop(); // Table.
 }
@@ -1042,6 +1161,8 @@ void ScriptTextEditor::_update_errors() {
 		errors_panel->add_text(err.message);
 		errors_panel->add_newline();
 		errors_panel->pop(); // Cell.
+
+		warnings_panel_tree->add_error(err);
 	}
 	errors_panel->pop(); // Table
 
@@ -1056,6 +1177,8 @@ void ScriptTextEditor::_update_errors() {
 		errors_panel->add_text(vformat(R"(%s:)", KV.key));
 		errors_panel->pop(); // Meta goto.
 		errors_panel->add_newline();
+
+		TreeItem *new_item = warnings_panel_tree->add_error(KV.key);
 
 		errors_panel->push_indent(1);
 		errors_panel->push_table(2);
@@ -1076,6 +1199,8 @@ void ScriptTextEditor::_update_errors() {
 			errors_panel->push_cell();
 			errors_panel->add_text(err.message);
 			errors_panel->pop(); // Cell.
+
+			warnings_panel_tree->add_suberror(new_item, err);
 		}
 		errors_panel->pop(); // Table
 		errors_panel->pop(); // Indent.
@@ -2727,6 +2852,7 @@ void ScriptTextEditor::_on_hover_tooltip_timer_timeout() {
 ScriptTextEditor::ScriptTextEditor() {
 	editor_box->add_child(code_editor);
 	editor_box->add_child(warnings_panel);
+	editor_box->add_child(warnings_panel_tree);
 
 	code_editor->get_text_editor()->set_draw_breakpoints_gutter(true);
 	code_editor->get_text_editor()->set_draw_executing_lines_gutter(true);

--- a/editor/shader/shader_text_editor.cpp
+++ b/editor/shader/shader_text_editor.cpp
@@ -1477,6 +1477,7 @@ ShaderTextEditor::ShaderTextEditor() {
 
 	editor_box->add_child(main_box);
 	editor_box->add_child(warnings_panel);
+	editor_box->add_child(warnings_panel_tree); // TODO: Rest of the warnings panel implementation, once it's working well in the script editor!
 
 	preview_timer = memnew(Timer);
 	add_child(preview_timer);


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Makes the diagnostic list use a more modern UI than just a RichTextLabel with "hyperlinks"
- Lays groundwork for integration with other PRs (see below)
- Addresses comment here: https://github.com/godotengine/godot/pull/123310#pullrequestreview-5161094512 (although I have had this prototype on my to-do list for a while before the comment was made)

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->

This branch explores replacing the RichTextLabel-based warning and error panels with a single unified diagnostic panel.

### Tree approach
The following screenshot shows the current state of this approach, with both the old warning panel above and the new diagnostic panel below:

<img width="780" height="683" alt="CleanShot 2026-09-11 at 13 26 35@2x" src="https://github.com/user-attachments/assets/5664d2de-880c-41c9-a548-1bc60f088117" />

#### Issues to address/consider
- TreeItems are only able to display a single line of text, whereas the RichTextLabel approach allows for a single entry to be wrapped across multiple lines.
  - For warnings, the inclusion of the string code (e.g., `INTEGER_DIVISION`) pushes the actual warning message out, making more of it likely to be truncated. To avoid this we could potentially omit the string code from the display here, but on the other hand I think it is good for quick identification and entry into search engines.
- TreeItems only allow a single formatting style (i.e., combination of text color and font weight) per column, whereas the RichTextLabel approach allows warning/error titles to be formatted separately from their full messages.

### Custom components approach
Due to some limitations of the Tree approach, I've also experimented with building custom item components that can be stacked and scrolled through:

<img width="2145" height="1886" alt="CleanShot 2026-09-14 at 10 03 40 AM@2x" src="https://github.com/user-attachments/assets/dc576771-15ff-4514-bbb2-c59913f8a334" />

## Remaining work
If this PR moves forward, the old warning panel will be removed. The dedicated error panel will also be removed, and the buttons for showing/hiding warnings and errors will both call up this unified panel.

Buttons to the right of each diagnostic allow users to act on the specific diagnostics. All diagnostics can have their messages copied, and warnings can also have the `@warning_ignore` annotation applied to them.

In the future, I hope/plan to add additional buttons to these items to integrate with other features I am developing in separate PRs:
- https://github.com/godotengine/godot-docs/pull/10635 – Warnings that have a dedicated explanation page could have a button that opens the page in the user's web browser, allowing them to quickly learn more about the warning and how to fix it.
- https://github.com/godotengine/godot/pull/121338 - If a diagnostic has quick fixes associated with it, a button could bring up those quick fixes.
