### PR TITLE
[.NET]: Use correct underlying type when marshalling enum `Error`

### DIFF
--- a/modules/mono/glue/runtime_interop.cpp
+++ b/modules/mono/glue/runtime_interop.cpp
@@ -87,9 +87,9 @@ Object *godotsharp_engine_get_singleton(const String *p_name) {
 	return Engine::get_singleton()->get_singleton_object(*p_name);
 }
 
-int32_t godotsharp_stack_info_vector_resize(
+int64_t godotsharp_stack_info_vector_resize(
 		Vector<ScriptLanguage::StackInfo> *p_stack_info_vector, int p_size) {
-	return (int32_t)p_stack_info_vector->resize(p_size);
+	return (int64_t)p_stack_info_vector->resize(p_size);
 }
 
 void godotsharp_stack_info_vector_destroy(
@@ -218,9 +218,9 @@ void godotsharp_internal_refcounted_disposed(Object *p_ptr, GCHandleIntPtr p_gch
 	}
 }
 
-int32_t godotsharp_internal_signal_awaiter_connect(Object *p_source, StringName *p_signal, Object *p_target, GCHandleIntPtr p_awaiter_handle_ptr) {
+int64_t godotsharp_internal_signal_awaiter_connect(Object *p_source, StringName *p_signal, Object *p_target, GCHandleIntPtr p_awaiter_handle_ptr) {
 	StringName signal = p_signal ? *p_signal : StringName();
-	return (int32_t)gd_mono_connect_signal_awaiter(p_source, signal, p_target, p_awaiter_handle_ptr);
+	return (int64_t)gd_mono_connect_signal_awaiter(p_source, signal, p_target, p_awaiter_handle_ptr);
 }
 
 GCHandleIntPtr godotsharp_internal_unmanaged_get_script_instance_managed(Object *p_unmanaged, bool *r_has_cs_script_instance) {
@@ -1150,8 +1150,8 @@ void godotsharp_array_remove_at(Array *p_self, int32_t p_index) {
 	p_self->remove_at(p_index);
 }
 
-int32_t godotsharp_array_resize(Array *p_self, int32_t p_new_size) {
-	return (int32_t)p_self->resize(p_new_size);
+int64_t godotsharp_array_resize(Array *p_self, int32_t p_new_size) {
+	return (int64_t)p_self->resize(p_new_size);
 }
 
 void godotsharp_array_reverse(Array *p_self) {


### PR DESCRIPTION
## What problem(s) does this PR solve?

The return type for the enum doesn't match the underlying type of the enum
<img width="834" height="107" alt="image" src="https://github.com/user-attachments/assets/67969822-a84e-4be5-91ad-de80102c56f3" />

## Additional information

This seems to be the only generated enum that is being used in the `runtime_interop.cpp`, so it is the only one that is affected. Causes `RuntimeError: function signature mismatch` in wasm, which is not relevant currently, but will be in the future. The other mismatches should be fixed by https://github.com/godotengine/godot/pull/122907 or something similar.