### PR TITLE
Metal: Fix crash on startup

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -714,6 +714,10 @@ Update instructions:
 - Download latest metal-cpp ZIP from https://developer.apple.com/metal/cpp/:
 - Run `update-metal-cpp.sh <path to the downloaded zip>` to extract the relevant files and apply patches.
 
+Patches:
+
+* 0002-sharedptr-nil-safe-retain-release.patch ([GH-123439](https://github.com/godotengine/godot/pull/123439))
+
 
 ## meshoptimizer
 

--- a/thirdparty/metal-cpp/Foundation/NSSharedPtr.hpp
+++ b/thirdparty/metal-cpp/Foundation/NSSharedPtr.hpp
@@ -22,6 +22,7 @@
 
 #include <cstddef>
 #include "NSDefines.hpp"
+#include "NSObject.hpp"
 
 namespace NS
 {
@@ -139,7 +140,7 @@ template <class _Class>
 _NS_INLINE NS::SharedPtr<_Class> RetainPtr(_Class* pObject)
 {
     NS::SharedPtr<_Class> ret;
-    ret.m_pObject = pObject->retain();
+    ret.m_pObject = Object::sendMessage<_Class*>(pObject, _NS_PRIVATE_SEL(retain));
     return ret;
 }
 
@@ -167,7 +168,7 @@ _NS_INLINE NS::SharedPtr<_Class>::SharedPtr()
 template <class _Class>
 _NS_INLINE NS::SharedPtr<_Class>::~SharedPtr<_Class>() __attribute__((no_sanitize("undefined")))
 {
-    m_pObject->release();
+    Object::sendMessage<void>(m_pObject, _NS_PRIVATE_SEL(release));
 }
 
 template <class _Class>
@@ -178,14 +179,14 @@ _NS_INLINE NS::SharedPtr<_Class>::SharedPtr(std::nullptr_t) noexcept
 
 template <class _Class>
 _NS_INLINE NS::SharedPtr<_Class>::SharedPtr(const SharedPtr<_Class>& other) noexcept
-    : m_pObject(other.m_pObject->retain())
+    : m_pObject(Object::sendMessage<_Class*>(other.m_pObject, _NS_PRIVATE_SEL(retain)))
 {
 }
 
 template <class _Class>
 template <class _OtherClass>
 _NS_INLINE NS::SharedPtr<_Class>::SharedPtr(const SharedPtr<_OtherClass>& other, typename std::enable_if_t<std::is_convertible_v<_OtherClass *, _Class *>> *) noexcept
-    : m_pObject(reinterpret_cast<_Class*>(other.get()->retain()))
+    : m_pObject(Object::sendMessage<_Class*>(other.get(), _NS_PRIVATE_SEL(retain)))
 {
 }
 
@@ -225,7 +226,7 @@ _NS_INLINE NS::SharedPtr<_Class>::operator bool() const
 template <class _Class>
 _NS_INLINE void NS::SharedPtr<_Class>::reset() __attribute__((no_sanitize("undefined")))
 {
-    m_pObject->release();
+    Object::sendMessage<void>(m_pObject, _NS_PRIVATE_SEL(release));
     m_pObject = nullptr;
 }
 
@@ -240,9 +241,9 @@ _NS_INLINE NS::SharedPtr<_Class>& NS::SharedPtr<_Class>::operator=(const SharedP
 {
     _Class* pOldObject = m_pObject;
 
-    m_pObject = other.m_pObject->retain();
+    m_pObject = Object::sendMessage<_Class*>(other.m_pObject, _NS_PRIVATE_SEL(retain));
 
-    pOldObject->release();
+    Object::sendMessage<void>(pOldObject, _NS_PRIVATE_SEL(release));
 
     return *this;
 }
@@ -254,9 +255,9 @@ _NS_INLINE NS::SharedPtr<_Class>::operator=(const SharedPtr<_OtherClass>& other)
 {
     _Class* pOldObject = m_pObject;
 
-    m_pObject = reinterpret_cast<_Class*>(other.get()->retain());
+    m_pObject = Object::sendMessage<_Class*>(other.get(), _NS_PRIVATE_SEL(retain));
 
-    pOldObject->release();
+    Object::sendMessage<void>(pOldObject, _NS_PRIVATE_SEL(release));
 
     return *this;
 }
@@ -266,13 +267,13 @@ _NS_INLINE NS::SharedPtr<_Class>& NS::SharedPtr<_Class>::operator=(SharedPtr<_Cl
 {
     if (m_pObject != other.m_pObject)
     {
-        m_pObject->release();
+        Object::sendMessage<void>(m_pObject, _NS_PRIVATE_SEL(release));
         m_pObject = other.m_pObject;
     }
     else
     {
         m_pObject = other.m_pObject;
-        other.m_pObject->release();
+        Object::sendMessage<void>(other.m_pObject, _NS_PRIVATE_SEL(release));
     }
     other.m_pObject = nullptr;
     return *this;
@@ -285,7 +286,7 @@ _NS_INLINE NS::SharedPtr<_Class>::operator=(SharedPtr<_OtherClass>&& other) __at
 {
     if (m_pObject != other.get())
     {
-        m_pObject->release();
+        Object::sendMessage<void>(m_pObject, _NS_PRIVATE_SEL(release));
         m_pObject = reinterpret_cast<_Class*>(other.get());
         other.detach();
     }

--- a/thirdparty/metal-cpp/patches/0002-sharedptr-nil-safe-retain-release.patch
+++ b/thirdparty/metal-cpp/patches/0002-sharedptr-nil-safe-retain-release.patch
@@ -1,0 +1,104 @@
+diff -ruN original/Foundation/NSSharedPtr.hpp patched/Foundation/NSSharedPtr.hpp
+--- original/Foundation/NSSharedPtr.hpp	2026-09-12 13:18:42
++++ patched/Foundation/NSSharedPtr.hpp	2026-09-12 13:18:42
+@@ -22,6 +22,7 @@
+ 
+ #include <cstddef>
+ #include "NSDefines.hpp"
++#include "NSObject.hpp"
+ 
+ namespace NS
+ {
+@@ -139,7 +140,7 @@
+ _NS_INLINE NS::SharedPtr<_Class> RetainPtr(_Class* pObject)
+ {
+     NS::SharedPtr<_Class> ret;
+-    ret.m_pObject = pObject->retain();
++    ret.m_pObject = Object::sendMessage<_Class*>(pObject, _NS_PRIVATE_SEL(retain));
+     return ret;
+ }
+ 
+@@ -167,7 +168,7 @@
+ template <class _Class>
+ _NS_INLINE NS::SharedPtr<_Class>::~SharedPtr<_Class>() __attribute__((no_sanitize("undefined")))
+ {
+-    m_pObject->release();
++    Object::sendMessage<void>(m_pObject, _NS_PRIVATE_SEL(release));
+ }
+ 
+ template <class _Class>
+@@ -178,14 +179,14 @@
+ 
+ template <class _Class>
+ _NS_INLINE NS::SharedPtr<_Class>::SharedPtr(const SharedPtr<_Class>& other) noexcept
+-    : m_pObject(other.m_pObject->retain())
++    : m_pObject(Object::sendMessage<_Class*>(other.m_pObject, _NS_PRIVATE_SEL(retain)))
+ {
+ }
+ 
+ template <class _Class>
+ template <class _OtherClass>
+ _NS_INLINE NS::SharedPtr<_Class>::SharedPtr(const SharedPtr<_OtherClass>& other, typename std::enable_if_t<std::is_convertible_v<_OtherClass *, _Class *>> *) noexcept
+-    : m_pObject(reinterpret_cast<_Class*>(other.get()->retain()))
++    : m_pObject(Object::sendMessage<_Class*>(other.get(), _NS_PRIVATE_SEL(retain)))
+ {
+ }
+ 
+@@ -225,7 +226,7 @@
+ template <class _Class>
+ _NS_INLINE void NS::SharedPtr<_Class>::reset() __attribute__((no_sanitize("undefined")))
+ {
+-    m_pObject->release();
++    Object::sendMessage<void>(m_pObject, _NS_PRIVATE_SEL(release));
+     m_pObject = nullptr;
+ }
+ 
+@@ -240,9 +241,9 @@
+ {
+     _Class* pOldObject = m_pObject;
+ 
+-    m_pObject = other.m_pObject->retain();
++    m_pObject = Object::sendMessage<_Class*>(other.m_pObject, _NS_PRIVATE_SEL(retain));
+ 
+-    pOldObject->release();
++    Object::sendMessage<void>(pOldObject, _NS_PRIVATE_SEL(release));
+ 
+     return *this;
+ }
+@@ -254,9 +255,9 @@
+ {
+     _Class* pOldObject = m_pObject;
+ 
+-    m_pObject = reinterpret_cast<_Class*>(other.get()->retain());
++    m_pObject = Object::sendMessage<_Class*>(other.get(), _NS_PRIVATE_SEL(retain));
+ 
+-    pOldObject->release();
++    Object::sendMessage<void>(pOldObject, _NS_PRIVATE_SEL(release));
+ 
+     return *this;
+ }
+@@ -266,13 +267,13 @@
+ {
+     if (m_pObject != other.m_pObject)
+     {
+-        m_pObject->release();
++        Object::sendMessage<void>(m_pObject, _NS_PRIVATE_SEL(release));
+         m_pObject = other.m_pObject;
+     }
+     else
+     {
+         m_pObject = other.m_pObject;
+-        other.m_pObject->release();
++        Object::sendMessage<void>(other.m_pObject, _NS_PRIVATE_SEL(release));
+     }
+     other.m_pObject = nullptr;
+     return *this;
+@@ -285,7 +286,7 @@
+ {
+     if (m_pObject != other.get())
+     {
+-        m_pObject->release();
++        Object::sendMessage<void>(m_pObject, _NS_PRIVATE_SEL(release));
+         m_pObject = reinterpret_cast<_Class*>(other.get());
+         other.detach();
+     }

--- a/thirdparty/metal-cpp/update-metal-cpp.sh
+++ b/thirdparty/metal-cpp/update-metal-cpp.sh
@@ -44,10 +44,11 @@ if [ -d "$PATCH_DIR" ]; then
         fi
 
         PATCH_NAME="$(basename "$PATCH")"
-        if git -C "$REPO_ROOT" apply --check "$PATCH" > /dev/null 2>&1; then
-            git -C "$REPO_ROOT" apply "$PATCH"
+        PATCH_DIRECTORY="${SCRIPT_DIR#"$REPO_ROOT"/}"
+        if git -C "$REPO_ROOT" apply --directory="$PATCH_DIRECTORY" --check "$PATCH" > /dev/null 2>&1; then
+            git -C "$REPO_ROOT" apply --directory="$PATCH_DIRECTORY" "$PATCH"
             echo "  $PATCH_NAME: applied"
-        elif git -C "$REPO_ROOT" apply --reverse --check "$PATCH" > /dev/null 2>&1; then
+        elif git -C "$REPO_ROOT" apply --directory="$PATCH_DIRECTORY" --reverse --check "$PATCH" > /dev/null 2>&1; then
             echo "  $PATCH_NAME: already applied"
         else
             echo "  $PATCH_NAME: failed to apply"


### PR DESCRIPTION
Closes #123394

Inline the Objective-C message send C API calls in `NS::SharedPtr`, so that it's never accessing `m_pObject` via `operator->`.

## Root Cause

llvm@21 determines if `NS::SharedPtr::m_pObject == nullptr` is `true`, calling the destructor is undefined behaviour. After multiple optimisation passes, it ends up `MetalAllocator::_free_allocation` changes from effectively:

```c++
void _free_allocation(MetalAllocation &p_allocation) {
  NS::SharedPtr<MTL::Heap> old_heap;
  if (p_allocation.kind == MetalAllocation::Kind::INVALID) {
    // do nothing
  } else if (p_allocation.kind == MetalAllocation::Kind::POOL) {
    SpinLockGuard lock(pool.mutex);
    // pool deallocation
  } else /* p_allocation.kind == MetalAllocation::Kind::DEDICATED */ {
    SpinLockGuard lock(pool.mutex);
    // dedicated deallocation
  }
}
```

to treating all instances of `p_allocation` as only two kinds:

```c++
void _free_allocation(MetalAllocation &p_allocation) {
  SpinLockGuard lock(pool.mutex);
  NS::SharedPtr<MTL::Heap> old_heap;
  if (p_allocation.kind == MetalAllocation::Kind::POOL) {
    // pool deallocation
  } else /* p_allocation.kind == MetalAllocation::Kind::DEDICATED */ {
    // dedicated deallocation
  }
}
```

> [!NOTE]
>
> 🤖 AI was used to diagnose the issue and identify the miscompilation