### PR TITLE
Add missing comma in docs

### DIFF
--- a/doc/classes/BoxShape3D.xml
+++ b/doc/classes/BoxShape3D.xml
@@ -14,7 +14,7 @@
 	</tutorials>
 	<members>
 		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(1, 1, 1)">
-			The box's width, height and depth.
+			The box's width, height, and depth.
 		</member>
 	</members>
 </class>


### PR DESCRIPTION
## What problem(s) does this PR solve?

Adds a missing Oxford comma to the `BoxShape3D` class docs, in accordance with the [Writing guidelines](https://contributing.godotengine.org/en/latest/documentation/guidelines/docs_writing_guidelines.html).

## Additional information

It was foretold

<img width="583" height="256" alt="image" src="https://github.com/user-attachments/assets/8768542f-9074-42d7-a945-80e66a20373f" />
