### PR TITLE
Always update the editor inspector on translation change

### DIFF
--- a/editor/inspector/editor_inspector.cpp
+++ b/editor/inspector/editor_inspector.cpp
@@ -6195,9 +6195,7 @@ void EditorInspector::_clear_current_favorites() {
 void EditorInspector::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
-			if (property_name_style == EditorPropertyNameProcessor::STYLE_LOCALIZED) {
-				update_tree_pending = true;
-			}
+			update_tree_pending = true;
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED: {


### PR DESCRIPTION
## What problem(s) does this PR solve?

Even if the localization of editor properties is disabled, there are still translatable strings that need to be updated on language change. This PR makes so that the tree is always updated when this happens, no matter what the property name styling is set to.