### PR TITLE
Fix SDFGI static light rendering

### DIFF
--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -2432,13 +2432,13 @@ void GI::SDFGI::render_static_lights(RenderDataRD *p_render_data, Ref<RenderScen
 	update_cascades();
 
 	SDFGIShader::Light lights[SDFGI::MAX_STATIC_LIGHTS];
-	uint32_t light_count[SDFGI::MAX_STATIC_LIGHTS];
+	uint32_t light_count[SDFGI::MAX_CASCADES];
 
 	for (uint32_t i = 0; i < p_cascade_count; i++) {
-		ERR_CONTINUE(p_cascade_indices[i] >= cascades.size());
+		uint32_t cascade_index = p_cascade_indices[i];
+		ERR_CONTINUE(cascade_index >= cascades.size());
 
-		SDFGI::Cascade &cc = cascades[p_cascade_indices[i]];
-
+		SDFGI::Cascade &cc = cascades[cascade_index];
 		{ //fill light buffer
 
 			AABB cascade_aabb;
@@ -2446,13 +2446,12 @@ void GI::SDFGI::render_static_lights(RenderDataRD *p_render_data, Ref<RenderScen
 			cascade_aabb.size = Vector3(1, 1, 1) * cascade_size * cc.cell_size;
 
 			int idx = 0;
-
-			for (uint32_t j = 0; j < (uint32_t)p_positional_light_cull_result[i].size(); j++) {
+			for (uint32_t j = 0; j < (uint32_t)p_positional_light_cull_result[cascade_index].size(); j++) {
 				if (idx == SDFGI::MAX_STATIC_LIGHTS) {
 					break;
 				}
 
-				RID light_instance = p_positional_light_cull_result[i][j];
+				RID light_instance = p_positional_light_cull_result[cascade_index][j];
 				ERR_CONTINUE(!light_storage->owns_light_instance(light_instance));
 
 				RID light = light_storage->light_instance_get_base_light(light_instance);
@@ -2460,7 +2459,7 @@ void GI::SDFGI::render_static_lights(RenderDataRD *p_render_data, Ref<RenderScen
 				Transform3D light_transform = light_storage->light_instance_get_base_transform(light_instance);
 
 				uint32_t max_sdfgi_cascade = RSG::light_storage->light_get_max_sdfgi_cascade(light);
-				if (p_cascade_indices[i] > max_sdfgi_cascade) {
+				if (cascade_index > max_sdfgi_cascade) {
 					continue;
 				}
 

--- a/servers/rendering/renderer_rd/shaders/environment/sdfgi_direct_light.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sdfgi_direct_light.glsl
@@ -291,6 +291,8 @@ void main() {
 
 #endif
 
+	vec3 l;
+	uint aniso;
 	{
 		uint rgbe = process_voxels.data[voxel_index].light;
 
@@ -301,13 +303,17 @@ void main() {
 		float e = float((rgbe >> 25) & 0x1F);
 		float m = pow(2.0, e - 15.0 - 9.0);
 
-		vec3 l = vec3(r, g, b) * m;
+		l = vec3(r, g, b) * m;
 
-		uint aniso = process_voxels.data[voxel_index].light_aniso;
+		aniso = process_voxels.data[voxel_index].light_aniso;
+
+		// In static mode, this will happen later
+#ifdef MODE_PROCESS_DYNAMIC
 		for (uint i = 0; i < 6; i++) {
 			float strength = ((aniso >> (i * 5)) & 0x1F) / float(0x1F);
 			light_accum[i] += l * strength;
 		}
+#endif
 	}
 
 	// Raytrace light
@@ -450,6 +456,10 @@ void main() {
 	vec3 light_total = vec3(0);
 
 	for (int i = 0; i < 6; i++) {
+#ifdef MODE_PROCESS_STATIC
+		float strength = ((aniso >> (i * 5)) & 0x1F) / float(0x1F);
+		light_accum[i] = max(light_accum[i], l * strength); // Prevent static light from stacking on itself infinitely
+#endif
 		light_total += light_accum[i];
 		lumas[i] = max(light_accum[i].r, max(light_accum[i].g, light_accum[i].b));
 	}

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3680,7 +3680,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 			//check if static lights were culled
 			bool static_lights_culled = false;
 			for (uint32_t i = 0; i < cull.sdfgi.cascade_light_count; i++) {
-				if (scene_cull_result.sdfgi_cascade_lights[i].size()) {
+				if (scene_cull_result.sdfgi_cascade_lights[cull.sdfgi.cascade_light_index[i]].size()) {
 					static_lights_culled = true;
 					break;
 				}


### PR DESCRIPTION
<!--
Please target the `master` branch. We will take care of backporting relevant fixes to older versions.

Before submitting, please read our checklist for contributors:
https://contributing.godotengine.org/en/latest/engine/introduction.html#checklist-for-new-contributors

Use of AI must be disclosed and should include a description of how it was used.
-->

## What problem(s) does this PR solve?

- Closes #77551
- Closes #55322

## Additional information

<!--
Provide additional information and explanation of your PR, including areas that you are uncertain of or require special attention from reviewers. For examples, please read our pull request guidelines: https://contributing.godotengine.org/en/latest/pull_requests/pull_request_guidelines.html#explain-your-contributions
-->
The first commit fixes the bug where static lights would only render close to the camera. This was caused by wrong cascade indices being used, where cascade 0 would usually line up by coincidence but the other cascades would usually not. I also reduced the size of the array "light_count" which was being allocated unnecessarily large.

The second commit fixes the bug where static light would increase infinitely during camera movement. In the direct light compute shader, instead of adding the static light to the voxel's existing light, I am taking the maximum of the two. This prevents the light from endlessly adding to itself every time the static lights are rendered.
This change introduces an inaccuracy where static direct light doesn't add to the light of emissive surfaces, but instead the maximum of the two is taken. I consider this a minor problem and a worthwhile tradeoff.