### PR TITLE
Add `get_stream_playback_position` method to `AudioStreamPlaybackPolyphonic`

### DIFF
--- a/doc/classes/AudioStreamPlaybackPolyphonic.xml
+++ b/doc/classes/AudioStreamPlaybackPolyphonic.xml
@@ -9,6 +9,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_stream_playback_position" qualifiers="const">
+			<return type="float" />
+			<param index="0" name="stream" type="int" />
+			<description>
+				Returns the stream playback position. The [param stream] argument is an integer ID returned by [method play_stream]. This function returns [code]0.0[/code] if the stream was not found.
+			</description>
+		</method>
 		<method name="is_stream_playing" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="stream" type="int" />

--- a/scene/resources/audio/audio_stream_polyphonic.cpp
+++ b/scene/resources/audio/audio_stream_polyphonic.cpp
@@ -296,6 +296,14 @@ const AudioStreamPlaybackPolyphonic::Stream *AudioStreamPlaybackPolyphonic::_fin
 	return &streams[index];
 }
 
+double AudioStreamPlaybackPolyphonic::get_stream_playback_position(ID p_stream_id) const {
+	const Stream *s = _find_stream(p_stream_id);
+	if (!s) {
+		return 0.0;
+	}
+	return s->stream_playback->get_playback_position();
+}
+
 void AudioStreamPlaybackPolyphonic::set_stream_volume(ID p_stream_id, float p_volume_db) {
 	Stream *s = _find_stream(p_stream_id);
 	if (!s) {
@@ -345,6 +353,7 @@ void AudioStreamPlaybackPolyphonic::set_sample_playback(const Ref<AudioSamplePla
 
 void AudioStreamPlaybackPolyphonic::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("play_stream", "stream", "from_offset", "volume_db", "pitch_scale", "playback_type", "bus"), &AudioStreamPlaybackPolyphonic::play_stream, DEFVAL(0), DEFVAL(0), DEFVAL(1.0), DEFVAL(0), DEFVAL(SceneStringName(Master)));
+	ClassDB::bind_method(D_METHOD("get_stream_playback_position", "stream"), &AudioStreamPlaybackPolyphonic::get_stream_playback_position);
 	ClassDB::bind_method(D_METHOD("set_stream_volume", "stream", "volume_db"), &AudioStreamPlaybackPolyphonic::set_stream_volume);
 	ClassDB::bind_method(D_METHOD("set_stream_pitch_scale", "stream", "pitch_scale"), &AudioStreamPlaybackPolyphonic::set_stream_pitch_scale);
 	ClassDB::bind_method(D_METHOD("is_stream_playing", "stream"), &AudioStreamPlaybackPolyphonic::is_stream_playing);

--- a/scene/resources/audio/audio_stream_polyphonic.h
+++ b/scene/resources/audio/audio_stream_polyphonic.h
@@ -113,6 +113,7 @@ public:
 	virtual int mix(AudioFrame *p_buffer, float p_rate_scale, int p_frames) override;
 
 	ID play_stream(const Ref<AudioStream> &p_stream, float p_from_offset = 0, float p_volume_db = 0, float p_pitch_scale = 1.0, AuSE::PlaybackType p_playback_type = AuSE::PlaybackType::PLAYBACK_TYPE_DEFAULT, const StringName &p_bus = SceneStringName(Master));
+	double get_stream_playback_position(ID p_stream_id) const;
 	void set_stream_volume(ID p_stream_id, float p_volume_db);
 	void set_stream_pitch_scale(ID p_stream_id, float p_pitch_scale);
 	bool is_stream_playing(ID p_stream_id) const;


### PR DESCRIPTION
- Closes #123398

Since `AudioStreamPolyphonic` can play multiple streams at once, we can't use `AudioStreamPlaybackPolyphonic.get_playback_position()` to get playback position of individual streams. To address this limitation, I added `get_stream_playback_position` method to `AudioStreamPlaybackPolyphonic`, which was proposed in the linked issue.