### PR TITLE
[3.x] Fix AudioServer bus index cache updates

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -705,6 +705,12 @@ int AudioServer::thread_find_bus_index(const StringName &p_name) {
 	}
 }
 
+void AudioServer::_update_bus_index_cache() {
+	for (int i = 0; i < buses.size(); i++) {
+		buses[i]->index_cache = i;
+	}
+}
+
 void AudioServer::set_bus_count(int p_count) {
 	ERR_FAIL_COND(p_count < 1);
 	ERR_FAIL_INDEX(p_count, 256);
@@ -760,6 +766,8 @@ void AudioServer::set_bus_count(int p_count) {
 		bus_map[attempt] = buses[i];
 	}
 
+	_update_bus_index_cache();
+
 	unlock();
 
 	emit_signal("bus_layout_changed");
@@ -775,6 +783,9 @@ void AudioServer::remove_bus(int p_index) {
 	bus_map.erase(buses[p_index]->name);
 	memdelete(buses[p_index]);
 	buses.remove(p_index);
+
+	_update_bus_index_cache();
+
 	unlock();
 
 	emit_signal("bus_layout_changed");
@@ -831,6 +842,8 @@ void AudioServer::add_bus(int p_at_pos) {
 		buses.insert(p_at_pos, bus);
 	}
 
+	_update_bus_index_cache();
+
 	emit_signal("bus_layout_changed");
 }
 
@@ -854,6 +867,8 @@ void AudioServer::move_bus(int p_bus, int p_to_pos) {
 	} else {
 		buses.insert(p_to_pos - 1, bus);
 	}
+
+	_update_bus_index_cache();
 
 	emit_signal("bus_layout_changed");
 }

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -269,6 +269,7 @@ private:
 	Map<StringName, Bus *> bus_map;
 
 	void _update_bus_effects(int p_bus);
+	void _update_bus_index_cache();
 
 	static AudioServer *singleton;
 


### PR DESCRIPTION
## What problem(s) does this PR solve?

- Closes #123409.

In Godot 3.x, `AudioServer::Bus::index_cache` is normally refreshed from
`_mix_step()`. If the bus layout changes between mix steps, however,
`thread_find_bus_index()` can observe an uninitialized or stale cached index.

This can affect buses which are added, removed, resized, or moved while the
engine is already running.

## Additional information

This adds a small `_update_bus_index_cache()` helper and refreshes cached bus
indices immediately after operations which change the bus vector:

- `set_bus_count()`
- `add_bus()`
- `remove_bus()`
- `move_bus()`

The existing refresh in `_mix_step()` is intentionally kept as a defensive
synchronization point.

Testing performed on macOS:

- Godot 3.x compiled successfully with `tools=no target=debug`
- `git diff --check` passes
- Only `servers/audio_server.cpp` and `servers/audio_server.h` are changed

AI usage disclosure: ChatGPT was used to help analyze the reported issue,
trace the affected bus-layout mutation paths, prepare the patch, and construct
the local validation workflow. The resulting C++ changes were validated by
building the Godot 3.x engine locally before opening this PR.
