### PR TITLE
Editor Profilers: Always generate plot texture in `NOTIFIACTION_THEME_CHANGED`

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -478,9 +478,7 @@ void EditorProfiler::_notification(int p_what) {
 			theme_cache.seek_line_hover_color = theme_cache.seek_line_color;
 			theme_cache.seek_line_hover_color.a = 0.4;
 
-			if (total_metrics > 0) {
-				_update_plot();
-			}
+			_update_plot();
 		} break;
 	}
 }

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -482,9 +482,7 @@ void EditorVisualProfiler::_notification(int p_what) {
 			clear_button->set_button_icon(get_editor_theme_icon(SNAME("Clear")));
 			graph_background->set_color(get_theme_color(SNAME("dark_color_1"), EditorStringName(Editor)));
 
-			if (last_metric > -1) {
-				_update_plot();
-			}
+			_update_plot();
 		} break;
 	}
 }


### PR DESCRIPTION
## What problem(s) does this PR solve?

In the Visual Profiler (and the basic Profiler), the plot/graph is made of two layers: A static `ColorRect` background and a texture. The problem is that the texture isn't generated until an update (e.g. changing some parameter, starting the profiling, ...), so when that first update occurs, there is a noticable color change of the plot. (Note that both the background and the texture use colors with alpha values not 1.0). The solution is to remove the condition to update it in `NOTIFICATION_THEME_CHANGED`, so the texture is generated by default. This also fixes the bug where after a theme change the texture would be a completely wrong color, because it hasn't updated yet (e.g. switching from light to dark mode would cause it to be too light for dark mode).

## Overview

| 4.8.dev5 | PR |
|--------|--------|
| https://github.com/user-attachments/assets/3153b7f0-f826-45f6-8997-ac7fe859125f  | https://github.com/user-attachments/assets/9fde2381-a7e5-45b8-a773-28e0b2cebf62 |
| https://github.com/user-attachments/assets/9c219cf4-b8c8-41df-a8c7-ca7899963a92  | https://github.com/user-attachments/assets/2f1a9c7a-77cc-4747-b1ae-df7e7c01e133 | 

## Additional information

No AI was used.